### PR TITLE
Fix Pass context to fetch functions #144

### DIFF
--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -110,9 +110,8 @@ func FetchHTTPWithContext(ctx context.Context, jwkurl string, options ...Option)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to new request to remote JWK")
 	}
-	req.WithContext(ctx)
 
-	res, err := httpcl.Do(req)
+	res, err := httpcl.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch remote JWK")
 	}


### PR DESCRIPTION
I'm sorry that I have to pass return value from WithContext to Do method.

#144

Thanks @zchee
https://github.com/lestrrat-go/jwx/commit/0363a73b1277f4f9c48b6ebc531f2bce0a6f4f25#r38431948

