### PR TITLE
jwt: remove unused writeJSON function, fix typo in error

### DIFF
--- a/jwt/internal/cmd/gentoken/main.go
+++ b/jwt/internal/cmd/gentoken/main.go
@@ -608,19 +608,6 @@ func generateToken(tt tokenType) error {
 	*/
 
 	// JSON related stuff
-	fmt.Fprintf(&buf, "\n\n// this is almost identical to json.Encoder.Encode(), but we use Marshal")
-	fmt.Fprintf(&buf, "\n// to avoid having to remove the trailing newline for each successive")
-	fmt.Fprintf(&buf, "\n// call to Encode()")
-	fmt.Fprintf(&buf, "\nfunc writeJSON(buf *bytes.Buffer, v interface{}, keyName string) error {")
-	fmt.Fprintf(&buf, "\nenc, err := json.Marshal(v)")
-	fmt.Fprintf(&buf, "\nif err != nil {")
-	fmt.Fprintf(&buf, "\nreturn errors.Wrapf(err, `failed to encode '%%s'`, keyName)")
-	fmt.Fprintf(&buf, "\n}")
-	fmt.Fprintf(&buf, "\nbuf.Write(enc)")
-	fmt.Fprintf(&buf, "\n")
-	fmt.Fprintf(&buf, "\nreturn nil")
-	fmt.Fprintf(&buf, "\n}")
-
 	fmt.Fprintf(&buf, "\n\nfunc (t *%s) UnmarshalJSON(buf []byte) error {", tt.structName)
 	fmt.Fprintf(&buf, "\nvar proxy %sTokenMarshalProxy", tt.prefix)
 	fmt.Fprintf(&buf, "\nif err := json.Unmarshal(buf, &proxy); err != nil {")
@@ -650,7 +637,7 @@ func generateToken(tt tokenType) error {
 	// have other parameters.
 	fmt.Fprintf(&buf, "\nvar m map[string]interface{}")
 	fmt.Fprintf(&buf, "\nif err := json.Unmarshal(buf, &m); err != nil {")
-	fmt.Fprintf(&buf, "\nreturn errors.Wrap(err, `failed to parse privsate parameters`)")
+	fmt.Fprintf(&buf, "\nreturn errors.Wrap(err, `failed to parse private parameters`)")
 	fmt.Fprintf(&buf, "\n}")
 	// Delete all known keys
 	for _, f := range fields {

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -801,19 +801,6 @@ func (t *stdToken) iterate(ctx context.Context, ch chan *ClaimPair) {
 	}
 }
 
-// this is almost identical to json.Encoder.Encode(), but we use Marshal
-// to avoid having to remove the trailing newline for each successive
-// call to Encode()
-func writeJSON(buf *bytes.Buffer, v interface{}, keyName string) error {
-	enc, err := json.Marshal(v)
-	if err != nil {
-		return errors.Wrapf(err, `failed to encode '%s'`, keyName)
-	}
-	buf.Write(enc)
-
-	return nil
-}
-
 func (t *stdToken) UnmarshalJSON(buf []byte) error {
 	var proxy openidTokenMarshalProxy
 	if err := json.Unmarshal(buf, &proxy); err != nil {
@@ -847,7 +834,7 @@ func (t *stdToken) UnmarshalJSON(buf []byte) error {
 	t.updatedAt = proxy.XupdatedAt
 	var m map[string]interface{}
 	if err := json.Unmarshal(buf, &m); err != nil {
-		return errors.Wrap(err, `failed to parse privsate parameters`)
+		return errors.Wrap(err, `failed to parse private parameters`)
 	}
 	delete(m, AudienceKey)
 	delete(m, ExpirationKey)

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -297,19 +297,6 @@ func (t *stdToken) iterate(ctx context.Context, ch chan *ClaimPair) {
 	}
 }
 
-// this is almost identical to json.Encoder.Encode(), but we use Marshal
-// to avoid having to remove the trailing newline for each successive
-// call to Encode()
-func writeJSON(buf *bytes.Buffer, v interface{}, keyName string) error {
-	enc, err := json.Marshal(v)
-	if err != nil {
-		return errors.Wrapf(err, `failed to encode '%s'`, keyName)
-	}
-	buf.Write(enc)
-
-	return nil
-}
-
 func (t *stdToken) UnmarshalJSON(buf []byte) error {
 	var proxy stdTokenMarshalProxy
 	if err := json.Unmarshal(buf, &proxy); err != nil {
@@ -324,7 +311,7 @@ func (t *stdToken) UnmarshalJSON(buf []byte) error {
 	t.subject = proxy.Xsubject
 	var m map[string]interface{}
 	if err := json.Unmarshal(buf, &m); err != nil {
-		return errors.Wrap(err, `failed to parse privsate parameters`)
+		return errors.Wrap(err, `failed to parse private parameters`)
 	}
 	delete(m, AudienceKey)
 	delete(m, ExpirationKey)


### PR DESCRIPTION
Noticed when running staticcheck over the repository.