### PR TITLE
KeyLookup hook to dynamically look up a key (by kid) during the verification phase

### DIFF
--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -161,6 +161,19 @@ func TestJWTParseVerify(t *testing.T) {
 	})
 	t.Run("Parse (w/jwk.Set)", func(t *testing.T) {
 		t.Parallel()
+		t.Run("Automatically pick a key from keyLookup", func(t *testing.T) {
+			t.Parallel()
+			t2, err := jwt.Parse(bytes.NewReader(signed),
+				jwt.WithKeyLookup(func(kid string) (interface{}, error) {
+					return &key.PublicKey, nil
+				}))
+			if !assert.NoError(t, err, `jwt.Parse with keyLookup should succeed`) {
+				return
+			}
+			if !assert.Equal(t, t1, t2, `t1 == t2`) {
+				return
+			}
+		})
 		t.Run("Automatically pick a key from set", func(t *testing.T) {
 			t.Parallel()
 			pubkey := jwk.NewRSAPublicKey()

--- a/jwt/options.go
+++ b/jwt/options.go
@@ -43,14 +43,14 @@ type ValidateOption interface {
 }
 
 const (
-	optkeyValidate = `validate`
-	optkeyVerify   = `verify`
-	optkeyToken    = `token`
-	optkeyKeySet   = `keySet`
-	optkeyKeyLookup   = `keyLookup`
-	optkeyHeaders  = `headers`
-	optkeyDefault  = `defaultKey`
-	optkeyClaim    = `claimValue`
+	optkeyValidate  = `validate`
+	optkeyVerify    = `verify`
+	optkeyToken     = `token`
+	optkeyKeySet    = `keySet`
+	optkeyKeyLookup = `keyLookup`
+	optkeyHeaders   = `headers`
+	optkeyDefault   = `defaultKey`
+	optkeyClaim     = `claimValue`
 )
 
 type VerifyParameters interface {

--- a/jwt/options.go
+++ b/jwt/options.go
@@ -47,6 +47,7 @@ const (
 	optkeyVerify   = `verify`
 	optkeyToken    = `token`
 	optkeyKeySet   = `keySet`
+	optkeyKeyLookup   = `keyLookup`
 	optkeyHeaders  = `headers`
 	optkeyDefault  = `defaultKey`
 	optkeyClaim    = `claimValue`
@@ -86,6 +87,15 @@ func WithVerify(alg jwa.SignatureAlgorithm, key interface{}) ParseOption {
 // give keys.
 func WithKeySet(set *jwk.Set) ParseOption {
 	return newParseOption(optkeyKeySet, set)
+}
+
+// KeyLookupFunc is a hook to lookup the key by kid
+type KeyLookupFunc func(kid string) (interface{}, error)
+
+// WithKeyLookup forces the Parse method to verify the JWT message
+// using KeyLookupFunc to load the key
+func WithKeyLookup(f KeyLookupFunc) ParseOption {
+	return newParseOption(optkeyKeyLookup, f)
 }
 
 // UseDefaultKey is used in conjunction with the option WithKeySet


### PR DESCRIPTION
this can address issue https://github.com/lestrrat-go/jwx/issues/231