### PR TITLE
Optimize jwt and jws parsing

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -26,8 +26,10 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"io/ioutil"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/lestrrat-go/jwx/internal/base64"
 	"github.com/lestrrat-go/jwx/internal/json"
@@ -274,7 +276,7 @@ func Verify(buf []byte, alg jwa.SignatureAlgorithm, key interface{}) (ret []byte
 		return nil, errors.New(`could not verify with any of the signatures`)
 	}
 
-	protected, payload, signature, err := SplitCompact(bytes.NewReader(buf))
+	protected, payload, signature, err := SplitCompactBytes(buf)
 	if err != nil {
 		return nil, errors.Wrap(err, `failed extract from compact serialization format`)
 	}
@@ -366,6 +368,15 @@ func VerifyWithJWKSet(buf []byte, keyset *jwk.Set, keyaccept JWKAcceptFunc) ([]b
 // Parse parses contents from the given source and creates a jws.Message
 // struct. The input can be in either compact or full JSON serialization.
 func Parse(src io.Reader) (m *Message, err error) {
+	switch src.(type) {
+	case *bytes.Reader, *bytes.Buffer, *strings.Reader:
+		data, err := ioutil.ReadAll(src)
+		if err != nil {
+			return nil, err
+		}
+		return ParseBytes(data)
+	}
+
 	rdr := bufio.NewReader(src)
 	var first rune
 	for {
@@ -400,7 +411,38 @@ func Parse(src io.Reader) (m *Message, err error) {
 
 // ParseString is the same as Parse, but take in a string
 func ParseString(s string) (*Message, error) {
-	return Parse(strings.NewReader(s))
+	for i := 0; i < len(s); i++ {
+		r := rune(s[i])
+		if r >= utf8.RuneSelf {
+			r, _ = utf8.DecodeRuneInString(s)
+		}
+		if !unicode.IsSpace(r) {
+			if r == '{' {
+				return parseJSONBytes([]byte(s))
+			} else {
+				return parseCompactBytes([]byte(s))
+			}
+		}
+	}
+	return nil, errors.New("invalid string")
+}
+
+// ParseBytes is the same as Parse, but take byte sequence.
+func ParseBytes(s []byte) (*Message, error) {
+	for i := 0; i < len(s); i++ {
+		r := rune(s[i])
+		if r >= utf8.RuneSelf {
+			r, _ = utf8.DecodeRune(s)
+		}
+		if !unicode.IsSpace(r) {
+			if r == '{' {
+				return parseJSONBytes(s)
+			} else {
+				return parseCompactBytes(s)
+			}
+		}
+	}
+	return nil, errors.New("invalid byte sequence")
 }
 
 func parseJSON(src io.Reader) (result *Message, err error) {
@@ -411,9 +453,26 @@ func parseJSON(src io.Reader) (result *Message, err error) {
 	return &m, nil
 }
 
+func parseJSONBytes(data []byte) (result *Message, err error) {
+	var m Message
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, errors.Wrap(err, `failed to unmarshal jws message`)
+	}
+	return &m, nil
+}
+
 // SplitCompact splits a JWT and returns its three parts
 // separately: protected headers, payload and signature.
 func SplitCompact(rdr io.Reader) ([]byte, []byte, []byte, error) {
+	switch rdr.(type) {
+	case *bytes.Buffer, *bytes.Reader, *strings.Reader:
+		data, err := ioutil.ReadAll(rdr)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		return SplitCompactBytes(data)
+	}
+
 	var protected []byte
 	var payload []byte
 	var signature []byte
@@ -477,13 +536,34 @@ func SplitCompact(rdr io.Reader) ([]byte, []byte, []byte, error) {
 	return protected, payload, signature, nil
 }
 
+// SplitCompactBytes splits a JWT and returns its three parts
+// separately: protected headers, payload and signature.
+func SplitCompactBytes(data []byte) ([]byte, []byte, []byte, error) {
+	parts := bytes.Split(data, []byte("."))
+	if len(parts) < 3 {
+		return nil, nil, nil, errors.New(`invalid number of segments`)
+	}
+	return parts[0], parts[1], parts[2], nil
+}
+
 // parseCompact parses a JWS value serialized via compact serialization.
 func parseCompact(rdr io.Reader) (m *Message, err error) {
 	protected, payload, signature, err := SplitCompact(rdr)
 	if err != nil {
 		return nil, errors.Wrap(err, `invalid compact serialization format`)
 	}
+	return parse(protected, payload, signature)
+}
 
+func parseCompactBytes(data []byte) (m *Message, err error) {
+	protected, payload, signature, err := SplitCompactBytes(data)
+	if err != nil {
+		return nil, errors.Wrap(err, `invalid compact serialization format`)
+	}
+	return parse(protected, payload, signature)
+}
+
+func parse(protected, payload, signature []byte) (*Message, error) {
 	decodedHeader, err := base64.Decode(protected)
 	if err != nil {
 		return nil, errors.Wrap(err, `failed to decode protected headers`)

--- a/jwt/jwt_benchmark_test.go
+++ b/jwt/jwt_benchmark_test.go
@@ -1,0 +1,33 @@
+package jwt_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/internal/jwxtest"
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/lestrrat-go/jwx/jwt"
+)
+
+func BenchmarkJWTParse(b *testing.B) {
+	alg := jwa.RS256
+
+	key, err := jwxtest.GenerateRsaJwk()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	t1 := jwt.New()
+	signed, err := jwt.Sign(t1, alg, key)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		t2, err := jwt.ParseBytes(signed)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = t2
+	}
+}


### PR DESCRIPTION
- Remove unnecessary type conversions
- Optimize when the input is a byte sequence, *bytes.Buffer, *bytes.Reader or *strings.Reader.
- Add benchmark for `jwt.ParseBytes`

Before
```
goos: linux
goarch: amd64
pkg: github.com/lestrrat-go/jwx/jwt
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkJWTParse-16    	  141610	     24251 ns/op	   16352 B/op	      69 allocs/op
PASS
ok  	github.com/lestrrat-go/jwx/jwt	8.545s
```

After
```
goos: linux
goarch: amd64
pkg: github.com/lestrrat-go/jwx/jwt
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkJWTParse-16    	  175860	     15419 ns/op	    7152 B/op	      63 allocs/op
PASS
ok  	github.com/lestrrat-go/jwx/jwt	7.782s
```

In the real world, io.Reader has some similar to byte sequences.
How about the real world use case of jwx? 