### PR TITLE
Low coverage and unused functions in token_gen.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ _testmain.go
 .idea
 .vscode
 .DS_Store
+
+coverage.out

--- a/jwt/date.go
+++ b/jwt/date.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -59,7 +60,23 @@ func (n *NumericDate) Accept(v interface{}) error {
 	return nil
 }
 
-// MarshalJSON generates JSON representation of this instant
-func (n NumericDate) MarshalJSON() ([]byte, error) {
+// MarshalJSON translates from internal representation to JSON NumericDate
+// See https://tools.ietf.org/html/rfc7519#page-6
+func (n *NumericDate) MarshalJSON() ([]byte, error) {
+	if n.IsZero() {
+		return json.Marshal(nil)
+	}
 	return json.Marshal(n.Unix())
+}
+
+// UnmarshalJSON translates between JSON NumericDate and internal representation
+// See https://tools.ietf.org/html/rfc7519#page-6
+func (n *NumericDate) UnmarshalJSON(b []byte) error {
+	i, err := strconv.ParseInt(string(b[:]), 10, 64)
+	if err != nil {
+		return errors.Errorf(`invalid type %T`, b)
+	}
+	tm := time.Unix(i, 0)
+	n.Time = tm.UTC()
+	return nil
 }

--- a/jwt/date_test.go
+++ b/jwt/date_test.go
@@ -1,0 +1,35 @@
+package jwt_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/jwt"
+)
+
+func TestDate(t *testing.T) {
+	// NumericDate allows assignment from various different Go types,
+	// so that it's easier for the devs, and conversion to/from JSON
+	// use of "127" is just to allow use of int8's
+	now := time.Unix(127, 0).UTC()
+	for _, ut := range []interface{}{int64(127), int32(127), int16(127), int8(127), float32(127), float64(127), json.Number("127")} {
+		t.Run(fmt.Sprintf("%T", ut), func(t *testing.T) {
+			var t1 jwt.Token
+			err := t1.Set(jwt.IssuedAtKey, ut)
+			if err != nil {
+				t.Fatalf("Failed to set IssuedAt value: %v", ut)
+			}
+			v, ok := t1.Get(jwt.IssuedAtKey)
+			if !ok {
+				t.Fatal("Failed to retrieve IssuedAt value")
+			}
+			realized := v.(time.Time)
+			if !reflect.DeepEqual(now, realized) {
+				t.Fatalf("Token time mistmatch. Expected:Realized (%v:%v)", now, realized)
+			}
+		})
+	}
+}

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -47,7 +47,9 @@ func ExampleSignAndParse() {
 	}
 	// OUTPUT:
 	// {
-	//   "foo": "bar"
+	//   "PrivateClaims": {
+	//     "foo": "bar"
+	//   }
 	// }
 }
 
@@ -65,21 +67,25 @@ func ExampleToken() {
 	}
 
 	fmt.Printf("%s\n", buf)
-	fmt.Printf("aud -> '%s'\n", t.Audience())
-	fmt.Printf("iat -> '%s'\n", t.IssuedAt().Format(time.RFC3339))
+	fmt.Printf("aud -> '%s'\n", t.GetAudience())
+	fmt.Printf("iat -> '%s'\n", t.GetIssuedAt().Format(time.RFC3339))
 	if v, ok := t.Get(`privateClaimKey`); ok {
 		fmt.Printf("privateClaimKey -> '%s'\n", v)
 	}
-	fmt.Printf("sub -> '%s'\n", t.Subject())
+	fmt.Printf("sub -> '%s'\n", t.GetSubject())
 
 	// OUTPUT:
 	// {
-	//   "aud": "Golang Users",
+	//   "aud": [
+	//     "Golang Users"
+	//   ],
 	//   "iat": 233431200,
-	//   "privateClaimKey": "Hello, World!",
-	//   "sub": "https://github.com/lestrrat-go/jwx/jwt"
+	//   "sub": "https://github.com/lestrrat-go/jwx/jwt",
+	//   "PrivateClaims": {
+	//     "privateClaimKey": "Hello, World!"
+	//   }
 	// }
-	// aud -> 'Golang Users'
+	// aud -> '[Golang Users]'
 	// iat -> '1977-05-25T18:00:00Z'
 	// privateClaimKey -> 'Hello, World!'
 	// sub -> 'https://github.com/lestrrat-go/jwx/jwt'

--- a/jwt/interface.go
+++ b/jwt/interface.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-type stringList []string
+type StringList []string
 
 // NumericDate represents the date format used in the 'nbf' claim
 type NumericDate struct {

--- a/jwt/string.go
+++ b/jwt/string.go
@@ -4,14 +4,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (l *stringList) Accept(v interface{}) error {
+func (l *StringList) Accept(v interface{}) error {
 	switch x := v.(type) {
 	case string:
-		*l = stringList([]string{x})
+		*l = StringList([]string{x})
 	case []string:
-		*l = stringList(x)
+		*l = StringList(x)
 	case []interface{}:
-		list := make([]string, len(x))
+		list := make(StringList, len(x))
 		for i, e := range x {
 			if s, ok := e.(string); ok {
 				list[i] = s

--- a/jwt/string_test.go
+++ b/jwt/string_test.go
@@ -1,0 +1,18 @@
+package jwt_test
+
+import (
+	"github.com/lestrrat-go/jwx/jwt"
+	"testing"
+)
+
+func TestStringList_Accept(t *testing.T) {
+
+	var x jwt.StringList
+	interfaceList := make([]interface{}, 0)
+	interfaceList = append(interfaceList, "first")
+	interfaceList = append(interfaceList, "second")
+	err := x.Accept(interfaceList)
+	if err != nil {
+		t.Fatal("Failed to convert []interface{} into StringList: %", err.Error())
+	}
+}

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -1,7 +1,7 @@
+// This file is auto-generated. DO NOT EDIT
 package jwt
 
 import (
-	"encoding/json"
 	"github.com/pkg/errors"
 	"time"
 )
@@ -18,67 +18,67 @@ const (
 )
 
 // Token represents a JWT token. The object has convenience accessors
-// to 7 standard claims including "aud", "exp", "iat", "iss", "jti", "nbf", and "sub"
+// to 7 standard claims including "aud", "exp", "iat", "iss", "jti", "nbf" and "sub"
 // which are type-aware (to an extent). Other claims may be accessed via the `Get`/`Set`
 // methods but their types are not taken into consideration at all. If you have non-standard
 // claims that you must frequently access, consider wrapping the token in a wrapper
 // by embedding the jwt.Token type in it
 type Token struct {
-	audience      stringList   // https://tools.ietf.org/html/rfc7519#section-4.1.3
-	expiration    *NumericDate // https://tools.ietf.org/html/rfc7519#section-4.1.4
-	issuedAt      *NumericDate // https://tools.ietf.org/html/rfc7519#section-4.1.6
-	issuer        *string      // https://tools.ietf.org/html/rfc7519#section-4.1.1
-	jwtID         *string      // https://tools.ietf.org/html/rfc7519#section-4.1.7
-	notBefore     *NumericDate // https://tools.ietf.org/html/rfc7519#section-4.1.5
-	subject       *string      // https://tools.ietf.org/html/rfc7519#section-4.1.2
-	privateClaims map[string]interface{}
+	Audience      StringList             `json:"aud,omitempty"` // https://tools.ietf.org/html/rfc7519#section-4.1.3
+	Expiration    *NumericDate           `json:"exp,omitempty"` // https://tools.ietf.org/html/rfc7519#section-4.1.4
+	IssuedAt      *NumericDate           `json:"iat,omitempty"` // https://tools.ietf.org/html/rfc7519#section-4.1.6
+	Issuer        *string                `json:"iss,omitempty"` // https://tools.ietf.org/html/rfc7519#section-4.1.1
+	JwtID         *string                `json:"jti,omitempty"` // https://tools.ietf.org/html/rfc7519#section-4.1.7
+	NotBefore     *NumericDate           `json:"nbf,omitempty"` // https://tools.ietf.org/html/rfc7519#section-4.1.5
+	Subject       *string                `json:"sub,omitempty"` // https://tools.ietf.org/html/rfc7519#section-4.1.2
+	PrivateClaims map[string]interface{} `json:",omitempty"`
 }
 
 func (t *Token) Get(s string) (interface{}, bool) {
 	switch s {
 	case AudienceKey:
-		if len(t.audience) == 0 {
+		if len(t.Audience) == 0 {
 			return nil, false
 		}
-		return []string(t.audience), true
+		return []string(t.Audience), true
 	case ExpirationKey:
-		if t.expiration == nil {
+		if t.Expiration == nil {
 			return nil, false
 		} else {
-			return t.expiration.Get(), true
+			return t.Expiration.Get(), true
 		}
 	case IssuedAtKey:
-		if t.issuedAt == nil {
+		if t.IssuedAt == nil {
 			return nil, false
 		} else {
-			return t.issuedAt.Get(), true
+			return t.IssuedAt.Get(), true
 		}
 	case IssuerKey:
-		if t.issuer == nil {
+		if t.Issuer == nil {
 			return nil, false
 		} else {
-			return *(t.issuer), true
+			return *(t.Issuer), true
 		}
 	case JwtIDKey:
-		if t.jwtID == nil {
+		if t.JwtID == nil {
 			return nil, false
 		} else {
-			return *(t.jwtID), true
+			return *(t.JwtID), true
 		}
 	case NotBeforeKey:
-		if t.notBefore == nil {
+		if t.NotBefore == nil {
 			return nil, false
 		} else {
-			return t.notBefore.Get(), true
+			return t.NotBefore.Get(), true
 		}
 	case SubjectKey:
-		if t.subject == nil {
+		if t.Subject == nil {
 			return nil, false
 		} else {
-			return *(t.subject), true
+			return *(t.Subject), true
 		}
 	}
-	if v, ok := t.privateClaims[s]; ok {
+	if v, ok := t.PrivateClaims[s]; ok {
 		return v, true
 	}
 	return nil, false
@@ -87,126 +87,71 @@ func (t *Token) Get(s string) (interface{}, bool) {
 func (t *Token) Set(name string, v interface{}) error {
 	switch name {
 	case AudienceKey:
-		var x stringList
+		var x StringList
 		if err := x.Accept(v); err != nil {
-			return errors.Wrap(err, `invalid value for 'audience' key`)
+			return errors.Wrap(err, `invalid value for 'Audience' key`)
 		}
-		t.audience = x
+		t.Audience = x
 	case ExpirationKey:
 		var x NumericDate
 		if err := x.Accept(v); err != nil {
-			return errors.Wrap(err, `invalid value for 'expiration' key`)
+			return errors.Wrap(err, `invalid value for 'Expiration' key`)
 		}
-		t.expiration = &x
+		t.Expiration = &x
 	case IssuedAtKey:
 		var x NumericDate
 		if err := x.Accept(v); err != nil {
-			return errors.Wrap(err, `invalid value for 'issuedAt' key`)
+			return errors.Wrap(err, `invalid value for 'IssuedAt' key`)
 		}
-		t.issuedAt = &x
+		t.IssuedAt = &x
 	case IssuerKey:
 		x, ok := v.(string)
 		if !ok {
-			return errors.Errorf(`invalid type for 'issuer' key: %T`, v)
+			return errors.Errorf(`invalid type for 'Issuer' key: %T`, v)
 		}
-		t.issuer = &x
+		t.Issuer = &x
 	case JwtIDKey:
 		x, ok := v.(string)
 		if !ok {
-			return errors.Errorf(`invalid type for 'jwtID' key: %T`, v)
+			return errors.Errorf(`invalid type for 'JwtID' key: %T`, v)
 		}
-		t.jwtID = &x
+		t.JwtID = &x
 	case NotBeforeKey:
 		var x NumericDate
 		if err := x.Accept(v); err != nil {
-			return errors.Wrap(err, `invalid value for 'notBefore' key`)
+			return errors.Wrap(err, `invalid value for 'NotBefore' key`)
 		}
-		t.notBefore = &x
+		t.NotBefore = &x
 	case SubjectKey:
 		x, ok := v.(string)
 		if !ok {
-			return errors.Errorf(`invalid type for 'subject' key: %T`, v)
+			return errors.Errorf(`invalid type for 'Subject' key: %T`, v)
 		}
-		t.subject = &x
+		t.Subject = &x
 	default:
-		t.privateClaims[name] = v
+		if t.PrivateClaims == nil {
+			t.PrivateClaims = make(map[string]interface{})
+		}
+		t.PrivateClaims[name] = v
 	}
 	return nil
 }
 
-func (t *Token) UnmarshalJSON(data []byte) error {
-	m := make(map[string]interface{})
-	if err := json.Unmarshal(data, &m); err != nil {
-		return errors.Wrap(err, `failed to unmarshal claims`)
-	}
-	t.privateClaims = make(map[string]interface{})
-	for k, v := range m {
-		if err := t.Set(k, v); err != nil {
-			return errors.Wrapf(err, `failed to set key '%s'`, k)
-		}
-	}
-	return nil
-}
-
-func (t Token) MarshalJSON() ([]byte, error) {
-	m := make(map[string]interface{})
-	for k, v := range t.privateClaims {
-		m[k] = v
-	}
-
-	if l := len(t.audience); l > 0 {
-		switch l {
-		case 0:
-		// no op
-		case 1:
-			m[AudienceKey] = t.audience[0]
-		default:
-			m[AudienceKey] = t.audience
-		}
-	}
-
-	if v := t.expiration; v != nil {
-		m[ExpirationKey] = *v
-	}
-
-	if v := t.issuedAt; v != nil {
-		m[IssuedAtKey] = *v
-	}
-
-	if v := t.issuer; v != nil {
-		m[IssuerKey] = *v
-	}
-
-	if v := t.jwtID; v != nil {
-		m[JwtIDKey] = *v
-	}
-
-	if v := t.notBefore; v != nil {
-		m[NotBeforeKey] = *v
-	}
-
-	if v := t.subject; v != nil {
-		m[SubjectKey] = *v
-	}
-
-	return json.Marshal(m)
-}
-
-func (t Token) Audience() string {
+func (t Token) GetAudience() StringList {
 	if v, ok := t.Get(AudienceKey); ok {
-		return (v.([]string))[0]
+		return v.([]string)
 	}
-	return ""
+	return nil
 }
 
-func (t Token) Expiration() time.Time {
+func (t Token) GetExpiration() time.Time {
 	if v, ok := t.Get(ExpirationKey); ok {
 		return v.(time.Time)
 	}
 	return time.Time{}
 }
 
-func (t Token) IssuedAt() time.Time {
+func (t Token) GetIssuedAt() time.Time {
 	if v, ok := t.Get(IssuedAtKey); ok {
 		return v.(time.Time)
 	}
@@ -215,7 +160,8 @@ func (t Token) IssuedAt() time.Time {
 
 // Issuer is a convenience function to retrieve the corresponding value store in the token
 // if there is a problem retrieving the value, the zero value is returned. If you need to differentiate between existing/non-existing values, use `Get` instead
-func (t Token) Issuer() string {
+
+func (t Token) GetIssuer() string {
 	if v, ok := t.Get(IssuerKey); ok {
 		return v.(string)
 	}
@@ -224,14 +170,15 @@ func (t Token) Issuer() string {
 
 // JwtID is a convenience function to retrieve the corresponding value store in the token
 // if there is a problem retrieving the value, the zero value is returned. If you need to differentiate between existing/non-existing values, use `Get` instead
-func (t Token) JwtID() string {
+
+func (t Token) GetJwtID() string {
 	if v, ok := t.Get(JwtIDKey); ok {
 		return v.(string)
 	}
 	return ""
 }
 
-func (t Token) NotBefore() time.Time {
+func (t Token) GetNotBefore() time.Time {
 	if v, ok := t.Get(NotBeforeKey); ok {
 		return v.(time.Time)
 	}
@@ -240,7 +187,8 @@ func (t Token) NotBefore() time.Time {
 
 // Subject is a convenience function to retrieve the corresponding value store in the token
 // if there is a problem retrieving the value, the zero value is returned. If you need to differentiate between existing/non-existing values, use `Get` instead
-func (t Token) Subject() string {
+
+func (t Token) GetSubject() string {
 	if v, ok := t.Get(SubjectKey); ok {
 		return v.(string)
 	}

--- a/jwt/token_gen_test.go
+++ b/jwt/token_gen_test.go
@@ -1,0 +1,155 @@
+package jwt_test
+
+import (
+	"encoding/json"
+	"github.com/lestrrat-go/jwx/jwt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestHeader(t *testing.T) {
+
+	const (
+		tokenTime = 233431200
+	)
+	expectedTokenTime := time.Unix(tokenTime, 0).UTC()
+
+	values := map[string]interface{}{
+		jwt.AudienceKey:   []string{"developers", "secops", "tac"},
+		jwt.ExpirationKey: expectedTokenTime,
+		jwt.IssuedAtKey:   expectedTokenTime,
+		jwt.IssuerKey:     "http://www.example.com",
+		jwt.JwtIDKey:      "e9bc097a-ce51-4036-9562-d2ade882db0d",
+		jwt.NotBeforeKey:  expectedTokenTime,
+		jwt.SubjectKey:    "unit test",
+	}
+
+	t.Run("Roundtrip", func(t *testing.T) {
+
+		var h jwt.Token
+		for k, v := range values {
+			err := h.Set(k, v)
+			if err != nil {
+				t.Fatalf("Set failed for %s", k)
+			}
+			got, ok := h.Get(k)
+			if !ok {
+				t.Fatalf("Set failed for %s", k)
+			}
+			if !reflect.DeepEqual(v, got) {
+				t.Fatalf("Values do not match: (%v, %v)", v, got)
+			}
+		}
+	})
+
+	t.Run("RoundtripError", func(t *testing.T) {
+
+		type dummyStruct struct {
+			dummy1 int
+			dummy2 float64
+		}
+		dummy := &dummyStruct{1, 3.4}
+
+		values := map[string]interface{}{
+			jwt.AudienceKey:   dummy,
+			jwt.ExpirationKey: dummy,
+			jwt.IssuedAtKey:   dummy,
+			jwt.IssuerKey:     dummy,
+			jwt.JwtIDKey:      dummy,
+			jwt.NotBeforeKey:  dummy,
+			jwt.SubjectKey:    dummy,
+		}
+
+		var h jwt.Token
+		for k, v := range values {
+			err := h.Set(k, v)
+			if err == nil {
+				t.Fatalf("Setting %s value should have failed", k)
+			}
+		}
+		err := h.Set("default", dummy) // private params
+		if err != nil {
+			t.Fatalf("Setting %s value failed", "default")
+		}
+		for k, _ := range values {
+			_, ok := h.Get(k)
+			if ok {
+				t.Fatalf("Getting %s value should have failed", k)
+			}
+		}
+		_, ok := h.Get("default")
+		if !ok {
+			t.Fatal("Failed to get default value")
+		}
+	})
+
+	t.Run("GetError", func(t *testing.T) {
+
+		var h jwt.Token
+		issuer := h.GetIssuer()
+		if issuer != "" {
+			t.Fatalf("Get Issuer should return empty string")
+		}
+		jwtId := h.GetJwtID()
+		if jwtId != "" {
+			t.Fatalf("Get JWT Id should return empty string")
+		}
+	})
+}
+
+func TestTokenMarshal(t *testing.T) {
+	t1 := jwt.New()
+	err := t1.Set(jwt.JwtIDKey, "AbCdEfG")
+	if err != nil {
+		t.Fatalf("Failed to set JWT ID: %s", err.Error())
+	}
+	err = t1.Set(jwt.SubjectKey, "foobar@example.com")
+	if err != nil {
+		t.Fatalf("Failed to set Subject: %s", err.Error())
+	}
+
+	// Silly fix to remove monotonic element from time.Time obtained
+	// from time.Now(). Without this, the equality comparison goes
+	// ga-ga for golang tip (1.9)
+	now := time.Unix(time.Now().Unix(), 0)
+	err = t1.Set(jwt.IssuedAtKey, now.Unix())
+	if err != nil {
+		t.Fatalf("Failed to set IssuedAt: %s", err.Error())
+	}
+	err = t1.Set(jwt.NotBeforeKey, now.Add(5*time.Second))
+	if err != nil {
+		t.Fatalf("Failed to set NotBefore: %s", err.Error())
+	}
+	err = t1.Set(jwt.ExpirationKey, now.Add(10*time.Second).Unix())
+	if err != nil {
+		t.Fatalf("Failed to set Expiration: %s", err.Error())
+	}
+	err = t1.Set(jwt.AudienceKey, []string{"devops", "secops", "tac"})
+	if err != nil {
+		t.Fatalf("Failed to set audience: %s", err.Error())
+	}
+	err = t1.Set("custom", "MyValue")
+	if err != nil {
+		t.Fatalf(`Failed to set private claim "custom": %s`, err.Error())
+	}
+	jsonbuf1, err := json.MarshalIndent(t1, "", "  ")
+	if err != nil {
+		t.Fatalf("JSON Marshal failed: %s", err.Error())
+	}
+
+	t2 := jwt.New()
+	err = json.Unmarshal(jsonbuf1, t2)
+	if err != nil {
+		t.Fatalf("JSON Unmarshal error: %s", err.Error())
+	}
+
+	if !reflect.DeepEqual(t1, t2) {
+		t.Fatalf("Mismatched tokens. \n Expected: %v \nReceived: %v", t1, t2)
+	}
+
+	_, err = json.MarshalIndent(t2, "", "  ")
+	if err != nil {
+		t.Fatalf("JSON marshal error: %s", err.Error())
+	}
+}

--- a/jwt/verify.go
+++ b/jwt/verify.go
@@ -93,21 +93,21 @@ func (t *Token) Verify(options ...Option) error {
 
 	// check for iss
 	if len(issuer) > 0 {
-		if v := t.issuer; v != nil && *v != issuer {
+		if v := t.GetIssuer(); v != "" && v != issuer {
 			return errors.New(`iss not satisfied`)
 		}
 	}
 
 	// check for jti
 	if len(jwtid) > 0 {
-		if v := t.jwtID; v != nil && *v != jwtid {
+		if v := t.GetJwtID(); v != "" && v != jwtid {
 			return errors.New(`jti not satisfied`)
 		}
 	}
 
 	// check for sub
 	if len(subject) > 0 {
-		if v := t.subject; v != nil && *v != subject {
+		if v := t.GetSubject(); v != "" && v != subject {
 			return errors.New(`sub not satisfied`)
 		}
 	}
@@ -115,7 +115,7 @@ func (t *Token) Verify(options ...Option) error {
 	// check for aud
 	if len(audience) > 0 {
 		var found bool
-		for _, v := range t.audience {
+		for _, v := range t.GetAudience() {
 			if v == audience {
 				found = true
 				break
@@ -127,27 +127,27 @@ func (t *Token) Verify(options ...Option) error {
 	}
 
 	// check for exp
-	if tv := t.expiration; tv != nil {
+	if tv := t.GetExpiration(); !tv.IsZero() {
 		now := clock.Now().Truncate(time.Second)
-		ttv := tv.Time.Truncate(time.Second)
+		ttv := tv.Truncate(time.Second)
 		if !now.Before(ttv.Add(skew)) {
 			return errors.New(`exp not satisfied`)
 		}
 	}
 
 	// check for iat
-	if tv := t.issuedAt; tv != nil {
+	if tv := t.GetIssuedAt(); !tv.IsZero() {
 		now := clock.Now().Truncate(time.Second)
-		ttv := tv.Time.Truncate(time.Second)
+		ttv := tv.Truncate(time.Second)
 		if now.Before(ttv.Add(-1 * skew)) {
 			return errors.New(`iat not satisfied`)
 		}
 	}
 
 	// check for nbf
-	if tv := t.notBefore; tv != nil {
+	if tv := t.GetNotBefore(); !tv.IsZero() {
 		now := clock.Now().Truncate(time.Second)
-		ttv := tv.Time.Truncate(time.Second)
+		ttv := tv.Truncate(time.Second)
 		// now cannot be before t, so we check for now > t - skew
 		if !now.After(ttv.Add(-1 * skew)) {
 			return errors.New(`nbf not satisfied`)

--- a/jwt/verify_test.go
+++ b/jwt/verify_test.go
@@ -1,0 +1,127 @@
+package jwt_test
+
+import (
+	"github.com/lestrrat-go/jwx/jwt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestGHIssue10(t *testing.T) {
+	t.Run(jwt.IssuerKey, func(t *testing.T) {
+		t1 := jwt.New()
+		t1.Set(jwt.IssuerKey, "github.com/lestrrat-go/jwx")
+
+		// This should succeed, because WithIssuer is not provided in the
+		// optional parameters
+		if !assert.NoError(t, t1.Verify(), "t1.Verify should succeed") {
+			return
+		}
+
+		// This should succeed, because WithIssuer is provided with same value
+		if !assert.NoError(t, t1.Verify(jwt.WithIssuer(t1.GetIssuer())), "t1.Verify should succeed") {
+			return
+		}
+
+		if !assert.Error(t, t1.Verify(jwt.WithIssuer("poop")), "t1.Verify should fail") {
+			return
+		}
+	})
+	t.Run(jwt.AudienceKey, func(t *testing.T) {
+		t1 := jwt.New()
+		err := t1.Set(jwt.AudienceKey, []string{"foo", "bar", "baz"})
+		if err != nil {
+			t.Fatalf("Failed to set audience claim: %s", err.Error())
+		}
+
+		// This should succeed, because WithAudience is not provided in the
+		// optional parameters
+		err = t1.Verify()
+		if err != nil {
+			t.Fatalf("Error varifying claim: %s", err.Error())
+		}
+
+		// This should succeed, because WithAudience is provided, and its
+		// value matches one of the audience values
+		if !assert.NoError(t, t1.Verify(jwt.WithAudience("baz")), "token.Verify should succeed") {
+			return
+		}
+
+		if !assert.Error(t, t1.Verify(jwt.WithAudience("poop")), "token.Verify should fail") {
+			return
+		}
+	})
+	t.Run(jwt.SubjectKey, func(t *testing.T) {
+		t1 := jwt.New()
+		t1.Set(jwt.SubjectKey, "github.com/lestrrat-go/jwx")
+
+		// This should succeed, because WithSubject is not provided in the
+		// optional parameters
+		if !assert.NoError(t, t1.Verify(), "token.Verify should succeed") {
+			return
+		}
+
+		// This should succeed, because WithSubject is provided with same value
+		if !assert.NoError(t, t1.Verify(jwt.WithSubject(t1.GetSubject())), "token.Verify should succeed") {
+			return
+		}
+
+		if !assert.Error(t, t1.Verify(jwt.WithSubject("poop")), "token.Verify should fail") {
+			return
+		}
+	})
+	t.Run(jwt.NotBeforeKey, func(t *testing.T) {
+		t1 := jwt.New()
+
+		// NotBefore is set to future date
+		tm := time.Now().Add(72 * time.Hour)
+		t1.Set(jwt.NotBeforeKey, tm)
+
+		// This should fail, because nbf is the future
+		if !assert.Error(t, t1.Verify(), "token.Verify should fail") {
+			return
+		}
+
+		// This should succeed, because we have given reaaaaaaly big skew
+		// that is well enough to get us accepted
+		if !assert.NoError(t, t1.Verify(jwt.WithAcceptableSkew(73*time.Hour)), "token.Verify should succeed") {
+			return
+		}
+
+		// This should succeed, because we have given a time
+		// that is well enough into the future
+		if !assert.NoError(t, t1.Verify(jwt.WithClock(jwt.ClockFunc(func() time.Time { return tm.Add(time.Hour) }))), "token.Verify should succeed") {
+			return
+		}
+	})
+	t.Run(jwt.ExpirationKey, func(t *testing.T) {
+		t1 := jwt.New()
+
+		// issuedat = 1 Hr before current time
+		tm := time.Now()
+		t1.Set(jwt.IssuedAtKey, tm.Add(-1*time.Hour))
+
+		// valid for 2 minutes only from IssuedAt
+		t1.Set(jwt.ExpirationKey, tm.Add(-58*time.Minute))
+
+		// This should fail, because exp is set in the past
+		if !assert.Error(t, t1.Verify(), "token.Verify should fail") {
+			return
+		}
+
+		// This should succeed, because we have given big skew
+		// that is well enough to get us accepted
+		if !assert.NoError(t, t1.Verify(jwt.WithAcceptableSkew(time.Hour)), "token.Verify should succeed (1)") {
+			return
+		}
+
+		// This should succeed, because we have given a time
+		// that is well enough into the past
+		clock := jwt.ClockFunc(func() time.Time {
+			return tm.Add(-59 * time.Minute)
+		})
+		if !assert.NoError(t, t1.Verify(jwt.WithClock(clock)), "token.Verify should succeed (2)") {
+			return
+		}
+	})
+}

--- a/jwx_example_test.go
+++ b/jwx_example_test.go
@@ -31,12 +31,12 @@ func ExampleJWT() {
 	}
 
 	fmt.Printf("%s\n", buf)
-	fmt.Printf("aud -> '%s'\n", t.Audience())
-	fmt.Printf("iat -> '%s'\n", t.IssuedAt().Format(time.RFC3339))
+	fmt.Printf("aud -> '%s'\n", t.GetAudience())
+	fmt.Printf("iat -> '%s'\n", t.GetIssuedAt().Format(time.RFC3339))
 	if v, ok := t.Get(`privateClaimKey`); ok {
 		fmt.Printf("privateClaimKey -> '%s'\n", v)
 	}
-	fmt.Printf("sub -> '%s'\n", t.Subject())
+	fmt.Printf("sub -> '%s'\n", t.GetSubject())
 }
 
 func ExampleJWK() {


### PR DESCRIPTION
fixes #85

1 - Overall Changes

- Removed Token Top Level (Un)Marshal and added JSON Tags for everything
  - This simplified code and increased coverage
- Added specific (un)Marshal for NumericDate so that we always return a
  number according to the definition of NumericDate on
  https://tools.ietf.org/html/rfc7519#page-6

2 - Token Behavior

- We should only accept audience(aud) claims as an array, even if it
  is an array of one element. This greatly simplifies code and coverage

3 - Bugs

- If we add private claims, we need to indicate as such when getting
  tokens. See example_test.go. We get this for free by using JSON tags
  for (un)Marshal.

- When creating a JWT the New() function should behave just
  like "var token Token". the New() function was creating an empty
  private PrivateClaims map and that would break JSON (un)Marshal. The
  PrivateClaims should be created on-demand much like existing JWS
  headers code.

4 - Testing and Coverage

- Added string_test.go to properly test stringlist implementation
- Moved date testing to date_test.go so we get proper coverage
- Moved token specific tests from jwt_test.go to token_gen_test.go
- Moved verify specific tests from jwt_test.go to verify_test.go

Coverage is at 90%+ for Token

thanks,