### PR TITLE
Add a way to configure the global behavior of json Marshaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,9 @@ func init()
 }
 ```
 
+Do be aware that this has *global* effect. All code that calls in to `encoding/json`
+within `jwx` *will* use your settings.
+
 ## Other related libraries:
 
 * https://github.com/dgrijalva/jwt-go

--- a/README.md
+++ b/README.md
@@ -359,6 +359,17 @@ Supported content encryption algorithm:
 
 PRs welcome to support missing algorithms!
 
+## Configuring JSON Parsing
+
+If you want to parse numbers in the incoming JSON objects as json.Number
+instead of floats, you can use the following call to globally affect the behavior of JSON parsing.
+
+```go
+func init()
+  jwx.DecoderSettings(jwx.WithUseNumber(true))
+}
+```
+
 ## Other related libraries:
 
 * https://github.com/dgrijalva/jwt-go

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -6,7 +6,8 @@ package buffer
 import (
 	"encoding/base64"
 	"encoding/binary"
-	"encoding/json"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/pkg/errors"
 )

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -13,13 +13,14 @@ type RawMessage = json.RawMessage
 var muGlobalConfig sync.RWMutex
 var useNumber bool
 
+// Sets the global configuration for json decoding
 func DecoderSettings(inUseNumber bool) {
 	muGlobalConfig.Lock()
 	useNumber = inUseNumber
 	muGlobalConfig.Unlock()
 }
 
-// Unmarshal respects the values specified in DecoderSettings,
+// NewDecoder respects the values specified in DecoderSettings,
 // and creates a Decoder that has certain features turned on/off
 func NewDecoder(r io.Reader) *json.Decoder {
 	dec := json.NewDecoder(r)

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -1,0 +1,56 @@
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"sync"
+)
+
+type Number = json.Number 
+type RawMessage = json.RawMessage
+
+var muGlobalConfig sync.RWMutex
+var useNumber bool
+
+func DecoderSettings(inUseNumber bool) {
+	muGlobalConfig.Lock()
+	useNumber = inUseNumber
+	muGlobalConfig.Unlock()
+}
+
+// Unmarshal respects the values specified in DecoderSettings,
+// and creates a Decoder that has certain features turned on/off
+func NewDecoder(r io.Reader) *json.Decoder {
+	dec := json.NewDecoder(r)
+
+	muGlobalConfig.RLock()
+	if useNumber {
+		dec.UseNumber()
+	}
+	muGlobalConfig.RUnlock()
+
+	return dec
+}
+
+// Unmarshal respects the values specified in DecoderSettings,
+// and uses a Decoder that has certain features turned on/off
+func Unmarshal(b []byte, v interface{}) error {
+	dec := NewDecoder(bytes.NewReader(b))
+	return dec.Decode(v)
+}
+
+// NewEncoder is just a proxy for "encoding/json".NewEncoder
+func NewEncoder(w io.Writer) *json.Encoder {
+	return json.NewEncoder(w)
+}
+
+// Marshal is just a proxy for "encoding/json".Marshal
+func Marshal(v interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// MarshalIndent is just a proxy for "encoding/json".MarshalIndent
+func MarshalIndent(v interface{}, prefix, indent string) ([]byte, error) {
+	return json.MarshalIndent(v, prefix, indent)
+}

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 )
 
-type Number = json.Number 
+type Number = json.Number
 type RawMessage = json.RawMessage
 
 var muGlobalConfig sync.RWMutex

--- a/jwe/headers.go
+++ b/jwe/headers.go
@@ -2,7 +2,7 @@ package jwe
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/iter/mapiter"
 	"github.com/lestrrat-go/jwx/buffer"

--- a/jwe/headers.go
+++ b/jwe/headers.go
@@ -2,6 +2,7 @@ package jwe
 
 import (
 	"context"
+
 	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/iter/mapiter"

--- a/jwe/headers_gen.go
+++ b/jwe/headers_gen.go
@@ -4,10 +4,11 @@ package jwe
 import (
 	"bytes"
 	"context"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"sort"
 	"strconv"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/buffer"
 	"github.com/lestrrat-go/jwx/jwa"

--- a/jwe/headers_gen.go
+++ b/jwe/headers_gen.go
@@ -4,7 +4,7 @@ package jwe
 import (
 	"bytes"
 	"context"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"sort"
 	"strconv"

--- a/jwe/internal/cmd/genheader/main.go
+++ b/jwe/internal/cmd/genheader/main.go
@@ -224,7 +224,7 @@ func generateHeaders() error {
 	pkgs := []string{
 		"bytes",
 		"context",
-		"encoding/json",
+		"github.com/lestrrat-go/jwx/internal/json",
 		"fmt",
 		"sort",
 		"strconv",

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/rsa"
+
 	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/buffer"

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/rsa"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/buffer"
 	"github.com/lestrrat-go/jwx/jwa"

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -7,9 +7,10 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"strings"
 	"testing"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwe"

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -7,7 +7,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"strings"
 	"testing"
 

--- a/jwe/message.go
+++ b/jwe/message.go
@@ -3,8 +3,9 @@ package jwe
 import (
 	"bytes"
 	"context"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/buffer"
 	"github.com/lestrrat-go/jwx/internal/base64"

--- a/jwe/message.go
+++ b/jwe/message.go
@@ -3,7 +3,7 @@ package jwe
 import (
 	"bytes"
 	"context"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 
 	"github.com/lestrrat-go/jwx/buffer"

--- a/jwe/message_test.go
+++ b/jwe/message_test.go
@@ -1,7 +1,7 @@
 package jwe_test
 
 import (
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/jwe"

--- a/jwe/message_test.go
+++ b/jwe/message_test.go
@@ -1,8 +1,9 @@
 package jwe_test
 
 import (
-	"github.com/lestrrat-go/jwx/internal/json"
 	"testing"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/jwe"
 	"github.com/stretchr/testify/assert"

--- a/jwe/serializer.go
+++ b/jwe/serializer.go
@@ -2,7 +2,7 @@ package jwe
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/internal/pool"
 	"github.com/pkg/errors"

--- a/jwe/serializer.go
+++ b/jwe/serializer.go
@@ -2,6 +2,7 @@ package jwe
 
 import (
 	"context"
+
 	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/internal/pool"

--- a/jwk/certchain.go
+++ b/jwk/certchain.go
@@ -2,7 +2,7 @@ package jwk
 
 import (
 	"crypto/x509"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/internal/base64"
 	"github.com/pkg/errors"

--- a/jwk/certchain.go
+++ b/jwk/certchain.go
@@ -2,6 +2,7 @@ package jwk
 
 import (
 	"crypto/x509"
+
 	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/internal/base64"

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/x509"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"sort"
 	"strconv"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/iter/mapiter"
 	"github.com/lestrrat-go/jwx/internal/base64"

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/x509"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"sort"
 	"strconv"

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -11,11 +11,10 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/lestrrat-go/jwx/internal/json"
-
 	"github.com/lestrrat-go/iter/mapiter"
 	"github.com/lestrrat-go/jwx/internal/base64"
 	"github.com/lestrrat-go/jwx/internal/iter"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/pkg/errors"
 )

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/jwa"

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -5,8 +5,9 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"testing"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"

--- a/jwk/iterator_test.go
+++ b/jwk/iterator_test.go
@@ -2,9 +2,10 @@ package jwk_test
 
 import (
 	"context"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"testing"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"

--- a/jwk/iterator_test.go
+++ b/jwk/iterator_test.go
@@ -2,7 +2,7 @@ package jwk_test
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"testing"
 

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -9,7 +9,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -254,7 +254,7 @@ func (s *Set) UnmarshalJSON(data []byte) error {
 // Parse parses JWK from the incoming io.Reader. This function can handle
 // both single-key and multi-key formats. If you know before hand which
 // format the incoming data is in, you might want to consider using
-// "encoding/json" directly
+// "github.com/lestrrat-go/jwx/internal/json" directly
 //
 // Note that a successful parsing does NOT guarantee a valid key
 func Parse(in io.Reader) (*Set, error) {

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -9,7 +9,6 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,6 +16,8 @@ import (
 	"os"
 	"reflect"
 	"strings"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/iter/arrayiter"
 	"github.com/lestrrat-go/jwx/internal/base64"

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -7,7 +7,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"reflect"
 	"testing"

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -7,10 +7,11 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/internal/base64"
 	"github.com/lestrrat-go/jwx/jwk"

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"sort"
 	"strconv"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/iter/mapiter"
 	"github.com/lestrrat-go/jwx/internal/base64"

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -11,11 +11,10 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/lestrrat-go/jwx/internal/json"
-
 	"github.com/lestrrat-go/iter/mapiter"
 	"github.com/lestrrat-go/jwx/internal/base64"
 	"github.com/lestrrat-go/jwx/internal/iter"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/pkg/errors"
 )

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"sort"
 	"strconv"

--- a/jwk/rsa_test.go
+++ b/jwk/rsa_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"crypto"
 	"crypto/rsa"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"testing"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/stretchr/testify/assert"

--- a/jwk/rsa_test.go
+++ b/jwk/rsa_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/rsa"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/jwk"

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"sort"
 	"strconv"

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -6,10 +6,11 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"sort"
 	"strconv"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/iter/mapiter"
 	"github.com/lestrrat-go/jwx/internal/base64"

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -10,11 +10,10 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/lestrrat-go/jwx/internal/json"
-
 	"github.com/lestrrat-go/iter/mapiter"
 	"github.com/lestrrat-go/jwx/internal/base64"
 	"github.com/lestrrat-go/jwx/internal/iter"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/pkg/errors"
 )

--- a/jwk/x5c_test.go
+++ b/jwk/x5c_test.go
@@ -1,7 +1,7 @@
 package jwk_test
 
 import (
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/jwk"

--- a/jwk/x5c_test.go
+++ b/jwk/x5c_test.go
@@ -1,8 +1,9 @@
 package jwk_test
 
 import (
-	"github.com/lestrrat-go/jwx/internal/json"
 	"testing"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/stretchr/testify/assert"

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 
 	"github.com/lestrrat-go/jwx/internal/json"
-
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/pkg/errors"

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -4,7 +4,7 @@ package jws
 import (
 	"bytes"
 	"context"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"sort"
 	"strconv"

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -4,10 +4,11 @@ package jws
 import (
 	"bytes"
 	"context"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"sort"
 	"strconv"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -2,7 +2,7 @@ package jws_test
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"reflect"
 	"testing"
 

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -2,9 +2,10 @@ package jws_test
 
 import (
 	"context"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"reflect"
 	"testing"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"

--- a/jws/internal/cmd/genheader/main.go
+++ b/jws/internal/cmd/genheader/main.go
@@ -174,7 +174,7 @@ func generateHeaders() error {
 	pkgs := []string{
 		"bytes",
 		"context",
-		"encoding/json",
+		"github.com/lestrrat-go/jwx/internal/json",
 		"fmt",
 		"sort",
 		"strconv",

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -26,7 +26,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"io"
 	"strings"
 	"unicode"

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -26,10 +26,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"io"
 	"strings"
 	"unicode"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/internal/pool"
 	"github.com/lestrrat-go/jwx/jwa"

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -7,10 +7,11 @@ import (
 	"crypto/rsa"
 	"crypto/sha512"
 	"encoding/base64"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"math/big"
 	"strings"
 	"testing"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/buffer"
 	"github.com/lestrrat-go/jwx/jwa"

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -7,7 +7,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha512"
 	"encoding/base64"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"math/big"
 	"strings"
 	"testing"

--- a/jws/signature.go
+++ b/jws/signature.go
@@ -1,7 +1,7 @@
 package jws
 
 import (
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/pkg/errors"
 )

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"time"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwt"

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"time"
 

--- a/jwt/internal/types/date.go
+++ b/jwt/internal/types/date.go
@@ -1,9 +1,10 @@
 package types
 
 import (
-	"github.com/lestrrat-go/jwx/internal/json"
 	"strconv"
 	"time"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/pkg/errors"
 )

--- a/jwt/internal/types/date.go
+++ b/jwt/internal/types/date.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"strconv"
 	"time"
 

--- a/jwt/internal/types/date_test.go
+++ b/jwt/internal/types/date_test.go
@@ -1,10 +1,11 @@
 package types_test
 
 import (
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/jwt"
 	"github.com/lestrrat-go/jwx/jwt/internal/types"

--- a/jwt/internal/types/date_test.go
+++ b/jwt/internal/types/date_test.go
@@ -1,7 +1,7 @@
 package types_test
 
 import (
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"testing"
 	"time"

--- a/jwt/internal/types/string.go
+++ b/jwt/internal/types/string.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/pkg/errors"
 )

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -5,10 +5,11 @@ package jwt
 
 import (
 	"bytes"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"io"
 	"io/ioutil"
 	"strings"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -5,7 +5,7 @@ package jwt
 
 import (
 	"bytes"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"io"
 	"io/ioutil"
 	"strings"

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -8,7 +8,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"strings"
 	"testing"
 	"time"

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -8,10 +8,11 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"

--- a/jwt/openid/address.go
+++ b/jwt/openid/address.go
@@ -1,7 +1,7 @@
 package openid
 
 import (
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/pkg/errors"
 )

--- a/jwt/openid/birthdate.go
+++ b/jwt/openid/birthdate.go
@@ -2,7 +2,7 @@ package openid
 
 import (
 	"bytes"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"io"
 	"regexp"

--- a/jwt/openid/birthdate.go
+++ b/jwt/openid/birthdate.go
@@ -2,11 +2,12 @@ package openid
 
 import (
 	"bytes"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"io"
 	"regexp"
 	"strconv"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/pkg/errors"
 )

--- a/jwt/openid/openid_test.go
+++ b/jwt/openid/openid_test.go
@@ -5,10 +5,11 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwt"

--- a/jwt/openid/openid_test.go
+++ b/jwt/openid/openid_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"testing"
 	"time"

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -4,11 +4,12 @@ package openid
 import (
 	"bytes"
 	"context"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/iter/mapiter"
 	"github.com/lestrrat-go/jwx/internal/iter"

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -4,7 +4,7 @@ package openid
 import (
 	"bytes"
 	"context"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"sort"
 	"strconv"

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -9,10 +9,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/lestrrat-go/jwx/internal/json"
-
 	"github.com/lestrrat-go/iter/mapiter"
 	"github.com/lestrrat-go/jwx/internal/iter"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"github.com/lestrrat-go/jwx/jwt/internal/types"
 	"github.com/pkg/errors"
 )

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -4,11 +4,12 @@ package jwt
 import (
 	"bytes"
 	"context"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/iter/mapiter"
 	"github.com/lestrrat-go/jwx/internal/iter"

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -4,7 +4,7 @@ package jwt
 import (
 	"bytes"
 	"context"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"fmt"
 	"sort"
 	"strconv"

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -9,10 +9,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/lestrrat-go/jwx/internal/json"
-
 	"github.com/lestrrat-go/iter/mapiter"
 	"github.com/lestrrat-go/jwx/internal/iter"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"github.com/lestrrat-go/jwx/jwt/internal/types"
 	"github.com/pkg/errors"
 )

--- a/jwt/token_test.go
+++ b/jwt/token_test.go
@@ -2,7 +2,7 @@ package jwt_test
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"reflect"
 	"testing"
 	"time"

--- a/jwt/token_test.go
+++ b/jwt/token_test.go
@@ -2,10 +2,11 @@ package jwt_test
 
 import (
 	"context"
-	"github.com/lestrrat-go/jwx/internal/json"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/lestrrat-go/jwx/internal/json"
 
 	"github.com/lestrrat-go/jwx/jwt"
 	"github.com/stretchr/testify/assert"

--- a/jwx.go
+++ b/jwx.go
@@ -21,3 +21,21 @@
 //
 // You can find more high level documentation at Github (https://github.com/lestrrat-go/jwx)
 package jwx
+
+import "github.com/lestrrat-go/jwx/internal/json"
+
+// DecoderSettings gives you a access to configure the "encoding/json".Decoder
+// used to decode JSON objects within the jwx framework.
+func DecoderSettings(options ...JSONOption) {
+	// XXX We're using this format instead of just passing a single boolean
+	// in case a new option is to be added some time later
+	var useNumber bool
+	for _, option := range options {
+		switch option.Name() {
+		case optkeyUseNumber:
+			useNumber = option.Value().(bool)
+		}
+	}
+
+	json.DecoderSettings(useNumber)
+}

--- a/jwx_example_test.go
+++ b/jwx_example_test.go
@@ -16,6 +16,17 @@ import (
 	"github.com/lestrrat-go/jwx/jwt/openid"
 )
 
+func ExampleDecoderSettings() {
+	// This has not been enabled in this example, but if you want to
+	// parse numbers in the incoming JSON objects as json.Number
+	// instead of floats, you can use the following call to globally
+	// affect the behavior of JSON parsing.
+
+	// func init() {
+	//   jwx.DecoderSettings(jwx.WithUseNumber(true))
+	// }
+}
+
 func Example_jwt() {
 	const aLongLongTimeAgo = 233431200
 

--- a/jwx_test.go
+++ b/jwx_test.go
@@ -1,0 +1,69 @@
+package jwx_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/jwx"
+	"github.com/lestrrat-go/jwx/internal/json"
+	"github.com/stretchr/testify/assert"
+)
+
+type jsonUnmarshalWrapper struct {
+	buf []byte
+}
+
+func (w jsonUnmarshalWrapper) Decode(v interface{}) error {
+	return json.Unmarshal(w.buf, v)
+}
+
+func TestDecoderSetting(t *testing.T) {
+	const src = `{"foo": 1}`
+
+	for _, useNumber := range []bool{true, false} {
+		useNumber := useNumber
+		t.Run(fmt.Sprintf("jwx.WithUseNumber(%t)", useNumber), func(t *testing.T) {
+			if useNumber {
+				jwx.DecoderSettings(jwx.WithUseNumber(useNumber))
+				t.Cleanup(func() {
+					jwx.DecoderSettings(jwx.WithUseNumber(false))
+				})
+			}
+
+			// json.NewDecoder must be called AFTER the above jwx.DecoderSettings call
+			decoders := []struct {
+				Name    string
+				Decoder interface{ Decode(interface{}) error }
+			}{
+				{Name: "Decoder", Decoder: json.NewDecoder(strings.NewReader(src))},
+				{Name: "Unmarshal", Decoder: jsonUnmarshalWrapper{buf: []byte(src)}},
+			}
+
+			for _, tc := range decoders {
+				tc := tc
+				t.Run(tc.Name, func(t *testing.T) {
+					var m map[string]interface{}
+					if !assert.NoError(t, tc.Decoder.Decode(&m), `Decode should succeed`) {
+						return
+					}
+
+					v, ok := m["foo"]
+					if !assert.True(t, ok, `m["foo"] should exist`) {
+						return
+					}
+
+					if useNumber {
+						if !assert.Equal(t, json.Number("1"), v, `v should be a json.Number object`) {
+							return
+						}
+					} else {
+						if !assert.Equal(t, float64(1), v, `v should be a float64`) {
+							return
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,34 @@
+package jwx
+
+import "github.com/lestrrat-go/jwx/internal/option"
+
+const (
+	optkeyUseNumber = "json-use-number"
+)
+
+type Option = option.Interface
+
+type JSONOption interface {
+	Option
+	isJSONOption() bool
+}
+
+type jsonOption struct {
+	Option
+}
+
+func (o *jsonOption) isJSONOption() bool { return true }
+
+func newJSONOption(n string, v interface{}) JSONOption {
+	return &jsonOption{
+		Option: option.New(n, v),
+	}
+}
+
+// WithUseNumber controls whethere the jwx package should unmarshal
+// JSON objects with the "encoding/json".Decoder.UseNumber feature on.
+//
+// Default is false.
+func WithUseNumber(b bool) JSONOption {
+	return newJSONOption(optkeyUseNumber, b)
+}


### PR DESCRIPTION
fixes #221

Introduce a function to configure global behavior of json Marshal/Unmarshaling. Currently only supports `jwx.WithUseNumber` to either toggle `"encoding/json".Decoder.UseNumber` on or off. This flag has global
effect, so the user must be aware of its existence, and opt to accept its side effects in the entire program
that uses this.

```go

func init() {
  jwx.DecoderSettings(jwx.WithUseNumber(true))
}

... elsewhere ...

jws.Parse(...) // uses json.Number
```