### PR TITLE
Add utilities to parse JWTs stored in http.Request, http.Header, or url.Values

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Changes
 =======
 
 v1.1.4
+[New features]
+  * jwt.ParseRequest, jwt.ParseHeader, jwt.ParseValues have been added.
+    They are convenience functions to parse JWTs out of a HTTP request.
+
 [Miscellaneous]
   * ES256K has been made non-default. You must enable it using a build tag
 

--- a/Changes
+++ b/Changes
@@ -7,6 +7,9 @@ v1.1.4
     They are convenience functions to parse JWTs out of a HTTP request.
 
 [Miscellaneous]
+  * Fix jwt.Equals() so that comparison between values containing time.Time
+    actually work
+
   * ES256K has been made non-default. You must enable it using a build tag
 
      go build -tags jwx_es256k ...

--- a/Changes
+++ b/Changes
@@ -3,7 +3,7 @@ Changes
 
 v1.1.4
 [New features]
-  * jwt.ParseRequest, jwt.ParseHeader, jwt.ParseValues have been added.
+  * jwt.ParseRequest, jwt.ParseHeader, jwt.ParseForm have been added.
     They are convenience functions to parse JWTs out of a HTTP request.
 
 [Miscellaneous]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Package [github.com/lestrrat-go/jwx/jwa](./jwa) defines the various algorithm de
 Package [github.com/lestrrat-go/jwx/jwt](./jwt) implements JSON Web Tokens as described in [RFC7519](https://tools.ietf.org/html/rfc7519).
 
 * Convenience methods for oft-used keys ("aud", "sub", "iss", etc)
+* Convenience functions to exstract/parse from http.Request, http.Header, url.Values
 * Ability to Get/Set arbitrary keys
 * Conversion to and from JSON
 * Generate signed tokens

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Command line tool [jwx](./cmd/jwx) and libraries implementing various JWx techno
 
 | Package name                                              | Notes                                           |
 |-----------------------------------------------------------|-------------------------------------------------|
-| [jwt](https://github.com/lestrrat-go/jwx/tree/master/jwt) | [RFC 7519](https://tools.ietf.org/html/rfc7519) |
-| [jwk](https://github.com/lestrrat-go/jwx/tree/master/jwk) | [RFC 7517](https://tools.ietf.org/html/rfc7517) + [RFC 7638](https://tools.ietf.org/html/rfc7638) |
-| [jwa](https://github.com/lestrrat-go/jwx/tree/master/jwa) | [RFC 7518](https://tools.ietf.org/html/rfc7518) |
-| [jws](https://github.com/lestrrat-go/jwx/tree/master/jws) | [RFC 7515](https://tools.ietf.org/html/rfc7515) |
-| [jwe](https://github.com/lestrrat-go/jwx/tree/master/jwe) | [RFC 7516](https://tools.ietf.org/html/rfc7516) |
+| [jwt](https://github.com/lestrrat-go/jwx/tree/main/jwt) | [RFC 7519](https://tools.ietf.org/html/rfc7519) |
+| [jwk](https://github.com/lestrrat-go/jwx/tree/main/jwk) | [RFC 7517](https://tools.ietf.org/html/rfc7517) + [RFC 7638](https://tools.ietf.org/html/rfc7638) |
+| [jwa](https://github.com/lestrrat-go/jwx/tree/main/jwa) | [RFC 7518](https://tools.ietf.org/html/rfc7518) |
+| [jws](https://github.com/lestrrat-go/jwx/tree/main/jws) | [RFC 7515](https://tools.ietf.org/html/rfc7515) |
+| [jwe](https://github.com/lestrrat-go/jwx/tree/main/jwe) | [RFC 7516](https://tools.ietf.org/html/rfc7516) |
 
 ## Why?
 

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,5 @@ require (
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20201217014255-9d1352758620
 	golang.org/x/mod v0.4.1 // indirect
-	golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963
+	golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963 // indirect
 )

--- a/jwt/README.md
+++ b/jwt/README.md
@@ -3,11 +3,11 @@
 Package jwt implements JSON Web Tokens as described in [RFC7519](https://tools.ietf.org/html/rfc7519).
 
 * Convenience methods for oft-used keys ("aud", "sub", "iss", etc)
+* Convenience functions to exstract/parse from http.Request, http.Header, url.Values
 * Ability to Get/Set arbitrary keys
 * Conversion to and from JSON
 * Generate signed tokens
 * Verify signed tokens
-
 
 # SYNOPSIS
 

--- a/jwt/http.go
+++ b/jwt/http.go
@@ -1,0 +1,124 @@
+package jwt
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// ParseHeader parses a JWT stored in a http.Header.
+//
+// For the header "Authorization", it will strip the prefix "Bearer " and will
+// treat the remaining value as a JWT.
+func ParseHeader(hdr http.Header, name string, options ...ParseOption) (Token, error) {
+	key := http.CanonicalHeaderKey(name)
+	v := strings.TrimSpace(hdr.Get(key))
+	if v == "" {
+		return nil, errors.Errorf(`empty header (%s)`, key)
+	}
+
+	if key == "Authorization" {
+		// Authorization header is an exception. We strip the "Bearer " from
+		// the prefix
+		v = strings.TrimSpace(strings.TrimPrefix(v, "Bearer"))
+	}
+
+	return ParseString(v, options...)
+}
+
+// ParseValues parses a JWT stored in a url.Value.
+func ParseValues(values url.Values, name string, options ...ParseOption) (Token, error) {
+	v := strings.TrimSpace(values.Get(name))
+	if v == "" {
+		return nil, errors.Errorf(`empty value (%s)`, name)
+	}
+
+	return ParseString(v, options...)
+}
+
+// ParseRequest searches a http.Request object for a JWT token. 
+// By default, "Authorization" header will always be searched.
+//
+// If WithHeaderKey() is used, you must explicitly re-enable searching for "Authorization" header.
+//
+//   # searches for "Authorization"
+//   jwthttp.ParseRequest(req)
+//
+//   # searches for "x-my-token"
+//   jwthttp.ParseRequest(req, http.WithHeaderKey("x-my-token"))
+//
+//   # searches for "Authorization" AND "x-my-token"
+//   jwthttp.ParseRequest(req, http.WithHeaderKey("Authorization"), http.WithHeaderKey("x-my-token"))
+func ParseRequest(req *http.Request, options ...HTTPParseOption) (Token, error) {
+	var hdrkeys []string
+	var formkeys []string
+	var parseOptions []ParseOption
+	for _, option := range options {
+		switch option.Ident() {
+		case identHeaderKey{}:
+			hdrkeys = append(hdrkeys, option.Value().(string))
+		case identFormKey{}:
+			formkeys = append(formkeys, option.Value().(string))
+		default:
+			parseOptions = append(parseOptions, option)
+		}
+	}
+	if len(hdrkeys) == 0 {
+		hdrkeys = append(hdrkeys, "Authorization")
+	}
+
+	for _, hdrkey := range hdrkeys {
+		if tok, err := ParseHeader(req.Header, hdrkey, parseOptions...); err == nil {
+			return tok, nil
+		}
+	}
+
+	if cl := req.ContentLength; cl > 0 {
+		if err := req.ParseForm(); err != nil {
+			return nil, errors.Wrap(err, `failed to parse form`)
+		}
+	}
+
+	for _, formkey := range formkeys {
+		if tok, err := ParseValues(req.Form, formkey, parseOptions...); err == nil {
+			return tok, nil
+		}
+	}
+
+	// Everything below is a preulde to error reporting.
+	var triedHdrs strings.Builder
+	for i, hdrkey := range hdrkeys {
+		if i > 0 {
+			triedHdrs.WriteString(", ")
+		}
+		triedHdrs.WriteString(strconv.Quote(hdrkey))
+	}
+
+	var triedForms strings.Builder
+	for i, formkey := range formkeys {
+		if i > 0 {
+			triedForms.WriteString(", ")
+		}
+		triedForms.WriteString(strconv.Quote(formkey))
+	}
+
+	var b strings.Builder
+	b.WriteString(`failed to find token in any location of the request (tried: [header keys: `)
+	if triedHdrs.Len() == 0 {
+		b.WriteString(`"Authorization"`)
+	} else {
+		b.WriteString(triedHdrs.String())
+	}
+	b.WriteByte(']')
+	if triedForms.Len() > 0 {
+		b.WriteString(", form keys: [")
+		b.WriteString(triedForms.String())
+		b.WriteByte(']')
+	}
+	b.WriteByte(')')
+
+	return nil, errors.New(b.String())
+}

--- a/jwt/http.go
+++ b/jwt/http.go
@@ -39,7 +39,7 @@ func ParseValues(values url.Values, name string, options ...ParseOption) (Token,
 	return ParseString(v, options...)
 }
 
-// ParseRequest searches a http.Request object for a JWT token. 
+// ParseRequest searches a http.Request object for a JWT token.
 // By default, "Authorization" header will always be searched.
 //
 // If WithHeaderKey() is used, you must explicitly re-enable searching for "Authorization" header.

--- a/jwt/http.go
+++ b/jwt/http.go
@@ -40,14 +40,19 @@ func ParseForm(values url.Values, name string, options ...ParseOption) (Token, e
 }
 
 // ParseRequest searches a http.Request object for a JWT token.
-// By default, "Authorization" header will always be searched.
+//
+// Specifying WithHeaderKey() will tell it to search under a specific
+// header key. Specifying WithFormKey() will tell it to search under
+// a specific form field.
+//
+// By default, "Authorization" header will be searched.
 //
 // If WithHeaderKey() is used, you must explicitly re-enable searching for "Authorization" header.
 //
 //   # searches for "Authorization"
 //   jwthttp.ParseRequest(req)
 //
-//   # searches for "x-my-token"
+//   # searches for "x-my-token" ONLY.
 //   jwthttp.ParseRequest(req, http.WithHeaderKey("x-my-token"))
 //
 //   # searches for "Authorization" AND "x-my-token"

--- a/jwt/http.go
+++ b/jwt/http.go
@@ -52,7 +52,7 @@ func ParseValues(values url.Values, name string, options ...ParseOption) (Token,
 //
 //   # searches for "Authorization" AND "x-my-token"
 //   jwthttp.ParseRequest(req, http.WithHeaderKey("Authorization"), http.WithHeaderKey("x-my-token"))
-func ParseRequest(req *http.Request, options ...HTTPParseOption) (Token, error) {
+func ParseRequest(req *http.Request, options ...ParseOption) (Token, error) {
 	var hdrkeys []string
 	var formkeys []string
 	var parseOptions []ParseOption

--- a/jwt/http.go
+++ b/jwt/http.go
@@ -29,8 +29,8 @@ func ParseHeader(hdr http.Header, name string, options ...ParseOption) (Token, e
 	return ParseString(v, options...)
 }
 
-// ParseValues parses a JWT stored in a url.Value.
-func ParseValues(values url.Values, name string, options ...ParseOption) (Token, error) {
+// ParseForm parses a JWT stored in a url.Value.
+func ParseForm(values url.Values, name string, options ...ParseOption) (Token, error) {
 	v := strings.TrimSpace(values.Get(name))
 	if v == "" {
 		return nil, errors.Errorf(`empty value (%s)`, name)
@@ -83,7 +83,7 @@ func ParseRequest(req *http.Request, options ...ParseOption) (Token, error) {
 	}
 
 	for _, formkey := range formkeys {
-		if tok, err := ParseValues(req.Form, formkey, parseOptions...); err == nil {
+		if tok, err := ParseForm(req.Form, formkey, parseOptions...); err == nil {
 			return tok, nil
 		}
 	}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
+	"time"
 
 	"github.com/lestrrat-go/jwx/internal/json"
 
@@ -241,10 +242,23 @@ func Sign(t Token, alg jwa.SignatureAlgorithm, key interface{}, options ...Optio
 // to compare tokens as they will also compare extra detail such as
 // sync.Mutex objects used to control concurrent access.
 //
-// The comparison for values is currently done using a simple equality ("==").
+// The comparison for values is currently done using a simple equality ("=="),
+// except for time.Time, which uses time.Equal after dropping the monotonic
+// clock and rounding the values up to 1 second accuraccy.
+//
+// if both t1 and t2 are nil, returns true
 func Equal(t1, t2 Token) bool {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	if t1 == nil && t2 == nil {
+		return true
+	}
+
+	// we already checked for t1 == t2 == nil, so safe to do this
+	if t1 == nil || t2 == nil {
+		return false
+	}
 
 	m1, err := t1.AsMap(ctx)
 	if err != nil {
@@ -253,8 +267,24 @@ func Equal(t1, t2 Token) bool {
 
 	for iter := t2.Iterate(ctx); iter.Next(ctx); {
 		pair := iter.Pair()
-		if m1[pair.Key.(string)] != pair.Value {
-			return false
+
+		v1 := m1[pair.Key.(string)]
+		v2 := pair.Value
+		switch tmp := v1.(type) {
+		case time.Time:
+			tmp = tmp.Round(0).Round(time.Second)
+			tmp2, ok := v2.(time.Time)
+			if !ok {
+				return false
+			}
+			tmp2 = tmp2.Round(0).Round(time.Second)
+			if !tmp.Equal(tmp2) {
+				return false
+			}
+		default:
+			if v1 != v2 {
+				return false
+			}
 		}
 		delete(m1, pair.Key.(string))
 	}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -244,7 +244,7 @@ func Sign(t Token, alg jwa.SignatureAlgorithm, key interface{}, options ...Optio
 //
 // The comparison for values is currently done using a simple equality ("=="),
 // except for time.Time, which uses time.Equal after dropping the monotonic
-// clock and rounding the values up to 1 second accuracy.
+// clock and truncating the values to 1 second accuracy.
 //
 // if both t1 and t2 are nil, returns true
 func Equal(t1, t2 Token) bool {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -244,7 +244,7 @@ func Sign(t Token, alg jwa.SignatureAlgorithm, key interface{}, options ...Optio
 //
 // The comparison for values is currently done using a simple equality ("=="),
 // except for time.Time, which uses time.Equal after dropping the monotonic
-// clock and rounding the values up to 1 second accuraccy.
+// clock and rounding the values up to 1 second accuracy.
 //
 // if both t1 and t2 are nil, returns true
 func Equal(t1, t2 Token) bool {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -272,12 +272,12 @@ func Equal(t1, t2 Token) bool {
 		v2 := pair.Value
 		switch tmp := v1.(type) {
 		case time.Time:
-			tmp = tmp.Round(0).Round(time.Second)
 			tmp2, ok := v2.(time.Time)
 			if !ok {
 				return false
 			}
-			tmp2 = tmp2.Round(0).Round(time.Second)
+			tmp = tmp.Round(0).Truncate(time.Second)
+			tmp2 = tmp2.Round(0).Truncate(time.Second)
 			if !tmp.Equal(tmp2) {
 				return false
 			}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -553,6 +553,31 @@ func TestParseRequest(t *testing.T) {
 		Error   bool
 	}{
 		{
+			Name: "Token not present (w/ multiple options)",
+			Request: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, u, nil)
+			},
+			Parse: func(req *http.Request) (jwt.Token, error) {
+				return jwt.ParseRequest(req, 
+					jwt.WithHeaderKey("Authorization"), 
+					jwt.WithHeaderKey("x-authorization"), 
+					jwt.WithFormKey("access_token"),
+					jwt.WithFormKey("token"),
+					jwt.WithVerify(jwa.ES256, pubkey))
+			},
+			Error: true,
+		},
+		{
+			Name: "Token not present (w/o options)",
+			Request: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, u, nil)
+			},
+			Parse: func(req *http.Request) (jwt.Token, error) {
+				return jwt.ParseRequest(req, jwt.WithVerify(jwa.ES256, pubkey))
+			},
+			Error: true,
+		},
+		{
 			Name: "Token in Authorization header (w/o options)",
 			Request: func() *http.Request {
 				req := httptest.NewRequest(http.MethodGet, u, nil)

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -541,7 +542,7 @@ func TestParseRequest(t *testing.T) {
 
 	tok := jwt.New()
 	tok.Set(jwt.IssuerKey, u)
-	tok.Set(jwt.IssuedAtKey, time.Now())
+	tok.Set(jwt.IssuedAtKey, time.Now().Round(0))
 
 	signed, _ := jwt.Sign(tok, jwa.ES256, privkey)
 
@@ -552,7 +553,7 @@ func TestParseRequest(t *testing.T) {
 		Error   bool
 	}{
 		{
-			Name: "Token in header (w/o options)",
+			Name: "Token in Authorization header (w/o options)",
 			Request: func() *http.Request {
 				req := httptest.NewRequest(http.MethodGet, u, nil)
 				req.Header.Add("Authorization", "Bearer "+string(signed))
@@ -561,6 +562,58 @@ func TestParseRequest(t *testing.T) {
 			Parse: func(req *http.Request) (jwt.Token, error) {
 				return jwt.ParseRequest(req, jwt.WithVerify(jwa.ES256, pubkey))
 			},
+		},
+		{
+			Name: "Token in Authorization header but we specified another header key",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, u, nil)
+				req.Header.Add("Authorization", "Bearer "+string(signed))
+				return req
+			},
+			Parse: func(req *http.Request) (jwt.Token, error) {
+				return jwt.ParseRequest(req, jwt.WithHeaderKey("x-authorization"), jwt.WithVerify(jwa.ES256, pubkey))
+			},
+			Error: true,
+		},
+		{
+			Name: "Token in x-authroization header (w/ option)",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, u, nil)
+				req.Header.Add("x-authorization", string(signed))
+				return req
+			},
+			Parse: func(req *http.Request) (jwt.Token, error) {
+				return jwt.ParseRequest(req, jwt.WithHeaderKey("x-authorization"), jwt.WithVerify(jwa.ES256, pubkey))
+			},
+		},
+		{
+			Name: "Token in access_token form field (w/ option)",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, u, nil)
+				// for whatever reason, I can't populate req.Body and get this to work
+				// so populating req.Form directly instead
+				req.Form = url.Values{}
+				req.Form.Add("access_token", string(signed))
+				return req
+			},
+			Parse: func(req *http.Request) (jwt.Token, error) {
+				return jwt.ParseRequest(req, jwt.WithFormKey("access_token"), jwt.WithVerify(jwa.ES256, pubkey))
+			},
+		},
+		{
+			Name: "Token in access_token form field (w/o option)",
+			Request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, u, nil)
+				// for whatever reason, I can't populate req.Body and get this to work
+				// so populating req.Form directly instead
+				req.Form = url.Values{}
+				req.Form.Add("access_token", string(signed))
+				return req
+			},
+			Parse: func(req *http.Request) (jwt.Token, error) {
+				return jwt.ParseRequest(req, jwt.WithVerify(jwa.ES256, pubkey))
+			},
+			Error: true,
 		},
 	}
 

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -630,6 +630,14 @@ func TestParseRequest(t *testing.T) {
 			}
 
 			if !assert.True(t, jwt.Equal(tok, got), `tokens should match`) {
+				{
+					buf, _ := json.MarshalIndent(tok, "", "  ")
+					t.Logf("expected: %s", buf)
+				}
+				{
+					buf, _ := json.MarshalIndent(got, "", "  ")
+					t.Logf("got: %s", buf)
+				}
 				return
 			}
 		})

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -558,9 +558,9 @@ func TestParseRequest(t *testing.T) {
 				return httptest.NewRequest(http.MethodGet, u, nil)
 			},
 			Parse: func(req *http.Request) (jwt.Token, error) {
-				return jwt.ParseRequest(req, 
-					jwt.WithHeaderKey("Authorization"), 
-					jwt.WithHeaderKey("x-authorization"), 
+				return jwt.ParseRequest(req,
+					jwt.WithHeaderKey("Authorization"),
+					jwt.WithHeaderKey("x-authorization"),
 					jwt.WithFormKey("access_token"),
 					jwt.WithFormKey("token"),
 					jwt.WithVerify(jwa.ES256, pubkey))

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -576,7 +576,7 @@ func TestParseRequest(t *testing.T) {
 			Error: true,
 		},
 		{
-			Name: "Token in x-authroization header (w/ option)",
+			Name: "Token in x-authorization header (w/ option)",
 			Request: func() *http.Request {
 				req := httptest.NewRequest(http.MethodGet, u, nil)
 				req.Header.Add("x-authorization", string(signed))
@@ -618,6 +618,7 @@ func TestParseRequest(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			got, err := tc.Parse(tc.Request())
 			if tc.Error {

--- a/jwt/options.go
+++ b/jwt/options.go
@@ -11,8 +11,8 @@ import (
 
 type Option = option.Interface
 
-// HTTPParseOption describes an Option that can be passed to `ParseRequest()`.
-type HTTPParseOption interface {
+// ParseRequestOption describes an Option that can be passed to `ParseRequest()`.
+type ParseRequestOption interface {
 	ParseOption
 	httpParseOption()
 }
@@ -192,7 +192,7 @@ func WithClaimValue(name string, v interface{}) ValidateOption {
 //
 // While the type system allows this option to be passed to jwt.Parse() directly,
 // doing so will have no effect. Only use it for HTTP request parsing functions
-func WithHeaderKey(v string) HTTPParseOption {
+func WithHeaderKey(v string) ParseRequestOption {
 	return &httpParseOption{newParseOption(identHeaderKey{}, v)}
 }
 
@@ -200,6 +200,6 @@ func WithHeaderKey(v string) HTTPParseOption {
 //
 // While the type system allows this option to be passed to jwt.Parse() directly,
 // doing so will have no effect. Only use it for HTTP request parsing functions
-func WithFormKey(v string) HTTPParseOption {
+func WithFormKey(v string) ParseRequestOption {
 	return &httpParseOption{newParseOption(identFormKey{}, v)}
 }

--- a/jwt/options.go
+++ b/jwt/options.go
@@ -11,6 +11,55 @@ import (
 
 type Option = option.Interface
 
+// HTTPParseOption describes an Option that can be passed to `ParseRequest()`.
+type HTTPParseOption interface {
+	ParseOption
+	httpParseOption()
+}
+
+type httpParseOption struct {
+	ParseOption
+}
+
+func (*httpParseOption) httpParseOption() {}
+
+// ParseOption describes an Option that can be passed to `Parse()`.
+// ParseOption also implements ReadFileOption, therefore it may be
+// safely pass them to `jwt.ReadFile()`
+type ParseOption interface {
+	ReadFileOption
+	parseOption()
+}
+
+type parseOption struct {
+	Option
+}
+
+func newParseOption(n interface{}, v interface{}) ParseOption {
+	return &parseOption{option.New(n, v)}
+}
+
+func (*parseOption) parseOption()    {}
+func (*parseOption) readFileOption() {}
+
+// ValidateOption describes an Option that can be passed to Validate().
+// ValidateOption also implements ParseOption, therefore it may be
+// safely passed to `Parse()` (and thus `jwt.ReadFile()`)
+type ValidateOption interface {
+	ParseOption
+	validateOption()
+}
+
+type validateOption struct {
+	ParseOption
+}
+
+func newValidateOption(n interface{}, v interface{}) ValidateOption {
+	return &validateOption{newParseOption(n, v)}
+}
+
+func (*validateOption) validateOption() {}
+
 type identAcceptableSkew struct{}
 type identAudience struct{}
 type identClaim struct{}
@@ -25,42 +74,8 @@ type identToken struct{}
 type identValidate struct{}
 type identVerify struct{}
 
-type parseOption struct {
-	Option
-}
-
-func newParseOption(n interface{}, v interface{}) ParseOption {
-	return &parseOption{option.New(n, v)}
-}
-
-func (*parseOption) parseOption()    {}
-func (*parseOption) readFileOption() {}
-
-// ParseOption describes an Option that can be passed to `Parse()`.
-// ParseOption also implements ReadFileOption, therefore it may be
-// safely pass them to `jwt.ReadFile()`
-type ParseOption interface {
-	ReadFileOption
-	parseOption()
-}
-
-type validateOption struct {
-	ParseOption
-}
-
-func newValidateOption(n interface{}, v interface{}) ValidateOption {
-	return &validateOption{newParseOption(n, v)}
-}
-
-func (*validateOption) validateOption() {}
-
-// ValidateOption describes an Option that can be passed to Validate().
-// ValidateOption also implements ParseOption, therefore it may be
-// safely passed to `Parse()` (and thus `jwt.ReadFile()`)
-type ValidateOption interface {
-	ParseOption
-	validateOption()
-}
+type identHeaderKey struct{}
+type identFormKey struct{}
 
 type VerifyParameters interface {
 	Algorithm() jwa.SignatureAlgorithm
@@ -171,4 +186,20 @@ type claimValue struct {
 // WithClaimValue specifies that expected any claim value.
 func WithClaimValue(name string, v interface{}) ValidateOption {
 	return newValidateOption(identClaim{}, claimValue{name, v})
+}
+
+// WithHeaderKey is used to specify header keys to search for tokens.
+//
+// While the type system allows this option to be passed to jwt.Parse() directly,
+// doing so will have no effect. Only use it for HTTP request parsing functions
+func WithHeaderKey(v string) HTTPParseOption {
+	return &httpParseOption{newParseOption(identHeaderKey{}, v)}
+}
+
+// WithFormKey is used to specify header keys to search for tokens.
+//
+// While the type system allows this option to be passed to jwt.Parse() directly,
+// doing so will have no effect. Only use it for HTTP request parsing functions
+func WithFormKey(v string) HTTPParseOption {
+	return &httpParseOption{newParseOption(identFormKey{}, v)}
 }


### PR DESCRIPTION
Also fix `jwt.Equal()`