### PR TITLE
Implement Custom Fields

### DIFF
--- a/internal/json/registry.go
+++ b/internal/json/registry.go
@@ -1,0 +1,53 @@
+package json
+
+import (
+	"reflect"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+type Registry struct {
+	mu   *sync.RWMutex
+	data map[string]reflect.Type
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		mu:   &sync.RWMutex{},
+		data: make(map[string]reflect.Type),
+	}
+}
+
+func (r *Registry) Register(name string, object interface{}) {
+	if object == nil {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		delete(r.data, name)
+		return
+	}
+
+	typ := reflect.TypeOf(object)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.data[name] = typ
+}
+
+func (r *Registry) Decode(dec *Decoder, name string) (interface{}, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if typ, ok := r.data[name]; ok {
+		ptr := reflect.New(typ).Interface()
+		if err := dec.Decode(ptr); err != nil {
+			return nil, errors.Wrapf(err, `failed to decode field %s`, name)
+		}
+		return reflect.ValueOf(ptr).Elem().Interface(), nil
+	} else {
+		var decoded interface{}
+		if err := dec.Decode(&decoded); err != nil {
+			return nil, errors.Wrapf(err, `failed to decode field %s`, name)
+		}
+		return decoded, nil
+	}
+}

--- a/internal/json/registry.go
+++ b/internal/json/registry.go
@@ -43,11 +43,11 @@ func (r *Registry) Decode(dec *Decoder, name string) (interface{}, error) {
 			return nil, errors.Wrapf(err, `failed to decode field %s`, name)
 		}
 		return reflect.ValueOf(ptr).Elem().Interface(), nil
-	} else {
-		var decoded interface{}
-		if err := dec.Decode(&decoded); err != nil {
-			return nil, errors.Wrapf(err, `failed to decode field %s`, name)
-		}
-		return decoded, nil
 	}
+
+	var decoded interface{}
+	if err := dec.Decode(&decoded); err != nil {
+		return nil, errors.Wrapf(err, `failed to decode field %s`, name)
+	}
+	return decoded, nil
 }

--- a/jwe/internal/cmd/genheader/main.go
+++ b/jwe/internal/cmd/genheader/main.go
@@ -337,6 +337,10 @@ func generateHeaders() error {
 	fmt.Fprintf(&buf, "\n\nfunc (h *stdHeaders) Set(name string, value interface{}) error {")
 	fmt.Fprintf(&buf, "\nh.mu.Lock()")
 	fmt.Fprintf(&buf, "\ndefer h.mu.Unlock()")
+	fmt.Fprintf(&buf, "\nreturn h.setNoLock(name, value)")
+	fmt.Fprintf(&buf, "\n}")
+
+	fmt.Fprintf(&buf, "\n\nfunc (h *stdHeaders) setNoLock(name string, value interface{}) error {")
 	fmt.Fprintf(&buf, "\nswitch name {")
 	for _, f := range fields {
 		fmt.Fprintf(&buf, "\ncase %sKey:", f.method)
@@ -456,14 +460,11 @@ func generateHeaders() error {
 		}
 	}
 	fmt.Fprintf(&buf, "\ndefault:")
-	fmt.Fprintf(&buf, "\nvar decoded interface{}")
-	fmt.Fprintf(&buf, "\nif err := dec.Decode(&decoded); err != nil {")
-	fmt.Fprintf(&buf, "\nreturn errors.Wrapf(err, `failed to decode field %%s`, tok)")
+	fmt.Fprintf(&buf, "\ndecoded, err := registry.Decode(dec, tok)")
+	fmt.Fprintf(&buf, "\nif err != nil {")
+	fmt.Fprintf(&buf, "\nreturn err")
 	fmt.Fprintf(&buf, "\n}")
-	fmt.Fprintf(&buf, "\nif h.privateParams == nil {")
-	fmt.Fprintf(&buf, "\nh.privateParams = make(map[string]interface{})")
-	fmt.Fprintf(&buf, "\n}")
-	fmt.Fprintf(&buf, "\nh.privateParams[tok] = decoded")
+	fmt.Fprintf(&buf, "\nh.setNoLock(tok, decoded)")
 	fmt.Fprintf(&buf, "\n}")
 	fmt.Fprintf(&buf, "\ndefault:")
 	fmt.Fprintf(&buf, "\nreturn errors.Errorf(`invalid token %%T`, tok)")

--- a/jwe/options.go
+++ b/jwe/options.go
@@ -1,9 +1,14 @@
 package jwe
 
-import "github.com/lestrrat-go/option"
+import (
+	"context"
+
+	"github.com/lestrrat-go/option"
+)
 
 type Option = option.Interface
 type identPrettyFormat struct{}
+type identProtectedHeader struct{}
 type SerializerOption interface {
 	Option
 	serializerOption()
@@ -15,8 +20,26 @@ type serializerOption struct {
 
 func (*serializerOption) serializerOption() {}
 
+type EncryptOption interface {
+	Option
+	encryptOption()
+}
+
+type encryptOption struct {
+	Option
+}
+
+func (*encryptOption) encryptOption() {}
+
 // WithPrettyFormat specifies if the `jwe.JSON` serialization tool
 // should generate pretty-formatted output
 func WithPrettyFormat(b bool) SerializerOption {
 	return &serializerOption{option.New(identPrettyFormat{}, b)}
+}
+
+// Specify contents of the protected header. Some fields such as
+// "enc" and "zip" will be overwritten when encryption is performed.
+func WithProtectedHeaders(h Headers) EncryptOption {
+	cloned, _ := h.Clone(context.Background())
+	return &encryptOption{option.New(identProtectedHeader{}, cloned)}
 }

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -270,6 +270,10 @@ func (h *ecdsaPrivateKey) Get(name string) (interface{}, bool) {
 func (h *ecdsaPrivateKey) Set(name string, value interface{}) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	return h.setNoLock(name, value)
+}
+
+func (h *ecdsaPrivateKey) setNoLock(name string, value interface{}) error {
 	switch name {
 	case "kty":
 		return nil
@@ -502,14 +506,11 @@ LOOP:
 					return errors.Wrapf(err, `failed to decode value for key %s`, ECDSAYKey)
 				}
 			default:
-				var decoded interface{}
-				if err := dec.Decode(&decoded); err != nil {
-					return errors.Wrapf(err, `failed to decode field %s`, tok)
+				decoded, err := registry.Decode(dec, tok)
+				if err != nil {
+					return err
 				}
-				if h.privateParams == nil {
-					h.privateParams = make(map[string]interface{})
-				}
-				h.privateParams[tok] = decoded
+				h.setNoLock(tok, decoded)
 			}
 		default:
 			return errors.Errorf(`invalid token %T`, tok)
@@ -825,6 +826,10 @@ func (h *ecdsaPublicKey) Get(name string) (interface{}, bool) {
 func (h *ecdsaPublicKey) Set(name string, value interface{}) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	return h.setNoLock(name, value)
+}
+
+func (h *ecdsaPublicKey) setNoLock(name string, value interface{}) error {
 	switch name {
 	case "kty":
 		return nil
@@ -1044,14 +1049,11 @@ LOOP:
 					return errors.Wrapf(err, `failed to decode value for key %s`, ECDSAYKey)
 				}
 			default:
-				var decoded interface{}
-				if err := dec.Decode(&decoded); err != nil {
-					return errors.Wrapf(err, `failed to decode field %s`, tok)
+				decoded, err := registry.Decode(dec, tok)
+				if err != nil {
+					return err
 				}
-				if h.privateParams == nil {
-					h.privateParams = make(map[string]interface{})
-				}
-				h.privateParams[tok] = decoded
+				h.setNoLock(tok, decoded)
 			}
 		default:
 			return errors.Errorf(`invalid token %T`, tok)

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -24,6 +24,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var registry = json.NewRegistry()
+
 // New creates a jwk.Key from the given key (RSA/ECDSA/symmetric keys).
 //
 // The constructor auto-detects the type of key to be instantiated
@@ -577,3 +579,26 @@ func asnEncode(key Key) (string, []byte, error) {
 		return "", nil, errors.Errorf(`unsupported key type %T`, key)
 	}
 }
+
+// RegisterCustomField allows users to specify that a private field
+// be decoded as an instance of the specified type. This option has
+// a global effect.
+//
+// For example, suppose you have a custom field `x-birthday`, which
+// you want to represent as a string formatted in RFC3339 in JSON,
+// but want it back as `time.Time`.
+//
+// In that case you would register a custom field as follows
+//
+//   jwk.RegisterCustomField(`x-birthday`, timeT)
+//
+// Then `key.Get("x-birthday")` will still return an `interface{}`,
+// but you can convert its type to `time.Time`
+//
+//   bdayif, _ := key.Get(`x-birthday`)
+//   bday := bdayif.(time.Time)
+//
+func RegisterCustomField(name string, object interface{}) {
+	registry.Register(name, object)
+}
+

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -601,4 +601,3 @@ func asnEncode(key Key) (string, []byte, error) {
 func RegisterCustomField(name string, object interface{}) {
 	registry.Register(name, object)
 }
-

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -254,6 +254,10 @@ func (h *okpPrivateKey) Get(name string) (interface{}, bool) {
 func (h *okpPrivateKey) Set(name string, value interface{}) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	return h.setNoLock(name, value)
+}
+
+func (h *okpPrivateKey) setNoLock(name string, value interface{}) error {
 	switch name {
 	case "kty":
 		return nil
@@ -473,14 +477,11 @@ LOOP:
 					return errors.Wrapf(err, `failed to decode value for key %s`, X509URLKey)
 				}
 			default:
-				var decoded interface{}
-				if err := dec.Decode(&decoded); err != nil {
-					return errors.Wrapf(err, `failed to decode field %s`, tok)
+				decoded, err := registry.Decode(dec, tok)
+				if err != nil {
+					return err
 				}
-				if h.privateParams == nil {
-					h.privateParams = make(map[string]interface{})
-				}
-				h.privateParams[tok] = decoded
+				h.setNoLock(tok, decoded)
 			}
 		default:
 			return errors.Errorf(`invalid token %T`, tok)
@@ -779,6 +780,10 @@ func (h *okpPublicKey) Get(name string) (interface{}, bool) {
 func (h *okpPublicKey) Set(name string, value interface{}) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	return h.setNoLock(name, value)
+}
+
+func (h *okpPublicKey) setNoLock(name string, value interface{}) error {
 	switch name {
 	case "kty":
 		return nil
@@ -985,14 +990,11 @@ LOOP:
 					return errors.Wrapf(err, `failed to decode value for key %s`, X509URLKey)
 				}
 			default:
-				var decoded interface{}
-				if err := dec.Decode(&decoded); err != nil {
-					return errors.Wrapf(err, `failed to decode field %s`, tok)
+				decoded, err := registry.Decode(dec, tok)
+				if err != nil {
+					return err
 				}
-				if h.privateParams == nil {
-					h.privateParams = make(map[string]interface{})
-				}
-				h.privateParams[tok] = decoded
+				h.setNoLock(tok, decoded)
 			}
 		default:
 			return errors.Errorf(`invalid token %T`, tok)

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -327,6 +327,10 @@ func (h *rsaPrivateKey) Get(name string) (interface{}, bool) {
 func (h *rsaPrivateKey) Set(name string, value interface{}) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	return h.setNoLock(name, value)
+}
+
+func (h *rsaPrivateKey) setNoLock(name string, value interface{}) error {
 	switch name {
 	case "kty":
 		return nil
@@ -609,14 +613,11 @@ LOOP:
 					return errors.Wrapf(err, `failed to decode value for key %s`, X509URLKey)
 				}
 			default:
-				var decoded interface{}
-				if err := dec.Decode(&decoded); err != nil {
-					return errors.Wrapf(err, `failed to decode field %s`, tok)
+				decoded, err := registry.Decode(dec, tok)
+				if err != nil {
+					return err
 				}
-				if h.privateParams == nil {
-					h.privateParams = make(map[string]interface{})
-				}
-				h.privateParams[tok] = decoded
+				h.setNoLock(tok, decoded)
 			}
 		default:
 			return errors.Errorf(`invalid token %T`, tok)
@@ -918,6 +919,10 @@ func (h *rsaPublicKey) Get(name string) (interface{}, bool) {
 func (h *rsaPublicKey) Set(name string, value interface{}) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	return h.setNoLock(name, value)
+}
+
+func (h *rsaPublicKey) setNoLock(name string, value interface{}) error {
 	switch name {
 	case "kty":
 		return nil
@@ -1122,14 +1127,11 @@ LOOP:
 					return errors.Wrapf(err, `failed to decode value for key %s`, X509URLKey)
 				}
 			default:
-				var decoded interface{}
-				if err := dec.Decode(&decoded); err != nil {
-					return errors.Wrapf(err, `failed to decode field %s`, tok)
+				decoded, err := registry.Decode(dec, tok)
+				if err != nil {
+					return err
 				}
-				if h.privateParams == nil {
-					h.privateParams = make(map[string]interface{})
-				}
-				h.privateParams[tok] = decoded
+				h.setNoLock(tok, decoded)
 			}
 		default:
 			return errors.Errorf(`invalid token %T`, tok)

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -221,6 +221,10 @@ func (h *symmetricKey) Get(name string) (interface{}, bool) {
 func (h *symmetricKey) Set(name string, value interface{}) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	return h.setNoLock(name, value)
+}
+
+func (h *symmetricKey) setNoLock(name string, value interface{}) error {
 	switch name {
 	case "kty":
 		return nil
@@ -412,14 +416,11 @@ LOOP:
 					return errors.Wrapf(err, `failed to decode value for key %s`, X509URLKey)
 				}
 			default:
-				var decoded interface{}
-				if err := dec.Decode(&decoded); err != nil {
-					return errors.Wrapf(err, `failed to decode field %s`, tok)
+				decoded, err := registry.Decode(dec, tok)
+				if err != nil {
+					return err
 				}
-				if h.privateParams == nil {
-					h.privateParams = make(map[string]interface{})
-				}
-				h.privateParams[tok] = decoded
+				h.setNoLock(tok, decoded)
 			}
 		default:
 			return errors.Errorf(`invalid token %T`, tok)

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -303,6 +303,10 @@ func (h *stdHeaders) Get(name string) (interface{}, bool) {
 func (h *stdHeaders) Set(name string, value interface{}) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	return h.setNoLock(name, value)
+}
+
+func (h *stdHeaders) setNoLock(name string, value interface{}) error {
 	switch name {
 	case AlgorithmKey:
 		var acceptor jwa.SignatureAlgorithm
@@ -499,14 +503,11 @@ LOOP:
 					return errors.Wrapf(err, `failed to decode value for key %s`, X509URLKey)
 				}
 			default:
-				var decoded interface{}
-				if err := dec.Decode(&decoded); err != nil {
-					return errors.Wrapf(err, `failed to decode field %s`, tok)
+				decoded, err := registry.Decode(dec, tok)
+				if err != nil {
+					return err
 				}
-				if h.privateParams == nil {
-					h.privateParams = make(map[string]interface{})
-				}
-				h.privateParams[tok] = decoded
+				h.setNoLock(tok, decoded)
 			}
 		default:
 			return errors.Errorf(`invalid token %T`, tok)

--- a/jws/internal/cmd/genheader/main.go
+++ b/jws/internal/cmd/genheader/main.go
@@ -429,11 +429,11 @@ func generateHeaders() error {
 		}
 	}
 	fmt.Fprintf(&buf, "\ndefault:")
-		fmt.Fprintf(&buf, "\ndecoded, err := registry.Decode(dec, tok)")
-		fmt.Fprintf(&buf, "\nif err != nil {")
-		fmt.Fprintf(&buf, "\nreturn err")
-		fmt.Fprintf(&buf, "\n}")
-		fmt.Fprintf(&buf, "\nh.setNoLock(tok, decoded)")
+	fmt.Fprintf(&buf, "\ndecoded, err := registry.Decode(dec, tok)")
+	fmt.Fprintf(&buf, "\nif err != nil {")
+	fmt.Fprintf(&buf, "\nreturn err")
+	fmt.Fprintf(&buf, "\n}")
+	fmt.Fprintf(&buf, "\nh.setNoLock(tok, decoded)")
 	fmt.Fprintf(&buf, "\n}")
 	fmt.Fprintf(&buf, "\ndefault:")
 	fmt.Fprintf(&buf, "\nreturn errors.Errorf(`invalid token %%T`, tok)")

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -556,4 +556,3 @@ func parse(protected, payload, signature []byte) (*Message, error) {
 func RegisterCustomField(name string, object interface{}) {
 	registry.Register(name, object)
 }
-

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -39,6 +39,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var registry = json.NewRegistry()
+
 type payloadSigner struct {
 	signer    Signer
 	key       interface{}
@@ -532,3 +534,26 @@ func parse(protected, payload, signature []byte) (*Message, error) {
 	})
 	return &msg, nil
 }
+
+// RegisterCustomField allows users to specify that a private field
+// be decoded as an instance of the specified type. This option has
+// a global effect.
+//
+// For example, suppose you have a custom field `x-birthday`, which
+// you want to represent as a string formatted in RFC3339 in JSON,
+// but want it back as `time.Time`.
+//
+// In that case you would register a custom field as follows
+//
+//   jwe.RegisterCustomField(`x-birthday`, timeT)
+//
+// Then `hdr.Get("x-birthday")` will still return an `interface{}`,
+// but you can convert its type to `time.Time`
+//
+//   bdayif, _ := hdr.Get(`x-birthday`)
+//   bday := bdayif.(time.Time)
+//
+func RegisterCustomField(name string, object interface{}) {
+	registry.Register(name, object)
+}
+

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -17,6 +17,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var registry = json.NewRegistry()
+
 // ParseString calls Parse against a string
 func ParseString(s string, options ...ParseOption) (Token, error) {
 	return parseBytes([]byte(s), options...)
@@ -271,4 +273,26 @@ func (t *stdToken) Clone() (Token, error) {
 		}
 	}
 	return dst, nil
+}
+
+// RegisterCustomField allows users to specify that a private field
+// be decoded as an instance of the specified type. This option has
+// a global effect.
+//
+// For example, suppose you have a custom field `x-birthday`, which
+// you want to represent as a string formatted in RFC3339 in JSON,
+// but want it back as `time.Time`.
+//
+// In that case you would register a custom field as follows
+//
+//   jwt.RegisterCustomField(`x-birthday`, timeT)
+//
+// Then `token.Get("x-birthday")` will still return an `interface{}`,
+// but you can convert its type to `time.Time`
+//
+//   bdayif, _ := token.Get(`x-birthday`)
+//   bday := bdayif.(time.Time)
+//
+func RegisterCustomField(name string, object interface{}) {
+	registry.Register(name, object)
 }

--- a/jwt/openid/openid.go
+++ b/jwt/openid/openid.go
@@ -10,9 +10,12 @@ package openid
 import (
 	"context"
 
+	"github.com/lestrrat-go/jwx/internal/json"
 	"github.com/lestrrat-go/jwx/jwt"
 	"github.com/pkg/errors"
 )
+
+var registry = json.NewRegistry()
 
 func (t *stdToken) Clone() (jwt.Token, error) {
 	var dst jwt.Token = New()
@@ -25,4 +28,26 @@ func (t *stdToken) Clone() (jwt.Token, error) {
 		}
 	}
 	return dst, nil
+}
+
+// RegisterCustomField allows users to specify that a private field
+// be decoded as an instance of the specified type. This option has
+// a global effect.
+//
+// For example, suppose you have a custom field `x-birthday`, which
+// you want to represent as a string formatted in RFC3339 in JSON,
+// but want it back as `time.Time`.
+//
+// In that case you would register a custom field as follows
+//
+//   jwt.RegisterCustomField(`x-birthday`, timeT)
+//
+// Then `token.Get("x-birthday")` will still return an `interface{}`,
+// but you can convert its type to `time.Time`
+//
+//   bdayif, _ := token.Get(`x-birthday`)
+//   bday := bdayif.(time.Time)
+//
+func RegisterCustomField(name string, object interface{}) {
+	registry.Register(name, object)
 }

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -385,6 +385,10 @@ func (t *stdToken) Remove(key string) error {
 func (t *stdToken) Set(name string, value interface{}) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	return t.setNoLock(name, value)
+}
+
+func (t *stdToken) setNoLock(name string, value interface{}) error {
 	switch name {
 	case AudienceKey:
 		var acceptor types.StringList
@@ -1077,14 +1081,11 @@ LOOP:
 				}
 				t.updatedAt = &decoded
 			default:
-				var decoded interface{}
-				if err := dec.Decode(&decoded); err != nil {
-					return errors.Wrapf(err, `failed to decode field %s`, tok)
+				decoded, err := registry.Decode(dec, tok)
+				if err != nil {
+					return err
 				}
-				if t.privateClaims == nil {
-					t.privateClaims = make(map[string]interface{})
-				}
-				t.privateClaims[tok] = decoded
+				t.setNoLock(tok, decoded)
 			}
 		default:
 			return errors.Errorf(`invalid token %T`, tok)


### PR DESCRIPTION
fixes #332

Each message in the `jwe`, `jwk`, `jws`, `jwt` protocols have predefined fields. Any other field which is not defined in the spec can be populated by the user. Howeversince we don't know the type information before hand we could not decode these values into Go objects.

This PR fixes this by creating a global registry of key names to their types. For example, this makes it so that when you either use `jwt.Parse` or `json.Unmarshal`, the value pointed by x-foo-bar is marshaled into `myawesomepkg.Object`.

```go
func init() {
  jwt.RegisterCustomField(`x-foo-bar`, myawesomepkg.Object{})
}
```

This has global effects.

It is the caller's responsibility to implement the proper `json.Unmarshaler` methods for custom unmarshaling.

