### PR TITLE
Toggle ES256K using a build tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        json_backend: [ 'stdlib', 'goccy' ]
+        json_backend: [ 'stdlib', 'goccy', 'es256k', 'all']
         go: [ '1.16.x', '1.15.x' ]
     name: "Test [ Go ${{ matrix.go }} / JSON Backend ${{ matrix.json_backend }} ]"
     steps:
@@ -26,7 +26,7 @@ jobs:
             ~/.cache/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-g, 'es256k', 'all'-
       - name: Install Go stable version
         if: matrix.go != 'tip'
         uses: actions/setup-go@v2
@@ -47,10 +47,10 @@ jobs:
       - name: Test with coverage
         run: make cover-${{ matrix.json_backend }}
       - name: Upload code coverage to codecov
-        if: matrix.go == '1.15.x'
+        if: matrix.go == '1.16.x'
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.out
       - name: Check difference between generation code and commit code
         run: make check_diffs
-
+ 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             ~/.cache/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-g, 'es256k', 'all'-
+            ${{ runner.os }}-go-
       - name: Install Go stable version
         if: matrix.go != 'tip'
         uses: actions/setup-go@v2

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -36,7 +36,7 @@ jobs:
         run: sudo apt-get install -y --no-install-recommends jose
       - run: make generate
       - name: Run smoke tests
-        run: make smoke
+        run: make smoke-${{ matrix.json_backend }}
       - name: Check difference between generation code and commit code
         run: make check_diffs
       - name: Run go mod tidy

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        json_backend: [ 'stdlib', 'goccy' ]
+        json_backend: [ 'stdlib', 'goccy', 'es256k', 'all' ]
         go: [ '1.16.x', '1.15.x' ]
     name: "Smoke [ Go ${{ matrix.go }} / JSON Backend ${{ matrix.json_backend }} ]"
     steps:

--- a/Changes
+++ b/Changes
@@ -7,6 +7,8 @@ v1.1.4
 
      go build -tags jwx_es256k ...
 
+    Your program will still compile without this tag, but it will return
+    an error during runtime, when ES256K is encountered.
     This feature is still experimental.
 
 v1.1.3 22 Feb 2021

--- a/Changes
+++ b/Changes
@@ -7,6 +7,8 @@ v1.1.4
 
      go build -tags jwx_es256k ...
 
+    This feature is still experimental.
+
 v1.1.3 22 Feb 2021
 [New features]
   * Implemented ES256K signing (#337)

--- a/Changes
+++ b/Changes
@@ -1,6 +1,12 @@
 Changes
 =======
 
+v1.1.4
+[Miscellaneous]
+  * ES256K has been made non-default. You must enable it using a build tag
+
+     go build -tags jwx_es256k ...
+
 v1.1.3 22 Feb 2021
 [New features]
   * Implemented ES256K signing (#337)

--- a/Makefile
+++ b/Makefile
@@ -10,19 +10,19 @@ generate-%:
 realclean:
 	rm coverage.out
 
-_test:
-	go test -race $(TESTOPTS)
+test-cmd:
+	go test -v -race $(TESTOPTS)
 
 test:
-	$(MAKE) -C examples _test
-	$(MAKE) -C bench _test
-	$(MAKE) _test TESOPTS=./...
+	$(MAKE) test-cmd TESOPTS=./...
+	$(MAKE) -f $(PWD)/Makefile -C examples test-cmd
+	$(MAKE) -f $(PWD)/Makefile -C bench test-cmd
 
 cover-cmd:
-	$(MAKE) -f $(PWD)/Makefile -C examples _test
-	$(MAKE) -f $(PWD)/Makefile -C bench _test
-	$(MAKE) -f $(PWD)/Makefile -C cmd/jwx _test
-	$(MAKE) _test 
+	$(MAKE) test-cmd 
+	$(MAKE) -f $(PWD)/Makefile -C examples test-cmd
+	$(MAKE) -f $(PWD)/Makefile -C bench test-cmd
+	$(MAKE) -f $(PWD)/Makefile -C cmd/jwx test-cmd
 	@# This is NOT cheating. tools to generate code don't need to be
 	@# included in the final result. Also, we currently don't do
 	@# any active development on the jwx command
@@ -45,10 +45,10 @@ cover-all:
 	$(MAKE) cover-cmd TESTOPTS="-tags jwx_goccy,jwx_es256k -coverpkg=./... -coverprofile=coverage.out.tmp ./..."
 
 smoke-cmd:
-	$(MAKE) -f $(PWD)/Makefile -C examples _test
-	$(MAKE) -f $(PWD)/Makefile -C bench _test
-	$(MAKE) -f $(PWD)/Makefile -C cmd/jwx _test
-	$(MAKE) _test
+	$(MAKE) test-cmd
+	$(MAKE) -f $(PWD)/Makefile -C examples test-cmd
+	$(MAKE) -f $(PWD)/Makefile -C bench test-cmd
+	$(MAKE) -f $(PWD)/Makefile -C cmd/jwx test-cmd
 
 smoke:
 	$(MAKE) smoke-stdlib
@@ -60,10 +60,10 @@ smoke-goccy:
 	$(MAKE) smoke-cmd TESTOPTS="-short -tags jwx_goccy ./..."
 
 smoke-es256k:
-	$(MAKE) smoke-cmd TESTOPTS="-short -tags jwx_256k ./..."
+	$(MAKE) smoke-cmd TESTOPTS="-short -tags jwx_es256k ./..."
 
 smoke-all:
-	$(MAKE) smoke-cmd TESTOPTS="-short -tags jwx_goccy,jwx_256k ./..."
+	$(MAKE) smoke-cmd TESTOPTS="-short -tags jwx_goccy,jwx_es256k ./..."
 
 viewcover:
 	go tool cover -html=coverage.out

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ test:
 
 cover-cmd:
 	$(MAKE) test-cmd 
-	$(MAKE) -f $(PWD)/Makefile -C examples test-cmd
-	$(MAKE) -f $(PWD)/Makefile -C bench test-cmd
-	$(MAKE) -f $(PWD)/Makefile -C cmd/jwx test-cmd
+	$(MAKE) -f $(PWD)/Makefile -C examples TESTOPTS= test-cmd
+	$(MAKE) -f $(PWD)/Makefile -C bench TESTOPTS= test-cmd
+	$(MAKE) -f $(PWD)/Makefile -C cmd/jwx TESTOPTS= test-cmd
 	@# This is NOT cheating. tools to generate code don't need to be
 	@# included in the final result. Also, we currently don't do
 	@# any active development on the jwx command

--- a/Makefile
+++ b/Makefile
@@ -18,43 +18,52 @@ test:
 	$(MAKE) -C bench _test
 	$(MAKE) _test TESOPTS=./...
 
-cover:
-	$(MAKE) cover-stdlib
-
-cover-stdlib:
+cover-cmd:
 	$(MAKE) -f $(PWD)/Makefile -C examples _test
 	$(MAKE) -f $(PWD)/Makefile -C bench _test
 	$(MAKE) -f $(PWD)/Makefile -C cmd/jwx _test
-	$(MAKE) _test TESTOPTS="-coverpkg=./... -coverprofile=coverage.out.tmp ./..."
+	$(MAKE) _test 
 	@# This is NOT cheating. tools to generate code don't need to be
 	@# included in the final result. Also, we currently don't do
 	@# any active development on the jwx command
 	@cat coverage.out.tmp | grep -v "internal/jose" | grep -v "internal/jwxtest" | grep -v "internal/cmd" | grep -v "cmd/jwx/jwx.go" > coverage.out
 	@rm coverage.out.tmp
 
+cover:
+	$(MAKE) cover-stdlib
+
+cover-stdlib:
+	$(MAKE) cover-cmd TESTOPTS="-coverpkg=./... -coverprofile=coverage.out.tmp ./..."
+
 cover-goccy:
-	$(MAKE) -f $(PWD)/Makefile -C examples _test TESTOPTS="-tags jwx_goccy"
-	$(MAKE) -f $(PWD)/Makefile -C cmd/jwx _test TESTOPTS="-tags jwx_goccy"
-	$(MAKE) _test TESTOPTS="-tags jwx_goccy -coverpkg=./... -coverprofile=coverage.out.tmp ./..."
-	@# This is NOT cheating. tools to generate code don't need to be
-	@# included in the final result
-	@cat coverage.out.tmp | grep -v "internal/jose" | grep -v "internal/jwxtest" | grep -v "internal/cmd" | grep -v "cmd/jwx/jwx.go" > coverage.out
-	@rm coverage.out.tmp
+	$(MAKE) cover-cmd TESTOPTS="-tags jwx_goccy -coverpkg=./... -coverprofile=coverage.out.tmp ./..."
+
+cover-es256k:
+	$(MAKE) cover-cmd TESTOPTS="-tags jwx_es256k -coverpkg=./... -coverprofile=coverage.out.tmp ./..."
+
+cover-all:
+	$(MAKE) cover-cmd TESTOPTS="-tags jwx_goccy,jwx_es256k -coverpkg=./... -coverprofile=coverage.out.tmp ./..."
+
+smoke-cmd:
+	$(MAKE) -f $(PWD)/Makefile -C examples _test
+	$(MAKE) -f $(PWD)/Makefile -C bench _test
+	$(MAKE) -f $(PWD)/Makefile -C cmd/jwx _test
+	$(MAKE) _test
 
 smoke:
 	$(MAKE) smoke-stdlib
 
 smoke-stdlib:
-	$(MAKE) -f $(PWD)/Makefile -C examples _test
-	$(MAKE) -f $(PWD)/Makefile -C bench _test
-	$(MAKE) -f $(PWD)/Makefile -C cmd/jwx _test
-	$(MAKE) _test TESTOPTS="-short ./..."
+	$(MAKE) smoke-cmd TESTOPTS="-short ./..."
 
 smoke-goccy:
-	$(MAKE) -f $(PWD)/Makefile -C examples _test TESTOPTS="-tags jwx_goccy"
-	$(MAKE) -f $(PWD)/Makefile -C bench _test TESTOPTS="-tags jwx_goccy"
-	$(MAKE) -f $(PWD)/Makefile -C cmd/jwx _test TESTOPTS="-tags jwx_goccy"
-	$(MAKE) _test TESOPTS="-short -tags jwx_goccy ./..."
+	$(MAKE) smoke-cmd TESTOPTS="-short -tags jwx_goccy ./..."
+
+smoke-es256k:
+	$(MAKE) smoke-cmd TESTOPTS="-short -tags jwx_256k ./..."
+
+smoke-all:
+	$(MAKE) smoke-cmd TESTOPTS="-short -tags jwx_goccy,jwx_256k ./..."
 
 viewcover:
 	go tool cover -html=coverage.out
@@ -69,6 +78,10 @@ imports:
 	goimports -w ./
 
 tidy:
+	$(MAKE) tidy-cmd
+	$(MAKE) -f $(PWD)/Makefile -C examples tidy-cmd
+	$(MAKE) -f $(PWD)/Makefile -C bench tidy-cmd
+	$(MAKE) -f $(PWD)/Makefile -C cmd/jwx tidy-cmd
+
+tidy-cmd:
 	go mod tidy
-	cd examples && go mod tidy && cd ..
-	cd bench && go mod tidy && cd ..

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,9 @@ cover-cmd:
 	$(MAKE) -f $(PWD)/Makefile -C examples TESTOPTS= test-cmd
 	$(MAKE) -f $(PWD)/Makefile -C bench TESTOPTS= test-cmd
 	$(MAKE) -f $(PWD)/Makefile -C cmd/jwx TESTOPTS= test-cmd
-	@# This is NOT cheating. tools to generate code don't need to be
-	@# included in the final result. Also, we currently don't do
-	@# any active development on the jwx command
-	@cat coverage.out.tmp | grep -v "internal/jose" | grep -v "internal/jwxtest" | grep -v "internal/cmd" | grep -v "cmd/jwx/jwx.go" > coverage.out
+	@# This is NOT cheating. tools to generate code, and tools to
+	@# run tests don't need to be included in the final result.
+	@cat coverage.out.tmp | grep -v "internal/jose" | grep -v "internal/jwxtest" | grep -v "internal/cmd" > coverage.out
 	@rm coverage.out.tmp
 
 cover:

--- a/README.md
+++ b/README.md
@@ -123,9 +123,10 @@ Supported signature algorithms:
 | RSASSA-PSS using SHA256 and MGF1-SHA256 | YES        | jwa.PS256                |
 | RSASSA-PSS using SHA384 and MGF1-SHA384 | YES        | jwa.PS384                |
 | RSASSA-PSS using SHA512 and MGF1-SHA512 | YES        | jwa.PS512                |
-| EdDSA (1)                               | YES        | jwa.EdDSA                |
+| EdDSA (2)                               | YES        | jwa.EdDSA                |
 
 * Note 1: Experimental
+* Note 2: Experimental, and must be toggled using `-tags jwx_es256k` build tag
 
 ## JWE [![Go Reference](https://pkg.go.dev/badge/github.com/lestrrat-go/jwx/jwe.svg)](https://pkg.go.dev/github.com/lestrrat-go/jwx/jwe)
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,17 @@ Supported content encryption algorithm:
 
 # Global Settings
 
+## Enabling ES256K
+
+Some algorithms are intentionally left out because they are not as common in the wild, and you may want to avoid compiling this extra information in.
+To enable these, you must explicitly provide a build tag.
+
+| Algorithm        | Build Tag  |
+|:-----------------|:-----------|
+| secp256k1/ES256K | jwx_es256k |
+
+If you do not provide these tags, the program will still compile, but it will return an error during runtime saying that these algorithms are not supported.
+
 ## Switching to a faster JSON library
 
 By default we use the standard library's `encoding/json` for all of our JSON needs.

--- a/cmd/jwx/go.mod
+++ b/cmd/jwx/go.mod
@@ -3,8 +3,10 @@ module github.com/lestrrat-go/jwx/cmd/jwx
 go 1.15
 
 require (
-	github.com/lestrrat-go/jwx v1.1.1-0.20210204233036-9593b54afe33
+	github.com/lestrrat-go/jwx v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/crypto v0.0.0-20201217014255-9d1352758620
 )
+
+replace github.com/lestrrat-go/jwx => ../..

--- a/cmd/jwx/go.sum
+++ b/cmd/jwx/go.sum
@@ -3,8 +3,12 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSY
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/goccy/go-json v0.3.5 h1:HqrLjEWx7hD62JRhBh+mHv+rEEzBANIu6O0kbDlaLzU=
-github.com/goccy/go-json v0.3.5/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0 h1:sgNeV1VRMDzs6rzyPpxyM0jp317hnwiq58Filgag2xw=
+github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0/go.mod h1:J70FGZSbzsjecRTiTzER+3f1KZLNaXkuv+yeFTKoxM8=
+github.com/goccy/go-json v0.4.7 h1:xGUjaNfhpqhKAV2LoyNXihFLZ8ABSST8B+W+duHqkPI=
+github.com/goccy/go-json v0.4.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/lestrrat-go/backoff/v2 v2.0.7 h1:i2SeK33aOFJlUNJZzf2IpXRBvqBBnaGXfY5Xaop/GsE=
 github.com/lestrrat-go/backoff/v2 v2.0.7/go.mod h1:rHP/q/r9aT27n24JQLa7JhSQZCKBBOiM/uP402WwN8Y=
 github.com/lestrrat-go/codegen v1.0.0/go.mod h1:JhJw6OQAuPEfVKUCLItpaVLumDGWQznd1VaXrBk9TdM=
@@ -12,8 +16,6 @@ github.com/lestrrat-go/httpcc v1.0.0 h1:FszVC6cKfDvBKcJv646+lkh4GydQg2Z29scgUfkO
 github.com/lestrrat-go/httpcc v1.0.0/go.mod h1:tGS/u00Vh5N6FHNkExqGGNId8e0Big+++0Gf8MBnAvE=
 github.com/lestrrat-go/iter v1.0.0 h1:QD+hHQPDSHC4rCJkZYY/yXChYr/vjfBopKekTc+7l4Q=
 github.com/lestrrat-go/iter v1.0.0/go.mod h1:zIdgO1mRKhn8l9vrZJZz9TUMMFbQbLeTsbqPDrJ/OJc=
-github.com/lestrrat-go/jwx v1.1.1-0.20210204233036-9593b54afe33 h1:+eOD953MdZnVecCScOxEagK80xaaa/DSMvBrCYkQYbM=
-github.com/lestrrat-go/jwx v1.1.1-0.20210204233036-9593b54afe33/go.mod h1:vn9FzD6gJtKkgYs7RTKV7CjWtEka8F/voUollhnn4QE=
 github.com/lestrrat-go/option v0.0.0-20210103042652-6f1ecfceda35/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/lestrrat-go/option v1.0.0 h1:WqAWL8kh8VcSoD6xjSH34/1m8yxluXQbDeKNfvFeEO4=
 github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
@@ -63,6 +65,7 @@ golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/ecutil/ecutil.go
+++ b/internal/ecutil/ecutil.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 func IsAvailable(alg jwa.EllipticCurveAlgorithm) bool {
-	_, ok := algToCurve[alg];
+	_, ok := algToCurve[alg]
 	return ok
 }
 

--- a/internal/ecutil/ecutil.go
+++ b/internal/ecutil/ecutil.go
@@ -6,7 +6,51 @@ import (
 	"crypto/elliptic"
 	"math/big"
 	"sync"
+
+	"github.com/lestrrat-go/jwx/jwa"
 )
+
+// data for available curves. Some algorithms may be compiled in/out
+var curveToAlg = map[elliptic.Curve]jwa.EllipticCurveAlgorithm{}
+var algToCurve = map[jwa.EllipticCurveAlgorithm]elliptic.Curve{}
+var availableAlgs []jwa.EllipticCurveAlgorithm
+var availableCrvs []elliptic.Curve
+
+func RegisterCurve(crv elliptic.Curve, alg jwa.EllipticCurveAlgorithm) {
+	curveToAlg[crv] = alg
+	algToCurve[alg] = crv
+	availableAlgs = append(availableAlgs, alg)
+	availableCrvs = append(availableCrvs, crv)
+}
+
+func init() {
+	RegisterCurve(elliptic.P256(), jwa.P256)
+	RegisterCurve(elliptic.P384(), jwa.P384)
+	RegisterCurve(elliptic.P521(), jwa.P521)
+}
+
+func IsAvailable(alg jwa.EllipticCurveAlgorithm) bool {
+	_, ok := algToCurve[alg];
+	return ok
+}
+
+func AvailableAlgorithms() []jwa.EllipticCurveAlgorithm {
+	return availableAlgs
+}
+
+func AvailableCurves() []elliptic.Curve {
+	return availableCrvs
+}
+
+func AlgorithmForCurve(crv elliptic.Curve) (jwa.EllipticCurveAlgorithm, bool) {
+	v, ok := curveToAlg[crv]
+	return v, ok
+}
+
+func CurveForAlgorithm(alg jwa.EllipticCurveAlgorithm) (elliptic.Curve, bool) {
+	v, ok := algToCurve[alg]
+	return v, ok
+}
 
 const (
 	// size of buffer that needs to be allocated for EC521 curve

--- a/internal/ecutil/ecutil.go
+++ b/internal/ecutil/ecutil.go
@@ -23,12 +23,6 @@ func RegisterCurve(crv elliptic.Curve, alg jwa.EllipticCurveAlgorithm) {
 	availableCrvs = append(availableCrvs, crv)
 }
 
-func init() {
-	RegisterCurve(elliptic.P256(), jwa.P256)
-	RegisterCurve(elliptic.P384(), jwa.P384)
-	RegisterCurve(elliptic.P521(), jwa.P521)
-}
-
 func IsAvailable(alg jwa.EllipticCurveAlgorithm) bool {
 	_, ok := algToCurve[alg]
 	return ok

--- a/internal/jwxtest/jwxtest.go
+++ b/internal/jwxtest/jwxtest.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/decred/dcrd/dcrec/secp256k1/v3"
+	"github.com/lestrrat-go/jwx/internal/ecutil"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwe"
 	"github.com/lestrrat-go/jwx/jwk"
@@ -54,21 +54,14 @@ func GenerateRsaPublicJwk() (jwk.Key, error) {
 }
 
 func GenerateEcdsaKey(alg jwa.EllipticCurveAlgorithm) (*ecdsa.PrivateKey, error) {
-	var curve elliptic.Curve
-	switch alg {
-	case jwa.P256:
-		curve = elliptic.P256()
-	case jwa.P384:
-		curve = elliptic.P384()
-	case jwa.P521:
-		curve = elliptic.P521()
-	case jwa.Secp256k1:
-		curve = secp256k1.S256()
-	default:
+	var crv elliptic.Curve
+	if tmp, ok := ecutil.CurveForAlgorithm(alg); ok {
+		crv = tmp
+	} else {
 		return nil, errors.Errorf(`invalid curve algorithm %s`, alg)
 	}
 
-	return ecdsa.GenerateKey(curve, rand.Reader)
+	return ecdsa.GenerateKey(crv, rand.Reader)
 }
 
 func GenerateEcdsaJwk() (jwk.Key, error) {

--- a/jwa/compression_gen.go
+++ b/jwa/compression_gen.go
@@ -4,6 +4,8 @@ package jwa
 
 import (
 	"fmt"
+	"sort"
+	"sync"
 
 	"github.com/pkg/errors"
 )
@@ -17,14 +19,26 @@ const (
 	NoCompress CompressionAlgorithm = ""    // No compression
 )
 
-var allCompressionAlgorithms = []CompressionAlgorithm{
-	Deflate,
-	NoCompress,
+var allCompressionAlgorithms = map[CompressionAlgorithm]struct{}{
+	Deflate:    {},
+	NoCompress: {},
 }
+
+var listCompressionAlgorithmOnce sync.Once
+var listCompressionAlgorithm []CompressionAlgorithm
 
 // CompressionAlgorithms returns a list of all available values for CompressionAlgorithm
 func CompressionAlgorithms() []CompressionAlgorithm {
-	return allCompressionAlgorithms
+	listCompressionAlgorithmOnce.Do(func() {
+		listCompressionAlgorithm = make([]CompressionAlgorithm, 0, len(allCompressionAlgorithms))
+		for v := range allCompressionAlgorithms {
+			listCompressionAlgorithm = append(listCompressionAlgorithm, v)
+		}
+		sort.Slice(listCompressionAlgorithm, func(i, j int) bool {
+			return string(listCompressionAlgorithm[i]) < string(listCompressionAlgorithm[j])
+		})
+	})
+	return listCompressionAlgorithm
 }
 
 // Accept is used when conversion from values given by
@@ -45,9 +59,7 @@ func (v *CompressionAlgorithm) Accept(value interface{}) error {
 		}
 		tmp = CompressionAlgorithm(s)
 	}
-	switch tmp {
-	case Deflate, NoCompress:
-	default:
+	if _, ok := allCompressionAlgorithms[tmp]; !ok {
 		return errors.Errorf(`invalid jwa.CompressionAlgorithm value`)
 	}
 

--- a/jwa/content_encryption_gen.go
+++ b/jwa/content_encryption_gen.go
@@ -4,6 +4,8 @@ package jwa
 
 import (
 	"fmt"
+	"sort"
+	"sync"
 
 	"github.com/pkg/errors"
 )
@@ -21,18 +23,30 @@ const (
 	A256GCM       ContentEncryptionAlgorithm = "A256GCM"       // AES-GCM (256)
 )
 
-var allContentEncryptionAlgorithms = []ContentEncryptionAlgorithm{
-	A128CBC_HS256,
-	A128GCM,
-	A192CBC_HS384,
-	A192GCM,
-	A256CBC_HS512,
-	A256GCM,
+var allContentEncryptionAlgorithms = map[ContentEncryptionAlgorithm]struct{}{
+	A128CBC_HS256: {},
+	A128GCM:       {},
+	A192CBC_HS384: {},
+	A192GCM:       {},
+	A256CBC_HS512: {},
+	A256GCM:       {},
 }
+
+var listContentEncryptionAlgorithmOnce sync.Once
+var listContentEncryptionAlgorithm []ContentEncryptionAlgorithm
 
 // ContentEncryptionAlgorithms returns a list of all available values for ContentEncryptionAlgorithm
 func ContentEncryptionAlgorithms() []ContentEncryptionAlgorithm {
-	return allContentEncryptionAlgorithms
+	listContentEncryptionAlgorithmOnce.Do(func() {
+		listContentEncryptionAlgorithm = make([]ContentEncryptionAlgorithm, 0, len(allContentEncryptionAlgorithms))
+		for v := range allContentEncryptionAlgorithms {
+			listContentEncryptionAlgorithm = append(listContentEncryptionAlgorithm, v)
+		}
+		sort.Slice(listContentEncryptionAlgorithm, func(i, j int) bool {
+			return string(listContentEncryptionAlgorithm[i]) < string(listContentEncryptionAlgorithm[j])
+		})
+	})
+	return listContentEncryptionAlgorithm
 }
 
 // Accept is used when conversion from values given by
@@ -53,9 +67,7 @@ func (v *ContentEncryptionAlgorithm) Accept(value interface{}) error {
 		}
 		tmp = ContentEncryptionAlgorithm(s)
 	}
-	switch tmp {
-	case A128CBC_HS256, A128GCM, A192CBC_HS384, A192GCM, A256CBC_HS512, A256GCM:
-	default:
+	if _, ok := allContentEncryptionAlgorithms[tmp]; !ok {
 		return errors.Errorf(`invalid jwa.ContentEncryptionAlgorithm value`)
 	}
 

--- a/jwa/elliptic_gen.go
+++ b/jwa/elliptic_gen.go
@@ -19,7 +19,6 @@ const (
 	P256                 EllipticCurveAlgorithm = "P-256"
 	P384                 EllipticCurveAlgorithm = "P-384"
 	P521                 EllipticCurveAlgorithm = "P-521"
-	Secp256k1            EllipticCurveAlgorithm = "secp256k1"
 	X25519               EllipticCurveAlgorithm = "X25519"
 	X448                 EllipticCurveAlgorithm = "X448"
 )

--- a/jwa/elliptic_gen_test.go
+++ b/jwa/elliptic_gen_test.go
@@ -191,42 +191,6 @@ func TestEllipticCurveAlgorithm(t *testing.T) {
 			return
 		}
 	})
-	t.Run(`accept jwa constant Secp256k1`, func(t *testing.T) {
-		t.Parallel()
-		var dst jwa.EllipticCurveAlgorithm
-		if !assert.NoError(t, dst.Accept(jwa.Secp256k1), `accept is successful`) {
-			return
-		}
-		if !assert.Equal(t, jwa.Secp256k1, dst, `accepted value should be equal to constant`) {
-			return
-		}
-	})
-	t.Run(`accept the string secp256k1`, func(t *testing.T) {
-		t.Parallel()
-		var dst jwa.EllipticCurveAlgorithm
-		if !assert.NoError(t, dst.Accept("secp256k1"), `accept is successful`) {
-			return
-		}
-		if !assert.Equal(t, jwa.Secp256k1, dst, `accepted value should be equal to constant`) {
-			return
-		}
-	})
-	t.Run(`accept fmt.Stringer for secp256k1`, func(t *testing.T) {
-		t.Parallel()
-		var dst jwa.EllipticCurveAlgorithm
-		if !assert.NoError(t, dst.Accept(stringer{src: "secp256k1"}), `accept is successful`) {
-			return
-		}
-		if !assert.Equal(t, jwa.Secp256k1, dst, `accepted value should be equal to constant`) {
-			return
-		}
-	})
-	t.Run(`stringification for secp256k1`, func(t *testing.T) {
-		t.Parallel()
-		if !assert.Equal(t, "secp256k1", jwa.Secp256k1.String(), `stringified value matches`) {
-			return
-		}
-	})
 	t.Run(`accept jwa constant X25519`, func(t *testing.T) {
 		t.Parallel()
 		var dst jwa.EllipticCurveAlgorithm

--- a/jwa/secp2561k.go
+++ b/jwa/secp2561k.go
@@ -2,4 +2,9 @@
 
 package jwa
 
+// This constant is only available if compiled with jwx_es256k build tag
 const Secp256k1 EllipticCurveAlgorithm = "secp256k1"
+
+func init() {
+	allEllipticCurveAlgorithms[Secp256k1] = struct{}{}
+}

--- a/jwa/secp2561k.go
+++ b/jwa/secp2561k.go
@@ -1,0 +1,5 @@
+// +build jwx_es256k
+
+package jwa
+
+const Secp256k1 EllipticCurveAlgorithm = "secp256k1"

--- a/jwa/secp2561k_test.go
+++ b/jwa/secp2561k_test.go
@@ -1,0 +1,49 @@
+// +build jwx_es256k
+
+package jwa_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecp256k1(t *testing.T) {
+	t.Parallel()
+	t.Run(`accept jwa constant Secp256k1`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept(jwa.Secp256k1), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.Secp256k1, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`accept the string secp256k1`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept("secp256k1"), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.Secp256k1, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`accept fmt.Stringer for secp256k1`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.EllipticCurveAlgorithm
+		if !assert.NoError(t, dst.Accept(stringer{src: "secp256k1"}), `accept is successful`) {
+			return
+		}
+		if !assert.Equal(t, jwa.Secp256k1, dst, `accepted value should be equal to constant`) {
+			return
+		}
+	})
+	t.Run(`stringification for secp256k1`, func(t *testing.T) {
+		t.Parallel()
+		if !assert.Equal(t, "secp256k1", jwa.Secp256k1.String(), `stringified value matches`) {
+			return
+		}
+	})
+}

--- a/jwa/secp2561k_test.go
+++ b/jwa/secp2561k_test.go
@@ -5,6 +5,7 @@ package jwa_test
 import (
 	"testing"
 
+	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -15,6 +15,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+func init() {
+	ecutil.RegisterCurve(elliptic.P256(), jwa.P256)
+	ecutil.RegisterCurve(elliptic.P384(), jwa.P384)
+	ecutil.RegisterCurve(elliptic.P521(), jwa.P521)
+}
+
 func (k *ecdsaPublicKey) FromRaw(rawKey *ecdsa.PublicKey) error {
 	k.mu.Lock()
 	defer k.mu.Unlock()

--- a/jwk/es256k.go
+++ b/jwk/es256k.go
@@ -1,0 +1,13 @@
+// +build jwx_es256k
+
+package jwk
+
+import (
+	"github.com/decred/dcrd/dcrec/secp256k1/v3"
+	"github.com/lestrrat-go/jwx/internal/ecutil"
+	"github.com/lestrrat-go/jwx/jwa"
+)
+
+func init() {
+	ecutil.RegisterCurve(secp256k1.S256(), jwa.Secp256k1)
+}

--- a/jwk/es256k_test.go
+++ b/jwk/es256k_test.go
@@ -1,0 +1,17 @@
+// +build jwx_es256k
+
+package jwk_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/internal/ecutil"
+	"github.com/lestrrat-go/jwx/jwa"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestES256K(t *testing.T) {
+	if !assert.True(t, ecutil.IsAvailable(jwa.Secp256k1), `jwa.Secp256k1 should be available`) {
+		return
+	}
+}

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lestrrat-go/jwx/internal/ecutil"
 	"github.com/lestrrat-go/jwx/internal/jose"
 	"github.com/lestrrat-go/jwx/internal/json"
 	"github.com/lestrrat-go/jwx/internal/jwxtest"
@@ -1141,12 +1142,10 @@ func TestECDSA(t *testing.T) {
 		})
 	})
 	t.Run("Curve types", func(t *testing.T) {
-		crvs := []jwa.EllipticCurveAlgorithm{jwa.P256, jwa.P384, jwa.P521, jwa.Secp256k1}
-
-		for _, crv := range crvs {
-			crv := crv
-			t.Run(crv.String(), func(t *testing.T) {
-				key, err := jwxtest.GenerateEcdsaKey(crv)
+		for _, alg := range ecutil.AvailableAlgorithms() {
+			alg := alg
+			t.Run(alg.String(), func(t *testing.T) {
+				key, err := jwxtest.GenerateEcdsaKey(alg)
 				if !assert.NoError(t, err, `jwxtest.GenerateEcdsaKey should succeed`) {
 					return
 				}

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/lestrrat-go/jwx/internal/base64"
-	"github.com/lestrrat-go/jwx/internal/ecutil"
 	"github.com/lestrrat-go/jwx/internal/json"
 	"github.com/lestrrat-go/jwx/internal/jwxtest"
 
@@ -209,24 +208,6 @@ func TestRoundtrip(t *testing.T) {
 				testRoundtrip(t, payload, alg, key, keys)
 			})
 		}
-	})
-	t.Run("ECDSA-256K", func(t *testing.T) {
-		if !ecutil.IsAvailable(jwa.Secp256k1) {
-			t.SkipNow()
-		}
-
-		t.Parallel()
-		key, err := jwxtest.GenerateEcdsaKey(jwa.Secp256k1)
-		if !assert.NoError(t, err, "ECDSA key generated") {
-			return
-		}
-		jwkKey, _ := jwk.New(key.PublicKey)
-		keys := map[string]interface{}{
-			"Verify(ecdsa.PublicKey)":  key.PublicKey,
-			"Verify(*ecdsa.PublicKey)": &key.PublicKey,
-			"Verify(jwk.Key)":          jwkKey,
-		}
-		testRoundtrip(t, payload, jwa.ES256K, key, keys)
 	})
 	t.Run("RSA", func(t *testing.T) {
 		t.Parallel()

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/lestrrat-go/jwx/internal/base64"
+	"github.com/lestrrat-go/jwx/internal/ecutil"
 	"github.com/lestrrat-go/jwx/internal/json"
 	"github.com/lestrrat-go/jwx/internal/jwxtest"
 
@@ -210,6 +211,10 @@ func TestRoundtrip(t *testing.T) {
 		}
 	})
 	t.Run("ECDSA-256K", func(t *testing.T) {
+		if !ecutil.IsAvailable(jwa.Secp256k1) {
+			t.SkipNow()
+		}
+
 		t.Parallel()
 		key, err := jwxtest.GenerateEcdsaKey(jwa.Secp256k1)
 		if !assert.NoError(t, err, "ECDSA key generated") {

--- a/jws/secp256k1_test.go
+++ b/jws/secp256k1_test.go
@@ -1,0 +1,31 @@
+// +build jwx_es256k
+
+package jws_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/internal/ecutil"
+	"github.com/lestrrat-go/jwx/internal/jwxtest"
+	"github.com/lestrrat-go/jwx/jwk"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestES256K(t *testing.T) {
+	if !ecutil.IsAvailable(jwa.Secp256k1) {
+		t.SkipNow()
+	}
+
+	t.Parallel()
+	key, err := jwxtest.GenerateEcdsaKey(jwa.Secp256k1)
+	if !assert.NoError(t, err, "ECDSA key generated") {
+		return
+	}
+	jwkKey, _ := jwk.New(key.PublicKey)
+	keys := map[string]interface{}{
+		"Verify(ecdsa.PublicKey)":  key.PublicKey,
+		"Verify(*ecdsa.PublicKey)": &key.PublicKey,
+		"Verify(jwk.Key)":          jwkKey,
+	}
+	testRoundtrip(t, payload, jwa.ES256K, key, keys)
+}

--- a/jws/secp256k1_test.go
+++ b/jws/secp256k1_test.go
@@ -5,16 +5,14 @@ package jws_test
 import (
 	"testing"
 
-	"github.com/lestrrat-go/jwx/internal/ecutil"
 	"github.com/lestrrat-go/jwx/internal/jwxtest"
+	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwk"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestES256K(t *testing.T) {
-	if !ecutil.IsAvailable(jwa.Secp256k1) {
-		t.SkipNow()
-	}
+	payload := []byte("Hello, World!")
 
 	t.Parallel()
 	key, err := jwxtest.GenerateEcdsaKey(jwa.Secp256k1)

--- a/jwx_test.go
+++ b/jwx_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/lestrrat-go/jwx"
+	"github.com/lestrrat-go/jwx/internal/ecutil"
 	"github.com/lestrrat-go/jwx/internal/jose"
 	"github.com/lestrrat-go/jwx/internal/json"
 	"github.com/lestrrat-go/jwx/internal/jwxtest"
@@ -18,8 +19,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestJSONEngine(t *testing.T) {
+func TestShowBuildInfo(t *testing.T) {
 	t.Logf("Running tests using JSON backend => %s\n", json.Engine())
+	t.Logf("Available elliptic curves:")
+	for _, alg := range ecutil.AvailableAlgorithms() {
+		t.Logf("  %s", alg)
+	}
 }
 
 type jsonUnmarshalWrapper struct {


### PR DESCRIPTION
Per #345 by default we're going to skip compiling in ES256K.

We WILL NOT be using `database/sql` style explicit importing scheme for the time being. If we do, this will be done in the next API breaking release. Instead we will just toggle these "extra" features using build tags like `jwx_goccy`. For this one we will be using `jwx_es256k`