### PR TITLE
Remove unused options

### DIFF
--- a/jws/option.go
+++ b/jws/option.go
@@ -10,12 +10,7 @@ type Option = option.Interface
 const (
 	optkeyPayloadSigner    = `payload-signer`
 	optkeyHeaders          = `headers`
-	optkeyPrettyJSONFormat = `format-json-pretty`
 )
-
-func WithPretty(b bool) Option {
-	return option.New(optkeyPrettyJSONFormat, b)
-}
 
 func WithSigner(signer sign.Signer, key interface{}, public, protected Headers) Option {
 	return option.New(optkeyPayloadSigner, &payloadSigner{


### PR DESCRIPTION
git blame / git log tells us that they had their use way back when, but not anymore

refs #79