### PR TITLE
Add WithClaimValue to JWT Verify options

### DIFF
--- a/jwt/verify_test.go
+++ b/jwt/verify_test.go
@@ -125,4 +125,29 @@ func TestGHIssue10(t *testing.T) {
 			return
 		}
 	})
+	t.Run("any claim value", func(t *testing.T) {
+		t1 := jwt.New()
+		t1.Set("email", "email@example.com")
+
+		// This should succeed, because WithClaimValue("email", "xxx") is not provided in the
+		// optional parameters
+		if !assert.NoError(t, t1.Verify(), "t1.Verify should succeed") {
+			return
+		}
+
+		// This should succeed, because WithClaimValue is provided with same value
+		if !assert.NoError(t, t1.Verify(jwt.WithClaimValue("email", "email@example.com")), "t1.Verify should succeed") {
+			return
+		}
+
+		if !assert.Error(t, t1.Verify(jwt.WithClaimValue("email", "poop")), "t1.Verify should fail") {
+			return
+		}
+		if !assert.Error(t, t1.Verify(jwt.WithClaimValue("xxxx", "email@example.com")), "t1.Verify should fail") {
+			return
+		}
+		if !assert.Error(t, t1.Verify(jwt.WithClaimValue("xxxx", "")), "t1.Verify should fail") {
+			return
+		}
+	})
 }


### PR DESCRIPTION
WithClaimValue allows you to verify any claim.

before

```go
	if err := token.Verify(
		jwt.WithClock(clock),
		jwt.WithIssuer("https://accounts.google.com"),
		jwt.WithAudience(audience),
	); err != nil {
		return xerrors.Errorf(": %w", err)
	}

	if emailVerified, ok := token.Get("email_verified"); !ok || emailVerified != true {
		return xerrors.Errorf("token not valid: email is not verified")
	}

	if email, ok := token.Get("email"); !ok || email != "email@example.com" {
		return xerrors.Errorf("token not valid: no permission %v", email)
	}
```

after
```go
	if err := token.Verify(
		jwt.WithClock(clock),
		jwt.WithIssuer("https://accounts.google.com"),
		jwt.WithAudience(audience),
		jwt.WithClaimValue("email_verified", true),
		jwt.WithClaimValue("email", "email@example.com"),
	); err != nil {
		return xerrors.Errorf(": %w", err)
	}
```