### PR TITLE
Pass context to fetch functions

### DIFF
--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -90,7 +90,7 @@ func Fetch(urlstring string, options ...Option) (*Set, error) {
 	return nil, errors.Errorf(`invalid url scheme %s`, u.Scheme)
 }
 
-// FetchHTTP fetches the remote JWK and parses its contents
+// FetchHTTP wraps FetchHTTPWithContext using the background context.
 func FetchHTTP(jwkurl string, options ...Option) (*Set, error) {
 	return FetchHTTPWithContext(context.Background(), jwkurl, options...)
 }
@@ -123,7 +123,6 @@ func FetchHTTPWithContext(ctx context.Context, jwkurl string, options ...Option)
 
 	return Parse(res.Body)
 }
-
 
 func (set *Set) UnmarshalJSON(data []byte) error {
 	v, err := ParseBytes(data)

--- a/jwk/option.go
+++ b/jwk/option.go
@@ -12,10 +12,6 @@ const (
 	optkeyHTTPClient = `http-client`
 )
 
-type HTTPClient interface {
-	Get(string) (*http.Response, error)
-}
-
-func WithHTTPClient(cl HTTPClient) Option {
+func WithHTTPClient(cl *http.Client) Option {
 	return option.New(optkeyHTTPClient, cl)
 }

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -24,6 +24,7 @@ package jws
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -322,10 +323,15 @@ func Verify(buf []byte, alg jwa.SignatureAlgorithm, key interface{}) (ret []byte
 	return decodedPayload, nil
 }
 
-// VerifyWithJKU verifies the JWS message using a remote JWK
-// file represented in the url.
+// VerifyWithJKU wraps VerifyWithJKUAndContext using the background context.
 func VerifyWithJKU(buf []byte, jwkurl string) ([]byte, error) {
-	key, err := jwk.FetchHTTP(jwkurl)
+	return VerifyWithJKUAndContext(context.Background(), buf, jwkurl)
+}
+
+// VerifyWithJKUAndContext verifies the JWS message using a remote JWK
+// file represented in the url.
+func VerifyWithJKUAndContext(ctx context.Context, buf []byte, jwkurl string) ([]byte, error) {
+	key, err := jwk.FetchHTTPWithContext(ctx, jwkurl)
 	if err != nil {
 		return nil, errors.Wrap(err, `failed to fetch jwk via HTTP`)
 	}


### PR DESCRIPTION
We can use `http.NewRequestWithContext` but it can use from Go 1.13.
I don't use it this PR.

```go
	req, err := http.NewRequest(http.MethodGet, jwkurl, nil)
	if err != nil {
		return nil, errors.Wrap(err, "failed to new request to remote JWK")
	}
	req.WithContext(ctx)
```

from Go 1.13
```go
	req, err := http.NewRequestWithContext(http.MethodGet, jwkurl, nil)
	if err != nil {
		return nil, errors.Wrap(err, "failed to new request to remote JWK")
	}
```

`http.NewRequestWithContext` has performace advantage. `req.WithContext(ctx)`copy http.Request.

```go
func (r *Request) WithContext(ctx context.Context) *Request {
	if ctx == nil {
		panic("nil context")
	}
	r2 := new(Request)
	*r2 = *r //--------------------------------- copy http.Request  -------------------------------
	r2.ctx = ctx
	r2.URL = cloneURL(r.URL) // legacy behavior; TODO: try to remove. Issue 23544
	return r2
}
```

Please give me advice use http.NewRequestWithContext or not.