### PR TITLE
Fixed data type of JWS["jwk"] to be JWK instead of JWKSet

### DIFF
--- a/jws/headers.go
+++ b/jws/headers.go
@@ -31,7 +31,7 @@ type StandardHeaders struct {
 	JWSalgorithm              jwa.SignatureAlgorithm `json:"alg,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.1
 	JWScontentType            string                 `json:"cty,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.10
 	JWScritical               []string               `json:"crit,omitempty"`     // https://tools.ietf.org/html/rfc7515#section-4.1.11
-	JWSjwk                    *jwk.Set               `json:"jwk,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.3
+	JWSjwk                    jwk.Key                `json:"jwk,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.3
 	JWSjwkSetURL              string                 `json:"jku,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.2
 	JWSkeyID                  string                 `json:"kid,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.4
 	JWStyp                    string                 `json:"typ,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.9
@@ -140,7 +140,7 @@ func (h *StandardHeaders) Set(name string, value interface{}) error {
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, CriticalKey, value)
 	case JWKKey:
-		v, ok := value.(*jwk.Set)
+		v, ok := value.(jwk.Key)
 		if ok {
 			h.JWSjwk = v
 			return nil

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -28,7 +28,7 @@ func TestHeader(t *testing.T) {
 		jws.AlgorithmKey:          jwa.ES256,
 		jws.ContentTypeKey:        "example",
 		jws.CriticalKey:           []string{"exp"},
-		jws.JWKKey:                jwkPublicKeySet,
+		jws.JWKKey:                jwkPublicKeySet.Keys[0],
 		jws.JWKSetURLKey:          "https://www.jwk.com/key.json",
 		jws.TypeKey:               "JWT",
 		jws.KeyIDKey:              "e9bc097a-ce51-4036-9562-d2ade882db0d",

--- a/jws/internal/cmd/genheader/main.go
+++ b/jws/internal/cmd/genheader/main.go
@@ -86,7 +86,7 @@ func generateHeaders() error {
 		{
 			name:    `JWSjwk`,
 			method:  `JWK`,
-			typ:     `*jwk.Set`,
+			typ:     `jwk.Key`,
 			key:     `jwk`,
 			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.3`,
 			jsonTag: "`" + `json:"jwk,omitempty"` + "`",


### PR DESCRIPTION
The datatype of the "jwk" field of JWS' currently incorrectly specified as jwk.Set. According to the spec this should be a plain JWK, rather than a set (https://tools.ietf.org/html/rfc7515#section-4.1.3).

This bug breaks compatibility with other JWS libraries.