### PR TITLE
remove unused json tags, fix other go vet complaints

### DIFF
--- a/jwe/headers_gen.go
+++ b/jwe/headers_gen.go
@@ -72,22 +72,22 @@ type Headers interface {
 }
 
 type stdHeaders struct {
-	agreementPartyUInfo    *buffer.Buffer                  `json:"apu,omitempty"`      //
-	agreementPartyVInfo    *buffer.Buffer                  `json:"apv,omitempty"`      //
-	algorithm              *jwa.KeyEncryptionAlgorithm     `json:"alg,omitempty"`      //
-	compression            *jwa.CompressionAlgorithm       `json:"zip,omitempty"`      //
-	contentEncryption      *jwa.ContentEncryptionAlgorithm `json:"enc,omitempty"`      //
-	contentType            *string                         `json:"cty,omitempty"`      //
-	critical               []string                        `json:"crit,omitempty"`     //
-	ephemeralPublicKey     jwk.Key                         `json:"epk,omitempty"`      //
-	jwk                    jwk.Key                         `json:"jwk,omitempty"`      //
-	jwkSetURL              *string                         `json:"jku,omitempty"`      //
-	keyID                  *string                         `json:"kid,omitempty"`      //
-	typ                    *string                         `json:"typ,omitempty"`      //
-	x509CertChain          []string                        `json:"x5c,omitempty"`      //
-	x509CertThumbprint     *string                         `json:"x5t,omitempty"`      //
-	x509CertThumbprintS256 *string                         `json:"x5t#S256,omitempty"` //
-	x509URL                *string                         `json:"x5u,omitempty"`      //
+	agreementPartyUInfo    *buffer.Buffer                  //
+	agreementPartyVInfo    *buffer.Buffer                  //
+	algorithm              *jwa.KeyEncryptionAlgorithm     //
+	compression            *jwa.CompressionAlgorithm       //
+	contentEncryption      *jwa.ContentEncryptionAlgorithm //
+	contentType            *string                         //
+	critical               []string                        //
+	ephemeralPublicKey     jwk.Key                         //
+	jwk                    jwk.Key                         //
+	jwkSetURL              *string                         //
+	keyID                  *string                         //
+	typ                    *string                         //
+	x509CertChain          []string                        //
+	x509CertThumbprint     *string                         //
+	x509CertThumbprintS256 *string                         //
+	x509URL                *string                         //
 	privateParams          map[string]interface{}
 	mu                     sync.RWMutex
 }
@@ -629,7 +629,7 @@ func (h *stdHeaders) UnmarshalJSON(buf []byte) error {
 	return nil
 }
 
-func (h stdHeaders) MarshalJSON() ([]byte, error) {
+func (h *stdHeaders) MarshalJSON() ([]byte, error) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	var proxy standardHeadersMarshalProxy

--- a/jwe/internal/cmd/genheader/main.go
+++ b/jwe/internal/cmd/genheader/main.go
@@ -281,7 +281,7 @@ func generateHeaders() error {
 
 	fmt.Fprintf(&buf, "\n\ntype stdHeaders struct {")
 	for _, f := range fields {
-		fmt.Fprintf(&buf, "\n%s %s %s // %s", f.name, fieldStorageType(f.typ), f.jsonTag, f.comment)
+		fmt.Fprintf(&buf, "\n%s %s // %s", f.name, fieldStorageType(f.typ), f.comment)
 	}
 	fmt.Fprintf(&buf, "\nprivateParams map[string]interface{}")
 	fmt.Fprintf(&buf, "\nmu sync.RWMutex")
@@ -483,7 +483,7 @@ func generateHeaders() error {
 	fmt.Fprintf(&buf, "\nreturn nil")
 	fmt.Fprintf(&buf, "\n}")
 
-	fmt.Fprintf(&buf, "\n\nfunc (h stdHeaders) MarshalJSON() ([]byte, error) {")
+	fmt.Fprintf(&buf, "\n\nfunc (h *stdHeaders) MarshalJSON() ([]byte, error) {")
 	fmt.Fprintf(&buf, "\nh.mu.RLock()")
 	fmt.Fprintf(&buf, "\ndefer h.mu.RUnlock()")
 	fmt.Fprintf(&buf, "\nvar proxy standardHeadersMarshalProxy")

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -54,17 +54,17 @@ type Headers interface {
 }
 
 type stdHeaders struct {
-	algorithm              *jwa.SignatureAlgorithm `json:"alg,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.1
-	contentType            *string                 `json:"cty,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.10
-	critical               []string                `json:"crit,omitempty"`     // https://tools.ietf.org/html/rfc7515#section-4.1.11
-	jwk                    jwk.Key                 `json:"jwk,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.3
-	jwkSetURL              *string                 `json:"jku,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.2
-	keyID                  *string                 `json:"kid,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.4
-	typ                    *string                 `json:"typ,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.9
-	x509CertChain          []string                `json:"x5c,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.6
-	x509CertThumbprint     *string                 `json:"x5t,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.7
-	x509CertThumbprintS256 *string                 `json:"x5t#S256,omitempty"` // https://tools.ietf.org/html/rfc7515#section-4.1.8
-	x509URL                *string                 `json:"x5u,omitempty"`      // https://tools.ietf.org/html/rfc7515#section-4.1.5
+	algorithm              *jwa.SignatureAlgorithm // https://tools.ietf.org/html/rfc7515#section-4.1.1
+	contentType            *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.10
+	critical               []string                // https://tools.ietf.org/html/rfc7515#section-4.1.11
+	jwk                    jwk.Key                 // https://tools.ietf.org/html/rfc7515#section-4.1.3
+	jwkSetURL              *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.2
+	keyID                  *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.4
+	typ                    *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.9
+	x509CertChain          []string                // https://tools.ietf.org/html/rfc7515#section-4.1.6
+	x509CertThumbprint     *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.7
+	x509CertThumbprintS256 *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.8
+	x509URL                *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.5
 	privateParams          map[string]interface{}
 }
 

--- a/jws/internal/cmd/genheader/main.go
+++ b/jws/internal/cmd/genheader/main.go
@@ -218,7 +218,7 @@ func generateHeaders() error {
 
 	fmt.Fprintf(&buf, "\n\ntype stdHeaders struct {")
 	for _, f := range fields {
-		fmt.Fprintf(&buf, "\n%s %s %s // %s", f.name, fieldStorageType(f.typ), f.jsonTag, f.comment)
+		fmt.Fprintf(&buf, "\n%s %s // %s", f.name, fieldStorageType(f.typ), f.comment)
 	}
 	fmt.Fprintf(&buf, "\nprivateParams map[string]interface{}")
 	fmt.Fprintf(&buf, "\n}") // end type StandardHeaders

--- a/jwt/internal/cmd/gentoken/main.go
+++ b/jwt/internal/cmd/gentoken/main.go
@@ -384,7 +384,7 @@ func generateToken(tt tokenType) error {
 	for _, f := range fields {
 		fmt.Fprintf(&buf, "\n%s %s // %s", f.name, fieldStorageType(f.typ), f.Comment)
 	}
-	fmt.Fprintf(&buf, "\nprivateClaims map[string]interface{} `json:\"-\"`")
+	fmt.Fprintf(&buf, "\nprivateClaims map[string]interface{}")
 	fmt.Fprintf(&buf, "\n}") // end type Token
 
 	// Proxy is used when unmarshaling headers

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -80,33 +80,33 @@ type Token interface {
 	AsMap(context.Context) (map[string]interface{}, error)
 }
 type stdToken struct {
-	audience            types.StringList       // https://tools.ietf.org/html/rfc7519#section-4.1.3
-	expiration          *types.NumericDate     // https://tools.ietf.org/html/rfc7519#section-4.1.4
-	issuedAt            *types.NumericDate     // https://tools.ietf.org/html/rfc7519#section-4.1.6
-	issuer              *string                // https://tools.ietf.org/html/rfc7519#section-4.1.1
-	jwtID               *string                // https://tools.ietf.org/html/rfc7519#section-4.1.7
-	notBefore           *types.NumericDate     // https://tools.ietf.org/html/rfc7519#section-4.1.5
-	subject             *string                // https://tools.ietf.org/html/rfc7519#section-4.1.2
-	name                *string                //
-	givenName           *string                //
-	middleName          *string                //
-	familyName          *string                //
-	nickname            *string                //
-	preferredUsername   *string                //
-	profile             *string                //
-	picture             *string                //
-	website             *string                //
-	email               *string                //
-	emailVerified       *bool                  //
-	gender              *string                //
-	birthdate           *BirthdateClaim        //
-	zoneinfo            *string                //
-	locale              *string                //
-	phoneNumber         *string                //
-	phoneNumberVerified *bool                  //
-	address             *AddressClaim          //
-	updatedAt           *types.NumericDate     //
-	privateClaims       map[string]interface{} `json:"-"`
+	audience            types.StringList   // https://tools.ietf.org/html/rfc7519#section-4.1.3
+	expiration          *types.NumericDate // https://tools.ietf.org/html/rfc7519#section-4.1.4
+	issuedAt            *types.NumericDate // https://tools.ietf.org/html/rfc7519#section-4.1.6
+	issuer              *string            // https://tools.ietf.org/html/rfc7519#section-4.1.1
+	jwtID               *string            // https://tools.ietf.org/html/rfc7519#section-4.1.7
+	notBefore           *types.NumericDate // https://tools.ietf.org/html/rfc7519#section-4.1.5
+	subject             *string            // https://tools.ietf.org/html/rfc7519#section-4.1.2
+	name                *string            //
+	givenName           *string            //
+	middleName          *string            //
+	familyName          *string            //
+	nickname            *string            //
+	preferredUsername   *string            //
+	profile             *string            //
+	picture             *string            //
+	website             *string            //
+	email               *string            //
+	emailVerified       *bool              //
+	gender              *string            //
+	birthdate           *BirthdateClaim    //
+	zoneinfo            *string            //
+	locale              *string            //
+	phoneNumber         *string            //
+	phoneNumberVerified *bool              //
+	address             *AddressClaim      //
+	updatedAt           *types.NumericDate //
+	privateClaims       map[string]interface{}
 }
 
 type openidTokenMarshalProxy struct {

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -54,14 +54,14 @@ type Token interface {
 	AsMap(context.Context) (map[string]interface{}, error)
 }
 type stdToken struct {
-	audience      types.StringList       // https://tools.ietf.org/html/rfc7519#section-4.1.3
-	expiration    *types.NumericDate     // https://tools.ietf.org/html/rfc7519#section-4.1.4
-	issuedAt      *types.NumericDate     // https://tools.ietf.org/html/rfc7519#section-4.1.6
-	issuer        *string                // https://tools.ietf.org/html/rfc7519#section-4.1.1
-	jwtID         *string                // https://tools.ietf.org/html/rfc7519#section-4.1.7
-	notBefore     *types.NumericDate     // https://tools.ietf.org/html/rfc7519#section-4.1.5
-	subject       *string                // https://tools.ietf.org/html/rfc7519#section-4.1.2
-	privateClaims map[string]interface{} `json:"-"`
+	audience      types.StringList   // https://tools.ietf.org/html/rfc7519#section-4.1.3
+	expiration    *types.NumericDate // https://tools.ietf.org/html/rfc7519#section-4.1.4
+	issuedAt      *types.NumericDate // https://tools.ietf.org/html/rfc7519#section-4.1.6
+	issuer        *string            // https://tools.ietf.org/html/rfc7519#section-4.1.1
+	jwtID         *string            // https://tools.ietf.org/html/rfc7519#section-4.1.7
+	notBefore     *types.NumericDate // https://tools.ietf.org/html/rfc7519#section-4.1.5
+	subject       *string            // https://tools.ietf.org/html/rfc7519#section-4.1.2
+	privateClaims map[string]interface{}
 }
 
 type stdTokenMarshalProxy struct {


### PR DESCRIPTION
The only semi-serious one is making the MarshalJSON receiver a pointer
due to the mutex lock.