### PR TITLE
copy only lower bits in ecdsaSignFunc

### DIFF
--- a/jws/sign/ecdsa.go
+++ b/jws/sign/ecdsa.go
@@ -41,7 +41,7 @@ func makeECDSASignFunc(hash crypto.Hash) ecdsaSignFunc {
 		rb := r.Bytes()
 		vb := v.Bytes()
 		copy(out[keysiz-len(rb):], rb)
-		copy(out[keysiz*2-len(vb):], v.Bytes())
+		copy(out[keysiz*2-len(vb):], vb)
 		return out, nil
 	})
 }

--- a/jws/sign/ecdsa.go
+++ b/jws/sign/ecdsa.go
@@ -38,8 +38,10 @@ func makeECDSASignFunc(hash crypto.Hash) ecdsaSignFunc {
 			return nil, errors.Wrap(err, "failed to sign payload using ecdsa")
 		}
 		out := make([]byte, keysiz*2)
-		copy(out, r.Bytes())
-		copy(out[keysiz:], v.Bytes())
+		rb := r.Bytes()
+		vb := v.Bytes()
+		copy(out[keysiz-len(rb):], rb)
+		copy(out[keysiz*2-len(vb):], v.Bytes())
 		return out, nil
 	})
 }


### PR DESCRIPTION
This fix #52 
The problem is dst of copy is larger size than src.
This PR adjusts dst size to fit with src.