### PR TITLE
Allow jwt.Parse using JWKS to use default single key when no kid in JWT header

### DIFF
--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -150,6 +150,22 @@ func TestJWTParseVerify(t *testing.T) {
 				return
 			}
 		})
+		t.Run("No kid should fail", func(t *testing.T) {
+			pubkey := jwk.NewRSAPublicKey()
+			if !assert.NoError(t, pubkey.FromRaw(&key.PublicKey)) {
+				return
+			}
+
+			pubkey.Set(jwk.KeyIDKey, kid)
+			signedNoKid, err := jwt.Sign(t1, alg, key)
+			if err != nil {
+				t.Fatal("Failed to sign JWT")
+			}
+			_, err = jwt.Parse(bytes.NewReader(signedNoKid), jwt.WithKeySet(&jwk.Set{Keys: []jwk.Key{pubkey}}))
+			if !assert.Error(t, err, `jwt.Parse should fail`) {
+				return
+			}
+		})
 		t.Run("Pick default key from set of 1", func(t *testing.T) {
 			pubkey := jwk.NewRSAPublicKey()
 			if !assert.NoError(t, pubkey.FromRaw(&key.PublicKey)) {

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -150,6 +150,46 @@ func TestJWTParseVerify(t *testing.T) {
 				return
 			}
 		})
+		t.Run("Pick default key from set of 1", func(t *testing.T) {
+			pubkey := jwk.NewRSAPublicKey()
+			if !assert.NoError(t, pubkey.FromRaw(&key.PublicKey)) {
+				return
+			}
+
+			pubkey.Set(jwk.KeyIDKey, kid)
+			signedNoKid, err := jwt.Sign(t1, alg, key)
+			if err != nil {
+				t.Fatal("Failed to sign JWT")
+			}
+			t2, err := jwt.Parse(bytes.NewReader(signedNoKid), jwt.WithKeySet(&jwk.Set{Keys: []jwk.Key{pubkey}}), jwt.UseDefaultKey(true))
+			if !assert.NoError(t, err, `jwt.Parse with key set should succeed`) {
+				return
+			}
+			if !assert.Equal(t, t1, t2, `t1 == t2`) {
+				return
+			}
+		})
+		t.Run("UseDefault with multiple keys should fail", func(t *testing.T) {
+			pubkey1 := jwk.NewRSAPublicKey()
+			if !assert.NoError(t, pubkey1.FromRaw(&key.PublicKey)) {
+				return
+			}
+			pubkey2 := jwk.NewRSAPublicKey()
+			if !assert.NoError(t, pubkey2.FromRaw(&key.PublicKey)) {
+				return
+			}
+
+			pubkey1.Set(jwk.KeyIDKey, kid)
+			pubkey2.Set(jwk.KeyIDKey, "test-jwt-parse-verify-kid-2")
+			signedNoKid, err := jwt.Sign(t1, alg, key)
+			if err != nil {
+				t.Fatal("Failed to sign JWT")
+			}
+			_, err = jwt.Parse(bytes.NewReader(signedNoKid), jwt.WithKeySet(&jwk.Set{Keys: []jwk.Key{pubkey1, pubkey2}}), jwt.UseDefaultKey(true))
+			if !assert.Error(t, err, `jwt.Parse should fail`) {
+				return
+			}
+		})
 	})
 
 	// This is a test to check if we allow alg: none in the protected header section.

--- a/jwt/options.go
+++ b/jwt/options.go
@@ -15,6 +15,7 @@ const (
 	optkeyToken   = `token`
 	optkeyKeySet  = `keySet`
 	optkeyHeaders = `headers`
+	optkeyDefault = `defaultKey`
 )
 
 type VerifyParameters interface {
@@ -51,6 +52,14 @@ func WithVerify(alg jwa.SignatureAlgorithm, key interface{}) Option {
 // give keys.
 func WithKeySet(set *jwk.Set) Option {
 	return option.New(optkeyKeySet, set)
+}
+
+// UseDefaultKey is used in conjunction with the option WithKeySet
+// to instruct the Parse method to default to the single key in a key
+// set when no Key ID is included in the JWT. If the key set contains
+// multiple keys then the behaviour is unchanged.
+func UseDefaultKey(value bool) Option {
+	return option.New(optkeyDefault, value)
 }
 
 // WithToken specifies the token instance that is used when parsing


### PR DESCRIPTION
I believe it's standard practice that if a JWKS only contains a single key then the kid isn't necessarily required in the JWT header. The validation code can assume it should use the only available key.

However, I haven't read the spec so if this is not the case then please disregard this PR and I'll continue to use my fork.

To keep the API the same and not change existing behaviour I added a new option for jwt.Parse to allow this behaviour.

- If the useDefault flag is true and there's a single key in the set it'll use that to verify the token.
- If the useDefault flag is true and there's multiple keys in the set it'll error.
- If the useDefault flag is false then the behaviour is unchanged.

I wasn't sure on naming, **_With..._** didn't seem to fit the use case here, so I went with **_UseDefaultKey_**.