### PR TITLE
using payload and err variables declared in function signature

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -363,7 +363,7 @@ func VerifyWithJWKSet(buf []byte, keyset *jwk.Set, keyaccept JWKAcceptFunc) (pay
 			continue
 		}
 
-		payload, err := VerifyWithJWK(buf, key)
+		payload, err = VerifyWithJWK(buf, key)
 		if err == nil {
 			return payload, nil
 		}


### PR DESCRIPTION
fix #140 