### PR TITLE
Switch to pdebug v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/lestrrat-go/httpcc v0.0.0-20210101035852-e7e8fea419e3
 	github.com/lestrrat-go/iter v0.0.0-20200422075355-fc1769541911
 	github.com/lestrrat-go/option v0.0.0-20210103042652-6f1ecfceda35
-	github.com/lestrrat-go/pdebug v0.0.0-20200204225717-4d6bd78da58d
+	github.com/lestrrat-go/pdebug/v3 v3.0.0-20210111091911-ec4f5c88c087
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20201217014255-9d1352758620

--- a/internal/concatkdf/concatkdf.go
+++ b/internal/concatkdf/concatkdf.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 
 	"github.com/lestrrat-go/jwx/buffer"
-	"github.com/lestrrat-go/pdebug"
+	"github.com/lestrrat-go/pdebug/v3"
 	"github.com/pkg/errors"
 )
 

--- a/internal/jose/jose.go
+++ b/internal/jose/jose.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/lestrrat-go/jwx/internal/jwxtest"
-	"github.com/lestrrat-go/pdebug"
+	"github.com/lestrrat-go/pdebug/v3"
 	"github.com/pkg/errors"
 )
 

--- a/internal/jwxtest/jwxtest.go
+++ b/internal/jwxtest/jwxtest.go
@@ -19,7 +19,7 @@ import (
 	"github.com/lestrrat-go/jwx/jwe"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/lestrrat-go/jwx/x25519"
-	"github.com/lestrrat-go/pdebug"
+	"github.com/lestrrat-go/pdebug/v3"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )

--- a/jwe/decrypt.go
+++ b/jwe/decrypt.go
@@ -17,7 +17,7 @@ import (
 	"github.com/lestrrat-go/jwx/jwe/internal/content_crypt"
 	"github.com/lestrrat-go/jwx/jwe/internal/keyenc"
 	"github.com/lestrrat-go/jwx/x25519"
-	"github.com/lestrrat-go/pdebug"
+	"github.com/lestrrat-go/pdebug/v3"
 	"github.com/pkg/errors"
 )
 
@@ -138,7 +138,7 @@ func (d *Decrypter) ContentCipher() (content_crypt.Cipher, error) {
 
 func (d *Decrypter) Decrypt(recipientKey, ciphertext []byte) (plaintext []byte, err error) {
 	if pdebug.Enabled {
-		g := pdebug.Marker("Decrypter.Decrypt").BindError(&err)
+		g := pdebug.FuncMarker().BindError(&err)
 		defer g.End()
 	}
 
@@ -253,7 +253,7 @@ func (d *Decrypter) decryptSymmetricKey(recipientKey, cek []byte) ([]byte, error
 
 func (d *Decrypter) DecryptKey(recipientKey []byte) (cek []byte, err error) {
 	if pdebug.Enabled {
-		g := pdebug.Marker("Decrypter.DecryptKey").BindError(&err)
+		g := pdebug.FuncMarker().BindError(&err)
 		defer g.End()
 	}
 	if d.keyalg.IsSymmetric() {

--- a/jwe/encrypt.go
+++ b/jwe/encrypt.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/lestrrat-go/jwx/buffer"
 	"github.com/lestrrat-go/jwx/jwa"
-	"github.com/lestrrat-go/pdebug"
+	"github.com/lestrrat-go/pdebug/v3"
 	"github.com/pkg/errors"
 )
 
@@ -31,7 +31,7 @@ func releaseEncryptCtx(ctx *encryptCtx) {
 // Encrypt takes the plaintext and encrypts into a JWE message.
 func (e encryptCtx) Encrypt(plaintext []byte) (*Message, error) {
 	if pdebug.Enabled {
-		g := pdebug.Marker("encryptCtx.Encrypt")
+		g := pdebug.FuncMarker()
 		defer g.End()
 	}
 

--- a/jwe/internal/aescbc/aescbc.go
+++ b/jwe/internal/aescbc/aescbc.go
@@ -11,7 +11,7 @@ import (
 	"hash"
 
 	"github.com/lestrrat-go/jwx/internal/padbuf"
-	"github.com/lestrrat-go/pdebug"
+	"github.com/lestrrat-go/pdebug/v3"
 	"github.com/pkg/errors"
 )
 
@@ -31,7 +31,7 @@ type BlockCipherFunc func([]byte) (cipher.Block, error)
 
 func New(key []byte, f BlockCipherFunc) (hmac *Hmac, err error) {
 	if pdebug.Enabled {
-		g := pdebug.Marker("Hmac.New").BindError(&err)
+		g := pdebug.FuncMarker().BindError(&err)
 		defer g.End()
 	}
 	keysize := len(key) / 2
@@ -161,7 +161,7 @@ func (c Hmac) Seal(dst, nonce, plaintext, data []byte) []byte {
 // Open fulfills the crypto.AEAD interface
 func (c Hmac) Open(dst, nonce, ciphertext, data []byte) ([]byte, error) {
 	if pdebug.Enabled {
-		g := pdebug.Marker("aescbc.Hmac.Open")
+		g := pdebug.FuncMarker()
 		defer g.End()
 	}
 

--- a/jwe/internal/cipher/cipher.go
+++ b/jwe/internal/cipher/cipher.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwe/internal/aescbc"
 	"github.com/lestrrat-go/jwx/jwe/internal/keygen"
-	"github.com/lestrrat-go/pdebug"
+	"github.com/lestrrat-go/pdebug/v3"
 	"github.com/pkg/errors"
 )
 
@@ -33,7 +33,7 @@ func (f gcmFetcher) Fetch(key []byte) (cipher.AEAD, error) {
 
 func (f cbcFetcher) Fetch(key []byte) (cipher.AEAD, error) {
 	if pdebug.Enabled {
-		g := pdebug.Marker("cipher.CBCFetcher.Fetch")
+		g := pdebug.FuncMarker()
 		defer g.End()
 	}
 	aead, err := aescbc.New(key, aes.NewCipher)
@@ -56,7 +56,7 @@ func (c AesContentCipher) TagSize() int {
 
 func NewAES(alg jwa.ContentEncryptionAlgorithm) (*AesContentCipher, error) {
 	if pdebug.Enabled {
-		g := pdebug.Marker("NewAES")
+		g := pdebug.FuncMarker()
 		defer g.End()
 	}
 
@@ -168,7 +168,7 @@ func (c AesContentCipher) Encrypt(cek, plaintext, aad []byte) (iv, ciphertext, t
 
 func (c AesContentCipher) Decrypt(cek, iv, ciphertxt, tag, aad []byte) (plaintext []byte, err error) {
 	if pdebug.Enabled {
-		g := pdebug.Marker("cipher.AesContentCipher.Decrypt").BindError(&err)
+		g := pdebug.FuncMarker().BindError(&err)
 		defer g.End()
 	}
 

--- a/jwe/internal/content_crypt/content_crypt.go
+++ b/jwe/internal/content_crypt/content_crypt.go
@@ -3,7 +3,7 @@ package content_crypt
 import (
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwe/internal/cipher"
-	"github.com/lestrrat-go/pdebug"
+	"github.com/lestrrat-go/pdebug/v3"
 	"github.com/pkg/errors"
 )
 
@@ -35,7 +35,7 @@ func (c Generic) Decrypt(cek, iv, ciphertext, tag, aad []byte) ([]byte, error) {
 
 func NewGeneric(alg jwa.ContentEncryptionAlgorithm) (*Generic, error) {
 	if pdebug.Enabled {
-		g := pdebug.Marker("NewAES (alg = %s)", alg)
+		g := pdebug.FuncMarker()
 		defer g.End()
 	}
 

--- a/jwe/internal/keyenc/keyenc.go
+++ b/jwe/internal/keyenc/keyenc.go
@@ -25,7 +25,7 @@ import (
 	contentcipher "github.com/lestrrat-go/jwx/jwe/internal/cipher"
 	"github.com/lestrrat-go/jwx/jwe/internal/keygen"
 	"github.com/lestrrat-go/jwx/x25519"
-	"github.com/lestrrat-go/pdebug"
+	"github.com/lestrrat-go/pdebug/v3"
 	"github.com/pkg/errors"
 )
 
@@ -310,7 +310,7 @@ func DeriveZ(privkeyif interface{}, pubkeyif interface{}) ([]byte, error) {
 
 func DeriveECDHES(alg, apu, apv []byte, privkey interface{}, pubkey interface{}, keysize uint32) ([]byte, error) {
 	if pdebug.Enabled {
-		g := pdebug.Marker("DeriveECDHES (keysize = %d)", keysize)
+		g := pdebug.FuncMarker()
 		defer g.End()
 	}
 
@@ -332,7 +332,7 @@ func DeriveECDHES(alg, apu, apv []byte, privkey interface{}, pubkey interface{},
 // Decrypt decrypts the encrypted key using ECDH-ES
 func (kw ECDHESDecrypt) Decrypt(enckey []byte) ([]byte, error) {
 	if pdebug.Enabled {
-		g := pdebug.Marker("keyenc.ECDHESDecrypt.Decrypt")
+		g := pdebug.FuncMarker()
 		defer g.End()
 	}
 
@@ -616,7 +616,7 @@ func Wrap(kek cipher.Block, cek []byte) ([]byte, error) {
 
 func Unwrap(block cipher.Block, ciphertxt []byte) ([]byte, error) {
 	if pdebug.Enabled {
-		g := pdebug.Marker("keyenc.Unwrap")
+		g := pdebug.FuncMarker()
 		defer g.End()
 	}
 

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -17,14 +17,14 @@ import (
 	"github.com/lestrrat-go/jwx/jwe/internal/keyenc"
 	"github.com/lestrrat-go/jwx/jwe/internal/keygen"
 	"github.com/lestrrat-go/jwx/x25519"
-	"github.com/lestrrat-go/pdebug"
+	"github.com/lestrrat-go/pdebug/v3"
 	"github.com/pkg/errors"
 )
 
 // Encrypt takes the plaintext payload and encrypts it in JWE compact format.
 func Encrypt(payload []byte, keyalg jwa.KeyEncryptionAlgorithm, key interface{}, contentalg jwa.ContentEncryptionAlgorithm, compressalg jwa.CompressionAlgorithm) ([]byte, error) {
 	if pdebug.Enabled {
-		g := pdebug.Marker("jwe.Encrypt")
+		g := pdebug.FuncMarker()
 		defer g.End()
 	}
 

--- a/jwe/message.go
+++ b/jwe/message.go
@@ -12,7 +12,7 @@ import (
 	"github.com/lestrrat-go/jwx/buffer"
 	"github.com/lestrrat-go/jwx/internal/base64"
 	"github.com/lestrrat-go/jwx/jwa"
-	"github.com/lestrrat-go/pdebug"
+	"github.com/lestrrat-go/pdebug/v3"
 	"github.com/pkg/errors"
 )
 
@@ -383,17 +383,11 @@ func (m *Message) makeDummyRecipient(enckeybuf buffer.Buffer, protected Headers)
 // Decrypt decrypts the message using the specified algorithm and key
 func (m *Message) Decrypt(alg jwa.KeyEncryptionAlgorithm, key interface{}) ([]byte, error) {
 	if pdebug.Enabled {
-		g := pdebug.Marker("Message.Decrypt (alg = %s, key typ = %T)", alg, key)
+		g := pdebug.FuncMarker()
 		defer g.End()
 	}
 
 	var err error
-
-	if pdebug.Enabled {
-		g := pdebug.Marker("message.Decrypt (alg = %s)", alg)
-		defer g.End()
-	}
-
 	ctx := context.TODO()
 	h, err := m.protectedHeaders.Clone(ctx)
 	if err != nil {


### PR DESCRIPTION
pdebug had a problem with race conditions. It's a print debug tool, so who cares if it's buggy, but yeah, testing with `-race` (and more parallelization in tests) ended up in errors, so ...