### PR TITLE
Fix wrong key size of ECDH-ES + AES key wrap

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -68,7 +68,7 @@ func Encrypt(payload []byte, keyalg jwa.KeyEncryptionAlgorithm, key interface{},
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create ECDHS key wrap encrypter")
 		}
-		keysize = contentcrypt.KeySize()
+		keysize = contentcrypt.KeySize() / 2
 	case jwa.ECDH_ES:
 		fallthrough
 	case jwa.A128GCMKW, jwa.A192GCMKW, jwa.A256GCMKW:

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -356,6 +356,35 @@ func TestEncode_ECDHES(t *testing.T) {
 	t.Logf("%s", decrypted)
 }
 
+func TestEncode_ECDH_ES_A256KW_A192KW_A128KW(t *testing.T) {
+	plaintext := []byte("Lorem ipsum")
+	privkey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if !assert.NoError(t, err, "ecdsa key generated") {
+		return
+	}
+
+	algorithms := []jwa.KeyEncryptionAlgorithm{jwa.ECDH_ES_A256KW, jwa.ECDH_ES_A192KW, jwa.ECDH_ES_A128KW}
+
+	for i := 0; i < len(algorithms); i++ {
+		encrypted, err := Encrypt(plaintext, algorithms[i], &privkey.PublicKey, jwa.A256GCM, jwa.NoCompress)
+		if !assert.NoError(t, err, "Encrypt succeeds") {
+			return
+		}
+
+		t.Logf("encrypted = %s", encrypted)
+
+		msg, _ := Parse(encrypted)
+		jsonbuf, _ := json.MarshalIndent(msg, "", "  ")
+		t.Logf("%s", jsonbuf)
+
+		decrypted, err := Decrypt(encrypted, algorithms[i], privkey)
+		if !assert.NoError(t, err, "Decrypt succeeds") {
+			return
+		}
+		t.Logf("%s", decrypted)
+	}
+}
+
 func Test_A256KW_A256CBC_HS512(t *testing.T) {
 	var keysize = 32
 	var key = make([]byte, keysize)


### PR DESCRIPTION
## Problem
When using `ECDH_ES_A256KW` to encrypt plaintext, error `invalid key size 64` will be thrown.

## Cause
In jwe.Encrypt(), content key size in switch case `jwa.ECDH_ES_A256KW`, `jwa.ECDH_ES_A192KW`, `jwa.ECDH_ES_A128KW` is wrong.

```golang
case jwa.ECDH_ES_A128KW, jwa.ECDH_ES_A192KW, jwa.ECDH_ES_A256KW:
    pubkey, ok := key.(*ecdsa.PublicKey)
    if !ok {
        return nil, errors.New("invalid key: *ecdsa.PublicKey required")
    }
    keyenc, err = NewEcdhesKeyWrapEncrypt(keyalg, pubkey)
    if err != nil {
        return nil, errors.Wrap(err, "failed to create ECDHS key wrap encrypter")
    }
    keysize = contentcrypt.KeySize() // content key size is wrong
}
```

## Solution
Key size divided by 2.

> Thanks my colleague @crownych, he found this bug.