### PR TITLE
Use fs.InMmeory instead of go:embed

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -3,8 +3,12 @@
 package fs
 
 import (
+	"bytes"
 	"io/fs"
+	"io/ioutil"
 	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/lestrrat-go/option"
 	"github.com/pkg/errors"
@@ -38,4 +42,69 @@ func Open(path string, options ...OpenOption) (fs.File, error) {
 		return nil, errors.Wrapf(err, `failed to open %s`, path)
 	}
 	return f, nil
+}
+
+type inMemoryEntry struct {
+	name  string
+	size  int64
+	mode  fs.FileMode
+	mtime time.Time
+	rdr   *bytes.Reader
+}
+
+func (e *inMemoryEntry) Stat() (fs.FileInfo, error) {
+	return e, nil
+}
+
+func (e *inMemoryEntry) Read(buf []byte) (int, error) { return e.rdr.Read(buf) }
+func (e *inMemoryEntry) Close() error                 { return nil }
+func (e *inMemoryEntry) Name() string                 { return e.name }
+func (e *inMemoryEntry) Size() int64                  { return e.size }
+func (e *inMemoryEntry) Mode() fs.FileMode            { return e.mode }
+func (e *inMemoryEntry) ModTime() time.Time           { return e.mtime }
+func (e *inMemoryEntry) IsDir() bool                  { return false }
+func (e *inMemoryEntry) Sys() interface{}             { return nil }
+
+type InMemory struct {
+	data map[string]*inMemoryEntry
+}
+
+func NewInMemory(dir string) (*InMemory, error) {
+	fs := &InMemory{
+		data: make(map[string]*inMemoryEntry),
+	}
+
+	filepath.Walk(dir, filepath.WalkFunc(func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		buf, err := ioutil.ReadFile(path)
+		if err != nil {
+			return errors.Wrapf(err, `failed to read %s`, path)
+		}
+		fs.data[path] = &inMemoryEntry{
+			name:  info.Name(),
+			size:  info.Size(),
+			mode:  info.Mode(),
+			mtime: info.ModTime(),
+			rdr:   bytes.NewReader(buf),
+		}
+		return nil
+	}))
+
+	return fs, nil
+}
+
+func (fs *InMemory) Open(path string) (fs.File, error) {
+	data, ok := fs.data[path]
+	if !ok {
+		return nil, errors.Errorf(`file not found %s`, path)
+	}
+
+	return data, nil
 }

--- a/jwk/fs_test.go
+++ b/jwk/fs_test.go
@@ -3,17 +3,19 @@
 package jwk_test
 
 import (
-	"embed"
 	"testing"
-	
+
+	"github.com/lestrrat-go/jwx/internal/fs"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/stretchr/testify/assert"
 )
 
-//go:embed testdata
-var testdata embed.FS
-
 func TestFS(t *testing.T) {
+	testdata, err := fs.NewInMemory("testdata")
+	if !assert.NoError(t, err, `fs.NewInMemory should succeed`) {
+		return
+	}
+
 	key, err := jwk.ReadFile("testdata/rs256.jwk", jwk.WithFS(testdata))
 	if !assert.NoError(t, err, `jwk.ReadFile + WithFS should succeed`) {
 		return


### PR DESCRIPTION
https://github.com/golang/go/issues/43980

go1.16 probably won't allow us to use go:embed, so just implement
an in memory FS