### PR TITLE
Encode x5c field as base64 with padding to conform with JWK and JWS RFCs

### DIFF
--- a/internal/base64/base64.go
+++ b/internal/base64/base64.go
@@ -7,7 +7,7 @@ import (
 )
 
 func EncodeToStringStd(src []byte) string {
-	return base64.RawStdEncoding.EncodeToString(src)
+	return base64.StdEncoding.EncodeToString(src)
 }
 
 func EncodeToString(src []byte) string {

--- a/internal/base64/base64_test.go
+++ b/internal/base64/base64_test.go
@@ -1,0 +1,18 @@
+package base64
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeToStringStd(t *testing.T) {
+	t.Parallel()
+	t.Run("Encodes to StdEncoding with padding", func(t *testing.T) {
+		t.Parallel()
+		out, err := base64.StdEncoding.DecodeString(EncodeToStringStd([]byte("Hello, World!")))
+		assert.NoError(t, err)
+		assert.NotNil(t, out)
+	})
+}

--- a/jwk/x5c_test.go
+++ b/jwk/x5c_test.go
@@ -18,7 +18,7 @@ func Test_X5CHeader(t *testing.T) {
 
 	t.Run("Marshal/Unmarshal", func(t *testing.T) {
 		// The input contains padding. We can accept either as input, but only emit
-		// strings encoded without padding
+		// strings encoded with padding
 		certsNopad := make([]string, len(certs))
 		for i, cert := range certs {
 			for len(cert) > 0 && cert[len(cert)-1] == '=' {
@@ -27,7 +27,7 @@ func Test_X5CHeader(t *testing.T) {
 			certsNopad[i] = cert
 		}
 
-		expected, err := json.Marshal(certsNopad)
+		expected, err := json.Marshal(certs)
 		if !assert.NoError(t, err, `json.Marshal should succeed`) {
 			return
 		}


### PR DESCRIPTION
Fixes https://github.com/lestrrat-go/jwx/issues/243