### PR TITLE
Refactor JWS API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ script:
   - go test -v ./...
   - ./scripts/check-diff.sh
 go:
-    - 1.12.x
     - 1.13.x
+    - 1.14.x
     - tip

--- a/internal/iter/mapiter.go
+++ b/internal/iter/mapiter.go
@@ -1,0 +1,34 @@
+package iter
+
+import (
+	"context"
+
+	"github.com/lestrrat-go/iter/mapiter"
+)
+
+// MapVisitor is a specialized visitor for our purposes.
+// Whereas mapiter.Visitor supports any type of key, this
+// visitor assumes the key is a string
+type MapVisitor interface {
+	Visit(string, interface{}) error
+}
+
+type MapVisitorFunc func(string, interface{}) error
+
+func (fn MapVisitorFunc) Visit(s string, v interface{}) error {
+	return fn(s, v)
+}
+
+func WalkMap(ctx context.Context, src mapiter.Source, visitor MapVisitor) error {
+	return mapiter.Walk(ctx, src, mapiter.VisitorFunc(func(k, v interface{}) error {
+		return visitor.Visit(k.(string), v)
+	}))
+}
+
+func AsMap(ctx context.Context, src mapiter.Source) (map[string]interface{}, error) {
+	var m map[string]interface{}
+	if err := mapiter.AsMap(ctx, src, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}

--- a/jws/headers.go
+++ b/jws/headers.go
@@ -1,0 +1,35 @@
+package jws
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// Iterate returns a channel that successively returns all the
+// header name and values.
+func (h *stdHeaders) Iterate(ctx context.Context) <-chan *HeaderPair {
+	ch := make(chan *HeaderPair)
+	go h.iterate(ctx, ch)
+	return ch
+}
+
+func (h *stdHeaders) Walk(ctx context.Context, visitor Visitor) error {
+	// XXX did we need to check for error cases here when reading from a channel?
+	for pair := range h.Iterate(ctx) {
+		if err := visitor.Visit(pair.Name, pair.Value); err != nil {
+			return errors.Wrapf(err, `failed to visit key %s`, pair.Name)
+		}
+	}
+	return nil
+}
+
+func (h *stdHeaders) AsMap(ctx context.Context) map[string]interface{} {
+	m := make(map[string]interface{})
+
+	for pair := range h.Iterate(ctx) {
+		m[pair.Name] = pair.Value
+	}
+
+	return m
+}

--- a/jws/headers.go
+++ b/jws/headers.go
@@ -3,33 +3,22 @@ package jws
 import (
 	"context"
 
-	"github.com/pkg/errors"
+	"github.com/lestrrat-go/iter/mapiter"
+	"github.com/lestrrat-go/jwx/internal/iter"
 )
 
 // Iterate returns a channel that successively returns all the
 // header name and values.
-func (h *stdHeaders) Iterate(ctx context.Context) <-chan *HeaderPair {
+func (h *stdHeaders) Iterate(ctx context.Context) Iterator {
 	ch := make(chan *HeaderPair)
 	go h.iterate(ctx, ch)
-	return ch
+	return mapiter.New(ch)
 }
 
 func (h *stdHeaders) Walk(ctx context.Context, visitor Visitor) error {
-	// XXX did we need to check for error cases here when reading from a channel?
-	for pair := range h.Iterate(ctx) {
-		if err := visitor.Visit(pair.Name, pair.Value); err != nil {
-			return errors.Wrapf(err, `failed to visit key %s`, pair.Name)
-		}
-	}
-	return nil
+	return iter.WalkMap(ctx, h, visitor)
 }
 
-func (h *stdHeaders) AsMap(ctx context.Context) map[string]interface{} {
-	m := make(map[string]interface{})
-
-	for pair := range h.Iterate(ctx) {
-		m[pair.Name] = pair.Value
-	}
-
-	return m
+func (h *stdHeaders) AsMap(ctx context.Context) (map[string]interface{}, error) {
+	return iter.AsMap(ctx, h)
 }

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -74,7 +74,6 @@ type standardHeadersMarshalProxy struct {
 	Xx509CertThumbprint     string                 `json:"x5t,omitempty"`
 	Xx509CertThumbprintS256 string                 `json:"x5t#S256,omitempty"`
 	Xx509URL                string                 `json:"x5u,omitempty"`
-	PrivateParams           map[string]interface{} `json:"-,omitempty"`
 }
 
 func NewHeaders() Headers {
@@ -352,7 +351,22 @@ func (h *stdHeaders) UnmarshalJSON(buf []byte) error {
 	h.x509CertThumbprint = proxy.Xx509CertThumbprint
 	h.x509CertThumbprintS256 = proxy.Xx509CertThumbprintS256
 	h.x509URL = proxy.Xx509URL
-	h.privateParams = proxy.PrivateParams
+	var m map[string]interface{}
+	if err := json.Unmarshal(buf, &m); err != nil {
+		return errors.Wrap(err, `failed to parse privsate parameters`)
+	}
+	delete(m, AlgorithmKey)
+	delete(m, ContentTypeKey)
+	delete(m, CriticalKey)
+	delete(m, JWKKey)
+	delete(m, JWKSetURLKey)
+	delete(m, KeyIDKey)
+	delete(m, TypeKey)
+	delete(m, X509CertChainKey)
+	delete(m, X509CertThumbprintKey)
+	delete(m, X509CertThumbprintS256Key)
+	delete(m, X509URLKey)
+	h.privateParams = m
 	return nil
 }
 

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -127,17 +127,39 @@ func (h *stdHeaders) X509URL() string {
 
 func (h *stdHeaders) iterate(ctx context.Context, ch chan *HeaderPair) {
 	var pairs []*HeaderPair
-	pairs = append(pairs, &HeaderPair{Name: "alg", Value: h.algorithm})
-	pairs = append(pairs, &HeaderPair{Name: "cty", Value: h.contentType})
-	pairs = append(pairs, &HeaderPair{Name: "crit", Value: h.critical})
-	pairs = append(pairs, &HeaderPair{Name: "jwk", Value: h.jwk})
-	pairs = append(pairs, &HeaderPair{Name: "jku", Value: h.jwkSetURL})
-	pairs = append(pairs, &HeaderPair{Name: "kid", Value: h.keyID})
-	pairs = append(pairs, &HeaderPair{Name: "typ", Value: h.typ})
-	pairs = append(pairs, &HeaderPair{Name: "x5c", Value: h.x509CertChain})
-	pairs = append(pairs, &HeaderPair{Name: "x5t", Value: h.x509CertThumbprint})
-	pairs = append(pairs, &HeaderPair{Name: "x5t#S256", Value: h.x509CertThumbprintS256})
-	pairs = append(pairs, &HeaderPair{Name: "x5u", Value: h.x509URL})
+	if h.algorithm != "" {
+		pairs = append(pairs, &HeaderPair{Name: "alg", Value: h.algorithm})
+	}
+	if h.contentType != "" {
+		pairs = append(pairs, &HeaderPair{Name: "cty", Value: h.contentType})
+	}
+	if len(h.critical) > 0 {
+		pairs = append(pairs, &HeaderPair{Name: "crit", Value: h.critical})
+	}
+	if h.jwk != nil {
+		pairs = append(pairs, &HeaderPair{Name: "jwk", Value: h.jwk})
+	}
+	if h.jwkSetURL != "" {
+		pairs = append(pairs, &HeaderPair{Name: "jku", Value: h.jwkSetURL})
+	}
+	if h.keyID != "" {
+		pairs = append(pairs, &HeaderPair{Name: "kid", Value: h.keyID})
+	}
+	if h.typ != "" {
+		pairs = append(pairs, &HeaderPair{Name: "typ", Value: h.typ})
+	}
+	if len(h.critical) > 0 {
+		pairs = append(pairs, &HeaderPair{Name: "x5c", Value: h.x509CertChain})
+	}
+	if h.x509CertThumbprint != "" {
+		pairs = append(pairs, &HeaderPair{Name: "x5t", Value: h.x509CertThumbprint})
+	}
+	if h.x509CertThumbprintS256 != "" {
+		pairs = append(pairs, &HeaderPair{Name: "x5t#S256", Value: h.x509CertThumbprintS256})
+	}
+	if h.x509URL != "" {
+		pairs = append(pairs, &HeaderPair{Name: "x5u", Value: h.x509URL})
+	}
 	for k, v := range h.privateParams {
 		pairs = append(pairs, &HeaderPair{Name: k, Value: v})
 	}

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -2,6 +2,7 @@
 package jws
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"
@@ -22,110 +23,197 @@ const (
 	X509URLKey                = "x5u"
 )
 
+// Headers describe a standard Header set.
 type Headers interface {
+	Algorithm() jwa.SignatureAlgorithm
+	ContentType() string
+	Critical() []string
+	JWK() jwk.Key
+	JWKSetURL() string
+	KeyID() string
+	Type() string
+	X509CertChain() []string
+	X509CertThumbprint() string
+	X509CertThumbprintS256() string
+	X509URL() string
+	Iterate(ctx context.Context) <-chan *HeaderPair
+	Walk(ctx context.Context, v Visitor) error
+	AsMap(ctx context.Context) map[string]interface{}
 	Get(string) (interface{}, bool)
 	Set(string, interface{}) error
-	Algorithm() jwa.SignatureAlgorithm
 }
 
-type StandardHeaders struct {
-	JWSalgorithm              jwa.SignatureAlgorithm `json:"alg,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.1
-	JWScontentType            string                 `json:"cty,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.10
-	JWScritical               []string               `json:"crit,omitempty"`     // https://tools.ietf.org/html/rfc7515#section-4.1.11
-	JWSjwk                    jwk.Key                `json:"jwk,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.3
-	JWSjwkSetURL              string                 `json:"jku,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.2
-	JWSkeyID                  string                 `json:"kid,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.4
-	JWStyp                    string                 `json:"typ,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.9
-	JWSx509CertChain          []string               `json:"x5c,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.6
-	JWSx509CertThumbprint     string                 `json:"x5t,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.7
-	JWSx509CertThumbprintS256 string                 `json:"x5t#S256,omitempty"` // https://tools.ietf.org/html/rfc7515#section-4.1.8
-	JWSx509URL                string                 `json:"x5u,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.5
-	privateParams             map[string]interface{}
+type stdHeaders struct {
+	algorithm              jwa.SignatureAlgorithm `json:"alg,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.1
+	contentType            string                 `json:"cty,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.10
+	critical               []string               `json:"crit,omitempty"`     // https://tools.ietf.org/html/rfc7515#section-4.1.11
+	jwk                    jwk.Key                `json:"jwk,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.3
+	jwkSetURL              string                 `json:"jku,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.2
+	keyID                  string                 `json:"kid,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.4
+	typ                    string                 `json:"typ,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.9
+	x509CertChain          []string               `json:"x5c,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.6
+	x509CertThumbprint     string                 `json:"x5t,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.7
+	x509CertThumbprintS256 string                 `json:"x5t#S256,omitempty"` // https://tools.ietf.org/html/rfc7515#section-4.1.8
+	x509URL                string                 `json:"x5u,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.5
+	privateParams          map[string]interface{}
 }
 
 type standardHeadersUnmarshalProxy struct {
-	JWSalgorithm              jwa.SignatureAlgorithm `json:"alg,omitempty"`
-	JWScontentType            string                 `json:"cty,omitempty"`
-	JWScritical               []string               `json:"crit,omitempty"`
-	JWSjwk                    json.RawMessage        `json:"jwk,omitempty"`
-	JWSjwkSetURL              string                 `json:"jku,omitempty"`
-	JWSkeyID                  string                 `json:"kid,omitempty"`
-	JWStyp                    string                 `json:"typ,omitempty"`
-	JWSx509CertChain          []string               `json:"x5c,omitempty"`
-	JWSx509CertThumbprint     string                 `json:"x5t,omitempty"`
-	JWSx509CertThumbprintS256 string                 `json:"x5t#S256,omitempty"`
-	JWSx509URL                string                 `json:"x5u,omitempty"`
-	privateParams             map[string]interface{}
+	Xalgorithm              jwa.SignatureAlgorithm `json:"alg,omitempty"`
+	XcontentType            string                 `json:"cty,omitempty"`
+	Xcritical               []string               `json:"crit,omitempty"`
+	Xjwk                    json.RawMessage        `json:"jwk,omitempty"`
+	XjwkSetURL              string                 `json:"jku,omitempty"`
+	XkeyID                  string                 `json:"kid,omitempty"`
+	Xtyp                    string                 `json:"typ,omitempty"`
+	Xx509CertChain          []string               `json:"x5c,omitempty"`
+	Xx509CertThumbprint     string                 `json:"x5t,omitempty"`
+	Xx509CertThumbprintS256 string                 `json:"x5t#S256,omitempty"`
+	Xx509URL                string                 `json:"x5u,omitempty"`
+	PrivateParams           map[string]interface{}
 }
 
-func (h *StandardHeaders) Algorithm() jwa.SignatureAlgorithm {
-	return h.JWSalgorithm
+func NewHeaders() Headers {
+	return &stdHeaders{}
 }
 
-func (h *StandardHeaders) Get(name string) (interface{}, bool) {
+func (h *stdHeaders) Algorithm() jwa.SignatureAlgorithm {
+	return h.algorithm
+}
+
+func (h *stdHeaders) ContentType() string {
+	return h.contentType
+}
+
+func (h *stdHeaders) Critical() []string {
+	return h.critical
+}
+
+func (h *stdHeaders) JWK() jwk.Key {
+	return h.jwk
+}
+
+func (h *stdHeaders) JWKSetURL() string {
+	return h.jwkSetURL
+}
+
+func (h *stdHeaders) KeyID() string {
+	return h.keyID
+}
+
+func (h *stdHeaders) Type() string {
+	return h.typ
+}
+
+func (h *stdHeaders) X509CertChain() []string {
+	return h.x509CertChain
+}
+
+func (h *stdHeaders) X509CertThumbprint() string {
+	return h.x509CertThumbprint
+}
+
+func (h *stdHeaders) X509CertThumbprintS256() string {
+	return h.x509CertThumbprintS256
+}
+
+func (h *stdHeaders) X509URL() string {
+	return h.x509URL
+}
+
+func (h *stdHeaders) iterate(ctx context.Context, ch chan *HeaderPair) {
+	var pairs []*HeaderPair
+	pairs = append(pairs, &HeaderPair{Name: "alg", Value: h.algorithm})
+	pairs = append(pairs, &HeaderPair{Name: "cty", Value: h.contentType})
+	pairs = append(pairs, &HeaderPair{Name: "crit", Value: h.critical})
+	pairs = append(pairs, &HeaderPair{Name: "jwk", Value: h.jwk})
+	pairs = append(pairs, &HeaderPair{Name: "jku", Value: h.jwkSetURL})
+	pairs = append(pairs, &HeaderPair{Name: "kid", Value: h.keyID})
+	pairs = append(pairs, &HeaderPair{Name: "typ", Value: h.typ})
+	pairs = append(pairs, &HeaderPair{Name: "x5c", Value: h.x509CertChain})
+	pairs = append(pairs, &HeaderPair{Name: "x5t", Value: h.x509CertThumbprint})
+	pairs = append(pairs, &HeaderPair{Name: "x5t#S256", Value: h.x509CertThumbprintS256})
+	pairs = append(pairs, &HeaderPair{Name: "x5u", Value: h.x509URL})
+	for k, v := range h.privateParams {
+		pairs = append(pairs, &HeaderPair{Name: k, Value: v})
+	}
+	for _, pair := range pairs {
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- pair:
+		}
+	}
+}
+
+func (h *stdHeaders) PrivateParams() map[string]interface{} {
+	return h.privateParams
+}
+
+func (h *stdHeaders) Get(name string) (interface{}, bool) {
 	switch name {
 	case AlgorithmKey:
-		v := h.JWSalgorithm
+		v := h.algorithm
 		if v == "" {
 			return nil, false
 		}
 		return v, true
 	case ContentTypeKey:
-		v := h.JWScontentType
+		v := h.contentType
 		if v == "" {
 			return nil, false
 		}
 		return v, true
 	case CriticalKey:
-		v := h.JWScritical
+		v := h.critical
 		if len(v) == 0 {
 			return nil, false
 		}
 		return v, true
 	case JWKKey:
-		v := h.JWSjwk
+		v := h.jwk
 		if v == nil {
 			return nil, false
 		}
 		return v, true
 	case JWKSetURLKey:
-		v := h.JWSjwkSetURL
+		v := h.jwkSetURL
 		if v == "" {
 			return nil, false
 		}
 		return v, true
 	case KeyIDKey:
-		v := h.JWSkeyID
+		v := h.keyID
 		if v == "" {
 			return nil, false
 		}
 		return v, true
 	case TypeKey:
-		v := h.JWStyp
+		v := h.typ
 		if v == "" {
 			return nil, false
 		}
 		return v, true
 	case X509CertChainKey:
-		v := h.JWSx509CertChain
+		v := h.x509CertChain
 		if len(v) == 0 {
 			return nil, false
 		}
 		return v, true
 	case X509CertThumbprintKey:
-		v := h.JWSx509CertThumbprint
+		v := h.x509CertThumbprint
 		if v == "" {
 			return nil, false
 		}
 		return v, true
 	case X509CertThumbprintS256Key:
-		v := h.JWSx509CertThumbprintS256
+		v := h.x509CertThumbprintS256
 		if v == "" {
 			return nil, false
 		}
 		return v, true
 	case X509URLKey:
-		v := h.JWSx509URL
+		v := h.x509URL
 		if v == "" {
 			return nil, false
 		}
@@ -136,71 +224,71 @@ func (h *StandardHeaders) Get(name string) (interface{}, bool) {
 	}
 }
 
-func (h *StandardHeaders) Set(name string, value interface{}) error {
+func (h *stdHeaders) Set(name string, value interface{}) error {
 	switch name {
 	case AlgorithmKey:
-		if err := h.JWSalgorithm.Accept(value); err != nil {
+		if err := h.algorithm.Accept(value); err != nil {
 			return errors.Wrapf(err, `invalid value for %s key`, AlgorithmKey)
 		}
 		return nil
 	case ContentTypeKey:
 		if v, ok := value.(string); ok {
-			h.JWScontentType = v
+			h.contentType = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, ContentTypeKey, value)
 	case CriticalKey:
 		if v, ok := value.([]string); ok {
-			h.JWScritical = v
+			h.critical = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, CriticalKey, value)
 	case JWKKey:
 		v, ok := value.(jwk.Key)
 		if ok {
-			h.JWSjwk = v
+			h.jwk = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, JWKKey, value)
 	case JWKSetURLKey:
 		if v, ok := value.(string); ok {
-			h.JWSjwkSetURL = v
+			h.jwkSetURL = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, JWKSetURLKey, value)
 	case KeyIDKey:
 		if v, ok := value.(string); ok {
-			h.JWSkeyID = v
+			h.keyID = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, KeyIDKey, value)
 	case TypeKey:
 		if v, ok := value.(string); ok {
-			h.JWStyp = v
+			h.typ = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, TypeKey, value)
 	case X509CertChainKey:
 		if v, ok := value.([]string); ok {
-			h.JWSx509CertChain = v
+			h.x509CertChain = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, X509CertChainKey, value)
 	case X509CertThumbprintKey:
 		if v, ok := value.(string); ok {
-			h.JWSx509CertThumbprint = v
+			h.x509CertThumbprint = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, X509CertThumbprintKey, value)
 	case X509CertThumbprintS256Key:
 		if v, ok := value.(string); ok {
-			h.JWSx509CertThumbprintS256 = v
+			h.x509CertThumbprintS256 = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, X509CertThumbprintS256Key, value)
 	case X509URLKey:
 		if v, ok := value.(string); ok {
-			h.JWSx509URL = v
+			h.x509URL = v
 			return nil
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, X509URLKey, value)
@@ -213,34 +301,34 @@ func (h *StandardHeaders) Set(name string, value interface{}) error {
 	return nil
 }
 
-func (h *StandardHeaders) UnmarshalJSON(buf []byte) error {
+func (h *stdHeaders) UnmarshalJSON(buf []byte) error {
 	var proxy standardHeadersUnmarshalProxy
 	if err := json.Unmarshal(buf, &proxy); err != nil {
 		return errors.Wrap(err, `failed to unmarshal headers`)
 	}
 
 	if h == nil {
-		h = &StandardHeaders{}
+		h = &stdHeaders{}
 	}
 
-	h.JWSjwk = nil
-	if jwkField := proxy.JWSjwk; len(jwkField) > 0 {
-		set, err := jwk.ParseBytes([]byte(proxy.JWSjwk))
+	h.jwk = nil
+	if jwkField := proxy.Xjwk; len(jwkField) > 0 {
+		set, err := jwk.ParseBytes([]byte(proxy.Xjwk))
 		if err != nil {
 			return errors.Wrap(err, `failed to parse jwk field`)
 		}
-		h.JWSjwk = set.Keys[0]
+		h.jwk = set.Keys[0]
 	}
-	h.JWSalgorithm = proxy.JWSalgorithm
-	h.JWScontentType = proxy.JWScontentType
-	h.JWScritical = proxy.JWScritical
-	h.JWSjwkSetURL = proxy.JWSjwkSetURL
-	h.JWSkeyID = proxy.JWSkeyID
-	h.JWStyp = proxy.JWStyp
-	h.JWSx509CertChain = proxy.JWSx509CertChain
-	h.JWSx509CertThumbprint = proxy.JWSx509CertThumbprint
-	h.JWSx509CertThumbprintS256 = proxy.JWSx509CertThumbprintS256
-	h.JWSx509URL = proxy.JWSx509URL
-	h.privateParams = proxy.privateParams
+	h.algorithm = proxy.Xalgorithm
+	h.contentType = proxy.XcontentType
+	h.critical = proxy.Xcritical
+	h.jwkSetURL = proxy.XjwkSetURL
+	h.keyID = proxy.XkeyID
+	h.typ = proxy.Xtyp
+	h.x509CertChain = proxy.Xx509CertChain
+	h.x509CertThumbprint = proxy.Xx509CertThumbprint
+	h.x509CertThumbprintS256 = proxy.Xx509CertThumbprintS256
+	h.x509URL = proxy.Xx509URL
+	h.privateParams = proxy.PrivateParams
 	return nil
 }

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"
@@ -394,9 +395,9 @@ func (h stdHeaders) MarshalJSON() ([]byte, error) {
 	if err := enc.Encode(proxy); err != nil {
 		return nil, errors.Wrap(err, `failed to encode proxy to JSON`)
 	}
-	buf.Truncate(buf.Len() - 1)
 	if l := len(h.privateParams); l > 0 {
-		keys := make([]string, l)
+		buf.Truncate(buf.Len() - 2)
+		keys := make([]string, 0, l)
 		for k := range h.privateParams {
 			keys = append(keys, k)
 		}
@@ -404,9 +405,10 @@ func (h stdHeaders) MarshalJSON() ([]byte, error) {
 		for i, k := range keys {
 			if i > 0 {
 				fmt.Fprintf(&buf, `,`)
-				if err := enc.Encode(h.privateParams[k]); err != nil {
-					return nil, errors.Wrapf(err, `failed to encode private param %s`, k)
-				}
+			}
+			fmt.Fprintf(&buf, `%s:`, strconv.Quote(k))
+			if err := enc.Encode(h.privateParams[k]); err != nil {
+				return nil, errors.Wrapf(err, `failed to encode private param %s`, k)
 			}
 		}
 		fmt.Fprintf(&buf, `}`)

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -40,9 +40,9 @@ type Headers interface {
 	X509CertThumbprint() string
 	X509CertThumbprintS256() string
 	X509URL() string
-	Iterate(ctx context.Context) <-chan *HeaderPair
+	Iterate(ctx context.Context) Iterator
 	Walk(ctx context.Context, v Visitor) error
-	AsMap(ctx context.Context) map[string]interface{}
+	AsMap(ctx context.Context) (map[string]interface{}, error)
 	Get(string) (interface{}, bool)
 	Set(string, interface{}) error
 }
@@ -128,40 +128,40 @@ func (h *stdHeaders) X509URL() string {
 func (h *stdHeaders) iterate(ctx context.Context, ch chan *HeaderPair) {
 	var pairs []*HeaderPair
 	if h.algorithm != "" {
-		pairs = append(pairs, &HeaderPair{Name: "alg", Value: h.algorithm})
+		pairs = append(pairs, &HeaderPair{Key: "alg", Value: h.algorithm})
 	}
 	if h.contentType != "" {
-		pairs = append(pairs, &HeaderPair{Name: "cty", Value: h.contentType})
+		pairs = append(pairs, &HeaderPair{Key: "cty", Value: h.contentType})
 	}
 	if len(h.critical) > 0 {
-		pairs = append(pairs, &HeaderPair{Name: "crit", Value: h.critical})
+		pairs = append(pairs, &HeaderPair{Key: "crit", Value: h.critical})
 	}
 	if h.jwk != nil {
-		pairs = append(pairs, &HeaderPair{Name: "jwk", Value: h.jwk})
+		pairs = append(pairs, &HeaderPair{Key: "jwk", Value: h.jwk})
 	}
 	if h.jwkSetURL != "" {
-		pairs = append(pairs, &HeaderPair{Name: "jku", Value: h.jwkSetURL})
+		pairs = append(pairs, &HeaderPair{Key: "jku", Value: h.jwkSetURL})
 	}
 	if h.keyID != "" {
-		pairs = append(pairs, &HeaderPair{Name: "kid", Value: h.keyID})
+		pairs = append(pairs, &HeaderPair{Key: "kid", Value: h.keyID})
 	}
 	if h.typ != "" {
-		pairs = append(pairs, &HeaderPair{Name: "typ", Value: h.typ})
+		pairs = append(pairs, &HeaderPair{Key: "typ", Value: h.typ})
 	}
 	if len(h.critical) > 0 {
-		pairs = append(pairs, &HeaderPair{Name: "x5c", Value: h.x509CertChain})
+		pairs = append(pairs, &HeaderPair{Key: "x5c", Value: h.x509CertChain})
 	}
 	if h.x509CertThumbprint != "" {
-		pairs = append(pairs, &HeaderPair{Name: "x5t", Value: h.x509CertThumbprint})
+		pairs = append(pairs, &HeaderPair{Key: "x5t", Value: h.x509CertThumbprint})
 	}
 	if h.x509CertThumbprintS256 != "" {
-		pairs = append(pairs, &HeaderPair{Name: "x5t#S256", Value: h.x509CertThumbprintS256})
+		pairs = append(pairs, &HeaderPair{Key: "x5t#S256", Value: h.x509CertThumbprintS256})
 	}
 	if h.x509URL != "" {
-		pairs = append(pairs, &HeaderPair{Name: "x5u", Value: h.x509URL})
+		pairs = append(pairs, &HeaderPair{Key: "x5u", Value: h.x509URL})
 	}
 	for k, v := range h.privateParams {
-		pairs = append(pairs, &HeaderPair{Name: k, Value: v})
+		pairs = append(pairs, &HeaderPair{Key: k, Value: v})
 	}
 	for _, pair := range pairs {
 		select {

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -126,6 +126,7 @@ func (h *stdHeaders) X509URL() string {
 }
 
 func (h *stdHeaders) iterate(ctx context.Context, ch chan *HeaderPair) {
+	defer close(ch)
 	var pairs []*HeaderPair
 	if h.algorithm != "" {
 		pairs = append(pairs, &HeaderPair{Key: "alg", Value: h.algorithm})
@@ -148,7 +149,7 @@ func (h *stdHeaders) iterate(ctx context.Context, ch chan *HeaderPair) {
 	if h.typ != "" {
 		pairs = append(pairs, &HeaderPair{Key: "typ", Value: h.typ})
 	}
-	if len(h.critical) > 0 {
+	if len(h.x509CertChain) > 0 {
 		pairs = append(pairs, &HeaderPair{Key: "x5c", Value: h.x509CertChain})
 	}
 	if h.x509CertThumbprint != "" {

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -38,9 +38,22 @@ func TestHeader(t *testing.T) {
 		jws.X509CertThumbprintKey: "QzY0NjREMjkyQTI4RTU2RkE4MUJBRDExNzY1MUY1N0I4QjFCODlBOQ",
 		jws.X509URLKey:            "https://www.x509.com/key.pem",
 	}
-	t.Run("Roundtrip", func(t *testing.T) {
 
-		var h jws.StandardHeaders
+	t.Run("Type", func(t *testing.T) {
+		var h jws.Headers = jws.NewHeaders()
+		_ = h
+	})
+	t.Run("Sanity", func(t *testing.T) {
+		h := jws.NewHeaders()
+		if !assert.NoError(t, json.Unmarshal([]byte(publicKey), h), "unmarshal public key should succeed") {
+			return
+		}
+		if !assert.NotEmpty(t, h.KeyID()) { // これあったっけ…
+			return
+		}
+	})
+	t.Run("Roundtrip", func(t *testing.T) {
+		h := jws.NewHeaders()
 		for k, v := range values {
 			if !assert.NoError(t, h.Set(k, v), "h.Set should succeed for %s", k) {
 				return
@@ -57,7 +70,7 @@ func TestHeader(t *testing.T) {
 		}
 	})
 	t.Run("JSON Roundtrip", func(t *testing.T) {
-		var h jws.StandardHeaders
+		h := jws.NewHeaders()
 		for k, v := range values {
 			err := h.Set(k, v)
 			if err != nil {
@@ -75,7 +88,7 @@ func TestHeader(t *testing.T) {
 		if err != nil {
 			t.Fatal("Failed to JSON marshal")
 		}
-		var hNew jws.StandardHeaders
+		hNew := jws.NewHeaders()
 
 		if !assert.NoError(t, json.Unmarshal(hByte, &hNew), "json.Unmarshal should succeed for headers") {
 			return
@@ -103,7 +116,7 @@ func TestHeader(t *testing.T) {
 			jws.X509URLKey:                dummy,
 		}
 
-		var h jws.StandardHeaders
+		h := jws.NewHeaders()
 		for k, v := range values {
 			err := h.Set(k, v)
 			if err == nil {

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -74,6 +74,14 @@ func TestHeader(t *testing.T) {
 				return
 			}
 		}
+
+		buf, err := json.Marshal(h)
+		if !assert.NoError(t, err, `json.Marshal should succeed`) {
+			return
+		}
+		if !assert.Equal(t, `{"bar":"two","baz":true,"foo":1}`, string(buf), `json.Marshal should succeed`) {
+			return
+		}
 	})
 	t.Run("Roundtrip", func(t *testing.T) {
 		h := jws.NewHeaders()

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -52,6 +52,29 @@ func TestHeader(t *testing.T) {
 			return
 		}
 	})
+	t.Run("Private parameters", func(t *testing.T) {
+		const src = `{ "foo": 1, "bar": "two", "baz": true }`
+		h := jws.NewHeaders()
+		if !assert.NoError(t, json.Unmarshal([]byte(src), h), "unmarshal should succeed") {
+			return
+		}
+
+		expected := map[string]interface{}{
+			"foo": 1.0, // JSON has no such thing as integers here
+			"bar": "two",
+			"baz": true,
+		}
+
+		for key, value := range expected {
+			v, ok := h.Get(key)
+			if !assert.True(t, ok, `h.Get(%#v) should succeed`, key) {
+				return
+			}
+			if !assert.Equal(t, v, value, `h.Get(%#v) should return %#v`, key, value) {
+				return
+			}
+		}
+	})
 	t.Run("Roundtrip", func(t *testing.T) {
 		h := jws.NewHeaders()
 		for k, v := range values {

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -127,7 +127,7 @@ func TestHeader(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Setting %s value failed", "default")
 		}
-		for k, _ := range values {
+		for k := range values {
 			_, ok := h.Get(k)
 			if ok {
 				t.Fatalf("Getting %s value should have failed", k)

--- a/jws/interface.go
+++ b/jws/interface.go
@@ -6,10 +6,6 @@ import (
 )
 
 type encodedSignature struct {
-	// このあたりは古いコードで、jws.Headersがひどい形だったので
-	// interfaceにして外から見えるフィールドを極力少なくしたい
-	// と思って変えていたら、さて、このHeadersはどうしようか、
-	// となってます。
 	Protected string  `json:"protected,omitempty"`
 	Headers   Headers `json:"header,omitempty"`
 	Signature string  `json:"signature,omitempty"`

--- a/jws/interface.go
+++ b/jws/interface.go
@@ -6,15 +6,20 @@ import (
 )
 
 type EncodedSignature struct {
-	Protected string          `json:"protected,omitempty"`
+	// このあたりは古いコードで、jws.Headersがひどい形だったので
+	// interfaceにして外から見えるフィールドを極力少なくしたい
+	// と思って変えていたら、さて、このHeadersはどうしようか、
+	// となってます。
+	Protected string  `json:"protected,omitempty"`
 	Headers   Headers `json:"header,omitempty"`
-	Signature string          `json:"signature,omitempty"`
+	Signature string  `json:"signature,omitempty"`
 }
 
+// XXX: KILL ME
 type EncodedSignatureUnmarshalProxy struct {
-	Protected string           `json:"protected,omitempty"`
-	Headers   *StandardHeaders `json:"header,omitempty"`
-	Signature string           `json:"signature,omitempty"`
+	Protected string  `json:"protected,omitempty"`
+	Headers   Headers `json:"header,omitempty"`
+	Signature string  `json:"signature,omitempty"`
 }
 
 type EncodedMessage struct {
@@ -22,6 +27,7 @@ type EncodedMessage struct {
 	Signatures []*EncodedSignature `json:"signatures,omitempty"`
 }
 
+// XXX: KILL ME
 type EncodedMessageUnmarshalProxy struct {
 	Payload    string                            `json:"payload"`
 	Signatures []*EncodedSignatureUnmarshalProxy `json:"signatures,omitempty"`
@@ -32,6 +38,7 @@ type FullEncodedMessage struct {
 	*EncodedMessage
 }
 
+// XXX: KILL ME
 type FullEncodedMessageUnmarshalProxy struct {
 	*EncodedSignatureUnmarshalProxy // embedded to pick up flattened JSON message
 	*EncodedMessageUnmarshalProxy
@@ -62,7 +69,7 @@ type Message struct {
 type Signature struct {
 	headers   Headers `json:"header,omitempty"`    // Unprotected Headers
 	protected Headers `json:"protected,omitempty"` // Protected Headers
-	signature []byte          `json:"signature,omitempty"` // Signature
+	signature []byte  `json:"signature,omitempty"` // Signature
 }
 
 // JWKAcceptor decides which keys can be accepted
@@ -89,3 +96,14 @@ var DefaultJWKAcceptor = JWKAcceptFunc(func(key jwk.Key) bool {
 	}
 	return true
 })
+
+type Visitor interface {
+	Visit(string, interface{}) error
+}
+
+type VisitFunc func(string, interface{}) error
+
+type HeaderPair struct {
+	Name string
+	Value interface{}
+}

--- a/jws/interface.go
+++ b/jws/interface.go
@@ -5,7 +5,7 @@ import (
 	"github.com/lestrrat-go/jwx/jwk"
 )
 
-type EncodedSignature struct {
+type encodedSignature struct {
 	// このあたりは古いコードで、jws.Headersがひどい形だったので
 	// interfaceにして外から見えるフィールドを極力少なくしたい
 	// と思って変えていたら、さて、このHeadersはどうしようか、
@@ -15,33 +15,9 @@ type EncodedSignature struct {
 	Signature string  `json:"signature,omitempty"`
 }
 
-// XXX: KILL ME
-type EncodedSignatureUnmarshalProxy struct {
-	Protected string  `json:"protected,omitempty"`
-	Headers   Headers `json:"header,omitempty"`
-	Signature string  `json:"signature,omitempty"`
-}
-
-type EncodedMessage struct {
+type encodedMessage struct {
 	Payload    string              `json:"payload"`
-	Signatures []*EncodedSignature `json:"signatures,omitempty"`
-}
-
-// XXX: KILL ME
-type EncodedMessageUnmarshalProxy struct {
-	Payload    string                            `json:"payload"`
-	Signatures []*EncodedSignatureUnmarshalProxy `json:"signatures,omitempty"`
-}
-
-type FullEncodedMessage struct {
-	*EncodedSignature // embedded to pick up flattened JSON message
-	*EncodedMessage
-}
-
-// XXX: KILL ME
-type FullEncodedMessageUnmarshalProxy struct {
-	*EncodedSignatureUnmarshalProxy // embedded to pick up flattened JSON message
-	*EncodedMessageUnmarshalProxy
+	Signatures []*encodedSignature `json:"signatures,omitempty"`
 }
 
 // PayloadSigner generates signature for the given payload

--- a/jws/interface.go
+++ b/jws/interface.go
@@ -1,6 +1,8 @@
 package jws
 
 import (
+	"github.com/lestrrat-go/iter/mapiter"
+	"github.com/lestrrat-go/jwx/internal/iter"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"
 )
@@ -69,13 +71,7 @@ var DefaultJWKAcceptor = JWKAcceptFunc(func(key jwk.Key) bool {
 	return true
 })
 
-type Visitor interface {
-	Visit(string, interface{}) error
-}
-
-type VisitFunc func(string, interface{}) error
-
-type HeaderPair struct {
-	Name string
-	Value interface{}
-}
+type Visitor = iter.MapVisitor
+type VisitorFunc = iter.MapVisitorFunc
+type HeaderPair = mapiter.Pair
+type Iterator = mapiter.Iterator

--- a/jws/internal/cmd/genheader/main.go
+++ b/jws/internal/cmd/genheader/main.go
@@ -187,9 +187,9 @@ func generateHeaders() error {
 	}
 
 	// These are used to iterate through all keys in a header
-	fmt.Fprintf(&buf, "\nIterate(ctx context.Context) <-chan *HeaderPair")
+	fmt.Fprintf(&buf, "\nIterate(ctx context.Context) Iterator")
 	fmt.Fprintf(&buf, "\nWalk(ctx context.Context, v Visitor) error")
-	fmt.Fprintf(&buf, "\nAsMap(ctx context.Context) map[string]interface{}")
+	fmt.Fprintf(&buf, "\nAsMap(ctx context.Context) (map[string]interface{}, error)")
 
 	// These are used to access a single element by key name
 	fmt.Fprintf(&buf, "\nGet(string) (interface{}, bool)")
@@ -241,11 +241,11 @@ func generateHeaders() error {
 		default:
 			fmt.Fprintf(&buf, "\nif h.%s != \"\" {", f.name)
 		}
-		fmt.Fprintf(&buf, "\npairs = append(pairs, &HeaderPair{Name: %s, Value: h.%s})", strconv.Quote(f.key), f.name)
+		fmt.Fprintf(&buf, "\npairs = append(pairs, &HeaderPair{Key: %s, Value: h.%s})", strconv.Quote(f.key), f.name)
 		fmt.Fprintf(&buf, "\n}")
 	}
 	fmt.Fprintf(&buf, "\nfor k, v := range h.privateParams {")
-	fmt.Fprintf(&buf, "\npairs = append(pairs, &HeaderPair{Name: k, Value: v})")
+	fmt.Fprintf(&buf, "\npairs = append(pairs, &HeaderPair{Key: k, Value: v})")
 	fmt.Fprintf(&buf, "\n}")
 	fmt.Fprintf(&buf, "\nfor _, pair := range pairs {")
 	fmt.Fprintf(&buf, "\nselect {")

--- a/jws/internal/cmd/genheader/main.go
+++ b/jws/internal/cmd/genheader/main.go
@@ -233,9 +233,16 @@ func generateHeaders() error {
 	// NOTE: building up an array is *slow*?
 	fmt.Fprintf(&buf, "\nvar pairs []*HeaderPair")
 	for _, f := range fields {
-		// TODO: need to check if values are acutally set?
-		// meh, that means we need to struct { foo *Type } instead of struct {foo Type} 
+		switch f.name {
+		case "jwk":
+			fmt.Fprintf(&buf, "\nif h.jwk != nil {")
+		case "critical", "x509CertChain":
+			fmt.Fprintf(&buf, "\nif len(h.critical) > 0 {")
+		default:
+			fmt.Fprintf(&buf, "\nif h.%s != \"\" {", f.name)
+		}
 		fmt.Fprintf(&buf, "\npairs = append(pairs, &HeaderPair{Name: %s, Value: h.%s})", strconv.Quote(f.key), f.name)
+		fmt.Fprintf(&buf, "\n}")
 	}
 	fmt.Fprintf(&buf, "\nfor k, v := range h.privateParams {")
 	fmt.Fprintf(&buf, "\npairs = append(pairs, &HeaderPair{Name: k, Value: v})")

--- a/jws/internal/cmd/genheader/main.go
+++ b/jws/internal/cmd/genheader/main.go
@@ -158,8 +158,7 @@ func generateHeaders() error {
 	fmt.Fprintf(&buf, "\n// This file is auto-generated. DO NOT EDIT")
 	fmt.Fprintf(&buf, "\npackage jws")
 	fmt.Fprintf(&buf, "\n\nimport (")
-
-	stdimports := []string{"bytes", "context", "encoding/json", "fmt", "sort"}
+	stdimports := []string{"bytes", "context", "encoding/json", "fmt", "sort", "strconv"}
 	extimports := []string{"github.com/lestrrat-go/jwx/jwa", "github.com/lestrrat-go/jwx/jwk", "github.com/pkg/errors"}
 
 	for _, pkg := range stdimports {
@@ -381,9 +380,9 @@ func generateHeaders() error {
 	fmt.Fprintf(&buf, "\nif err := enc.Encode(proxy); err != nil {")
 	fmt.Fprintf(&buf, "\nreturn nil, errors.Wrap(err, `failed to encode proxy to JSON`)")
 	fmt.Fprintf(&buf, "\n}")
-	fmt.Fprintf(&buf, "\nbuf.Truncate(buf.Len()-1)")
 	fmt.Fprintf(&buf, "\nif l := len(h.privateParams); l> 0 {")
-	fmt.Fprintf(&buf, "\nkeys := make([]string, l)")
+	fmt.Fprintf(&buf, "\nbuf.Truncate(buf.Len()-2)")
+	fmt.Fprintf(&buf, "\nkeys := make([]string, 0, l)")
 	fmt.Fprintf(&buf, "\nfor k := range h.privateParams {")
 	fmt.Fprintf(&buf, "\nkeys = append(keys, k)")
 	fmt.Fprintf(&buf, "\n}")
@@ -391,9 +390,10 @@ func generateHeaders() error {
 	fmt.Fprintf(&buf, "\nfor i, k := range keys {")
 	fmt.Fprintf(&buf, "\nif i > 0 {")
 	fmt.Fprintf(&buf, "\nfmt.Fprintf(&buf, `,`)")
+	fmt.Fprintf(&buf, "\n}")
+	fmt.Fprintf(&buf, "\nfmt.Fprintf(&buf, `%%s:`, strconv.Quote(k))")
 	fmt.Fprintf(&buf, "\nif err := enc.Encode(h.privateParams[k]); err != nil {")
 	fmt.Fprintf(&buf, "\nreturn nil, errors.Wrapf(err, `failed to encode private param %%s`, k)")
-	fmt.Fprintf(&buf, "\n}")
 	fmt.Fprintf(&buf, "\n}")
 	fmt.Fprintf(&buf, "\n}")
 	fmt.Fprintf(&buf, "\nfmt.Fprintf(&buf, `}`)")

--- a/jws/internal/cmd/genheader/main.go
+++ b/jws/internal/cmd/genheader/main.go
@@ -237,7 +237,7 @@ func generateHeaders() error {
 		case "jwk":
 			fmt.Fprintf(&buf, "\nif h.jwk != nil {")
 		case "critical", "x509CertChain":
-			fmt.Fprintf(&buf, "\nif len(h.critical) > 0 {")
+			fmt.Fprintf(&buf, "\nif len(h.%s) > 0 {", f.name)
 		default:
 			fmt.Fprintf(&buf, "\nif h.%s != \"\" {", f.name)
 		}

--- a/jws/internal/cmd/genheader/main.go
+++ b/jws/internal/cmd/genheader/main.go
@@ -229,6 +229,7 @@ func generateHeaders() error {
 	// Generate a function that iterates through all of the keys
 	// in this header.
 	fmt.Fprintf(&buf, "\n\nfunc (h *stdHeaders) iterate(ctx context.Context, ch chan *HeaderPair) {")
+	fmt.Fprintf(&buf, "\ndefer close(ch)")
 
 	// NOTE: building up an array is *slow*?
 	fmt.Fprintf(&buf, "\nvar pairs []*HeaderPair")

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -203,7 +203,7 @@ func SignMulti(payload []byte, options ...Option) ([]byte, error) {
 		return nil, errors.New(`no signers provided`)
 	}
 
-	var result EncodedMessage
+	var result encodedMessage
 
 	result.Payload = base64.RawURLEncoding.EncodeToString(payload)
 
@@ -229,7 +229,7 @@ func SignMulti(payload []byte, options ...Option) ([]byte, error) {
 			return nil, errors.Wrap(err, `failed to sign payload`)
 		}
 
-		result.Signatures = append(result.Signatures, &EncodedSignature{
+		result.Signatures = append(result.Signatures, &encodedSignature{
 			Headers:   signer.PublicHeader(),
 			Protected: encodedHeader,
 			Signature: base64.RawURLEncoding.EncodeToString(signature),
@@ -438,12 +438,12 @@ type fullMessageProxy struct {
 	Protected json.RawMessage `json:"protected"`
 
 	// encoded message fields
-	Signatures []*EncodedSignature `json:"signatures"`
+	Signatures []*encodedSignature `json:"signatures"`
 	Payload    string              `json:"payload"`
 }
 
-func (proxy *fullMessageProxy) encodedSignature() (*EncodedSignature, error) {
-	var encodedSig EncodedSignature
+func (proxy *fullMessageProxy) encodedSignature() (*encodedSignature, error) {
+	var encodedSig encodedSignature
 	if err := json.Unmarshal(proxy.Protected, &encodedSig.Protected); err != nil {
 		return nil, errors.Wrap(err, `failed to unmarshal 'protected' field`)
 	}

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -268,7 +268,7 @@ func Verify(buf []byte, alg jwa.SignatureAlgorithm, key interface{}) (ret []byte
 			return nil, errors.New(`invalid JWS message format (missing payload)`)
 		}
 
-		// if we're using the flattened serialization format, then m.Signature
+		// if we're using the compact serialization format, then m.Signature
 		// will be non-nil
 		if len(proxy.Signature) > 0 {
 			if len(proxy.Signatures) > 0 {
@@ -466,7 +466,7 @@ func parseJSON(src io.Reader) (result *Message, err error) {
 
 	if len(proxy.Signature) > 0 {
 		if len(proxy.Signatures) > 0 {
-			return nil, errors.New("invalid message: mixed flattened/full json serialization")
+			return nil, errors.New("invalid message: mixed compact/full json serialization")
 		}
 
 		encodedSig, err := proxy.encodedSignature()

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -313,7 +313,7 @@ func TestEncode(t *testing.T) {
 		if err != nil {
 			t.Fatal("Failed to base64 encode protected header")
 		}
-		standardHeaders := &jws.StandardHeaders{}
+		standardHeaders := jws.NewHeaders()
 		err = json.Unmarshal(hdrBytes, standardHeaders)
 		if err != nil {
 			t.Fatal("Failed to parse protected header")
@@ -382,7 +382,7 @@ func TestEncode(t *testing.T) {
 		// "Payload"
 		jwsPayload := []byte{80, 97, 121, 108, 111, 97, 100}
 
-		standardHeaders := &jws.StandardHeaders{}
+		standardHeaders := jws.NewHeaders()
 		err := json.Unmarshal(hdr, standardHeaders)
 		if err != nil {
 			t.Fatal("Failed to parse header")
@@ -434,9 +434,8 @@ func TestEncode(t *testing.T) {
 		)
 		hashed512 := sha512.Sum512(jwsSigningInput)
 		ecdsaPrivateKey := key.(*ecdsa.PrivateKey)
-		verified := ecdsa.Verify(&ecdsaPrivateKey.PublicKey, hashed512[:], r, s)
-		if !verified {
-			t.Fatal("Failed to verify message")
+		if !assert.True(t, ecdsa.Verify(&ecdsaPrivateKey.PublicKey, hashed512[:], r, s), "ecdsa.Verify should succeed") {
+			return
 		}
 
 		// Verify with API library
@@ -678,6 +677,7 @@ func TestEncode(t *testing.T) {
 			return
 		}
 
+		t.Logf("%#v", m)
 		if !assert.Len(t, m.Signatures(), 2, "There should be 2 signatures") {
 			return
 		}
@@ -932,7 +932,7 @@ func TestGHIssue126(t *testing.T) {
 		return
 	}
 
-	if !assert.Equal(t, err.Error(), `invalid JWS message format`) {
+	if !assert.Equal(t, err.Error(), `invalid JWS message format (missing payload)`) {
 		return
 	}
 }

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -383,10 +383,10 @@ func TestEncode(t *testing.T) {
 		jwsPayload := []byte{80, 97, 121, 108, 111, 97, 100}
 
 		standardHeaders := jws.NewHeaders()
-		err := json.Unmarshal(hdr, standardHeaders)
-		if err != nil {
-			t.Fatal("Failed to parse header")
+		if !assert.NoError(t, json.Unmarshal(hdr, standardHeaders), `parsing headers should succeed`) {
+			return
 		}
+
 		alg := standardHeaders.Algorithm()
 
 		keys, err := jwk.ParseString(jwksrc)

--- a/jws/message.go
+++ b/jws/message.go
@@ -26,16 +26,16 @@ func (m Message) LookupSignature(kid string) []*Signature {
 	var sigs []*Signature
 	for _, sig := range m.signatures {
 		if hdr := sig.PublicHeaders(); hdr != nil {
-			hdrKeyId, ok := hdr.Get(KeyIDKey)
-			if ok && hdrKeyId == kid {
+			hdrKeyId := hdr.KeyID()
+			if hdrKeyId == kid {
 				sigs = append(sigs, sig)
 				continue
 			}
 		}
 
 		if hdr := sig.ProtectedHeaders(); hdr != nil {
-			hdrKeyId, ok := hdr.Get(KeyIDKey)
-			if ok && hdrKeyId == kid {
+			hdrKeyId := hdr.KeyID()
+			if hdrKeyId == kid {
 				sigs = append(sigs, sig)
 				continue
 			}

--- a/jws/signature.go
+++ b/jws/signature.go
@@ -12,7 +12,7 @@ type encodedSignatureProxy struct {
 	Signature string          `json:"signature,omitempty"`
 }
 
-func (sig *EncodedSignature) UnmarshalJSON(buf []byte) error {
+func (sig *encodedSignature) UnmarshalJSON(buf []byte) error {
 	var proxy encodedSignatureProxy
 	if err := json.Unmarshal(buf, &proxy); err != nil {
 		return errors.Wrap(err, `failed to unmarshal into temporary struct`)
@@ -24,10 +24,6 @@ func (sig *EncodedSignature) UnmarshalJSON(buf []byte) error {
 		if err := json.Unmarshal(proxy.Headers, h); err != nil {
 			return errors.Wrap(err, `failed to unmarshal headers`)
 		}
-	}
-
-	if sig == nil {
-		sig = &EncodedSignature{}
 	}
 
 	// XXX: sigh, dream of the day when we kill public fields

--- a/jws/signature.go
+++ b/jws/signature.go
@@ -1,0 +1,39 @@
+package jws
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+type encodedSignatureProxy struct {
+	Protected string          `json:"protected,omitempty"`
+	Headers   json.RawMessage `json:"header,omitempty"`
+	Signature string          `json:"signature,omitempty"`
+}
+
+func (sig *EncodedSignature) UnmarshalJSON(buf []byte) error {
+	var proxy encodedSignatureProxy
+	if err := json.Unmarshal(buf, &proxy); err != nil {
+		return errors.Wrap(err, `failed to unmarshal into temporary struct`)
+	}
+
+	var h Headers
+	if len(proxy.Headers) > 0 {
+		h = NewHeaders()
+		if err := json.Unmarshal(proxy.Headers, h); err != nil {
+			return errors.Wrap(err, `failed to unmarshal headers`)
+		}
+	}
+
+	if sig == nil {
+		sig = &EncodedSignature{}
+	}
+
+	// XXX: sigh, dream of the day when we kill public fields
+	sig.Protected = proxy.Protected
+	sig.Signature = proxy.Signature
+	sig.Headers = h
+
+	return nil
+}

--- a/jws/signer_test.go
+++ b/jws/signer_test.go
@@ -77,20 +77,20 @@ func TestSignMulti(t *testing.T) {
 	if !assert.NoError(t, err, "RSA Signer created") {
 		return
 	}
-	var s1hdr jws.StandardHeaders
+	s1hdr := jws.NewHeaders()
 	s1hdr.Set(jws.KeyIDKey, "2010-12-29")
 
 	s2, err := sign.New(jwa.ES256)
 	if !assert.NoError(t, err, "DSA Signer created") {
 		return
 	}
-	var s2hdr jws.StandardHeaders
+	s2hdr := jws.NewHeaders()
 	s2hdr.Set(jws.KeyIDKey, "e9bc097a-ce51-4036-9562-d2ade882db0d")
 
 	v := strings.Join([]string{`{"iss":"joe",`, ` "exp":1300819380,`, ` "http://example.com/is_root":true}`}, "\r\n")
 	m, err := jws.SignMulti([]byte(v),
-		jws.WithSigner(s1, rsakey, &s1hdr, nil),
-		jws.WithSigner(s2, dsakey, &s2hdr, nil),
+		jws.WithSigner(s1, rsakey, s1hdr, nil),
+		jws.WithSigner(s2, dsakey, s2hdr, nil),
 	)
 	if !assert.NoError(t, err, "jws.SignMulti should succeed") {
 		return

--- a/jwt/interface.go
+++ b/jwt/interface.go
@@ -1,3 +1,13 @@
 package jwt
 
+import (
+	"github.com/lestrrat-go/iter/mapiter"
+	"github.com/lestrrat-go/jwx/internal/iter"
+)
+
 type StringList []string
+
+type ClaimPair = mapiter.Pair
+type Iterator = mapiter.Iterator
+type Visitor = iter.MapVisitor
+type VisitorFunc iter.MapVisitorFunc

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -90,14 +90,14 @@ func (t *Token) Sign(method jwa.SignatureAlgorithm, key interface{}) ([]byte, er
 		return nil, errors.Wrap(err, `failed to marshal token`)
 	}
 
-	var hdr jws.StandardHeaders
+	hdr := jws.NewHeaders()
 	if hdr.Set(`alg`, method.String()) != nil {
 		return nil, errors.Wrap(err, `failed to sign payload`)
 	}
 	if hdr.Set(`typ`, `JWT`) != nil {
 		return nil, errors.Wrap(err, `failed to sign payload`)
 	}
-	sign, err := jws.Sign(buf, method, key, jws.WithHeaders(&hdr))
+	sign, err := jws.Sign(buf, method, key, jws.WithHeaders(hdr))
 	if err != nil {
 		return nil, errors.Wrap(err, `failed to sign payload`)
 	}

--- a/jwt/token_test.go
+++ b/jwt/token_test.go
@@ -178,8 +178,9 @@ func TestToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	for pair := range tok.Claims(ctx) {
-		t.Logf("%s -> %v", pair.Name, pair.Value)
+	for iter := tok.Iterate(ctx); iter.Next(ctx); {
+		pair := iter.Pair()
+		t.Logf("%s -> %v", pair.Key, pair.Value)
 	}
 
 	m, err := tok.AsMap(ctx)


### PR DESCRIPTION
fixes #149

# what's new

* API to iterate all headers pairs in a header
* API to access common headers (e.g. `h.Algorithm()`, `h.KeyID()`, etc.)

# what's changed

* Public fields have all been changed to private fields
* Types which didn't need to be public have been either removed or unexported
* `jws.Header` is now an interface. `jws.StandardHeader` no longer exists
* `jwt` Iterator API has been changed to conform with the new API for `jws`