### PR TITLE
jws.Sign() removes whitespace and newlines from JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# IDE
+.idea
+.vscode
+.DS_Store

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -1,5 +1,5 @@
 // Package buffer provides a very thin wrapper around []byte buffer called
-// `Buffer`, to provide functionalitites that are often used wthin the jwx
+// `Buffer`, to provide functionalities that are often used within the jwx
 // related packages
 package buffer
 


### PR DESCRIPTION
fixes #62
Added idea folders to gitignore

This PR adds a new function that serializes protected headers "as is", without formatting  or removing whitespace. 