### PR TITLE
Reinstate codecov uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Test with coverage
         run: make cover
       - name: Upload code coverage to codecov
-        if: matrix.go == 'tip'
+        if: matrix.go == '1.15'
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.out


### PR DESCRIPTION
The tip strategy was removed a while back. Update codecov to upload for the 1.15 go version.

Not 100% sure on how the codecov upload works, so just guessing here... should it somehow be disabled for PRs?