### PR TITLE
Add EdDSA signature/verify with Ed25519 curve and ECDH-ES(+*) encryption with X25519 curve support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ _testmain.go
 .idea
 .vscode
 .DS_Store
+*~
 
 coverage.out
 go.sum

--- a/README.md
+++ b/README.md
@@ -261,12 +261,13 @@ func main() {
 
 Supported key types:
 
-| kty | Curve                   | Go Key Type                            |
-|:----|:------------------------|:---------------------------------------|
-| RSA | N/A                     | rsa.PrivateKey / rsa.PublicKey         |
-| EC  | P-256<br>P-384<br>P-521 | ecdsa.PrivateKey / ecdsa.PublicKey     |
-| oct | N/A                     | []byte                                 |
-| OKP | Ed25519 (1)             | ed25519.PrivateKey / ed25519.PublicKey |
+| kty | Curve                   | Go Key Type                                |
+|:----|:------------------------|:-------------------------------------------|
+| RSA | N/A                     | rsa.PrivateKey / rsa.PublicKey             |
+| EC  | P-256<br>P-384<br>P-521 | ecdsa.PrivateKey / ecdsa.PublicKey         |
+| oct | N/A                     | []byte                                     |
+| OKP | Ed25519 (1)             | ed25519.PrivateKey / ed25519.PublicKey     |
+|     | X25519 (1)              | (jwx/)x25519.PrivateKey / x25519.PublicKey |
 
 Note 1: Experimental
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,17 @@ func main() {
 }
 ```
 
+Supported key types:
+
+| kty | Curve                   | Go Key Type                            |
+|:----|:------------------------|:---------------------------------------|
+| RSA | N/A                     | rsa.PrivateKey / rsa.PublicKey         |
+| EC  | P-256<br>P-384<br>P-521 | ecdsa.PrivateKey / ecdsa.PublicKey     |
+| oct | N/A                     | []byte                                 |
+| OKP | Ed25519 (1)             | ed25519.PrivateKey / ed25519.PublicKey |
+
+Note 1: Experimental
+
 ### JWS
 
 See also `VerifyWithJWK` and `VerifyWithJKU`

--- a/README.md
+++ b/README.md
@@ -325,6 +325,9 @@ Supported signature algorithms:
 | RSASSA-PSS using SHA256 and MGF1-SHA256 | YES        | jwa.PS256          |
 | RSASSA-PSS using SHA384 and MGF1-SHA384 | YES        | jwa.PS384          |
 | RSASSA-PSS using SHA512 and MGF1-SHA512 | YES        | jwa.PS512          |
+| EdDSA (1)                               | YES        | jwa.EdDSA          |
+
+Note 1: Experimental
 
 ### JWE
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/lestrrat-go/pdebug v0.0.0-20200204225717-4d6bd78da58d
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.5.1
-	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+	golang.org/x/crypto v0.0.0-20201217014255-9d1352758620
 	golang.org/x/tools v0.0.0-20200417140056-c07e33ef3290
 )

--- a/internal/jwxtest/jwxtest.go
+++ b/internal/jwxtest/jwxtest.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -90,6 +91,25 @@ func GenerateSymmetricJwk() (jwk.Key, error) {
 	}
 
 	return key, nil
+}
+
+func GenerateEd25519Key() (ed25519.PrivateKey, error) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	return priv, err
+}
+
+func GenerateEd25519Jwk() (jwk.Key, error) {
+	key, err := GenerateEd25519Key()
+	if err != nil {
+		return nil, errors.Wrap(err, `failed to generate Ed25519 private key`)
+	}
+
+	k, err := jwk.New(key)
+	if err != nil {
+		return nil, errors.Wrap(err, `failed to generate jwk.OKPPrivateKey`)
+	}
+
+	return k, nil
 }
 
 func WriteFile(template string, src io.Reader) (string, func(), error) {

--- a/internal/jwxtest/jwxtest.go
+++ b/internal/jwxtest/jwxtest.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwe"
 	"github.com/lestrrat-go/jwx/jwk"
+	"github.com/lestrrat-go/jwx/x25519"
 	"github.com/lestrrat-go/pdebug"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -102,6 +103,25 @@ func GenerateEd25519Jwk() (jwk.Key, error) {
 	key, err := GenerateEd25519Key()
 	if err != nil {
 		return nil, errors.Wrap(err, `failed to generate Ed25519 private key`)
+	}
+
+	k, err := jwk.New(key)
+	if err != nil {
+		return nil, errors.Wrap(err, `failed to generate jwk.OKPPrivateKey`)
+	}
+
+	return k, nil
+}
+
+func GenerateX25519Key() (x25519.PrivateKey, error) {
+	_, priv, err := x25519.GenerateKey(rand.Reader)
+	return priv, err
+}
+
+func GenerateX25519Jwk() (jwk.Key, error) {
+	key, err := GenerateX25519Key()
+	if err != nil {
+		return nil, errors.Wrap(err, `failed to generate X25519 private key`)
 	}
 
 	k, err := jwk.New(key)

--- a/jwa/elliptic_gen.go
+++ b/jwa/elliptic_gen.go
@@ -13,10 +13,14 @@ type EllipticCurveAlgorithm string
 
 // Supported values for EllipticCurveAlgorithm
 const (
+	Ed25519              EllipticCurveAlgorithm = "Ed25519"
+	Ed448                EllipticCurveAlgorithm = "Ed448"
 	InvalidEllipticCurve EllipticCurveAlgorithm = "P-invalid"
 	P256                 EllipticCurveAlgorithm = "P-256"
 	P384                 EllipticCurveAlgorithm = "P-384"
 	P521                 EllipticCurveAlgorithm = "P-521"
+	X25519               EllipticCurveAlgorithm = "X25519"
+	X448                 EllipticCurveAlgorithm = "X448"
 )
 
 // Accept is used when conversion from values given by
@@ -38,7 +42,7 @@ func (v *EllipticCurveAlgorithm) Accept(value interface{}) error {
 		tmp = EllipticCurveAlgorithm(s)
 	}
 	switch tmp {
-	case P256, P384, P521:
+	case Ed25519, Ed448, P256, P384, P521, X25519, X448:
 	default:
 		return errors.Errorf(`invalid jwa.EllipticCurveAlgorithm value`)
 	}

--- a/jwa/elliptic_gen_test.go
+++ b/jwa/elliptic_gen_test.go
@@ -11,6 +11,78 @@ import (
 
 func TestEllipticCurveAlgorithm(t *testing.T) {
 	t.Parallel()
+	t.Run(`accept jwa constant Ed25519`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept(jwa.Ed25519), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.Ed25519, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`accept the string Ed25519`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept("Ed25519"), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.Ed25519, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`accept fmt.Stringer for Ed25519`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept(stringer{src: "Ed25519"}), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.Ed25519, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`stringification for Ed25519`, func(t *testing.T) {
+		t.Parallel()
+		if !assert.Equal(t, "Ed25519", jwa.Ed25519.String(), `stringified value matches`) {
+			return
+		}
+	})
+	t.Run(`accept jwa constant Ed448`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept(jwa.Ed448), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.Ed448, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`accept the string Ed448`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept("Ed448"), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.Ed448, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`accept fmt.Stringer for Ed448`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept(stringer{src: "Ed448"}), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.Ed448, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`stringification for Ed448`, func(t *testing.T) {
+		t.Parallel()
+		if !assert.Equal(t, "Ed448", jwa.Ed448.String(), `stringified value matches`) {
+			return
+		}
+	})
 	t.Run(`accept jwa constant P256`, func(t *testing.T) {
 		t.Parallel()
 		var dst jwa.EllipticCurveAlgorithm
@@ -116,6 +188,78 @@ func TestEllipticCurveAlgorithm(t *testing.T) {
 	t.Run(`stringification for P-521`, func(t *testing.T) {
 		t.Parallel()
 		if !assert.Equal(t, "P-521", jwa.P521.String(), `stringified value matches`) {
+			return
+		}
+	})
+	t.Run(`accept jwa constant X25519`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept(jwa.X25519), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.X25519, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`accept the string X25519`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept("X25519"), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.X25519, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`accept fmt.Stringer for X25519`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept(stringer{src: "X25519"}), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.X25519, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`stringification for X25519`, func(t *testing.T) {
+		t.Parallel()
+		if !assert.Equal(t, "X25519", jwa.X25519.String(), `stringified value matches`) {
+			return
+		}
+	})
+	t.Run(`accept jwa constant X448`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept(jwa.X448), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.X448, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`accept the string X448`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept("X448"), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.X448, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`accept fmt.Stringer for X448`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept(stringer{src: "X448"}), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.X448, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`stringification for X448`, func(t *testing.T) {
+		t.Parallel()
+		if !assert.Equal(t, "X448", jwa.X448.String(), `stringified value matches`) {
 			return
 		}
 	})

--- a/jwa/internal/cmd/gentypes/main.go
+++ b/jwa/internal/cmd/gentypes/main.go
@@ -102,6 +102,11 @@ func _main() error {
 					value:   `oct`,
 					comment: `Octet sequence (used to represent symmetric keys)`,
 				},
+				{
+					name:    `OKP`,
+					value:   `OKP`,
+					comment: `Octet string key pairs`,
+				},
 			},
 		},
 		{
@@ -125,6 +130,22 @@ func _main() error {
 				{
 					name:  `P521`,
 					value: `P-521`,
+				},
+				{
+					name:  `Ed25519`,
+					value: `Ed25519`,
+				},
+				{
+					name:  `Ed448`,
+					value: `Ed448`,
+				},
+				{
+					name:  `X25519`,
+					value: `X25519`,
+				},
+				{
+					name:  `X448`,
+					value: `X448`,
 				},
 			},
 		},
@@ -181,6 +202,11 @@ func _main() error {
 					name:    `ES512`,
 					value:   "ES512",
 					comment: `ECDSA using P-521 and SHA-512`,
+				},
+				{
+					name:    `EdDSA`,
+					value:   `EdDSA`,
+					comment: `EdDSA signature algorithms`,
 				},
 				{
 					name:    `PS256`,

--- a/jwa/key_type_gen.go
+++ b/jwa/key_type_gen.go
@@ -15,6 +15,7 @@ type KeyType string
 const (
 	EC             KeyType = "EC"  // Elliptic Curve
 	InvalidKeyType KeyType = ""    // Invalid KeyType
+	OKP            KeyType = "OKP" // Octet string key pairs
 	OctetSeq       KeyType = "oct" // Octet sequence (used to represent symmetric keys)
 	RSA            KeyType = "RSA" // RSA
 )
@@ -38,7 +39,7 @@ func (v *KeyType) Accept(value interface{}) error {
 		tmp = KeyType(s)
 	}
 	switch tmp {
-	case EC, OctetSeq, RSA:
+	case EC, OKP, OctetSeq, RSA:
 	default:
 		return errors.Errorf(`invalid jwa.KeyType value`)
 	}

--- a/jwa/key_type_gen_test.go
+++ b/jwa/key_type_gen_test.go
@@ -47,6 +47,42 @@ func TestKeyType(t *testing.T) {
 			return
 		}
 	})
+	t.Run(`accept jwa constant OKP`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.KeyType
+		if !assert.NoError(t, dst.Accept(jwa.OKP), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.OKP, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`accept the string OKP`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.KeyType
+		if !assert.NoError(t, dst.Accept("OKP"), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.OKP, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`accept fmt.Stringer for OKP`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.KeyType
+		if !assert.NoError(t, dst.Accept(stringer{src: "OKP"}), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.OKP, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`stringification for OKP`, func(t *testing.T) {
+		t.Parallel()
+		if !assert.Equal(t, "OKP", jwa.OKP.String(), `stringified value matches`) {
+			return
+		}
+	})
 	t.Run(`accept jwa constant OctetSeq`, func(t *testing.T) {
 		t.Parallel()
 		var dst jwa.KeyType

--- a/jwa/signature_gen.go
+++ b/jwa/signature_gen.go
@@ -16,6 +16,7 @@ const (
 	ES256       SignatureAlgorithm = "ES256" // ECDSA using P-256 and SHA-256
 	ES384       SignatureAlgorithm = "ES384" // ECDSA using P-384 and SHA-384
 	ES512       SignatureAlgorithm = "ES512" // ECDSA using P-521 and SHA-512
+	EdDSA       SignatureAlgorithm = "EdDSA" // EdDSA signature algorithms
 	HS256       SignatureAlgorithm = "HS256" // HMAC using SHA-256
 	HS384       SignatureAlgorithm = "HS384" // HMAC using SHA-384
 	HS512       SignatureAlgorithm = "HS512" // HMAC using SHA-512
@@ -47,7 +48,7 @@ func (v *SignatureAlgorithm) Accept(value interface{}) error {
 		tmp = SignatureAlgorithm(s)
 	}
 	switch tmp {
-	case ES256, ES384, ES512, HS256, HS384, HS512, NoSignature, PS256, PS384, PS512, RS256, RS384, RS512:
+	case ES256, ES384, ES512, EdDSA, HS256, HS384, HS512, NoSignature, PS256, PS384, PS512, RS256, RS384, RS512:
 	default:
 		return errors.Errorf(`invalid jwa.SignatureAlgorithm value`)
 	}

--- a/jwa/signature_gen_test.go
+++ b/jwa/signature_gen_test.go
@@ -119,6 +119,42 @@ func TestSignatureAlgorithm(t *testing.T) {
 			return
 		}
 	})
+	t.Run(`accept jwa constant EdDSA`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.SignatureAlgorithm
+		if !assert.NoError(t, dst.Accept(jwa.EdDSA), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.EdDSA, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`accept the string EdDSA`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.SignatureAlgorithm
+		if !assert.NoError(t, dst.Accept("EdDSA"), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.EdDSA, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`accept fmt.Stringer for EdDSA`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.SignatureAlgorithm
+		if !assert.NoError(t, dst.Accept(stringer{src: "EdDSA"}), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.EdDSA, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`stringification for EdDSA`, func(t *testing.T) {
+		t.Parallel()
+		if !assert.Equal(t, "EdDSA", jwa.EdDSA.String(), `stringified value matches`) {
+			return
+		}
+	})
 	t.Run(`accept jwa constant HS256`, func(t *testing.T) {
 		t.Parallel()
 		var dst jwa.SignatureAlgorithm

--- a/jwe/headers_gen.go
+++ b/jwe/headers_gen.go
@@ -44,7 +44,7 @@ type Headers interface {
 	ContentEncryption() jwa.ContentEncryptionAlgorithm
 	ContentType() string
 	Critical() []string
-	EphemeralPublicKey() jwk.ECDSAPublicKey
+	EphemeralPublicKey() jwk.Key
 	JWK() jwk.Key
 	JWKSetURL() string
 	KeyID() string
@@ -79,7 +79,7 @@ type stdHeaders struct {
 	contentEncryption      *jwa.ContentEncryptionAlgorithm `json:"enc,omitempty"`      //
 	contentType            *string                         `json:"cty,omitempty"`      //
 	critical               []string                        `json:"crit,omitempty"`     //
-	ephemeralPublicKey     jwk.ECDSAPublicKey              `json:"epk,omitempty"`      //
+	ephemeralPublicKey     jwk.Key                         `json:"epk,omitempty"`      //
 	jwk                    jwk.Key                         `json:"jwk,omitempty"`      //
 	jwkSetURL              *string                         `json:"jku,omitempty"`      //
 	keyID                  *string                         `json:"kid,omitempty"`      //
@@ -177,7 +177,7 @@ func (h *stdHeaders) Critical() []string {
 	return h.critical
 }
 
-func (h *stdHeaders) EphemeralPublicKey() jwk.ECDSAPublicKey {
+func (h *stdHeaders) EphemeralPublicKey() jwk.Key {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	return h.ephemeralPublicKey
@@ -462,7 +462,7 @@ func (h *stdHeaders) Set(name string, value interface{}) error {
 		}
 		return errors.Errorf(`invalid value for %s key: %T`, CriticalKey, value)
 	case EphemeralPublicKeyKey:
-		if v, ok := value.(jwk.ECDSAPublicKey); ok {
+		if v, ok := value.(jwk.Key); ok {
 			h.ephemeralPublicKey = v
 			return nil
 		}
@@ -589,11 +589,7 @@ func (h *stdHeaders) UnmarshalJSON(buf []byte) error {
 		if err != nil {
 			return errors.Wrap(err, `failed to parse epk field`)
 		}
-		if ecEpk, ok := epk.(jwk.ECDSAPublicKey); ok {
-			h.ephemeralPublicKey = ecEpk
-		} else {
-			return errors.Errorf(`invalid type for epk field %T`, epk)
-		}
+		h.ephemeralPublicKey = epk
 	}
 	h.agreementPartyUInfo = proxy.XagreementPartyUInfo
 	h.agreementPartyVInfo = proxy.XagreementPartyVInfo

--- a/jwe/internal/cmd/genheader/main.go
+++ b/jwe/internal/cmd/genheader/main.go
@@ -140,7 +140,7 @@ func generateHeaders() error {
 		{
 			name:   `ephemeralPublicKey`,
 			method: `EphemeralPublicKey`,
-			typ:    `jwk.ECDSAPublicKey`,
+			typ:    `jwk.Key`,
 			key:    `epk`,
 			//			comment: `https://tools.ietf.org/html/rfc7515#section-4.1.3`,
 			jsonTag: "`" + `json:"epk,omitempty"` + "`",
@@ -458,11 +458,7 @@ func generateHeaders() error {
 	fmt.Fprintf(&buf, "\nif err != nil {")
 	fmt.Fprintf(&buf, "\nreturn errors.Wrap(err, `failed to parse epk field`)")
 	fmt.Fprintf(&buf, "\n}")
-	fmt.Fprintf(&buf, "\nif ecEpk, ok := epk.(jwk.ECDSAPublicKey); ok {")
-	fmt.Fprintf(&buf, "\nh.ephemeralPublicKey = ecEpk")
-	fmt.Fprintf(&buf, "\n} else {")
-	fmt.Fprintf(&buf, "\nreturn errors.Errorf(`invalid type for epk field %%T`, epk)")
-	fmt.Fprintf(&buf, "\n}")
+	fmt.Fprintf(&buf, "\nh.ephemeralPublicKey = epk")
 	fmt.Fprintf(&buf, "\n}")
 
 	for _, f := range fields {

--- a/jwe/internal/keyenc/interface.go
+++ b/jwe/internal/keyenc/interface.go
@@ -1,7 +1,6 @@
 package keyenc
 
 import (
-	"crypto/ecdsa"
 	"crypto/rsa"
 	"hash"
 
@@ -59,8 +58,8 @@ type ECDHESDecrypt struct {
 	contentalg jwa.ContentEncryptionAlgorithm
 	apu        []byte
 	apv        []byte
-	privkey    *ecdsa.PrivateKey
-	pubkey     *ecdsa.PublicKey
+	privkey    interface{}
+	pubkey     interface{}
 }
 
 // RSAOAEPEncrypt encrypts keys using RSA OAEP algorithm

--- a/jwe/internal/keygen/interface.go
+++ b/jwe/internal/keygen/interface.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 
 	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/lestrrat-go/jwx/x25519"
 )
 
 type Generator interface {
@@ -19,7 +20,7 @@ type Random struct {
 	keysize int
 }
 
-// EcdhesKeyGenerate generates keys using ECDH-ES algorithm
+// EcdhesKeyGenerate generates keys using ECDH-ES algorithm / EC-DSA curve
 type Ecdhes struct {
 	algorithm jwa.KeyEncryptionAlgorithm
 	enc       jwa.ContentEncryptionAlgorithm
@@ -27,17 +28,25 @@ type Ecdhes struct {
 	pubkey    *ecdsa.PublicKey
 }
 
+// X25519KeyGenerate generates keys using ECDH-ES algorithm / X25519 curve
+type X25519 struct {
+	algorithm jwa.KeyEncryptionAlgorithm
+	enc       jwa.ContentEncryptionAlgorithm
+	keysize   int
+	pubkey    x25519.PublicKey
+}
+
 // ByteKey is a generated key that only has the key's byte buffer
 // as its instance data. If a ke needs to do more, such as providing
 // values to be set in a JWE header, that key type wraps a ByteKey
 type ByteKey []byte
 
-// ByteWithECPrivateKey holds the EC-DSA private key that generated
+// ByteWithECPublicKey holds the EC private key that generated
 // the key along with the key itself. This is required to set the
 // proper values in the JWE headers
-type ByteWithECPrivateKey struct {
+type ByteWithECPublicKey struct {
 	ByteKey
-	PrivateKey *ecdsa.PrivateKey
+	PublicKey interface{}
 }
 
 type ByteWithIVAndTag struct {

--- a/jwe/internal/keygen/keygen.go
+++ b/jwe/internal/keygen/keygen.go
@@ -7,11 +7,14 @@ import (
 	"encoding/binary"
 	"io"
 
+	"golang.org/x/crypto/curve25519"
+
 	"github.com/lestrrat-go/jwx/buffer"
 	"github.com/lestrrat-go/jwx/internal/concatkdf"
 	"github.com/lestrrat-go/jwx/internal/ecutil"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"
+	"github.com/lestrrat-go/jwx/x25519"
 	"github.com/pkg/errors"
 )
 
@@ -93,16 +96,64 @@ func (g Ecdhes) Generate() (ByteSource, error) {
 		return nil, errors.Wrap(err, "failed to read kdf")
 	}
 
-	return ByteWithECPrivateKey{
-		PrivateKey: priv,
-		ByteKey:    ByteKey(kek),
+	return ByteWithECPublicKey{
+		PublicKey: &priv.PublicKey,
+		ByteKey:   ByteKey(kek),
+	}, nil
+}
+
+// NewX25519 creates a new key generator using ECDH-ES
+func NewX25519(alg jwa.KeyEncryptionAlgorithm, enc jwa.ContentEncryptionAlgorithm, keysize int, pubkey x25519.PublicKey) (*X25519, error) {
+	return &X25519{
+		algorithm: alg,
+		enc:       enc,
+		keysize:   keysize,
+		pubkey:    pubkey,
+	}, nil
+}
+
+// Size returns the key size associated with this generator
+func (g X25519) Size() int {
+	return g.keysize
+}
+
+// Generate generates new keys using ECDH-ES
+func (g X25519) Generate() (ByteSource, error) {
+	pub, priv, err := x25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to generate key for X25519")
+	}
+
+	var algorithm string
+	if g.algorithm == jwa.ECDH_ES {
+		algorithm = g.enc.String()
+	} else {
+		algorithm = g.algorithm.String()
+	}
+
+	pubinfo := make([]byte, 4)
+	binary.BigEndian.PutUint32(pubinfo, uint32(g.keysize)*8)
+
+	zBytes, err := curve25519.X25519(priv.Seed(), g.pubkey)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to compute Z")
+	}
+	kdf := concatkdf.New(crypto.SHA256, []byte(algorithm), zBytes, []byte{}, []byte{}, pubinfo, []byte{})
+	kek := make([]byte, g.keysize)
+	if _, err := kdf.Read(kek); err != nil {
+		return nil, errors.Wrap(err, "failed to read kdf")
+	}
+
+	return ByteWithECPublicKey{
+		PublicKey: pub,
+		ByteKey:   ByteKey(kek),
 	}, nil
 }
 
 // HeaderPopulate populates the header with the required EC-DSA public key
 // information ('epk' key)
-func (k ByteWithECPrivateKey) Populate(h Setter) error {
-	key, err := jwk.New(&k.PrivateKey.PublicKey)
+func (k ByteWithECPublicKey) Populate(h Setter) error {
+	key, err := jwk.New(k.PublicKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to create JWK")
 	}

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwe"
 	"github.com/lestrrat-go/jwx/jwk"
+	"github.com/lestrrat-go/jwx/x25519"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -427,6 +428,15 @@ func TestEncode_ECDH(t *testing.T) {
 			testEncodeECDHWithKey(t, privkey, &privkey.PublicKey)
 		})
 	}
+}
+
+func TestEncode_X25519(t *testing.T) {
+	pubkey, privkey, err := x25519.GenerateKey(rand.Reader)
+	if !assert.NoError(t, err, `x25519.GenerateKey should succeed`) {
+		return
+	}
+
+	testEncodeECDHWithKey(t, privkey, pubkey)
 }
 
 func Test_GHIssue207(t *testing.T) {

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -367,12 +367,8 @@ func TestEncode_A128KW_A128CBC_HS256(t *testing.T) {
 	}
 }
 
-func TestEncode_ECDH(t *testing.T) {
+func testEncodeECDHWithKey(t *testing.T, privkey interface{}, pubkey interface{}) {
 	plaintext := []byte("Lorem ipsum")
-	privkey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if !assert.NoError(t, err, `ecdsa.GenerateKey should succeed`) {
-		return
-	}
 
 	algorithms := []jwa.KeyEncryptionAlgorithm{
 		jwa.ECDH_ES,
@@ -384,7 +380,7 @@ func TestEncode_ECDH(t *testing.T) {
 	for _, alg := range algorithms {
 		alg := alg
 		t.Run(alg.String(), func(t *testing.T) {
-			encrypted, err := jwe.Encrypt(plaintext, alg, &privkey.PublicKey, jwa.A256GCM, jwa.NoCompress)
+			encrypted, err := jwe.Encrypt(plaintext, alg, pubkey, jwa.A256GCM, jwa.NoCompress)
 			if !assert.NoError(t, err, "Encrypt succeeds") {
 				return
 			}
@@ -410,6 +406,25 @@ func TestEncode_ECDH(t *testing.T) {
 				return
 			}
 			t.Logf("%s", decrypted)
+		})
+	}
+}
+
+func TestEncode_ECDH(t *testing.T) {
+	curves := []elliptic.Curve{
+		elliptic.P256(),
+		elliptic.P384(),
+		elliptic.P521(),
+	}
+	for _, crv := range curves {
+		crv := crv
+		t.Run(crv.Params().Name, func(t *testing.T) {
+			privkey, err := ecdsa.GenerateKey(crv, rand.Reader)
+			if !assert.NoError(t, err, `ecdsa.GenerateKey should succeed`) {
+				return
+			}
+
+			testEncodeECDHWithKey(t, privkey, &privkey.PublicKey)
 		})
 	}
 }

--- a/jwk/internal/cmd/genheader/main.go
+++ b/jwk/internal/cmd/genheader/main.go
@@ -363,6 +363,58 @@ var keyTypes = []keyType{
 			},
 		},
 	},
+	{
+		filename: `okp_gen.go`,
+		prefix:   `OKP`,
+		keyType:  `jwa.OKP`,
+		headerTypes: []headerType{
+			{
+				name:       "PublicKey",
+				rawKeyType: `interface{}`,
+				headers: []headerField{
+					{
+						name:   `x`,
+						method: `X`,
+						typ:    `[]byte`,
+						key:    `x`,
+					},
+					{
+						name:   `crv`,
+						method: `Crv`,
+						typ:    `jwa.EllipticCurveAlgorithm`,
+						key:    `crv`,
+					},
+				},
+			},
+			{
+				name:       "PrivateKey",
+				rawKeyType: `interface{}`,
+				ifMethods: []string{
+					`PublicKey() (OKPPublicKey, error)`,
+				},
+				headers: []headerField{
+					{
+						name:   `x`,
+						method: `X`,
+						typ:    `[]byte`,
+						key:    `x`,
+					},
+					{
+						name:   `d`,
+						method: `D`,
+						typ:    `[]byte`,
+						key:    `d`,
+					},
+					{
+						name:   `crv`,
+						method: `Crv`,
+						typ:    `jwa.EllipticCurveAlgorithm`,
+						key:    `crv`,
+					},
+				},
+			},
+		},
+	},
 }
 
 func generateGenericHeaders() error {

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -17,11 +17,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/lestrrat-go/jwx/internal/json"
-
 	"github.com/lestrrat-go/iter/arrayiter"
 	"github.com/lestrrat-go/jwx/internal/base64"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/lestrrat-go/jwx/x25519"
 	"github.com/pkg/errors"
 )
 
@@ -90,6 +90,18 @@ func New(key interface{}) (Key, error) {
 			return nil, errors.Wrapf(err, `failed to initialize %T from %T`, k, rawKey)
 		}
 		return k, nil
+	case x25519.PrivateKey:
+		k := NewOKPPrivateKey()
+		if err := k.FromRaw(rawKey); err != nil {
+			return nil, errors.Wrapf(err, `failed to initialize %T from %T`, k, rawKey)
+		}
+		return k, nil
+	case x25519.PublicKey:
+		k := NewOKPPublicKey()
+		if err := k.FromRaw(rawKey); err != nil {
+			return nil, errors.Wrapf(err, `failed to initialize %T from %T`, k, rawKey)
+		}
+		return k, nil
 	case []byte:
 		k := NewSymmetricKey()
 		if err := k.FromRaw(rawKey); err != nil {
@@ -145,6 +157,10 @@ func PublicKeyOf(v interface{}) (interface{}, error) {
 	case ed25519.PrivateKey:
 		return x.Public(), nil
 	case ed25519.PublicKey:
+		return x, nil
+	case x25519.PrivateKey:
+		return x.Public(), nil
+	case x25519.PublicKey:
 		return x, nil
 	case []byte:
 		return x, nil

--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -1,0 +1,146 @@
+package jwk
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ed25519"
+	"fmt"
+
+	"github.com/lestrrat-go/jwx/internal/base64"
+	"github.com/lestrrat-go/jwx/internal/blackmagic"
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/pkg/errors"
+)
+
+func NewOKPPublicKey() OKPPublicKey {
+	return newOKPPublicKey()
+}
+
+func newOKPPublicKey() *okpPublicKey {
+	return &okpPublicKey{
+		privateParams: make(map[string]interface{}),
+	}
+}
+
+func NewOKPPrivateKey() OKPPrivateKey {
+	return newOKPPrivateKey()
+}
+
+func newOKPPrivateKey() *okpPrivateKey {
+	return &okpPrivateKey{
+		privateParams: make(map[string]interface{}),
+	}
+}
+
+func (k *okpPublicKey) FromRaw(rawKeyIf interface{}) error {
+	switch rawKey := rawKeyIf.(type) {
+	case ed25519.PublicKey:
+		k.x = rawKey
+		if err := k.Set(OKPCrvKey, jwa.Ed25519); err != nil {
+			return errors.Wrap(err, `failed to set header`)
+		}
+	default:
+		return errors.Errorf(`unknown key type %T`, rawKeyIf)
+	}
+
+	return nil
+}
+
+func (k *okpPrivateKey) FromRaw(rawKeyIf interface{}) error {
+	switch rawKey := rawKeyIf.(type) {
+	case ed25519.PrivateKey:
+		k.d = rawKey.Seed()
+		k.x = rawKey.Public().(ed25519.PublicKey)
+		if err := k.Set(OKPCrvKey, jwa.Ed25519); err != nil {
+			return errors.Wrap(err, `failed to set header`)
+		}
+	default:
+		return errors.Errorf(`unknown key type %T`, rawKeyIf)
+	}
+
+	return nil
+}
+
+func buildOKPPublicKey(alg jwa.EllipticCurveAlgorithm, xbuf []byte) (interface{}, error) {
+	switch alg {
+	case jwa.Ed25519:
+		return ed25519.PublicKey(xbuf), nil
+	default:
+		return nil, errors.Errorf(`invalid curve algorithm %s`, alg)
+	}
+}
+
+// Raw returns the EC-DSA public key represented by this JWK
+func (k *okpPublicKey) Raw(v interface{}) error {
+	pubk, err := buildOKPPublicKey(k.Crv(), k.x)
+	if err != nil {
+		return errors.Wrap(err, `failed to build public key`)
+	}
+
+	return blackmagic.AssignIfCompatible(v, pubk)
+}
+
+func buildOKPPrivateKey(alg jwa.EllipticCurveAlgorithm, xbuf []byte, dbuf []byte) (interface{}, error) {
+	switch alg {
+	case jwa.Ed25519:
+		ret := ed25519.NewKeyFromSeed(dbuf)
+		if !bytes.Equal(xbuf, ret.Public().(ed25519.PublicKey)) {
+			return nil, errors.Errorf(`invalid x value given d value`)
+		}
+		return ret, nil
+	default:
+		return nil, errors.Errorf(`invalid curve algorithm %s`, alg)
+	}
+}
+
+func (k *okpPrivateKey) Raw(v interface{}) error {
+	privk, err := buildOKPPrivateKey(k.Crv(), k.x, k.d)
+	if err != nil {
+		return errors.Wrap(err, `failed to build public key`)
+	}
+
+	return blackmagic.AssignIfCompatible(v, privk)
+}
+
+func (k *okpPrivateKey) PublicKey() (OKPPublicKey, error) {
+	newKey := NewOKPPublicKey()
+	switch k.Crv() {
+	case jwa.Ed25519:
+		if err := newKey.FromRaw(ed25519.PublicKey(k.x)); err != nil {
+			return nil, errors.Wrap(err, `failed to initialize OKPPublicKey`)
+		}
+	default:
+		return nil, errors.Errorf(`invalid curve algorithm %s`, k.Crv())
+	}
+	return newKey, nil
+}
+
+func okpThumbprint(hash crypto.Hash, crv, x string) []byte {
+	h := hash.New()
+	fmt.Fprint(h, `{"crv":"`)
+	fmt.Fprint(h, crv)
+	fmt.Fprint(h, `","kty":"OKP","x":"`)
+	fmt.Fprint(h, x)
+	fmt.Fprint(h, `"}`)
+	return h.Sum(nil)
+}
+
+// Thumbprint returns the JWK thumbprint using the indicated
+// hashing algorithm, according to RFC 7638 / 8037
+func (k okpPublicKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
+	return okpThumbprint(
+		hash,
+		k.Crv().String(),
+		base64.EncodeToString(k.x),
+	), nil
+}
+
+// Thumbprint returns the JWK thumbprint using the indicated
+// hashing algorithm, according to RFC 7638 / 8037
+func (k okpPrivateKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
+	return okpThumbprint(
+		hash,
+		k.Crv().String(),
+		base64.EncodeToString(k.x),
+	), nil
+}

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -1,0 +1,862 @@
+// This file is auto-generated. DO NOT EDIT
+
+package jwk
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/lestrrat-go/iter/mapiter"
+	"github.com/lestrrat-go/jwx/internal/base64"
+	"github.com/lestrrat-go/jwx/internal/iter"
+	"github.com/lestrrat-go/jwx/internal/json"
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/pkg/errors"
+)
+
+const (
+	OKPCrvKey = "crv"
+	OKPDKey   = "d"
+	OKPXKey   = "x"
+)
+
+type OKPPrivateKey interface {
+	Key
+	FromRaw(interface{}) error
+	Crv() jwa.EllipticCurveAlgorithm
+	D() []byte
+	X() []byte
+	PublicKey() (OKPPublicKey, error)
+}
+
+type okpPrivateKey struct {
+	algorithm              *string // https://tools.ietf.org/html/rfc7517#section-4.4
+	crv                    *jwa.EllipticCurveAlgorithm
+	d                      []byte
+	keyID                  *string           // https://tools.ietf.org/html/rfc7515#section-4.1.4
+	keyUsage               *string           // https://tools.ietf.org/html/rfc7517#section-4.2
+	keyops                 *KeyOperationList // https://tools.ietf.org/html/rfc7517#section-4.3
+	x                      []byte
+	x509CertChain          *CertificateChain // https://tools.ietf.org/html/rfc7515#section-4.1.6
+	x509CertThumbprint     *string           // https://tools.ietf.org/html/rfc7515#section-4.1.7
+	x509CertThumbprintS256 *string           // https://tools.ietf.org/html/rfc7515#section-4.1.8
+	x509URL                *string           // https://tools.ietf.org/html/rfc7515#section-4.1.5
+	privateParams          map[string]interface{}
+}
+
+type okpPrivateKeyMarshalProxy struct {
+	XkeyType                jwa.KeyType                 `json:"kty"`
+	Xalgorithm              *string                     `json:"alg,omitempty"`
+	Xcrv                    *jwa.EllipticCurveAlgorithm `json:"crv,omitempty"`
+	Xd                      *string                     `json:"d,omitempty"`
+	XkeyID                  *string                     `json:"kid,omitempty"`
+	XkeyUsage               *string                     `json:"use,omitempty"`
+	Xkeyops                 *KeyOperationList           `json:"key_ops,omitempty"`
+	Xx                      *string                     `json:"x,omitempty"`
+	Xx509CertChain          *CertificateChain           `json:"x5c,omitempty"`
+	Xx509CertThumbprint     *string                     `json:"x5t,omitempty"`
+	Xx509CertThumbprintS256 *string                     `json:"x5t#S256,omitempty"`
+	Xx509URL                *string                     `json:"x5u,omitempty"`
+}
+
+func (h okpPrivateKey) KeyType() jwa.KeyType {
+	return jwa.OKP
+}
+
+func (h *okpPrivateKey) Algorithm() string {
+	if h.algorithm != nil {
+		return *(h.algorithm)
+	}
+	return ""
+}
+
+func (h *okpPrivateKey) Crv() jwa.EllipticCurveAlgorithm {
+	if h.crv != nil {
+		return *(h.crv)
+	}
+	return jwa.InvalidEllipticCurve
+}
+
+func (h *okpPrivateKey) D() []byte {
+	return h.d
+}
+
+func (h *okpPrivateKey) KeyID() string {
+	if h.keyID != nil {
+		return *(h.keyID)
+	}
+	return ""
+}
+
+func (h *okpPrivateKey) KeyUsage() string {
+	if h.keyUsage != nil {
+		return *(h.keyUsage)
+	}
+	return ""
+}
+
+func (h *okpPrivateKey) KeyOps() KeyOperationList {
+	if h.keyops != nil {
+		return *(h.keyops)
+	}
+	return nil
+}
+
+func (h *okpPrivateKey) X() []byte {
+	return h.x
+}
+
+func (h *okpPrivateKey) X509CertChain() []*x509.Certificate {
+	if h.x509CertChain != nil {
+		return h.x509CertChain.Get()
+	}
+	return nil
+}
+
+func (h *okpPrivateKey) X509CertThumbprint() string {
+	if h.x509CertThumbprint != nil {
+		return *(h.x509CertThumbprint)
+	}
+	return ""
+}
+
+func (h *okpPrivateKey) X509CertThumbprintS256() string {
+	if h.x509CertThumbprintS256 != nil {
+		return *(h.x509CertThumbprintS256)
+	}
+	return ""
+}
+
+func (h *okpPrivateKey) X509URL() string {
+	if h.x509URL != nil {
+		return *(h.x509URL)
+	}
+	return ""
+}
+
+func (h *okpPrivateKey) iterate(ctx context.Context, ch chan *HeaderPair) {
+	defer close(ch)
+
+	var pairs []*HeaderPair
+	pairs = append(pairs, &HeaderPair{Key: "kty", Value: jwa.OKP})
+	if h.algorithm != nil {
+		pairs = append(pairs, &HeaderPair{Key: AlgorithmKey, Value: *(h.algorithm)})
+	}
+	if h.crv != nil {
+		pairs = append(pairs, &HeaderPair{Key: OKPCrvKey, Value: *(h.crv)})
+	}
+	if h.d != nil {
+		pairs = append(pairs, &HeaderPair{Key: OKPDKey, Value: h.d})
+	}
+	if h.keyID != nil {
+		pairs = append(pairs, &HeaderPair{Key: KeyIDKey, Value: *(h.keyID)})
+	}
+	if h.keyUsage != nil {
+		pairs = append(pairs, &HeaderPair{Key: KeyUsageKey, Value: *(h.keyUsage)})
+	}
+	if h.keyops != nil {
+		pairs = append(pairs, &HeaderPair{Key: KeyOpsKey, Value: *(h.keyops)})
+	}
+	if h.x != nil {
+		pairs = append(pairs, &HeaderPair{Key: OKPXKey, Value: h.x})
+	}
+	if h.x509CertChain != nil {
+		pairs = append(pairs, &HeaderPair{Key: X509CertChainKey, Value: *(h.x509CertChain)})
+	}
+	if h.x509CertThumbprint != nil {
+		pairs = append(pairs, &HeaderPair{Key: X509CertThumbprintKey, Value: *(h.x509CertThumbprint)})
+	}
+	if h.x509CertThumbprintS256 != nil {
+		pairs = append(pairs, &HeaderPair{Key: X509CertThumbprintS256Key, Value: *(h.x509CertThumbprintS256)})
+	}
+	if h.x509URL != nil {
+		pairs = append(pairs, &HeaderPair{Key: X509URLKey, Value: *(h.x509URL)})
+	}
+	for k, v := range h.privateParams {
+		pairs = append(pairs, &HeaderPair{Key: k, Value: v})
+	}
+	for _, pair := range pairs {
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- pair:
+		}
+	}
+}
+
+func (h *okpPrivateKey) PrivateParams() map[string]interface{} {
+	return h.privateParams
+}
+
+func (h *okpPrivateKey) Get(name string) (interface{}, bool) {
+	switch name {
+	case KeyTypeKey:
+		return h.KeyType(), true
+	case AlgorithmKey:
+		if h.algorithm == nil {
+			return nil, false
+		}
+		return *(h.algorithm), true
+	case OKPCrvKey:
+		if h.crv == nil {
+			return nil, false
+		}
+		return *(h.crv), true
+	case OKPDKey:
+		if h.d == nil {
+			return nil, false
+		}
+		return h.d, true
+	case KeyIDKey:
+		if h.keyID == nil {
+			return nil, false
+		}
+		return *(h.keyID), true
+	case KeyUsageKey:
+		if h.keyUsage == nil {
+			return nil, false
+		}
+		return *(h.keyUsage), true
+	case KeyOpsKey:
+		if h.keyops == nil {
+			return nil, false
+		}
+		return *(h.keyops), true
+	case OKPXKey:
+		if h.x == nil {
+			return nil, false
+		}
+		return h.x, true
+	case X509CertChainKey:
+		if h.x509CertChain == nil {
+			return nil, false
+		}
+		return *(h.x509CertChain), true
+	case X509CertThumbprintKey:
+		if h.x509CertThumbprint == nil {
+			return nil, false
+		}
+		return *(h.x509CertThumbprint), true
+	case X509CertThumbprintS256Key:
+		if h.x509CertThumbprintS256 == nil {
+			return nil, false
+		}
+		return *(h.x509CertThumbprintS256), true
+	case X509URLKey:
+		if h.x509URL == nil {
+			return nil, false
+		}
+		return *(h.x509URL), true
+	default:
+		v, ok := h.privateParams[name]
+		return v, ok
+	}
+}
+
+func (h *okpPrivateKey) Set(name string, value interface{}) error {
+	switch name {
+	case "kty":
+		return nil
+	case AlgorithmKey:
+		switch v := value.(type) {
+		case string:
+			h.algorithm = &v
+		case fmt.Stringer:
+			tmp := v.String()
+			h.algorithm = &tmp
+		default:
+			return errors.Errorf(`invalid type for %s key: %T`, AlgorithmKey, value)
+		}
+		return nil
+	case OKPCrvKey:
+		if v, ok := value.(jwa.EllipticCurveAlgorithm); ok {
+			h.crv = &v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, OKPCrvKey, value)
+	case OKPDKey:
+		if v, ok := value.([]byte); ok {
+			h.d = v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, OKPDKey, value)
+	case KeyIDKey:
+		if v, ok := value.(string); ok {
+			h.keyID = &v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, KeyIDKey, value)
+	case KeyUsageKey:
+		if v, ok := value.(string); ok {
+			h.keyUsage = &v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, KeyUsageKey, value)
+	case KeyOpsKey:
+		var acceptor KeyOperationList
+		if err := acceptor.Accept(value); err != nil {
+			return errors.Wrapf(err, `invalid value for %s key`, KeyOpsKey)
+		}
+		h.keyops = &acceptor
+		return nil
+	case OKPXKey:
+		if v, ok := value.([]byte); ok {
+			h.x = v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, OKPXKey, value)
+	case X509CertChainKey:
+		var acceptor CertificateChain
+		if err := acceptor.Accept(value); err != nil {
+			return errors.Wrapf(err, `invalid value for %s key`, X509CertChainKey)
+		}
+		h.x509CertChain = &acceptor
+		return nil
+	case X509CertThumbprintKey:
+		if v, ok := value.(string); ok {
+			h.x509CertThumbprint = &v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, X509CertThumbprintKey, value)
+	case X509CertThumbprintS256Key:
+		if v, ok := value.(string); ok {
+			h.x509CertThumbprintS256 = &v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, X509CertThumbprintS256Key, value)
+	case X509URLKey:
+		if v, ok := value.(string); ok {
+			h.x509URL = &v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, X509URLKey, value)
+	default:
+		if h.privateParams == nil {
+			h.privateParams = map[string]interface{}{}
+		}
+		h.privateParams[name] = value
+	}
+	return nil
+}
+
+func (h *okpPrivateKey) UnmarshalJSON(buf []byte) error {
+	var proxy okpPrivateKeyMarshalProxy
+	if err := json.Unmarshal(buf, &proxy); err != nil {
+		return errors.Wrap(err, `failed to unmarshal okpPrivateKey`)
+	}
+	if proxy.XkeyType != jwa.OKP {
+		return errors.Errorf(`invalid kty value for OKPPrivateKey (%s)`, proxy.XkeyType)
+	}
+	h.algorithm = proxy.Xalgorithm
+	h.crv = proxy.Xcrv
+	if proxy.Xd == nil {
+		return errors.New(`required field d is missing`)
+	}
+	if h.d = nil; proxy.Xd != nil {
+		decoded, err := base64.DecodeString(*(proxy.Xd))
+		if err != nil {
+			return errors.Wrap(err, `failed to decode base64 value for d`)
+		}
+		h.d = decoded
+	}
+	h.keyID = proxy.XkeyID
+	h.keyUsage = proxy.XkeyUsage
+	h.keyops = proxy.Xkeyops
+	if proxy.Xx == nil {
+		return errors.New(`required field x is missing`)
+	}
+	if h.x = nil; proxy.Xx != nil {
+		decoded, err := base64.DecodeString(*(proxy.Xx))
+		if err != nil {
+			return errors.Wrap(err, `failed to decode base64 value for x`)
+		}
+		h.x = decoded
+	}
+	h.x509CertChain = proxy.Xx509CertChain
+	h.x509CertThumbprint = proxy.Xx509CertThumbprint
+	h.x509CertThumbprintS256 = proxy.Xx509CertThumbprintS256
+	h.x509URL = proxy.Xx509URL
+	var m map[string]interface{}
+	if err := json.Unmarshal(buf, &m); err != nil {
+		return errors.Wrap(err, `failed to parse privsate parameters`)
+	}
+	delete(m, `kty`)
+	delete(m, AlgorithmKey)
+	delete(m, OKPCrvKey)
+	delete(m, OKPDKey)
+	delete(m, KeyIDKey)
+	delete(m, KeyUsageKey)
+	delete(m, KeyOpsKey)
+	delete(m, OKPXKey)
+	delete(m, X509CertChainKey)
+	delete(m, X509CertThumbprintKey)
+	delete(m, X509CertThumbprintS256Key)
+	delete(m, X509URLKey)
+	h.privateParams = m
+	return nil
+}
+
+func (h okpPrivateKey) MarshalJSON() ([]byte, error) {
+	var proxy okpPrivateKeyMarshalProxy
+	proxy.XkeyType = jwa.OKP
+	proxy.Xalgorithm = h.algorithm
+	proxy.Xcrv = h.crv
+	if len(h.d) > 0 {
+		v := base64.EncodeToString(h.d)
+		proxy.Xd = &v
+	}
+	proxy.XkeyID = h.keyID
+	proxy.XkeyUsage = h.keyUsage
+	proxy.Xkeyops = h.keyops
+	if len(h.x) > 0 {
+		v := base64.EncodeToString(h.x)
+		proxy.Xx = &v
+	}
+	proxy.Xx509CertChain = h.x509CertChain
+	proxy.Xx509CertThumbprint = h.x509CertThumbprint
+	proxy.Xx509CertThumbprintS256 = h.x509CertThumbprintS256
+	proxy.Xx509URL = h.x509URL
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	if err := enc.Encode(proxy); err != nil {
+		return nil, errors.Wrap(err, `failed to encode proxy to JSON`)
+	}
+	hasContent := buf.Len() > 3 // encoding/json always adds a newline, so "{}\n" is the empty hash
+	if l := len(h.privateParams); l > 0 {
+		buf.Truncate(buf.Len() - 2)
+		keys := make([]string, 0, l)
+		for k := range h.privateParams {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for i, k := range keys {
+			if hasContent || i > 0 {
+				fmt.Fprintf(&buf, `,`)
+			}
+			fmt.Fprintf(&buf, `%s:`, strconv.Quote(k))
+			if err := enc.Encode(h.privateParams[k]); err != nil {
+				return nil, errors.Wrapf(err, `failed to encode private param %s`, k)
+			}
+		}
+		fmt.Fprintf(&buf, `}`)
+	}
+	return buf.Bytes(), nil
+}
+
+func (h *okpPrivateKey) Iterate(ctx context.Context) HeaderIterator {
+	ch := make(chan *HeaderPair)
+	go h.iterate(ctx, ch)
+	return mapiter.New(ch)
+}
+
+func (h *okpPrivateKey) Walk(ctx context.Context, visitor HeaderVisitor) error {
+	return iter.WalkMap(ctx, h, visitor)
+}
+
+func (h *okpPrivateKey) AsMap(ctx context.Context) (map[string]interface{}, error) {
+	return iter.AsMap(ctx, h)
+}
+
+type OKPPublicKey interface {
+	Key
+	FromRaw(interface{}) error
+	Crv() jwa.EllipticCurveAlgorithm
+	X() []byte
+}
+
+type okpPublicKey struct {
+	algorithm              *string // https://tools.ietf.org/html/rfc7517#section-4.4
+	crv                    *jwa.EllipticCurveAlgorithm
+	keyID                  *string           // https://tools.ietf.org/html/rfc7515#section-4.1.4
+	keyUsage               *string           // https://tools.ietf.org/html/rfc7517#section-4.2
+	keyops                 *KeyOperationList // https://tools.ietf.org/html/rfc7517#section-4.3
+	x                      []byte
+	x509CertChain          *CertificateChain // https://tools.ietf.org/html/rfc7515#section-4.1.6
+	x509CertThumbprint     *string           // https://tools.ietf.org/html/rfc7515#section-4.1.7
+	x509CertThumbprintS256 *string           // https://tools.ietf.org/html/rfc7515#section-4.1.8
+	x509URL                *string           // https://tools.ietf.org/html/rfc7515#section-4.1.5
+	privateParams          map[string]interface{}
+}
+
+type okpPublicKeyMarshalProxy struct {
+	XkeyType                jwa.KeyType                 `json:"kty"`
+	Xalgorithm              *string                     `json:"alg,omitempty"`
+	Xcrv                    *jwa.EllipticCurveAlgorithm `json:"crv,omitempty"`
+	XkeyID                  *string                     `json:"kid,omitempty"`
+	XkeyUsage               *string                     `json:"use,omitempty"`
+	Xkeyops                 *KeyOperationList           `json:"key_ops,omitempty"`
+	Xx                      *string                     `json:"x,omitempty"`
+	Xx509CertChain          *CertificateChain           `json:"x5c,omitempty"`
+	Xx509CertThumbprint     *string                     `json:"x5t,omitempty"`
+	Xx509CertThumbprintS256 *string                     `json:"x5t#S256,omitempty"`
+	Xx509URL                *string                     `json:"x5u,omitempty"`
+}
+
+func (h okpPublicKey) KeyType() jwa.KeyType {
+	return jwa.OKP
+}
+
+func (h *okpPublicKey) Algorithm() string {
+	if h.algorithm != nil {
+		return *(h.algorithm)
+	}
+	return ""
+}
+
+func (h *okpPublicKey) Crv() jwa.EllipticCurveAlgorithm {
+	if h.crv != nil {
+		return *(h.crv)
+	}
+	return jwa.InvalidEllipticCurve
+}
+
+func (h *okpPublicKey) KeyID() string {
+	if h.keyID != nil {
+		return *(h.keyID)
+	}
+	return ""
+}
+
+func (h *okpPublicKey) KeyUsage() string {
+	if h.keyUsage != nil {
+		return *(h.keyUsage)
+	}
+	return ""
+}
+
+func (h *okpPublicKey) KeyOps() KeyOperationList {
+	if h.keyops != nil {
+		return *(h.keyops)
+	}
+	return nil
+}
+
+func (h *okpPublicKey) X() []byte {
+	return h.x
+}
+
+func (h *okpPublicKey) X509CertChain() []*x509.Certificate {
+	if h.x509CertChain != nil {
+		return h.x509CertChain.Get()
+	}
+	return nil
+}
+
+func (h *okpPublicKey) X509CertThumbprint() string {
+	if h.x509CertThumbprint != nil {
+		return *(h.x509CertThumbprint)
+	}
+	return ""
+}
+
+func (h *okpPublicKey) X509CertThumbprintS256() string {
+	if h.x509CertThumbprintS256 != nil {
+		return *(h.x509CertThumbprintS256)
+	}
+	return ""
+}
+
+func (h *okpPublicKey) X509URL() string {
+	if h.x509URL != nil {
+		return *(h.x509URL)
+	}
+	return ""
+}
+
+func (h *okpPublicKey) iterate(ctx context.Context, ch chan *HeaderPair) {
+	defer close(ch)
+
+	var pairs []*HeaderPair
+	pairs = append(pairs, &HeaderPair{Key: "kty", Value: jwa.OKP})
+	if h.algorithm != nil {
+		pairs = append(pairs, &HeaderPair{Key: AlgorithmKey, Value: *(h.algorithm)})
+	}
+	if h.crv != nil {
+		pairs = append(pairs, &HeaderPair{Key: OKPCrvKey, Value: *(h.crv)})
+	}
+	if h.keyID != nil {
+		pairs = append(pairs, &HeaderPair{Key: KeyIDKey, Value: *(h.keyID)})
+	}
+	if h.keyUsage != nil {
+		pairs = append(pairs, &HeaderPair{Key: KeyUsageKey, Value: *(h.keyUsage)})
+	}
+	if h.keyops != nil {
+		pairs = append(pairs, &HeaderPair{Key: KeyOpsKey, Value: *(h.keyops)})
+	}
+	if h.x != nil {
+		pairs = append(pairs, &HeaderPair{Key: OKPXKey, Value: h.x})
+	}
+	if h.x509CertChain != nil {
+		pairs = append(pairs, &HeaderPair{Key: X509CertChainKey, Value: *(h.x509CertChain)})
+	}
+	if h.x509CertThumbprint != nil {
+		pairs = append(pairs, &HeaderPair{Key: X509CertThumbprintKey, Value: *(h.x509CertThumbprint)})
+	}
+	if h.x509CertThumbprintS256 != nil {
+		pairs = append(pairs, &HeaderPair{Key: X509CertThumbprintS256Key, Value: *(h.x509CertThumbprintS256)})
+	}
+	if h.x509URL != nil {
+		pairs = append(pairs, &HeaderPair{Key: X509URLKey, Value: *(h.x509URL)})
+	}
+	for k, v := range h.privateParams {
+		pairs = append(pairs, &HeaderPair{Key: k, Value: v})
+	}
+	for _, pair := range pairs {
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- pair:
+		}
+	}
+}
+
+func (h *okpPublicKey) PrivateParams() map[string]interface{} {
+	return h.privateParams
+}
+
+func (h *okpPublicKey) Get(name string) (interface{}, bool) {
+	switch name {
+	case KeyTypeKey:
+		return h.KeyType(), true
+	case AlgorithmKey:
+		if h.algorithm == nil {
+			return nil, false
+		}
+		return *(h.algorithm), true
+	case OKPCrvKey:
+		if h.crv == nil {
+			return nil, false
+		}
+		return *(h.crv), true
+	case KeyIDKey:
+		if h.keyID == nil {
+			return nil, false
+		}
+		return *(h.keyID), true
+	case KeyUsageKey:
+		if h.keyUsage == nil {
+			return nil, false
+		}
+		return *(h.keyUsage), true
+	case KeyOpsKey:
+		if h.keyops == nil {
+			return nil, false
+		}
+		return *(h.keyops), true
+	case OKPXKey:
+		if h.x == nil {
+			return nil, false
+		}
+		return h.x, true
+	case X509CertChainKey:
+		if h.x509CertChain == nil {
+			return nil, false
+		}
+		return *(h.x509CertChain), true
+	case X509CertThumbprintKey:
+		if h.x509CertThumbprint == nil {
+			return nil, false
+		}
+		return *(h.x509CertThumbprint), true
+	case X509CertThumbprintS256Key:
+		if h.x509CertThumbprintS256 == nil {
+			return nil, false
+		}
+		return *(h.x509CertThumbprintS256), true
+	case X509URLKey:
+		if h.x509URL == nil {
+			return nil, false
+		}
+		return *(h.x509URL), true
+	default:
+		v, ok := h.privateParams[name]
+		return v, ok
+	}
+}
+
+func (h *okpPublicKey) Set(name string, value interface{}) error {
+	switch name {
+	case "kty":
+		return nil
+	case AlgorithmKey:
+		switch v := value.(type) {
+		case string:
+			h.algorithm = &v
+		case fmt.Stringer:
+			tmp := v.String()
+			h.algorithm = &tmp
+		default:
+			return errors.Errorf(`invalid type for %s key: %T`, AlgorithmKey, value)
+		}
+		return nil
+	case OKPCrvKey:
+		if v, ok := value.(jwa.EllipticCurveAlgorithm); ok {
+			h.crv = &v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, OKPCrvKey, value)
+	case KeyIDKey:
+		if v, ok := value.(string); ok {
+			h.keyID = &v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, KeyIDKey, value)
+	case KeyUsageKey:
+		if v, ok := value.(string); ok {
+			h.keyUsage = &v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, KeyUsageKey, value)
+	case KeyOpsKey:
+		var acceptor KeyOperationList
+		if err := acceptor.Accept(value); err != nil {
+			return errors.Wrapf(err, `invalid value for %s key`, KeyOpsKey)
+		}
+		h.keyops = &acceptor
+		return nil
+	case OKPXKey:
+		if v, ok := value.([]byte); ok {
+			h.x = v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, OKPXKey, value)
+	case X509CertChainKey:
+		var acceptor CertificateChain
+		if err := acceptor.Accept(value); err != nil {
+			return errors.Wrapf(err, `invalid value for %s key`, X509CertChainKey)
+		}
+		h.x509CertChain = &acceptor
+		return nil
+	case X509CertThumbprintKey:
+		if v, ok := value.(string); ok {
+			h.x509CertThumbprint = &v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, X509CertThumbprintKey, value)
+	case X509CertThumbprintS256Key:
+		if v, ok := value.(string); ok {
+			h.x509CertThumbprintS256 = &v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, X509CertThumbprintS256Key, value)
+	case X509URLKey:
+		if v, ok := value.(string); ok {
+			h.x509URL = &v
+			return nil
+		}
+		return errors.Errorf(`invalid value for %s key: %T`, X509URLKey, value)
+	default:
+		if h.privateParams == nil {
+			h.privateParams = map[string]interface{}{}
+		}
+		h.privateParams[name] = value
+	}
+	return nil
+}
+
+func (h *okpPublicKey) UnmarshalJSON(buf []byte) error {
+	var proxy okpPublicKeyMarshalProxy
+	if err := json.Unmarshal(buf, &proxy); err != nil {
+		return errors.Wrap(err, `failed to unmarshal okpPublicKey`)
+	}
+	if proxy.XkeyType != jwa.OKP {
+		return errors.Errorf(`invalid kty value for OKPPublicKey (%s)`, proxy.XkeyType)
+	}
+	h.algorithm = proxy.Xalgorithm
+	h.crv = proxy.Xcrv
+	h.keyID = proxy.XkeyID
+	h.keyUsage = proxy.XkeyUsage
+	h.keyops = proxy.Xkeyops
+	if proxy.Xx == nil {
+		return errors.New(`required field x is missing`)
+	}
+	if h.x = nil; proxy.Xx != nil {
+		decoded, err := base64.DecodeString(*(proxy.Xx))
+		if err != nil {
+			return errors.Wrap(err, `failed to decode base64 value for x`)
+		}
+		h.x = decoded
+	}
+	h.x509CertChain = proxy.Xx509CertChain
+	h.x509CertThumbprint = proxy.Xx509CertThumbprint
+	h.x509CertThumbprintS256 = proxy.Xx509CertThumbprintS256
+	h.x509URL = proxy.Xx509URL
+	var m map[string]interface{}
+	if err := json.Unmarshal(buf, &m); err != nil {
+		return errors.Wrap(err, `failed to parse privsate parameters`)
+	}
+	delete(m, `kty`)
+	delete(m, AlgorithmKey)
+	delete(m, OKPCrvKey)
+	delete(m, KeyIDKey)
+	delete(m, KeyUsageKey)
+	delete(m, KeyOpsKey)
+	delete(m, OKPXKey)
+	delete(m, X509CertChainKey)
+	delete(m, X509CertThumbprintKey)
+	delete(m, X509CertThumbprintS256Key)
+	delete(m, X509URLKey)
+	h.privateParams = m
+	return nil
+}
+
+func (h okpPublicKey) MarshalJSON() ([]byte, error) {
+	var proxy okpPublicKeyMarshalProxy
+	proxy.XkeyType = jwa.OKP
+	proxy.Xalgorithm = h.algorithm
+	proxy.Xcrv = h.crv
+	proxy.XkeyID = h.keyID
+	proxy.XkeyUsage = h.keyUsage
+	proxy.Xkeyops = h.keyops
+	if len(h.x) > 0 {
+		v := base64.EncodeToString(h.x)
+		proxy.Xx = &v
+	}
+	proxy.Xx509CertChain = h.x509CertChain
+	proxy.Xx509CertThumbprint = h.x509CertThumbprint
+	proxy.Xx509CertThumbprintS256 = h.x509CertThumbprintS256
+	proxy.Xx509URL = h.x509URL
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	if err := enc.Encode(proxy); err != nil {
+		return nil, errors.Wrap(err, `failed to encode proxy to JSON`)
+	}
+	hasContent := buf.Len() > 3 // encoding/json always adds a newline, so "{}\n" is the empty hash
+	if l := len(h.privateParams); l > 0 {
+		buf.Truncate(buf.Len() - 2)
+		keys := make([]string, 0, l)
+		for k := range h.privateParams {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for i, k := range keys {
+			if hasContent || i > 0 {
+				fmt.Fprintf(&buf, `,`)
+			}
+			fmt.Fprintf(&buf, `%s:`, strconv.Quote(k))
+			if err := enc.Encode(h.privateParams[k]); err != nil {
+				return nil, errors.Wrapf(err, `failed to encode private param %s`, k)
+			}
+		}
+		fmt.Fprintf(&buf, `}`)
+	}
+	return buf.Bytes(), nil
+}
+
+func (h *okpPublicKey) Iterate(ctx context.Context) HeaderIterator {
+	ch := make(chan *HeaderPair)
+	go h.iterate(ctx, ch)
+	return mapiter.New(ch)
+}
+
+func (h *okpPublicKey) Walk(ctx context.Context, visitor HeaderVisitor) error {
+	return iter.WalkMap(ctx, h, visitor)
+}
+
+func (h *okpPublicKey) AsMap(ctx context.Context) (map[string]interface{}, error) {
+	return iter.AsMap(ctx, h)
+}

--- a/jws/sign/eddsa.go
+++ b/jws/sign/eddsa.go
@@ -1,0 +1,25 @@
+package sign
+
+import (
+	"crypto/ed25519"
+
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/pkg/errors"
+)
+
+func newEdDSA() (*EdDSASigner, error) {
+	return &EdDSASigner{}, nil
+}
+
+func (s EdDSASigner) Algorithm() jwa.SignatureAlgorithm {
+	return jwa.EdDSA
+}
+
+func (s EdDSASigner) Sign(payload []byte, keyif interface{}) ([]byte, error) {
+	switch key := keyif.(type) {
+	case ed25519.PrivateKey:
+		return ed25519.Sign(key, payload), nil
+	default:
+		return nil, errors.Errorf(`invalid key type %T`, keyif)
+	}
+}

--- a/jws/sign/interface.go
+++ b/jws/sign/interface.go
@@ -42,3 +42,6 @@ type HMACSigner struct {
 	alg  jwa.SignatureAlgorithm
 	sign hmacSignFunc
 }
+
+type EdDSASigner struct {
+}

--- a/jws/sign/sign.go
+++ b/jws/sign/sign.go
@@ -14,6 +14,8 @@ func New(alg jwa.SignatureAlgorithm) (Signer, error) {
 		return newECDSA(alg)
 	case jwa.HS256, jwa.HS384, jwa.HS512:
 		return newHMAC(alg)
+	case jwa.EdDSA:
+		return newEdDSA()
 	default:
 		return nil, errors.Errorf(`unsupported signature algorithm %s`, alg)
 	}

--- a/jws/verify/eddsa.go
+++ b/jws/verify/eddsa.go
@@ -1,0 +1,23 @@
+package verify
+
+import (
+	"crypto/ed25519"
+
+	"github.com/pkg/errors"
+)
+
+func newEdDSA() (*EdDSAVerifier, error) {
+	return &EdDSAVerifier{}, nil
+}
+
+func (v EdDSAVerifier) Verify(payload, signature []byte, keyIf interface{}) (err error) {
+	switch key := keyIf.(type) {
+	case ed25519.PublicKey:
+		if !ed25519.Verify(key, payload, signature) {
+			return errors.New(`failed to match EdDSA signature`)
+		}
+		return nil
+	default:
+		return errors.Errorf(`invalid key type %T`, keyIf)
+	}
+}

--- a/jws/verify/interface.go
+++ b/jws/verify/interface.go
@@ -33,3 +33,6 @@ type ECDSAVerifier struct {
 type HMACVerifier struct {
 	signer sign.Signer
 }
+
+type EdDSAVerifier struct {
+}

--- a/jws/verify/verify.go
+++ b/jws/verify/verify.go
@@ -15,6 +15,8 @@ func New(alg jwa.SignatureAlgorithm) (Verifier, error) {
 		return newECDSA(alg)
 	case jwa.HS256, jwa.HS384, jwa.HS512:
 		return newHMAC(alg)
+	case jwa.EdDSA:
+		return newEdDSA()
 	default:
 		return nil, errors.Errorf(`unsupported signature algorithm: %#v`, alg)
 	}

--- a/x25519/x25519.go
+++ b/x25519/x25519.go
@@ -1,0 +1,116 @@
+package x25519
+
+import (
+	"bytes"
+	"crypto"
+	cryptorand "crypto/rand"
+	"io"
+
+	"golang.org/x/crypto/curve25519"
+
+	"github.com/pkg/errors"
+)
+
+// This mirrors ed25519's structure for private/public "keys". jwx
+// requires dedicated types for these as they drive
+// serialization/deserialization logic, as well as encryption types.
+//
+// Note that with the x25519 scheme, the private key is a sequence of
+// 32 bytes, while the public key is the result of X25519(private,
+// basepoint).
+//
+// Portions of this file are from Go's ed25519.go, which is
+// Copyright 2016 The Go Authors. All rights reserved.
+
+const (
+	// PublicKeySize is the size, in bytes, of public keys as used in this package.
+	PublicKeySize = 32
+	// PrivateKeySize is the size, in bytes, of private keys as used in this package.
+	PrivateKeySize = 64
+	// SeedSize is the size, in bytes, of private key seeds. These are the private key representations used by RFC 8032.
+	SeedSize = 32
+)
+
+// PublicKey is the type of X25519 public keys
+type PublicKey []byte
+
+// Any methods implemented on PublicKey might need to also be implemented on
+// PrivateKey, as the latter embeds the former and will expose its methods.
+
+// Equal reports whether pub and x have the same value.
+func (pub PublicKey) Equal(x crypto.PublicKey) bool {
+	xx, ok := x.(PublicKey)
+	if !ok {
+		return false
+	}
+	return bytes.Equal(pub, xx)
+}
+
+// PrivateKey is the type of X25519 private key
+type PrivateKey []byte
+
+// Public returns the PublicKey corresponding to priv.
+func (priv PrivateKey) Public() crypto.PublicKey {
+	publicKey := make([]byte, PublicKeySize)
+	copy(publicKey, priv[SeedSize:])
+	return PublicKey(publicKey)
+}
+
+// Equal reports whether priv and x have the same value.
+func (priv PrivateKey) Equal(x crypto.PrivateKey) bool {
+	xx, ok := x.(PrivateKey)
+	if !ok {
+		return false
+	}
+	return bytes.Equal(priv, xx)
+}
+
+// Seed returns the private key seed corresponding to priv. It is provided for
+// interoperability with RFC 7748. RFC 7748's private keys correspond to seeds
+// in this package.
+func (priv PrivateKey) Seed() []byte {
+	seed := make([]byte, SeedSize)
+	copy(seed, priv[:SeedSize])
+	return seed
+}
+
+// NewKeyFromSeed calculates a private key from a seed. It will return
+// an error if len(seed) is not SeedSize. This function is provided
+// for interoperability with RFC 7748. RFC 7748's private keys
+// correspond to seeds in this package.
+func NewKeyFromSeed(seed []byte) (PrivateKey, error) {
+	privateKey := make([]byte, PrivateKeySize)
+	if len(seed) != SeedSize {
+		return nil, errors.Errorf("unexpected seed size: %d", len(seed))
+	}
+	copy(privateKey, seed)
+	public, err := curve25519.X25519(seed, curve25519.Basepoint)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to compute public key")
+	}
+	copy(privateKey[SeedSize:], public)
+
+	return privateKey, nil
+}
+
+// GenerateKey generates a public/private key pair using entropy from rand.
+// If rand is nil, crypto/rand.Reader will be used.
+func GenerateKey(rand io.Reader) (PublicKey, PrivateKey, error) {
+	if rand == nil {
+		rand = cryptorand.Reader
+	}
+
+	seed := make([]byte, SeedSize)
+	if _, err := io.ReadFull(rand, seed); err != nil {
+		return nil, nil, err
+	}
+
+	privateKey, err := NewKeyFromSeed(seed)
+	if err != nil {
+		return nil, nil, err
+	}
+	publicKey := make([]byte, PublicKeySize)
+	copy(publicKey, privateKey[SeedSize:])
+
+	return publicKey, privateKey, nil
+}

--- a/x25519/x25519_test.go
+++ b/x25519/x25519_test.go
@@ -1,0 +1,44 @@
+package x25519
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewKeyFromSeed(t *testing.T) {
+	// These test vectors are from RFC7748 Section 6.1
+	const alicePrivHex = `77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a`
+	const alicePubHex = `8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a`
+	const bobPrivHex = `5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb`
+	const bobPubHex = `de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f`
+
+	alicePrivSeed, err := hex.DecodeString(alicePrivHex)
+	if !assert.NoError(t, err, `alice seed decoded`) {
+		return
+	}
+	alicePriv, err := NewKeyFromSeed(alicePrivSeed)
+	if !assert.NoError(t, err, `alice private key`) {
+		return
+	}
+
+	alicePub := alicePriv.Public().(PublicKey)
+	if !assert.Equal(t, hex.EncodeToString(alicePub), alicePubHex, `alice public key`) {
+		return
+	}
+
+	bobPrivSeed, err := hex.DecodeString(bobPrivHex)
+	if !assert.NoError(t, err, `bob seed decoded`) {
+		return
+	}
+	bobPriv, err := NewKeyFromSeed(bobPrivSeed)
+	if !assert.NoError(t, err, `bob private key`) {
+		return
+	}
+
+	bobPub := bobPriv.Public().(PublicKey)
+	if !assert.Equal(t, hex.EncodeToString(bobPub), bobPubHex, `bob public key`) {
+		return
+	}
+}


### PR DESCRIPTION
I haven't tested this with any external applications. jose does not support this. There are internal round-trip tests, but those just validate that we have an equal number of bugs on the encrypt/sign and decrypt/verify paths.

There's at least a node-based jose which does support it, but I haven't gotten around to figuring out how to operate it. Feedback welcome as always.

This addresses the 25519-curve-based part of #250. I think the 448 curve should probably wait until there are more "mainstream" implementations of it (i.e. x/crypto or stdlib).