### PR TITLE
Fix Parse function comments

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -40,8 +40,8 @@ func ParseBytes(s []byte, options ...Option) (Token, error) {
 // If you do not specify these parameters, no verification will be performed.
 //
 // If you also want to assert the validity of the JWT itself (i.e. expiration
-// and such), use the `Valid()` function on the returned token, or pass the
-// `WithValidation(true)` option. Validation options can also be passed to
+// and such), use the `Validate()` function on the returned token, or pass the
+// `WithValidate(true)` option. Validate options can also be passed to
 // `Parse`
 //
 // This function takes both ParseOption and Validate Option types:


### PR DESCRIPTION
Thanks for your awesome work!

Look like typos because I found some function names and option names used in Parse function comments do not exist in this module.

If they are not typos, sorry for bothering you.