### PR TITLE
Sign a token directly with a JWT key

### DIFF
--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -355,6 +355,8 @@ func TestSignWithKey(t *testing.T) {
 	assert.Nil(t, err)
 
 	header, err := jws.ParseString(string(signed))
+	assert.Nil(t, err)
+
 	signatures := header.LookupSignature("test")
 	assert.Len(t, signatures, 1)
 }

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -338,3 +338,23 @@ func TestSignErrors(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "missing private key")
 }
+
+func TestSignWithKey(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(t, err)
+
+	key := jwk.NewRSAPrivateKey()
+	err = key.FromRaw(priv)
+	assert.Nil(t, err)
+
+	key.Set(jwk.KeyIDKey, "test")
+	key.Set(jwk.AlgorithmKey, jwa.RS256)
+
+	tok := jwt.New()
+	signed, err := jwt.SignWithKey(tok, key)
+	assert.Nil(t, err)
+
+	header, err := jws.ParseString(string(signed))
+	signatures := header.LookupSignature("test")
+	assert.Len(t, signatures, 1)
+}


### PR DESCRIPTION
Hello, 

I used this module today for the first time.
One thing was confusing. Why can't I sign a token directly with an given JWT Key?
If you have a valid Key (from a private KeySet) it should be straight forward to us this key to sing a token.
This pull request adds a new "SignWithKey" function that makes that easy.

Regards