### PR TITLE
v1.1.0: Standardize on Parse([]byte), ParseString(string), and ParseReader(io.Reader)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,17 @@ realclean:
 	rm coverage.out
 
 test:
-	go test -v -race ./...
+	cd examples && go test -v -race && cd .. && go test -v -race ./...
 
 cover:
-	go test -v -race -coverpkg=./... -coverprofile=coverage.out.tmp ./...
+	cd examples && go test -v -race && cd .. && go test -v -race -coverpkg=./... -coverprofile=coverage.out.tmp ./...
 	@# This is NOT cheating. tools to generate code don't need to be
 	@# included in the final result
 	@cat coverage.out.tmp | grep -v "internal/cmd" > coverage.out
 	@rm coverage.out.tmp
 
 smoke:
-	go test -v -race -short ./...
+	cd examples && go test -v -race && cd .. && go test -v -race -short ./...
 
 viewcover:
 	go tool cover -html=coverage.out

--- a/cmd/jwx/jwx.go
+++ b/cmd/jwx/jwx.go
@@ -115,7 +115,7 @@ func doJWK() int {
 	var buf bytes.Buffer
 	src = io.TeeReader(src, &buf)
 
-	message, err := jws.Parse(src)
+	message, err := jws.ParseReader(src)
 	if err != nil {
 		log.Printf("%s", err)
 		return 0

--- a/examples/jwk_example_test.go
+++ b/examples/jwk_example_test.go
@@ -70,7 +70,7 @@ func ExampleJWK_Usage() {
 		// jwk.Key, which can't be used as the first argument to json.Unmarshal
 		//
 		// In this case, use jwk.Parse()
-		fromJSONKey, err := jwk.ParseBytes(jsonbuf)
+		fromJSONKey, err := jwk.Parse(jsonbuf)
 		if err != nil {
 			log.Printf("failed to parse json: %s", err)
 			return

--- a/examples/jwt_benchmark_test.go
+++ b/examples/jwt_benchmark_test.go
@@ -1,6 +1,7 @@
 package examples_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/internal/jwxtest"
@@ -23,6 +24,7 @@ func BenchmarkJWTParse(b *testing.B) {
 	}
 
 	signedString := string(signed)
+	signedReader := bytes.NewReader(signed)
 	b.Run("ParseString", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -33,10 +35,20 @@ func BenchmarkJWTParse(b *testing.B) {
 			_ = t2
 		}
 	})
-	b.Run("ParseBytes", func(b *testing.B) {
+	b.Run("Parse", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			t2, err := jwt.ParseBytes(signed)
+			t2, err := jwt.Parse(signed)
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = t2
+		}
+	})
+	b.Run("ParseReader", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			t2, err := jwt.ParseReader(signedReader)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/examples/jwt_example_test.go
+++ b/examples/jwt_example_test.go
@@ -1,7 +1,6 @@
 package examples_test
 
 import (
-	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
@@ -87,7 +86,7 @@ func ExampleJWT_ParseJWKS() {
 			// There was a lot of code above, but as a consumer, below is really all you need
 			// to write in your code
 			token, err := jwt.Parse(
-				bytes.NewReader(payload),
+				payload,
 				// Tell the parser that you want to use this keyset
 				jwt.WithKeySet(keyset),
 			)
@@ -139,12 +138,13 @@ func ExampleJWT_ParseJWKS() {
 			}
 
 			// This JWKS can *only* have 1 key.
-			keyset = &jwk.Set{Keys: []jwk.Key{pubKey}}
+			keyset = jwk.NewSet()
+			keyset.Add(pubKey)
 		}
 
 		{
 			token, err := jwt.Parse(
-				bytes.NewReader(payload),
+				payload,
 				// Tell the parser that you want to use this keyset
 				jwt.WithKeySet(keyset),
 				// Tell the parser that you can trust this KeySet, and that
@@ -182,7 +182,8 @@ func ExampleJWT_Sign() {
 	{ // Parse signed payload, and perform (1) verification of the signature
 		// and (2) validation of the JWT token
 		// Validation can be performed in a separate step using `jwt.Validate`
-		token, err := jwt.Parse(bytes.NewReader(payload),
+		token, err := jwt.Parse(
+			payload,
 			jwt.WithValidate(true),
 			jwt.WithVerify(jwa.RS256, &privKey.PublicKey),
 		)
@@ -302,7 +303,7 @@ func ExampleJWT_OpenIDToken() {
 	}
 	fmt.Printf("%s\n", buf)
 
-	t2, err := jwt.ParseBytes(buf, jwt.WithOpenIDClaims())
+	t2, err := jwt.Parse(buf, jwt.WithOpenIDClaims())
 	if err != nil {
 		fmt.Printf("failed to parse JSON: %s\n", err)
 		return

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"crypto/rsa"
+	"io"
+	"io/ioutil"
 
 	"github.com/lestrrat-go/jwx/internal/json"
 	"github.com/lestrrat-go/jwx/internal/keyconv"
@@ -170,6 +172,15 @@ func Parse(buf []byte) (*Message, error) {
 // ParseString is the same as Parse, but takes a string.
 func ParseString(s string) (*Message, error) {
 	return Parse([]byte(s))
+}
+
+// ParseReader is the same as Parse, but takes an io.Reader.
+func ParseReader(src io.Reader) (*Message, error) {
+	buf, err := ioutil.ReadAll(src)
+	if err != nil {
+		return nil, errors.Wrap(err, `failed to read from io.Reader`)
+	}
+	return Parse(buf)
 }
 
 func parseJSON(buf []byte) (*Message, error) {

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -4,7 +4,6 @@
 package jwk
 
 import (
-	"bytes"
 	"context"
 	"crypto"
 	"crypto/ecdsa"
@@ -15,7 +14,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 
 	"github.com/lestrrat-go/jwx/internal/base64"
 	"github.com/lestrrat-go/jwx/internal/json"
@@ -214,7 +212,7 @@ func Fetch(urlstring string, options ...Option) (Set, error) {
 		}
 		defer f.Close()
 
-		return Parse(f)
+		return ParseReader(f)
 	}
 	return nil, errors.Errorf(`invalid url scheme %s`, u.Scheme)
 }
@@ -249,7 +247,7 @@ func FetchHTTPWithContext(ctx context.Context, jwkurl string, options ...Option)
 		return nil, fmt.Errorf("failed to fetch remote JWK (status = %d)", res.StatusCode)
 	}
 
-	return Parse(res.Body)
+	return ParseReader(res.Body)
 }
 
 // ParseRawKey is a combination of ParseKey and Raw. It parses a single JWK key,
@@ -269,9 +267,11 @@ func ParseRawKey(data []byte, rawkey interface{}) error {
 	return nil
 }
 
-// ParseKey parses a single key JWK. This method will report failure for
-// JWK with multiple keys, even if the JWK is valid: You must specify a single
-// key only.
+// ParseKey parses a single key JWK. Unlike `jwk.Parse` this method will
+// report failure if you attempt to pass a JWK set. Only use this function
+// when you know that the data is a single JWK.
+//
+// Note that a successful parsing does NOT guarantee a valid key
 func ParseKey(data []byte) (Key, error) {
 	var hint struct {
 		Kty string          `json:"kty"`
@@ -315,41 +315,37 @@ func ParseKey(data []byte) (Key, error) {
 	return key, nil
 }
 
-// Parse parses JWK from the incoming io.Reader. This function can handle
-// both single-key and multi-key formats. If you know before hand which
-// format the incoming data is in, you might want to consider using
-// "github.com/lestrrat-go/jwx/internal/json" directly
+// Parse parses JWK from the incoming []byte.
 //
-// Note that a successful parsing does NOT guarantee a valid key
+// For JWK sets, this is a convenience function. It is perfectly safe
+// to call `json.Unmarshal` against a `jwk.Set`, including when you
+// are not sure if the `src` contains a single JWK or a JWK set.
+// `(jwk.Set).Unmarshal` will properly take care of either case,
+// and stow the JWKs in a set accordingly.
 //
-// Parse will be removed in v1.1.0.
-// v1.1.0 will introduce `Parse([]byte)` and `ParseReader(`io.Reader`)
-func Parse(in io.Reader) (Set, error) {
+// If you want to parse a single key, you should use `jwk.ParseKey`
+// instead, as you would need to inspect the contents of the JSON
+// payload to figure out the concrete type of a jwk.Key
+func Parse(src []byte) (Set, error) {
 	s := NewSet()
-	if err := json.NewDecoder(in).Decode(s); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal JWK")
+	if err := json.Unmarshal(src, s); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal JWK set")
 	}
 	return s, nil
 }
 
-// ParseBytes parses JWK from the incoming byte buffer.
-//
-// Note that a successful parsing does NOT guarantee a valid key
-//
-// ParseBytes will be removed in v1.1.0.
-// v1.1.0 will introduce `Parse([]byte)` and `ParseReader(`io.Reader`)
-func ParseBytes(buf []byte) (Set, error) {
-	return Parse(bytes.NewReader(buf))
+// ParseReader parses JWK from the incoming byte buffer.
+func ParseReader(src io.Reader) (Set, error) {
+	s := NewSet()
+	if err := json.NewDecoder(src).Decode(s); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal JWK set")
+	}
+	return s, nil
 }
 
 // ParseString parses JWK from the incoming string.
-//
-// Note that a successful parsing does NOT guarantee a valid key
-//
-// ParseString will be removed in v1.1.0.
-// v1.1.0 will introduce `Parse([]byte)` and `ParseReader(`io.Reader`)
 func ParseString(s string) (Set, error) {
-	return Parse(strings.NewReader(s))
+	return Parse([]byte(s))
 }
 
 // AssignKeyID is a convenience function to automatically assign the "kid"

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -57,7 +57,7 @@ func TestParse(t *testing.T) {
 		})
 		t.Run("jwk.Parse", func(t *testing.T) {
 			t.Helper()
-			set, err := jwk.ParseBytes([]byte(`{"keys":[` + src + `]}`))
+			set, err := jwk.Parse([]byte(`{"keys":[` + src + `]}`))
 			if !assert.NoError(t, err, `jwk.Parse should succeed`) {
 				return
 			}
@@ -396,7 +396,7 @@ func TestRoundtrip(t *testing.T) {
 		return
 	}
 
-	ks2, err := jwk.ParseBytes(buf)
+	ks2, err := jwk.Parse(buf)
 	if !assert.NoError(t, err, "JSON unmarshal succeeded") {
 		t.Logf("%s", buf)
 		return

--- a/jwk/refresh.go
+++ b/jwk/refresh.go
@@ -456,7 +456,7 @@ func (af *AutoRefresh) doRefreshRequest(ctx context.Context, url string, enableB
 			continue
 		}
 
-		keyset, err := Parse(res.Body)
+		keyset, err := ParseReader(res.Body)
 		if err != nil {
 			// We don't delete the old key. We persist the old key set, even if it may be stale.
 			// so the user has something to work with

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -26,18 +26,18 @@ const examplePayload = `{"iss":"joe",` + "\r\n" + ` "exp":1300819380,` + "\r\n" 
 const exampleCompactSerialization = `eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk`
 const badValue = "%badvalue%"
 
-func TestParse(t *testing.T) {
+func TestParseReader(t *testing.T) {
 	t.Parallel()
 	t.Run("Empty []byte", func(t *testing.T) {
 		t.Parallel()
-		_, err := jws.ParseBytes(nil)
+		_, err := jws.Parse(nil)
 		if !assert.Error(t, err, "Parsing an empty byte slice should result in an error") {
 			return
 		}
 	})
 	t.Run("Empty bytes.Buffer", func(t *testing.T) {
 		t.Parallel()
-		_, err := jws.Parse(&bytes.Buffer{})
+		_, err := jws.ParseReader(&bytes.Buffer{})
 		if !assert.Error(t, err, "Parsing an empty buffer should result in an error") {
 			return
 		}
@@ -55,8 +55,8 @@ func TestParse(t *testing.T) {
 		for _, useReader := range []bool{true, false} {
 			var err error
 			if useReader {
-				// Force Parse() to choose un-optimized path by using bufio.NewReader
-				_, err = jws.Parse(bufio.NewReader(strings.NewReader(incoming)))
+				// Force ParseReader() to choose un-optimized path by using bufio.NewReader
+				_, err = jws.ParseReader(bufio.NewReader(strings.NewReader(incoming)))
 			} else {
 				_, err = jws.ParseString(incoming)
 			}
@@ -74,7 +74,7 @@ func TestParse(t *testing.T) {
 		for _, useReader := range []bool{true, false} {
 			var err error
 			if useReader {
-				_, err = jws.Parse(bufio.NewReader(strings.NewReader(incoming)))
+				_, err = jws.ParseReader(bufio.NewReader(strings.NewReader(incoming)))
 			} else {
 				_, err = jws.ParseString(incoming)
 			}
@@ -92,7 +92,7 @@ func TestParse(t *testing.T) {
 		for _, useReader := range []bool{true, false} {
 			var err error
 			if useReader {
-				_, err = jws.Parse(bufio.NewReader(strings.NewReader(incoming)))
+				_, err = jws.ParseReader(bufio.NewReader(strings.NewReader(incoming)))
 			} else {
 				_, err = jws.ParseString(incoming)
 			}
@@ -110,7 +110,7 @@ func TestParse(t *testing.T) {
 		for _, useReader := range []bool{true, false} {
 			var err error
 			if useReader {
-				_, err = jws.Parse(bufio.NewReader(strings.NewReader(incoming)))
+				_, err = jws.ParseReader(bufio.NewReader(strings.NewReader(incoming)))
 			} else {
 				_, err = jws.ParseString(incoming)
 			}
@@ -250,8 +250,9 @@ func TestRoundtrip_RSACompact(t *testing.T) {
 		}
 
 		parsers := map[string]func([]byte) (*jws.Message, error){
-			"Parse(io.Reader)": func(b []byte) (*jws.Message, error) { return jws.Parse(bufio.NewReader(bytes.NewReader(b))) },
-			"Parse(string)":    func(b []byte) (*jws.Message, error) { return jws.ParseString(string(b)) },
+			"ParseReader(io.Reader)": func(b []byte) (*jws.Message, error) { return jws.ParseReader(bufio.NewReader(bytes.NewReader(b))) },
+			"Parse([]byte)":          func(b []byte) (*jws.Message, error) { return jws.Parse(b) },
+			"ParseString(string)":    func(b []byte) (*jws.Message, error) { return jws.ParseString(string(b)) },
 		}
 		for name, f := range parsers {
 			m, err := f(buf)
@@ -333,7 +334,7 @@ func TestEncode(t *testing.T) {
 			return
 		}
 
-		msg, err := jws.Parse(bytes.NewReader(encoded))
+		msg, err := jws.ParseReader(bytes.NewReader(encoded))
 		if !assert.NoError(t, err, "Parsing compact encoded serialization succeeds") {
 			return
 		}
@@ -394,7 +395,7 @@ func TestEncode(t *testing.T) {
 			t.Fatal("Failed to sign message")
 		}
 
-		msg, err := jws.Parse(bytes.NewReader(jwsCompact))
+		msg, err := jws.ParseReader(bytes.NewReader(jwsCompact))
 		if !assert.NoError(t, err, "Parsing compact encoded serialization succeeds") {
 			return
 		}
@@ -576,7 +577,7 @@ func TestEncode(t *testing.T) {
 			return
 		}
 
-		msg, err := jws.Parse(bytes.NewReader(encoded))
+		msg, err := jws.ParseReader(bytes.NewReader(encoded))
 		if !assert.NoError(t, err, "Parsing compact encoded serialization succeeds") {
 			return
 		}
@@ -663,7 +664,7 @@ func TestEncode(t *testing.T) {
 		// the output against a fixed expected outcome. We'll wave doing an
 		// exact match, and just try to verify using the signature
 
-		msg, err := jws.Parse(bytes.NewReader(encoded))
+		msg, err := jws.ParseReader(bytes.NewReader(encoded))
 		if !assert.NoError(t, err, "Parsing compact encoded serialization succeeds") {
 			return
 		}
@@ -756,7 +757,7 @@ func TestEncode(t *testing.T) {
 		// the output against a fixed expected outcome. We'll wave doing an
 		// exact match, and just try to verify using the signature
 
-		msg, err := jws.Parse(bytes.NewReader(encoded))
+		msg, err := jws.ParseReader(bytes.NewReader(encoded))
 		if !assert.NoError(t, err, "Parsing compact encoded serialization succeeds") {
 			return
 		}
@@ -786,7 +787,7 @@ func TestEncode(t *testing.T) {
 		t.Parallel()
 		s := `eyJhbGciOiJub25lIn0.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.`
 
-		m, err := jws.Parse(strings.NewReader(s))
+		m, err := jws.ParseReader(strings.NewReader(s))
 		if !assert.NoError(t, err, "Parsing compact serialization") {
 			return
 		}
@@ -839,7 +840,7 @@ func TestEncode(t *testing.T) {
     ]
   }`
 
-		m, err := jws.Parse(strings.NewReader(s))
+		m, err := jws.ParseReader(strings.NewReader(s))
 		if !assert.NoError(t, err, "Unmarshal complete json serialization") {
 			return
 		}
@@ -871,7 +872,7 @@ func TestEncode(t *testing.T) {
 		// This protected header combination forces the parser/unmarshal to go trough the code path to populate and look for protected header fields.
 		// The signature is valid.
 
-		m, err := jws.Parse(strings.NewReader(s))
+		m, err := jws.ParseReader(strings.NewReader(s))
 		if !assert.NoError(t, err, "Unmarshal complete json serialization") {
 			return
 		}
@@ -895,7 +896,7 @@ func TestEncode(t *testing.T) {
     "signature": "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
   }`
 
-		m, err := jws.Parse(strings.NewReader(s))
+		m, err := jws.ParseReader(strings.NewReader(s))
 		if !assert.NoError(t, err, "Parsing flattened json serialization") {
 			return
 		}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -16,20 +16,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ParseString calls Parse with the given string
-//
-// ParseString will be removed in v1.1.0.
-// v1.1.0 will introduce `Parse([]byte)` and `ParseReader(io.Reader)`.
+// ParseString calls Parse against a string
 func ParseString(s string, options ...Option) (Token, error) {
 	return parseBytes([]byte(s), options...)
-}
-
-// ParseBytes calls Parse with the given byte sequence
-//
-// ParseBytes will be removed in v1.1.0.
-// v1.1.0 will introduce `Parse([]byte)` and `ParseReader(io.Reader)`.
-func ParseBytes(s []byte, options ...Option) (Token, error) {
-	return parseBytes(s, options...)
 }
 
 // Parse parses the JWT token payload and creates a new `jwt.Token` object.
@@ -47,10 +36,12 @@ func ParseBytes(s []byte, options ...Option) (Token, error) {
 // This function takes both ParseOption and Validate Option types:
 // ParseOptions control the parsing behavior, and ValidateOptions are
 // passed to `Validate()` when `jwt.WithValidate` is specified.
-//
-// Parse will be removed in v1.1.0.
-// v1.1.0 will introduce `Parse([]byte)` and `ParseReader(io.Reader)`.
-func Parse(src io.Reader, options ...Option) (Token, error) {
+func Parse(s []byte, options ...Option) (Token, error) {
+	return parseBytes(s, options...)
+}
+
+// ParseString calls Parse against an io.Reader
+func ParseReader(src io.Reader, options ...Option) (Token, error) {
 	// We're going to need the raw bytes regardless. Read it.
 	data, err := ioutil.ReadAll(src)
 	if err != nil {
@@ -190,19 +181,6 @@ func lookupMatchingKey(data []byte, keyset jwk.Set, useDefault bool) (jwa.Signat
 	}
 
 	return headers.Algorithm(), rawKey, nil
-}
-
-// ParseVerify is marked to be deprecated. Please use jwt.Parse
-// with appropriate options instead.
-//
-// ParseVerify a function that is similar to Parse(), but does not
-// allow for parsing without signature verification parameters.
-//
-// If you want to provide a jwk.Set and allow the library to automatically
-// choose the key to use using the Key IDs, use the jwt.WithKeySet option
-// along with the jwt.Parse function.
-func ParseVerify(src io.Reader, alg jwa.SignatureAlgorithm, key interface{}) (Token, error) {
-	return Parse(src, WithVerify(alg, key))
 }
 
 // Sign is a convenience function to create a signed JWT token serialized in

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -115,7 +115,7 @@ func parse(token Token, data []byte, verify bool, alg jwa.SignatureAlgorithm, ke
 		// 2. { "signatures": [ ... ] }
 		// 3. { "foo": "bar" }
 		if data[0] == '{' {
-			m, err := jws.ParseBytes(data)
+			m, err := jws.Parse(data)
 			if err == nil {
 				payload = m.Payload()
 			} else {
@@ -124,7 +124,7 @@ func parse(token Token, data []byte, verify bool, alg jwa.SignatureAlgorithm, ke
 			}
 		} else {
 			// Probably compact JWS
-			m, err := jws.ParseBytes(data)
+			m, err := jws.Parse(data)
 			if err != nil {
 				return nil, errors.Wrap(err, `invalid jws message`)
 			}
@@ -155,7 +155,7 @@ func parse(token Token, data []byte, verify bool, alg jwa.SignatureAlgorithm, ke
 }
 
 func lookupMatchingKey(data []byte, keyset jwk.Set, useDefault bool) (jwa.SignatureAlgorithm, interface{}, error) {
-	msg, err := jws.ParseBytes(data)
+	msg, err := jws.Parse(data)
 	if err != nil {
 		return "", nil, errors.Wrap(err, `failed to parse token data`)
 	}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -56,14 +56,21 @@ func parseBytes(data []byte, options ...Option) (Token, error) {
 	var useDefault bool
 	var token Token
 	var validate bool
+	var ok bool
 	for _, o := range options {
 		switch o.Ident() {
 		case identVerify{}:
 			params = o.Value().(VerifyParameters)
 		case identKeySet{}:
-			keyset = o.Value().(jwk.Set)
+			keyset, ok = o.Value().(jwk.Set)
+			if !ok {
+				return nil, errors.Errorf(`invalid JWK set passed via WithKeySet() option (%T)`, o.Value())
+			}
 		case identToken{}:
-			token = o.Value().(Token)
+			token, ok = o.Value().(Token)
+			if !ok {
+				return nil, errors.Errorf(`invalid token passed via WithToken() option (%T)`, o.Value())
+			}
 		case identDefault{}:
 			useDefault = o.Value().(bool)
 		case identValidate{}:

--- a/jwt/openid/openid_test.go
+++ b/jwt/openid/openid_test.go
@@ -1,7 +1,6 @@
 package openid_test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -455,7 +454,7 @@ func TestOpenIDClaims(t *testing.T) {
 				return
 			}
 
-			tokenTmp, err := jwt.Parse(bytes.NewReader(signed), jwt.WithOpenIDClaims(), jwt.WithVerify(alg, &key.PublicKey))
+			tokenTmp, err := jwt.Parse(signed, jwt.WithOpenIDClaims(), jwt.WithVerify(alg, &key.PublicKey))
 			if !assert.NoError(t, err, `parsing the token via jwt.Parse should succeed`) {
 				return
 			}

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -148,16 +148,16 @@ func TestGHIssue10(t *testing.T) {
 			return
 		}
 
-		_, err = jwt.ParseBytes(buf, jwt.WithValidate(true))
+		_, err = jwt.Parse(buf, jwt.WithValidate(true))
 		// This should fail, because exp is set in the past
-		if !assert.Error(t, err, "jwt.ParseBytes should fail") {
+		if !assert.Error(t, err, "jwt.Parse should fail") {
 			return
 		}
 
-		_, err = jwt.ParseBytes(buf, jwt.WithValidate(true), jwt.WithAcceptableSkew(time.Hour))
+		_, err = jwt.Parse(buf, jwt.WithValidate(true), jwt.WithAcceptableSkew(time.Hour))
 		// This should succeed, because we have given big skew
 		// that is well enough to get us accepted
-		if !assert.NoError(t, err, "jwt.ParseBytes should succeed (1)") {
+		if !assert.NoError(t, err, "jwt.Parse should succeed (1)") {
 			return
 		}
 
@@ -166,8 +166,8 @@ func TestGHIssue10(t *testing.T) {
 		clock := jwt.ClockFunc(func() time.Time {
 			return tm.Add(-59 * time.Minute)
 		})
-		_, err = jwt.ParseBytes(buf, jwt.WithValidate(true), jwt.WithClock(clock))
-		if !assert.NoError(t, err, "jwt.ParseBytes should succeed (2)") {
+		_, err = jwt.Parse(buf, jwt.WithValidate(true), jwt.WithClock(clock))
+		if !assert.NoError(t, err, "jwt.Parse should succeed (2)") {
 			return
 		}
 	})


### PR DESCRIPTION
fixes #291