### PR TITLE
Low coverage and unused functions in jws

### DIFF
--- a/cmd/jwx/jwx.go
+++ b/cmd/jwx/jwx.go
@@ -142,7 +142,8 @@ func doJWK() int {
 			log.Printf("%s", l)
 		}
 
-		if _, err := jws.Verify(buf.Bytes(), sig.ProtectedHeaders().Algorithm(), pubkey); err == nil {
+		alg := sig.ProtectedHeaders().Algorithm()
+		if _, err := jws.Verify(buf.Bytes(), alg, pubkey); err == nil {
 			log.Printf("=== Verified with signature %d! ===", i)
 		}
 	}

--- a/jws/headers.go
+++ b/jws/headers.go
@@ -2,10 +2,10 @@
 package jws
 
 import (
-	"encoding/json"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/pkg/errors"
+	"reflect"
 )
 
 const (
@@ -26,169 +26,95 @@ type Headers interface {
 	Get(string) (interface{}, bool)
 	Set(string, interface{}) error
 	Algorithm() jwa.SignatureAlgorithm
-	ContentType() string
-	Critical() []string
-	JWK() jwk.Key
-	JWKSetURL() string
-	KeyID() string
-	Type() string
-	X509CertChain() []string
-	X509CertThumbprint() string
-	X509CertThumbprintS256() string
-	X509URL() string
 }
 
 type StandardHeaders struct {
-	algorithm              *jwa.SignatureAlgorithm // https://tools.ietf.org/html/rfc7515#section-4.1.1
-	contentType            *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.10
-	critical               []string                // https://tools.ietf.org/html/rfc7515#section-4.1.11
-	jwk                    jwk.Key                 // https://tools.ietf.org/html/rfc7515#section-4.1.3
-	jwkSetURL              *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.2
-	keyID                  *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.4
-	typ                    *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.9
-	x509CertChain          []string                // https://tools.ietf.org/html/rfc7515#section-4.1.6
-	x509CertThumbprint     *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.7
-	x509CertThumbprintS256 *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.8
-	x509URL                *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.5
-	privateParams          map[string]interface{}
+	JWSalgorithm              jwa.SignatureAlgorithm `json:"alg,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.1
+	JWScontentType            string                 `json:"cty,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.10
+	JWScritical               []string               `json:"crit,omitempty"`     // https://tools.ietf.org/html/rfc7515#section-4.1.11
+	JWSjwk                    *jwk.Set               `json:"jwk,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.3
+	JWSjwkSetURL              string                 `json:"jku,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.2
+	JWSkeyID                  string                 `json:"kid,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.4
+	JWStyp                    string                 `json:"typ,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.9
+	JWSx509CertChain          []string               `json:"x5c,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.6
+	JWSx509CertThumbprint     string                 `json:"x5t,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.7
+	JWSx509CertThumbprintS256 string                 `json:"x5t#S256,omitempty"` // https://tools.ietf.org/html/rfc7515#section-4.1.8
+	JWSx509URL                string                 `json:"x5u,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.5
+	privateParams             map[string]interface{}
 }
 
 func (h *StandardHeaders) Algorithm() jwa.SignatureAlgorithm {
-	if v := h.algorithm; v != nil {
-		return *v
-	}
-	return jwa.NoSignature
-}
-
-func (h *StandardHeaders) ContentType() string {
-	if v := h.contentType; v != nil {
-		return *v
-	}
-	return ""
-}
-
-func (h *StandardHeaders) Critical() []string {
-	return h.critical
-}
-
-func (h *StandardHeaders) JWK() jwk.Key {
-	return h.jwk
-}
-
-func (h *StandardHeaders) JWKSetURL() string {
-	if v := h.jwkSetURL; v != nil {
-		return *v
-	}
-	return ""
-}
-
-func (h *StandardHeaders) KeyID() string {
-	if v := h.keyID; v != nil {
-		return *v
-	}
-	return ""
-}
-
-func (h *StandardHeaders) Type() string {
-	if v := h.typ; v != nil {
-		return *v
-	}
-	return ""
-}
-
-func (h *StandardHeaders) X509CertChain() []string {
-	return h.x509CertChain
-}
-
-func (h *StandardHeaders) X509CertThumbprint() string {
-	if v := h.x509CertThumbprint; v != nil {
-		return *v
-	}
-	return ""
-}
-
-func (h *StandardHeaders) X509CertThumbprintS256() string {
-	if v := h.x509CertThumbprintS256; v != nil {
-		return *v
-	}
-	return ""
-}
-
-func (h *StandardHeaders) X509URL() string {
-	if v := h.x509URL; v != nil {
-		return *v
-	}
-	return ""
+	return h.JWSalgorithm
 }
 
 func (h *StandardHeaders) Get(name string) (interface{}, bool) {
 	switch name {
 	case AlgorithmKey:
-		v := h.algorithm
-		if v == nil {
+		v := h.JWSalgorithm
+		if v == "" {
 			return nil, false
 		}
-		return *v, true
+		return v, true
 	case ContentTypeKey:
-		v := h.contentType
-		if v == nil {
+		v := h.JWScontentType
+		if v == "" {
 			return nil, false
 		}
-		return *v, true
+		return v, true
 	case CriticalKey:
-		v := h.critical
-		if v == nil {
+		v := h.JWScritical
+		if len(v) == 0 {
 			return nil, false
 		}
 		return v, true
 	case JWKKey:
-		v := h.jwk
+		v := h.JWSjwk
 		if v == nil {
 			return nil, false
 		}
 		return v, true
 	case JWKSetURLKey:
-		v := h.jwkSetURL
-		if v == nil {
+		v := h.JWSjwkSetURL
+		if v == "" {
 			return nil, false
 		}
-		return *v, true
+		return v, true
 	case KeyIDKey:
-		v := h.keyID
-		if v == nil {
+		v := h.JWSkeyID
+		if v == "" {
 			return nil, false
 		}
-		return *v, true
+		return v, true
 	case TypeKey:
-		v := h.typ
-		if v == nil {
+		v := h.JWStyp
+		if v == "" {
 			return nil, false
 		}
-		return *v, true
+		return v, true
 	case X509CertChainKey:
-		v := h.x509CertChain
-		if v == nil {
+		v := h.JWSx509CertChain
+		if len(v) == 0 {
 			return nil, false
 		}
 		return v, true
 	case X509CertThumbprintKey:
-		v := h.x509CertThumbprint
-		if v == nil {
+		v := h.JWSx509CertThumbprint
+		if v == "" {
 			return nil, false
 		}
-		return *v, true
+		return v, true
 	case X509CertThumbprintS256Key:
-		v := h.x509CertThumbprintS256
-		if v == nil {
+		v := h.JWSx509CertThumbprintS256
+		if v == "" {
 			return nil, false
 		}
-		return *v, true
+		return v, true
 	case X509URLKey:
-		v := h.x509URL
-		if v == nil {
+		v := h.JWSx509URL
+		if v == "" {
 			return nil, false
 		}
-		return *v, true
+		return v, true
 	default:
 		v, ok := h.privateParams[name]
 		return v, ok
@@ -198,69 +124,68 @@ func (h *StandardHeaders) Get(name string) (interface{}, bool) {
 func (h *StandardHeaders) Set(name string, value interface{}) error {
 	switch name {
 	case AlgorithmKey:
-		var acceptor jwa.SignatureAlgorithm
-		if err := acceptor.Accept(value); err != nil {
+		if err := h.JWSalgorithm.Accept(value); err != nil {
 			return errors.Wrapf(err, `invalid value for %s key`, AlgorithmKey)
 		}
-		h.algorithm = &acceptor
 		return nil
 	case ContentTypeKey:
 		if v, ok := value.(string); ok {
-			h.contentType = &v
+			h.JWScontentType = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, ContentTypeKey, value)
 	case CriticalKey:
 		if v, ok := value.([]string); ok {
-			h.critical = v
+			h.JWScritical = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, CriticalKey, value)
 	case JWKKey:
-		if v, ok := value.(jwk.Key); ok {
-			h.jwk = v
+		v, ok := reflect.ValueOf(value).Interface().(*jwk.Set)
+		if ok {
+			h.JWSjwk = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, JWKKey, value)
 	case JWKSetURLKey:
 		if v, ok := value.(string); ok {
-			h.jwkSetURL = &v
+			h.JWSjwkSetURL = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, JWKSetURLKey, value)
 	case KeyIDKey:
 		if v, ok := value.(string); ok {
-			h.keyID = &v
+			h.JWSkeyID = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, KeyIDKey, value)
 	case TypeKey:
 		if v, ok := value.(string); ok {
-			h.typ = &v
+			h.JWStyp = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, TypeKey, value)
 	case X509CertChainKey:
 		if v, ok := value.([]string); ok {
-			h.x509CertChain = v
+			h.JWSx509CertChain = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, X509CertChainKey, value)
 	case X509CertThumbprintKey:
 		if v, ok := value.(string); ok {
-			h.x509CertThumbprint = &v
+			h.JWSx509CertThumbprint = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, X509CertThumbprintKey, value)
 	case X509CertThumbprintS256Key:
 		if v, ok := value.(string); ok {
-			h.x509CertThumbprintS256 = &v
+			h.JWSx509CertThumbprintS256 = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, X509CertThumbprintS256Key, value)
 	case X509URLKey:
 		if v, ok := value.(string); ok {
-			h.x509URL = &v
+			h.JWSx509URL = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, X509URLKey, value)
@@ -269,134 +194,6 @@ func (h *StandardHeaders) Set(name string, value interface{}) error {
 			h.privateParams = map[string]interface{}{}
 		}
 		h.privateParams[name] = value
-	}
-	return nil
-}
-
-func (h StandardHeaders) MarshalJSON() ([]byte, error) {
-	m := map[string]interface{}{}
-	for k, v := range h.privateParams {
-		m[k] = v
-	}
-	m[AlgorithmKey] = h.algorithm
-
-	if h.contentType != nil {
-		m[ContentTypeKey] = h.contentType
-	}
-
-	if len(h.critical) > 0 {
-		m[CriticalKey] = h.critical
-	}
-
-	if h.jwk != nil {
-		m[JWKKey] = h.jwk
-	}
-
-	if h.jwkSetURL != nil {
-		m[JWKSetURLKey] = h.jwkSetURL
-	}
-
-	if h.keyID != nil {
-		m[KeyIDKey] = h.keyID
-	}
-
-	if h.typ != nil {
-		m[TypeKey] = h.typ
-	}
-
-	if len(h.x509CertChain) > 0 {
-		m[X509CertChainKey] = h.x509CertChain
-	}
-
-	if h.x509CertThumbprint != nil {
-		m[X509CertThumbprintKey] = h.x509CertThumbprint
-	}
-
-	if h.x509CertThumbprintS256 != nil {
-		m[X509CertThumbprintS256Key] = h.x509CertThumbprintS256
-	}
-
-	if h.x509URL != nil {
-		m[X509URLKey] = h.x509URL
-	}
-
-	return json.Marshal(m)
-}
-
-func (h *StandardHeaders) UnmarshalJSON(buf []byte) error {
-	var m map[string]interface{}
-	if err := json.Unmarshal(buf, &m); err != nil {
-		return errors.Wrap(err, `failed to unmarshal headers`)
-	}
-	if v, ok := m[AlgorithmKey]; ok {
-		if err := h.Set(AlgorithmKey, v); err != nil {
-			return errors.Wrapf(err, `failed to set value for key %s`, AlgorithmKey)
-		}
-		delete(m, AlgorithmKey)
-	}
-	if v, ok := m[ContentTypeKey]; ok {
-		if err := h.Set(ContentTypeKey, v); err != nil {
-			return errors.Wrapf(err, `failed to set value for key %s`, ContentTypeKey)
-		}
-		delete(m, ContentTypeKey)
-	}
-	if v, ok := m[CriticalKey]; ok {
-		if err := h.Set(CriticalKey, v); err != nil {
-			return errors.Wrapf(err, `failed to set value for key %s`, CriticalKey)
-		}
-		delete(m, CriticalKey)
-	}
-	if v, ok := m[JWKKey]; ok {
-		if err := h.Set(JWKKey, v); err != nil {
-			return errors.Wrapf(err, `failed to set value for key %s`, JWKKey)
-		}
-		delete(m, JWKKey)
-	}
-	if v, ok := m[JWKSetURLKey]; ok {
-		if err := h.Set(JWKSetURLKey, v); err != nil {
-			return errors.Wrapf(err, `failed to set value for key %s`, JWKSetURLKey)
-		}
-		delete(m, JWKSetURLKey)
-	}
-	if v, ok := m[KeyIDKey]; ok {
-		if err := h.Set(KeyIDKey, v); err != nil {
-			return errors.Wrapf(err, `failed to set value for key %s`, KeyIDKey)
-		}
-		delete(m, KeyIDKey)
-	}
-	if v, ok := m[TypeKey]; ok {
-		if err := h.Set(TypeKey, v); err != nil {
-			return errors.Wrapf(err, `failed to set value for key %s`, TypeKey)
-		}
-		delete(m, TypeKey)
-	}
-	if v, ok := m[X509CertChainKey]; ok {
-		if err := h.Set(X509CertChainKey, v); err != nil {
-			return errors.Wrapf(err, `failed to set value for key %s`, X509CertChainKey)
-		}
-		delete(m, X509CertChainKey)
-	}
-	if v, ok := m[X509CertThumbprintKey]; ok {
-		if err := h.Set(X509CertThumbprintKey, v); err != nil {
-			return errors.Wrapf(err, `failed to set value for key %s`, X509CertThumbprintKey)
-		}
-		delete(m, X509CertThumbprintKey)
-	}
-	if v, ok := m[X509CertThumbprintS256Key]; ok {
-		if err := h.Set(X509CertThumbprintS256Key, v); err != nil {
-			return errors.Wrapf(err, `failed to set value for key %s`, X509CertThumbprintS256Key)
-		}
-		delete(m, X509CertThumbprintS256Key)
-	}
-	if v, ok := m[X509URLKey]; ok {
-		if err := h.Set(X509URLKey, v); err != nil {
-			return errors.Wrapf(err, `failed to set value for key %s`, X509URLKey)
-		}
-		delete(m, X509URLKey)
-	}
-	// Fix: A nil map is different from a empty map as far as deep.equal is concerned
-	if len(m) > 0 {
-		h.privateParams = m
 	}
 	return nil
 }

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -1,6 +1,7 @@
 package jws_test
 
 import (
+	"encoding/json"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/lestrrat-go/jwx/jws"
@@ -9,32 +10,52 @@ import (
 )
 
 func TestHeader(t *testing.T) {
-	t.Run("Roundtrip", func(t *testing.T) {
-		publicKey := `{"kty":"RSA",
+	publicKey := `{"kty":"RSA",
 	             "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
 	             "e":"AQAB",
 	             "alg":"RS256",
 	             "kid":"2011-04-29"}`
-		jwkPublicKeySet, err := jwk.ParseString(publicKey)
-		if err != nil {
-			t.Fatal("Failed to parse RSA public key")
-		}
-		jwkPublicKey := jwkPublicKeySet.Keys[0]
-		certChain := []string{
-			"MIIE3jCCA8agAwIBAgICAwEwDQYJKoZIhvcNAQEFBQAwYzELMAkGA1UEBhMCVVMxITAfBgNVBAoTGFRoZSBHbyBEYWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR28gRGFkZHkgQ2xhc3MgMiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw0wNjExMTYwMTU0MzdaFw0yNjExMTYwMTU0MzdaMIHKMQswCQYDVQQGEwJVUzEQMA4GA1UECBMHQXJpem9uYTETMBEGA1UEBxMKU2NvdHRzZGFsZTEaMBgGA1UEChMRR29EYWRkeS5jb20sIEluYy4xMzAxBgNVBAsTKmh0dHA6Ly9jZXJ0aWZpY2F0ZXMuZ29kYWRkeS5jb20vcmVwb3NpdG9yeTEwMC4GA1UEAxMnR28gRGFkZHkgU2VjdXJlIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MREwDwYDVQQFEwgwNzk2OTI4NzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMQt1RWMnCZM7DI161+4WQFapmGBWTtwY6vj3D3HKrjJM9N55DrtPDAjhI6zMBS2sofDPZVUBJ7fmd0LJR4h3mUpfjWoqVTr9vcyOdQmVZWt7/v+WIbXnvQAjYwqDL1CBM6nPwT27oDyqu9SoWlm2r4arV3aLGbqGmu75RpRSgAvSMeYddi5Kcju+GZtCpyz8/x4fKL4o/K1w/O5epHBp+YlLpyo7RJlbmr2EkRTcDCVw5wrWCs9CHRK8r5RsL+H0EwnWGu1NcWdrxcx+AuP7q2BNgWJCJjPOq8lh8BJ6qf9Z/dFjpfMFDniNoW1fho3/Rb2cRGadDAW/hOUoz+EDU8CAwEAAaOCATIwggEuMB0GA1UdDgQWBBT9rGEyk2xF1uLuhV+auud2mWjM5zAfBgNVHSMEGDAWgBTSxLDSkdRMEXGzYcs9of7dqGrU4zASBgNVHRMBAf8ECDAGAQH/AgEAMDMGCCsGAQUFBwEBBCcwJTAjBggrBgEFBQcwAYYXaHR0cDovL29jc3AuZ29kYWRkeS5jb20wRgYDVR0fBD8wPTA7oDmgN4Y1aHR0cDovL2NlcnRpZmljYXRlcy5nb2RhZGR5LmNvbS9yZXBvc2l0b3J5L2dkcm9vdC5jcmwwSwYDVR0gBEQwQjBABgRVHSAAMDgwNgYIKwYBBQUHAgEWKmh0dHA6Ly9jZXJ0aWZpY2F0ZXMuZ29kYWRkeS5jb20vcmVwb3NpdG9yeTAOBgNVHQ8BAf8EBAMCAQYwDQYJKoZIhvcNAQEFBQADggEBANKGwOy9+aG2Z+5mC6IGOgRQjhVyrEp0lVPLN8tESe8HkGsz2ZbwlFalEzAFPIUyIXvJxwqoJKSQ3kbTJSMUA2fCENZvD117esyfxVgqwcSeIaha86ykRvOe5GPLL5CkKSkB2XIsKd83ASe8T+5o0yGPwLPk9Qnt0hCqU7S+8MxZC9Y7lhyVJEnfzuz9p0iRFEUOOjZv2kWzRaJBydTXRE4+uXR21aITVSzGh6O1mawGhId/dQb8vxRMDsxuxN89txJx9OjxUUAiKEngHUuHqDTMBqLdElrRhjZkAzVvb3du6/KFUJheqwNTrZEjYx8WnM25sgVjOuH0aBsXBTWVU+4=",
-			"MIIE+zCCBGSgAwIBAgICAQ0wDQYJKoZIhvcNAQEFBQAwgbsxJDAiBgNVBAcTG1ZhbGlDZXJ0IFZhbGlkYXRpb24gTmV0d29yazEXMBUGA1UEChMOVmFsaUNlcnQsIEluYy4xNTAzBgNVBAsTLFZhbGlDZXJ0IENsYXNzIDIgUG9saWN5IFZhbGlkYXRpb24gQXV0aG9yaXR5MSEwHwYDVQQDExhodHRwOi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAeBgkqhkiG9w0BCQEWEWluZm9AdmFsaWNlcnQuY29tMB4XDTA0MDYyOTE3MDYyMFoXDTI0MDYyOTE3MDYyMFowYzELMAkGA1UEBhMCVVMxITAfBgNVBAoTGFRoZSBHbyBEYWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR28gRGFkZHkgQ2xhc3MgMiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAN6d1+pXGEmhW+vXX0iG6r7d/+TvZxz0ZWizV3GgXne77ZtJ6XCAPVYYYwhv2vLM0D9/AlQiVBDYsoHUwHU9S3/Hd8M+eKsaA7Ugay9qK7HFiH7Eux6wwdhFJ2+qN1j3hybX2C32qRe3H3I2TqYXP2WYktsqbl2i/ojgC95/5Y0V4evLOtXiEqITLdiOr18SPaAIBQi2XKVlOARFmR6jYGB0xUGlcmIbYsUfb18aQr4CUWWoriMYavx4A6lNf4DD+qta/KFApMoZFv6yyO9ecw3ud72a9nmYvLEHZ6IVDd2gWMZEewo+YihfukEHU1jPEX44dMX4/7VpkI+EdOqXG68CAQOjggHhMIIB3TAdBgNVHQ4EFgQU0sSw0pHUTBFxs2HLPaH+3ahq1OMwgdIGA1UdIwSByjCBx6GBwaSBvjCBuzEkMCIGA1UEBxMbVmFsaUNlcnQgVmFsaWRhdGlvbiBOZXR3b3JrMRcwFQYDVQQKEw5WYWxpQ2VydCwgSW5jLjE1MDMGA1UECxMsVmFsaUNlcnQgQ2xhc3MgMiBQb2xpY3kgVmFsaWRhdGlvbiBBdXRob3JpdHkxITAfBgNVBAMTGGh0dHA6Ly93d3cudmFsaWNlcnQuY29tLzEgMB4GCSqGSIb3DQEJARYRaW5mb0B2YWxpY2VydC5jb22CAQEwDwYDVR0TAQH/BAUwAwEB/zAzBggrBgEFBQcBAQQnMCUwIwYIKwYBBQUHMAGGF2h0dHA6Ly9vY3NwLmdvZGFkZHkuY29tMEQGA1UdHwQ9MDswOaA3oDWGM2h0dHA6Ly9jZXJ0aWZpY2F0ZXMuZ29kYWRkeS5jb20vcmVwb3NpdG9yeS9yb290LmNybDBLBgNVHSAERDBCMEAGBFUdIAAwODA2BggrBgEFBQcCARYqaHR0cDovL2NlcnRpZmljYXRlcy5nb2RhZGR5LmNvbS9yZXBvc2l0b3J5MA4GA1UdDwEB/wQEAwIBBjANBgkqhkiG9w0BAQUFAAOBgQC1QPmnHfbq/qQaQlpE9xXUhUaJwL6e4+PrxeNYiY+Sn1eocSxI0YGyeR+sBjUZsE4OWBsUs5iB0QQeyAfJg594RAoYC5jcdnplDQ1tgMQLARzLrUc+cb53S8wGd9D0VmsfSxOaFIqII6hR8INMqzW/Rn453HWkrugp++85j09VZw==",
-			"MIIC5zCCAlACAQEwDQYJKoZIhvcNAQEFBQAwgbsxJDAiBgNVBAcTG1ZhbGlDZXJ0IFZhbGlkYXRpb24gTmV0d29yazEXMBUGA1UEChMOVmFsaUNlcnQsIEluYy4xNTAzBgNVBAsTLFZhbGlDZXJ0IENsYXNzIDIgUG9saWN5IFZhbGlkYXRpb24gQXV0aG9yaXR5MSEwHwYDVQQDExhodHRwOi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAeBgkqhkiG9w0BCQEWEWluZm9AdmFsaWNlcnQuY29tMB4XDTk5MDYyNjAwMTk1NFoXDTE5MDYyNjAwMTk1NFowgbsxJDAiBgNVBAcTG1ZhbGlDZXJ0IFZhbGlkYXRpb24gTmV0d29yazEXMBUGA1UEChMOVmFsaUNlcnQsIEluYy4xNTAzBgNVBAsTLFZhbGlDZXJ0IENsYXNzIDIgUG9saWN5IFZhbGlkYXRpb24gQXV0aG9yaXR5MSEwHwYDVQQDExhodHRwOi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAeBgkqhkiG9w0BCQEWEWluZm9AdmFsaWNlcnQuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDOOnHK5avIWZJV16vYdA757tn2VUdZZUcOBVXc65g2PFxTXdMwzzjsvUGJ7SVCCSRrCl6zfN1SLUzm1NZ9WlmpZdRJEy0kTRxQb7XBhVQ7/nHk01xC+YDgkRoKWzk2Z/M/VXwbP7RfZHM047QSv4dk+NoS/zcnwbNDu+97bi5p9wIDAQABMA0GCSqGSIb3DQEBBQUAA4GBADt/UG9vUJSZSWI4OB9L+KXIPqeCgfYrx+jFzug6EILLGACOTb2oWH+heQC1u+mNr0HZDzTuIYEZoDJJKPTEjlbVUjP9UNV+mWwD5MlM/Mtsq2azSiGM5bUMMj4QssxsodyamEwCW/POuZ6lcg5Ktz885hZo+L7tdEy8W9ViH0Pd",
-		}
+	jwkPublicKeySet, err := jwk.ParseString(publicKey)
+	if err != nil {
+		t.Fatal("Failed to parse RSA public key")
+	}
+	certChain := []string{
+		"MIIE3jCCA8agAwIBAgICAwEwDQYJKoZIhvcNAQEFBQAwYzELMAkGA1UEBhMCVVMxITAfBgNVBAoTGFRoZSBHbyBEYWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR28gRGFkZHkgQ2xhc3MgMiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw0wNjExMTYwMTU0MzdaFw0yNjExMTYwMTU0MzdaMIHKMQswCQYDVQQGEwJVUzEQMA4GA1UECBMHQXJpem9uYTETMBEGA1UEBxMKU2NvdHRzZGFsZTEaMBgGA1UEChMRR29EYWRkeS5jb20sIEluYy4xMzAxBgNVBAsTKmh0dHA6Ly9jZXJ0aWZpY2F0ZXMuZ29kYWRkeS5jb20vcmVwb3NpdG9yeTEwMC4GA1UEAxMnR28gRGFkZHkgU2VjdXJlIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MREwDwYDVQQFEwgwNzk2OTI4NzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMQt1RWMnCZM7DI161+4WQFapmGBWTtwY6vj3D3HKrjJM9N55DrtPDAjhI6zMBS2sofDPZVUBJ7fmd0LJR4h3mUpfjWoqVTr9vcyOdQmVZWt7/v+WIbXnvQAjYwqDL1CBM6nPwT27oDyqu9SoWlm2r4arV3aLGbqGmu75RpRSgAvSMeYddi5Kcju+GZtCpyz8/x4fKL4o/K1w/O5epHBp+YlLpyo7RJlbmr2EkRTcDCVw5wrWCs9CHRK8r5RsL+H0EwnWGu1NcWdrxcx+AuP7q2BNgWJCJjPOq8lh8BJ6qf9Z/dFjpfMFDniNoW1fho3/Rb2cRGadDAW/hOUoz+EDU8CAwEAAaOCATIwggEuMB0GA1UdDgQWBBT9rGEyk2xF1uLuhV+auud2mWjM5zAfBgNVHSMEGDAWgBTSxLDSkdRMEXGzYcs9of7dqGrU4zASBgNVHRMBAf8ECDAGAQH/AgEAMDMGCCsGAQUFBwEBBCcwJTAjBggrBgEFBQcwAYYXaHR0cDovL29jc3AuZ29kYWRkeS5jb20wRgYDVR0fBD8wPTA7oDmgN4Y1aHR0cDovL2NlcnRpZmljYXRlcy5nb2RhZGR5LmNvbS9yZXBvc2l0b3J5L2dkcm9vdC5jcmwwSwYDVR0gBEQwQjBABgRVHSAAMDgwNgYIKwYBBQUHAgEWKmh0dHA6Ly9jZXJ0aWZpY2F0ZXMuZ29kYWRkeS5jb20vcmVwb3NpdG9yeTAOBgNVHQ8BAf8EBAMCAQYwDQYJKoZIhvcNAQEFBQADggEBANKGwOy9+aG2Z+5mC6IGOgRQjhVyrEp0lVPLN8tESe8HkGsz2ZbwlFalEzAFPIUyIXvJxwqoJKSQ3kbTJSMUA2fCENZvD117esyfxVgqwcSeIaha86ykRvOe5GPLL5CkKSkB2XIsKd83ASe8T+5o0yGPwLPk9Qnt0hCqU7S+8MxZC9Y7lhyVJEnfzuz9p0iRFEUOOjZv2kWzRaJBydTXRE4+uXR21aITVSzGh6O1mawGhId/dQb8vxRMDsxuxN89txJx9OjxUUAiKEngHUuHqDTMBqLdElrRhjZkAzVvb3du6/KFUJheqwNTrZEjYx8WnM25sgVjOuH0aBsXBTWVU+4=",
+		"MIIE+zCCBGSgAwIBAgICAQ0wDQYJKoZIhvcNAQEFBQAwgbsxJDAiBgNVBAcTG1ZhbGlDZXJ0IFZhbGlkYXRpb24gTmV0d29yazEXMBUGA1UEChMOVmFsaUNlcnQsIEluYy4xNTAzBgNVBAsTLFZhbGlDZXJ0IENsYXNzIDIgUG9saWN5IFZhbGlkYXRpb24gQXV0aG9yaXR5MSEwHwYDVQQDExhodHRwOi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAeBgkqhkiG9w0BCQEWEWluZm9AdmFsaWNlcnQuY29tMB4XDTA0MDYyOTE3MDYyMFoXDTI0MDYyOTE3MDYyMFowYzELMAkGA1UEBhMCVVMxITAfBgNVBAoTGFRoZSBHbyBEYWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR28gRGFkZHkgQ2xhc3MgMiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAN6d1+pXGEmhW+vXX0iG6r7d/+TvZxz0ZWizV3GgXne77ZtJ6XCAPVYYYwhv2vLM0D9/AlQiVBDYsoHUwHU9S3/Hd8M+eKsaA7Ugay9qK7HFiH7Eux6wwdhFJ2+qN1j3hybX2C32qRe3H3I2TqYXP2WYktsqbl2i/ojgC95/5Y0V4evLOtXiEqITLdiOr18SPaAIBQi2XKVlOARFmR6jYGB0xUGlcmIbYsUfb18aQr4CUWWoriMYavx4A6lNf4DD+qta/KFApMoZFv6yyO9ecw3ud72a9nmYvLEHZ6IVDd2gWMZEewo+YihfukEHU1jPEX44dMX4/7VpkI+EdOqXG68CAQOjggHhMIIB3TAdBgNVHQ4EFgQU0sSw0pHUTBFxs2HLPaH+3ahq1OMwgdIGA1UdIwSByjCBx6GBwaSBvjCBuzEkMCIGA1UEBxMbVmFsaUNlcnQgVmFsaWRhdGlvbiBOZXR3b3JrMRcwFQYDVQQKEw5WYWxpQ2VydCwgSW5jLjE1MDMGA1UECxMsVmFsaUNlcnQgQ2xhc3MgMiBQb2xpY3kgVmFsaWRhdGlvbiBBdXRob3JpdHkxITAfBgNVBAMTGGh0dHA6Ly93d3cudmFsaWNlcnQuY29tLzEgMB4GCSqGSIb3DQEJARYRaW5mb0B2YWxpY2VydC5jb22CAQEwDwYDVR0TAQH/BAUwAwEB/zAzBggrBgEFBQcBAQQnMCUwIwYIKwYBBQUHMAGGF2h0dHA6Ly9vY3NwLmdvZGFkZHkuY29tMEQGA1UdHwQ9MDswOaA3oDWGM2h0dHA6Ly9jZXJ0aWZpY2F0ZXMuZ29kYWRkeS5jb20vcmVwb3NpdG9yeS9yb290LmNybDBLBgNVHSAERDBCMEAGBFUdIAAwODA2BggrBgEFBQcCARYqaHR0cDovL2NlcnRpZmljYXRlcy5nb2RhZGR5LmNvbS9yZXBvc2l0b3J5MA4GA1UdDwEB/wQEAwIBBjANBgkqhkiG9w0BAQUFAAOBgQC1QPmnHfbq/qQaQlpE9xXUhUaJwL6e4+PrxeNYiY+Sn1eocSxI0YGyeR+sBjUZsE4OWBsUs5iB0QQeyAfJg594RAoYC5jcdnplDQ1tgMQLARzLrUc+cb53S8wGd9D0VmsfSxOaFIqII6hR8INMqzW/Rn453HWkrugp++85j09VZw==",
+		"MIIC5zCCAlACAQEwDQYJKoZIhvcNAQEFBQAwgbsxJDAiBgNVBAcTG1ZhbGlDZXJ0IFZhbGlkYXRpb24gTmV0d29yazEXMBUGA1UEChMOVmFsaUNlcnQsIEluYy4xNTAzBgNVBAsTLFZhbGlDZXJ0IENsYXNzIDIgUG9saWN5IFZhbGlkYXRpb24gQXV0aG9yaXR5MSEwHwYDVQQDExhodHRwOi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAeBgkqhkiG9w0BCQEWEWluZm9AdmFsaWNlcnQuY29tMB4XDTk5MDYyNjAwMTk1NFoXDTE5MDYyNjAwMTk1NFowgbsxJDAiBgNVBAcTG1ZhbGlDZXJ0IFZhbGlkYXRpb24gTmV0d29yazEXMBUGA1UEChMOVmFsaUNlcnQsIEluYy4xNTAzBgNVBAsTLFZhbGlDZXJ0IENsYXNzIDIgUG9saWN5IFZhbGlkYXRpb24gQXV0aG9yaXR5MSEwHwYDVQQDExhodHRwOi8vd3d3LnZhbGljZXJ0LmNvbS8xIDAeBgkqhkiG9w0BCQEWEWluZm9AdmFsaWNlcnQuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDOOnHK5avIWZJV16vYdA757tn2VUdZZUcOBVXc65g2PFxTXdMwzzjsvUGJ7SVCCSRrCl6zfN1SLUzm1NZ9WlmpZdRJEy0kTRxQb7XBhVQ7/nHk01xC+YDgkRoKWzk2Z/M/VXwbP7RfZHM047QSv4dk+NoS/zcnwbNDu+97bi5p9wIDAQABMA0GCSqGSIb3DQEBBQUAA4GBADt/UG9vUJSZSWI4OB9L+KXIPqeCgfYrx+jFzug6EILLGACOTb2oWH+heQC1u+mNr0HZDzTuIYEZoDJJKPTEjlbVUjP9UNV+mWwD5MlM/Mtsq2azSiGM5bUMMj4QssxsodyamEwCW/POuZ6lcg5Ktz885hZo+L7tdEy8W9ViH0Pd",
+	}
+	values := map[string]interface{}{
+		jws.AlgorithmKey:          jwa.ES256,
+		jws.ContentTypeKey:        "example",
+		jws.CriticalKey:           []string{"exp"},
+		jws.JWKKey:                jwkPublicKeySet,
+		jws.JWKSetURLKey:          "https://www.jwk.com/key.json",
+		jws.TypeKey:               "JWT",
+		jws.KeyIDKey:              "e9bc097a-ce51-4036-9562-d2ade882db0d",
+		jws.X509CertChainKey:      certChain,
+		jws.X509CertThumbprintKey: "QzY0NjREMjkyQTI4RTU2RkE4MUJBRDExNzY1MUY1N0I4QjFCODlBOQ",
+		jws.X509URLKey:            "https://www.x509.com/key.pem",
+	}
+	t.Run("Roundtrip", func(t *testing.T) {
 
-		values := map[string]interface{}{
-			jws.AlgorithmKey:     jwa.ES256,
-			jws.ContentTypeKey:   "example",
-			jws.CriticalKey:      []string{"exp"},
-			jws.JWKKey:           jwkPublicKey,
-			jws.TypeKey:          "JWT",
-			jws.KeyIDKey:         "e9bc097a-ce51-4036-9562-d2ade882db0d",
-			jws.X509CertChainKey: certChain,
+		var h jws.StandardHeaders
+		for k, v := range values {
+			err := h.Set(k, v)
+			if err != nil {
+				t.Fatalf("Set failed for %s", k)
+			}
+			got, ok := h.Get(k)
+			if !ok {
+				t.Fatalf("Set failed for %s", k)
+			}
+			//fmt.Println(reflect.TypeOf(got).String())
+			//fmt.Println(reflect.TypeOf(v).String())
+			if !reflect.DeepEqual(v, got) {
+				t.Fatalf("Values do not match: (%v, %v)", v, got)
+			}
 		}
+	})
+	t.Run("JSON Marshal Unmarshal", func(t *testing.T) {
 
 		var h jws.StandardHeaders
 		for k, v := range values {
@@ -50,20 +71,58 @@ func TestHeader(t *testing.T) {
 				t.Fatalf("Values do not match: (%v, %v)", v, got)
 			}
 		}
-		if h.ContentType() != values[jws.ContentTypeKey] {
-			t.Fatal("Content Type Key values do not match")
+		hByte, err := json.Marshal(h)
+		if err != nil {
+			t.Fatal("Failed to JSON marshal")
 		}
-		if !reflect.DeepEqual(h.Critical(), values[jws.CriticalKey]) {
-			t.Fatal("Critical values do not match")
+		var hNew jws.StandardHeaders
+		err = json.Unmarshal(hByte, &hNew)
+		if err != nil {
+			t.Fatal("Failed to JSON marshal")
 		}
-		if !reflect.DeepEqual(h.JWK(), values[jws.JWKKey]) {
-			t.Fatal("JWK values do not match")
+	})
+	t.Run("RoundtripError", func(t *testing.T) {
+
+		type dummyStruct struct {
+			dummy1 int
+			dummy2 float64
 		}
-		if !reflect.DeepEqual(h.Type(), values[jws.TypeKey]) {
-			t.Fatal("Type values do not match")
+		dummy := &dummyStruct{1, 3.4}
+
+		values := map[string]interface{}{
+			jws.AlgorithmKey:              dummy,
+			jws.ContentTypeKey:            dummy,
+			jws.CriticalKey:               dummy,
+			jws.JWKKey:                    dummy,
+			jws.JWKSetURLKey:              dummy,
+			jws.KeyIDKey:                  dummy,
+			jws.TypeKey:                   dummy,
+			jws.X509CertChainKey:          dummy,
+			jws.X509CertThumbprintKey:     dummy,
+			jws.X509CertThumbprintS256Key: dummy,
+			jws.X509URLKey:                dummy,
 		}
-		if !reflect.DeepEqual(h.X509CertChain(), values[jws.X509CertChainKey]) {
-			t.Fatal("Cert chain values do not match")
+
+		var h jws.StandardHeaders
+		for k, v := range values {
+			err := h.Set(k, v)
+			if err == nil {
+				t.Fatalf("Setting %s value should have failed", k)
+			}
+		}
+		err := h.Set("default", dummy) // private params
+		if err != nil {
+			t.Fatalf("Setting %s value failed", "default")
+		}
+		for k, _ := range values {
+			_, ok := h.Get(k)
+			if ok {
+				t.Fatalf("Getting %s value should have failed", k)
+			}
+		}
+		_, ok := h.Get("default")
+		if !ok {
+			t.Fatal("Failed to get default value")
 		}
 	})
 }

--- a/jws/internal/cmd/genheader/main.go
+++ b/jws/internal/cmd/genheader/main.go
@@ -32,6 +32,7 @@ type headerField struct {
 	comment   string
 	hasAccept bool
 	noDeref   bool
+	jsonTag   string
 }
 
 func (f headerField) IsPointer() bool {
@@ -44,7 +45,8 @@ func (f headerField) PointerElem() string {
 
 var zerovals = map[string]string{
 	"string":                 `""`,
-	"jwa.SignatureAlgorithm": "jwa.NoSignature",
+	"jwa.SignatureAlgorithm": `""`,
+	"[]string":               "0",
 }
 
 func zeroval(s string) string {
@@ -57,82 +59,93 @@ func zeroval(s string) string {
 func generateHeaders() error {
 	fields := []headerField{
 		{
-			name:      `algorithm`,
+			name:      `JWSalgorithm`,
 			method:    `Algorithm`,
-			typ:       `*jwa.SignatureAlgorithm`,
+			typ:       `jwa.SignatureAlgorithm`,
 			key:       `alg`,
 			comment:   `https://tools.ietf.org/html/rfc7515#section-4.1.1`,
 			hasAccept: true,
+			jsonTag:   "`" + `json:"alg,omitempty"` + "`",
 		},
 		{
-			name:    `jwkSetURL`,
-			method:  `JWKSetURL`,
-			typ:     `*string`,
-			key:     `jku`,
-			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.2`,
-		},
-		{
-			name:    `jwk`,
-			method:  `JWK`,
-			typ:     `jwk.Key`,
-			key:     `jwk`,
-			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.3`,
-		},
-		{
-			name:    `keyID`,
-			method:  `KeyID`,
-			typ:     `*string`,
-			key:     `kid`,
-			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.4`,
-		},
-		{
-			name:    `x509URL`,
-			method:  `X509URL`,
-			typ:     `*string`,
-			key:     `x5u`,
-			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.5`,
-		},
-		{
-			name:    `x509CertChain`,
-			method:  `X509CertChain`,
-			typ:     `[]string`,
-			key:     `x5c`,
-			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.6`,
-		},
-		{
-			name:    `x509CertThumbprint`,
-			method:  `X509CertThumbprint`,
-			typ:     `*string`,
-			key:     `x5t`,
-			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.7`,
-		},
-		{
-			name:    `x509CertThumbprintS256`,
-			method:  `X509CertThumbprintS256`,
-			typ:     `*string`,
-			key:     `x5t#S256`,
-			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.8`,
-		},
-		{
-			name:    `typ`,
-			method:  `Type`,
-			typ:     `*string`,
-			key:     `typ`,
-			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.9`,
-		},
-		{
-			name:    `contentType`,
+			name:    `JWScontentType`,
 			method:  `ContentType`,
-			typ:     `*string`,
+			typ:     `string`,
 			key:     `cty`,
 			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.10`,
+			jsonTag: "`" + `json:"cty,omitempty"` + "`",
 		},
 		{
-			name:    `critical`,
+			name:    `JWScritical`,
 			method:  `Critical`,
 			typ:     `[]string`,
 			key:     `crit`,
 			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.11`,
+			jsonTag: "`" + `json:"crit,omitempty"` + "`",
+		},
+		{
+			name:    `JWSjwk`,
+			method:  `JWK`,
+			typ:     `*jwk.Set`,
+			key:     `jwk`,
+			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.3`,
+			jsonTag: "`" + `json:"jwk,omitempty"` + "`",
+		},
+		{
+			name:    `JWSjwkSetURL`,
+			method:  `JWKSetURL`,
+			typ:     `string`,
+			key:     `jku`,
+			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.2`,
+			jsonTag: "`" + `json:"jku,omitempty"` + "`",
+		},
+		{
+			name:    `JWSkeyID`,
+			method:  `KeyID`,
+			typ:     `string`,
+			key:     `kid`,
+			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.4`,
+			jsonTag: "`" + `json:"kid,omitempty"` + "`",
+		},
+		{
+			name:    `JWStyp`,
+			method:  `Type`,
+			typ:     `string`,
+			key:     `typ`,
+			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.9`,
+			jsonTag: "`" + `json:"typ,omitempty"` + "`",
+		},
+		{
+			name:    `JWSx509CertChain`,
+			method:  `X509CertChain`,
+			typ:     `[]string`,
+			key:     `x5c`,
+			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.6`,
+			jsonTag: "`" + `json:"x5c,omitempty"` + "`",
+		},
+		{
+			name:    `JWSx509CertThumbprint`,
+			method:  `X509CertThumbprint`,
+			typ:     `string`,
+			key:     `x5t`,
+			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.7`,
+			jsonTag: "`" + `json:"x5t,omitempty"` + "`",
+		},
+		{
+			name:    `JWSx509CertThumbprintS256`,
+			method:  `X509CertThumbprintS256`,
+			typ:     `string`,
+			key:     `x5t#S256`,
+			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.8`,
+			jsonTag: "`" + `json:"x5t#S256,omitempty"` + "`",
+		},
+		{
+			name:    `JWSx509URL`,
+			method:  `X509URL`,
+			typ:     `string`,
+			key:     `x5u`,
+			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.5`,
+			jsonTag: "`" + `json:"x5u,omitempty"` + "`",
 		},
 	}
 
@@ -145,7 +158,7 @@ func generateHeaders() error {
 	fmt.Fprintf(&buf, "\n// This file is auto-generated. DO NOT EDIT")
 	fmt.Fprintf(&buf, "\npackage jws")
 	fmt.Fprintf(&buf, "\n\nimport (")
-	for _, pkg := range []string{"encoding/json", "github.com/lestrrat-go/jwx/jwa", "github.com/lestrrat-go/jwx/jwk", "github.com/pkg/errors"} {
+	for _, pkg := range []string{"reflect", "github.com/lestrrat-go/jwx/jwa", "github.com/lestrrat-go/jwx/jwk", "github.com/pkg/errors"} {
 		fmt.Fprintf(&buf, "\n%s", strconv.Quote(pkg))
 	}
 	fmt.Fprintf(&buf, "\n)")
@@ -159,33 +172,22 @@ func generateHeaders() error {
 	fmt.Fprintf(&buf, "\n\ntype Headers interface {")
 	fmt.Fprintf(&buf, "\nGet(string) (interface{}, bool)")
 	fmt.Fprintf(&buf, "\nSet(string, interface{}) error")
-	for _, f := range fields {
+	fmt.Fprintf(&buf, "\nAlgorithm() jwa.SignatureAlgorithm")
+
+	/*	for _, f := range fields {
 		fmt.Fprintf(&buf, "\n%s() %s", f.method, f.PointerElem())
-	}
+	}*/
 	fmt.Fprintf(&buf, "\n}") // end type Headers interface
 	fmt.Fprintf(&buf, "\n\ntype StandardHeaders struct {")
 	for _, f := range fields {
-		fmt.Fprintf(&buf, "\n%s %s // %s", f.name, f.typ, f.comment)
+		fmt.Fprintf(&buf, "\n%s %s %s // %s", f.name, f.typ, f.jsonTag, f.comment)
 	}
 	fmt.Fprintf(&buf, "\nprivateParams map[string]interface{}")
 	fmt.Fprintf(&buf, "\n}") // end type StandardHeaders
 
-	for _, f := range fields {
-		fmt.Fprintf(&buf, "\n\nfunc (h *StandardHeaders) %s() %s {", f.method, f.PointerElem())
-		if !f.IsPointer() {
-			fmt.Fprintf(&buf, "\nreturn h.%s", f.name)
-		} else {
-			fmt.Fprintf(&buf, "\nif v := h.%s; v != %s {", f.name, zeroval(f.typ))
-			if f.IsPointer() && !f.noDeref {
-				fmt.Fprintf(&buf, "\nreturn *v")
-			} else {
-				fmt.Fprintf(&buf, "\nreturn v")
-			}
-			fmt.Fprintf(&buf, "\n}") // if h.%s != %s
-			fmt.Fprintf(&buf, "\nreturn %s", zeroval(f.PointerElem()))
-		}
-		fmt.Fprintf(&buf, "\n}") // func (h *StandardHeaders) %s() %s
-	}
+	fmt.Fprintf(&buf, "\n\nfunc (h *StandardHeaders) Algorithm() jwa.SignatureAlgorithm {")
+	fmt.Fprintf(&buf, "\nreturn h.JWSalgorithm")
+	fmt.Fprintf(&buf, "\n}") // func (h *StandardHeaders) %s() %s
 
 	fmt.Fprintf(&buf, "\n\nfunc (h *StandardHeaders) Get(name string) (interface{}, bool) {")
 	fmt.Fprintf(&buf, "\nswitch name {")
@@ -193,14 +195,15 @@ func generateHeaders() error {
 		fmt.Fprintf(&buf, "\ncase %sKey:", f.method)
 		fmt.Fprintf(&buf, "\nv := h.%s", f.name)
 
-		fmt.Fprintf(&buf, "\nif v == %s {", zeroval(f.typ))
+		if f.typ == "[]string" {
+			fmt.Fprintf(&buf, "\nif len(v) == %s {", zeroval(f.typ))
+		} else {
+			fmt.Fprintf(&buf, "\nif v == %s {", zeroval(f.typ))
+		}
 		fmt.Fprintf(&buf, "\nreturn nil, false")
 		fmt.Fprintf(&buf, "\n}") // end if h.%s == nil
-		if f.IsPointer() && !f.noDeref {
-			fmt.Fprintf(&buf, "\nreturn *v, true")
-		} else {
-			fmt.Fprintf(&buf, "\nreturn v, true")
-		}
+		fmt.Fprintf(&buf, "\nreturn v, true")
+
 	}
 	fmt.Fprintf(&buf, "\ndefault:")
 	fmt.Fprintf(&buf, "\nv, ok := h.privateParams[name]")
@@ -226,9 +229,10 @@ func generateHeaders() error {
 			}
 			fmt.Fprintf(&buf, "\nreturn nil")
 		} else {
-			if f.IsPointer() {
-				fmt.Fprintf(&buf, "\nif v, ok := value.(%s); ok {", f.PointerElem())
-				fmt.Fprintf(&buf, "\nh.%s = &v", f.name)
+			if f.name == "JWSjwk" {
+				fmt.Fprintf(&buf, "\nv, ok := reflect.ValueOf(value).Interface().(%s)", f.typ)
+				fmt.Fprintf(&buf, "\nif ok {")
+				fmt.Fprintf(&buf, "\nh.%s = v", f.name)
 			} else {
 				fmt.Fprintf(&buf, "\nif v, ok := value.(%s); ok {", f.typ)
 				fmt.Fprintf(&buf, "\nh.%s = v", f.name)
@@ -246,47 +250,6 @@ func generateHeaders() error {
 	fmt.Fprintf(&buf, "\n}") // end switch name
 	fmt.Fprintf(&buf, "\nreturn nil")
 	fmt.Fprintf(&buf, "\n}") // end func (h *StandardHeaders) Set(name string, value interface{})
-	fmt.Fprintf(&buf, "\n\nfunc (h StandardHeaders) MarshalJSON() ([]byte, error) {")
-	fmt.Fprintf(&buf, "\nm := map[string]interface{}{}")
-	fmt.Fprintf(&buf, "\nfor k, v := range h.privateParams {")
-	fmt.Fprintf(&buf, "\nm[k] = v")
-	fmt.Fprintf(&buf, "\n}") // end for k, v := range h.privateParams
-	for _, f := range fields {
-		switch {
-		case f.name == "algorithm":
-			fmt.Fprintf(&buf, "\nm[%sKey] = h.%s", f.method, f.name)
-		case strings.HasPrefix(f.typ, `[]`):
-			fmt.Fprintf(&buf, "\n\nif len(h.%s) > 0 {", f.name)
-			fmt.Fprintf(&buf, "\nm[%sKey] = h.%s", f.method, f.name)
-			fmt.Fprintf(&buf, "\n}") // end if h.%s == %s
-		default:
-			fmt.Fprintf(&buf, "\n\nif h.%s != %s {", f.name, zeroval(f.typ))
-			fmt.Fprintf(&buf, "\nm[%sKey] = h.%s", f.method, f.name)
-			fmt.Fprintf(&buf, "\n}") // end if h.%s == %s
-		}
-	}
-	fmt.Fprintf(&buf, "\n\nreturn json.Marshal(m)")
-	fmt.Fprintf(&buf, "\n}") // end func (h StandardHeaders) MarshalJSON()
-
-	fmt.Fprintf(&buf, "\n\nfunc (h *StandardHeaders) UnmarshalJSON(buf []byte) error {")
-	fmt.Fprintf(&buf, "\nvar m map[string]interface{}")
-	fmt.Fprintf(&buf, "\nif err := json.Unmarshal(buf, &m); err != nil {")
-	fmt.Fprintf(&buf, "\nreturn errors.Wrap(err, `failed to unmarshal headers`)")
-	fmt.Fprintf(&buf, "\n}") // end if err := json.Unmarshal(buf, &m)
-	for _, f := range fields {
-		fmt.Fprintf(&buf, "\nif v, ok := m[%sKey]; ok {", f.method)
-		fmt.Fprintf(&buf, "\nif err := h.Set(%sKey, v); err != nil {", f.method)
-		fmt.Fprintf(&buf, "\nreturn errors.Wrapf(err, `failed to set value for key %%s`, %sKey)", f.method)
-		fmt.Fprintf(&buf, "\n}")
-		fmt.Fprintf(&buf, "\ndelete(m, %sKey)", f.method)
-		fmt.Fprintf(&buf, "\n}") // end if v, ok := m[%sKey]
-	}
-	fmt.Fprintf(&buf, "\n// Fix: A nil map is different from a empty map as far as deep.equal is concerned")
-	fmt.Fprintf(&buf, "\nif len(m) > 0 {")
-	fmt.Fprintf(&buf, "\nh.privateParams = m")
-	fmt.Fprintf(&buf, "\n}")
-	fmt.Fprintf(&buf, "\nreturn nil")
-	fmt.Fprintf(&buf, "\n}") // end func (h *StandardHeaders) UnmarshalJSON(buf []byte) error
 
 	formatted, err := format.Source(buf.Bytes())
 	if err != nil {

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -277,8 +277,9 @@ func TestEncode(t *testing.T) {
 			return
 		}
 
-		if !assert.Equal(t, signatures[0].ProtectedHeaders().Algorithm(), jwa.HS256, "Algorithm in header matches") {
-			return
+		algorithm := signatures[0].ProtectedHeaders().Algorithm()
+		if algorithm != jwa.HS256 {
+			t.Fatal("Algorithm in header does not match")
 		}
 
 		v, err := verify.New(jwa.HS256)
@@ -304,7 +305,7 @@ func TestEncode(t *testing.T) {
 			t.Fatal("Failed to base64 encode protected header")
 		}
 		standardHeaders := &jws.StandardHeaders{}
-		err = standardHeaders.UnmarshalJSON(hdrBytes)
+		err = json.Unmarshal(hdrBytes, standardHeaders)
 		if err != nil {
 			t.Fatal("Failed to parse protected header")
 		}
@@ -336,8 +337,9 @@ func TestEncode(t *testing.T) {
 			return
 		}
 
-		if !assert.Equal(t, signatures[0].ProtectedHeaders().Algorithm(), alg, "Algorithm in header matches") {
-			return
+		algorithm := signatures[0].ProtectedHeaders().Algorithm()
+		if algorithm != alg {
+			t.Fatal("Algorithm in header does not match")
 		}
 
 		v, err := verify.New(alg)
@@ -372,14 +374,11 @@ func TestEncode(t *testing.T) {
 		jwsPayload := []byte{80, 97, 121, 108, 111, 97, 100}
 
 		standardHeaders := &jws.StandardHeaders{}
-		err := standardHeaders.UnmarshalJSON(hdr)
+		err := json.Unmarshal(hdr, standardHeaders)
 		if err != nil {
 			t.Fatal("Failed to parse header")
 		}
 		alg := standardHeaders.Algorithm()
-		if err != nil {
-			t.Fatal("Failed to parse header")
-		}
 
 		keys, err := jwk.ParseString(jwksrc)
 		if err != nil {
@@ -515,8 +514,9 @@ func TestEncode(t *testing.T) {
 			return
 		}
 
-		if !assert.Equal(t, signatures[0].ProtectedHeaders().Algorithm(), jwa.RS256, "Algorithm in header matches") {
-			return
+		algorithm := signatures[0].ProtectedHeaders().Algorithm()
+		if algorithm != jwa.RS256 {
+			t.Fatal("Algorithm in header does not match")
 		}
 
 		v, err := verify.New(jwa.RS256)
@@ -596,8 +596,9 @@ func TestEncode(t *testing.T) {
 			return
 		}
 
-		if !assert.Equal(t, signatures[0].ProtectedHeaders().Algorithm(), jwa.ES256, "Algorithm in header matches") {
-			return
+		algorithm := signatures[0].ProtectedHeaders().Algorithm()
+		if algorithm != jwa.ES256 {
+			t.Fatal("Algorithm in header does not match")
 		}
 
 		v, err := verify.New(jwa.ES256)
@@ -637,9 +638,11 @@ func TestEncode(t *testing.T) {
 		}
 
 		signatures := m.Signatures()
-		if !assert.Equal(t, signatures[0].ProtectedHeaders().Algorithm(), jwa.NoSignature, "Algorithm = 'none'") {
-			return
+		algorithm := signatures[0].ProtectedHeaders().Algorithm()
+		if algorithm != jwa.NoSignature {
+			t.Fatal("Algorithm in header does not match")
 		}
+
 		if !assert.Empty(t, signatures[0].Signature(), "Signature should be empty") {
 			return
 		}

--- a/jws/message.go
+++ b/jws/message.go
@@ -26,14 +26,16 @@ func (m Message) LookupSignature(kid string) []*Signature {
 	var sigs []*Signature
 	for _, sig := range m.signatures {
 		if hdr := sig.PublicHeaders(); hdr != nil {
-			if hdr.KeyID() == kid {
+			hdrKeyId, ok := hdr.Get(KeyIDKey)
+			if ok && hdrKeyId == kid {
 				sigs = append(sigs, sig)
 				continue
 			}
 		}
 
 		if hdr := sig.ProtectedHeaders(); hdr != nil {
-			if hdr.KeyID() == kid {
+			hdrKeyId, ok := hdr.Get(KeyIDKey)
+			if ok && hdrKeyId == kid {
 				sigs = append(sigs, sig)
 				continue
 			}

--- a/jws/sign/ecdsa_test.go
+++ b/jws/sign/ecdsa_test.go
@@ -1,0 +1,34 @@
+package sign
+
+import (
+	"github.com/lestrrat-go/jwx/jwa"
+	"testing"
+)
+
+func TestECDSASign(t *testing.T) {
+	type dummyStruct struct {
+		dummy1 int
+		dummy2 float64
+	}
+	dummy := &dummyStruct{1, 3.4}
+	t.Run("ECDSA Creation Error", func(t *testing.T) {
+		_, err := newECDSA(jwa.HS256)
+		if err == nil {
+			t.Fatal("ECDSA Object creation should fail")
+		}
+	})
+	t.Run("ECDSA Sign Error", func(t *testing.T) {
+		signer, err := newECDSA(jwa.ES512)
+		if err != nil {
+			t.Fatalf("Signer creation failure: %v", jwa.ES512)
+		}
+		_, err = signer.Sign([]byte("payload"), dummy)
+		if err == nil {
+			t.Fatal("HMAC Object creation should fail")
+		}
+		_, err = signer.Sign([]byte("payload"), []byte(""))
+		if err == nil {
+			t.Fatal("HMAC Object creation should fail")
+		}
+	})
+}

--- a/jws/sign/hmac.go
+++ b/jws/sign/hmac.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var hmacSignFuncs = map[jwa.SignatureAlgorithm]hmacSignFunc{}
+var HMACSignFuncs = map[jwa.SignatureAlgorithm]hmacSignFunc{}
 
 func init() {
 	algs := map[jwa.SignatureAlgorithm]func() hash.Hash{
@@ -20,13 +20,13 @@ func init() {
 	}
 
 	for alg, h := range algs {
-		hmacSignFuncs[alg] = makeHMACSignFunc(h)
+		HMACSignFuncs[alg] = makeHMACSignFunc(h)
 
 	}
 }
 
 func newHMAC(alg jwa.SignatureAlgorithm) (*HMACSigner, error) {
-	signer, ok := hmacSignFuncs[alg]
+	signer, ok := HMACSignFuncs[alg]
 	if !ok {
 		return nil, errors.Errorf(`unsupported algorithm while trying to create HMAC signer: %s`, alg)
 	}

--- a/jws/sign/hmac_test.go
+++ b/jws/sign/hmac_test.go
@@ -1,0 +1,34 @@
+package sign
+
+import (
+	"github.com/lestrrat-go/jwx/jwa"
+	"testing"
+)
+
+func TestHMACSign(t *testing.T) {
+	type dummyStruct struct {
+		dummy1 int
+		dummy2 float64
+	}
+	dummy := &dummyStruct{1, 3.4}
+	t.Run("HMAC Creation Error", func(t *testing.T) {
+		_, err := newHMAC(jwa.ES256)
+		if err == nil {
+			t.Fatal("HMAC Object creation should fail")
+		}
+	})
+	t.Run("HMAC Sign Error", func(t *testing.T) {
+		signer, err := newHMAC(jwa.HS512)
+		if err != nil {
+			t.Fatalf("Signer creation failure: %v", jwa.HS512)
+		}
+		_, err = signer.Sign([]byte("payload"), dummy)
+		if err == nil {
+			t.Fatal("HMAC Object creation should fail")
+		}
+		_, err = signer.Sign([]byte("payload"), []byte(""))
+		if err == nil {
+			t.Fatal("HMAC Object creation should fail")
+		}
+	})
+}

--- a/jws/verify/ecdsa_test.go
+++ b/jws/verify/ecdsa_test.go
@@ -1,0 +1,34 @@
+package verify
+
+import (
+	"github.com/lestrrat-go/jwx/jwa"
+	"testing"
+)
+
+func TestECDSAVerify(t *testing.T) {
+	type dummyStruct struct {
+		dummy1 int
+		dummy2 float64
+	}
+	dummy := &dummyStruct{1, 3.4}
+	t.Run("ECDSA Verifier Creation Error", func(t *testing.T) {
+		_, err := newECDSA(jwa.HS256)
+		if err == nil {
+			t.Fatal("ECDSA Verifier Object creation should fail")
+		}
+	})
+	t.Run("ECDSA Verifier Sign Error", func(t *testing.T) {
+		pVerifier, err := newECDSA(jwa.ES512)
+		if err != nil {
+			t.Fatalf("Signer creation failure: %v", jwa.ES512)
+		}
+		err = pVerifier.Verify([]byte("payload"), []byte("signature"), dummy)
+		if err == nil {
+			t.Fatal("ECDSA Verification should fail")
+		}
+		err = pVerifier.Verify([]byte("payload"), []byte("signature"), nil)
+		if err == nil {
+			t.Fatal("ECDSA Verification should fail")
+		}
+	})
+}

--- a/jws/verify/hmac.go
+++ b/jws/verify/hmac.go
@@ -2,15 +2,16 @@ package verify
 
 import (
 	"crypto/hmac"
-	"encoding/base64"
-
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jws/sign"
-	pdebug "github.com/lestrrat-go/pdebug"
 	"github.com/pkg/errors"
 )
 
 func newHMAC(alg jwa.SignatureAlgorithm) (*HMACVerifier, error) {
+	_, ok := sign.HMACSignFuncs[alg]
+	if !ok {
+		return nil, errors.Errorf(`unsupported algorithm while trying to create HMAC signer: %s`, alg)
+	}
 	s, err := sign.New(alg)
 	if err != nil {
 		return nil, errors.Wrap(err, `failed to generate HMAC signer`)
@@ -19,19 +20,10 @@ func newHMAC(alg jwa.SignatureAlgorithm) (*HMACVerifier, error) {
 }
 
 func (v HMACVerifier) Verify(payload, signature []byte, key interface{}) (err error) {
-	if pdebug.Enabled {
-		g := pdebug.Marker("HMACVerifier.Verify").BindError(&err)
-		defer g.End()
-	}
 
 	expected, err := v.signer.Sign(payload, key)
 	if err != nil {
 		return errors.Wrap(err, `failed to generated signature`)
-	}
-
-	if pdebug.Enabled {
-		pdebug.Printf("generated signature %s", base64.RawURLEncoding.EncodeToString(signature))
-		pdebug.Printf("expected  signature %s", base64.RawURLEncoding.EncodeToString(expected))
 	}
 
 	if !hmac.Equal(signature, expected) {

--- a/jws/verify/hmac_test.go
+++ b/jws/verify/hmac_test.go
@@ -1,0 +1,31 @@
+package verify
+
+import (
+	"github.com/lestrrat-go/jwx/jwa"
+	"testing"
+)
+
+func TestHMACVerify(t *testing.T) {
+	type dummyStruct struct {
+		dummy1 int
+		dummy2 float64
+	}
+	dummy := &dummyStruct{1, 3.4}
+	t.Run("HMAC Verifier Creation Error", func(t *testing.T) {
+		_, err := newHMAC(jwa.ES256)
+		if err == nil {
+			t.Fatal("HMAC Verifier Object creation should fail")
+		}
+	})
+	t.Run("HMAC Verifier Sign Error", func(t *testing.T) {
+		pVerifier, err := newHMAC(jwa.HS512)
+		if err != nil {
+			t.Fatalf("Signer creation failure: %v", jwa.HS512)
+		}
+		err = pVerifier.Verify([]byte("payload"), []byte("signature"), dummy)
+		if err == nil {
+			t.Fatal("HMAC Verification should fail")
+		}
+
+	})
+}

--- a/jws/verify/rsa_test.go
+++ b/jws/verify/rsa_test.go
@@ -1,0 +1,34 @@
+package verify
+
+import (
+	"github.com/lestrrat-go/jwx/jwa"
+	"testing"
+)
+
+func TestRSAVerify(t *testing.T) {
+	type dummyStruct struct {
+		dummy1 int
+		dummy2 float64
+	}
+	dummy := &dummyStruct{1, 3.4}
+	t.Run("RSA Verifier Creation Error", func(t *testing.T) {
+		_, err := newRSA(jwa.HS256)
+		if err == nil {
+			t.Fatal("ECDSA Verifier Object creation should fail")
+		}
+	})
+	t.Run("RSA Verifier Sign Error", func(t *testing.T) {
+		pVerifier, err := newRSA(jwa.PS512)
+		if err != nil {
+			t.Fatalf("Signer creation failure: %v", jwa.ES512)
+		}
+		err = pVerifier.Verify([]byte("payload"), []byte("signature"), dummy)
+		if err == nil {
+			t.Fatal("RSA Verification should fail")
+		}
+		err = pVerifier.Verify([]byte("payload"), []byte("signature"), nil)
+		if err == nil {
+			t.Fatal("RSA Verification should fail")
+		}
+	})
+}


### PR DESCRIPTION
fixes #89
- During fixing noticed that marshal and unmarshal were not reversible,
  i.e., if you marshaled with existing function, unmarshal would fail.
  This is due to the fact that []string become []interface{} and those
  are not the same:
  https://stackoverflow.com/questions/32530952/should-i-be-able-to-type-assert-a-slice-of-string-maps
  https://golang.org/doc/faq#convert_slice_of_interface
- Simplified significantly (un)marshal by using JSON tags. This
  increased coverage and made code simpler
- Removed unused code
- Simplified interface by removing unused or duplicate functions
- Increase coverage of verify and sign functions to 80%+
- Increased test coverage of headers.go to 80%+
- Overall coverage (if we removed pdebug) would 90%+

thanks,