### PR TITLE
jwt: allow setting a custom value to "typ" JOSE header parameter

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -227,9 +227,12 @@ func Sign(t Token, alg jwa.SignatureAlgorithm, key interface{}, options ...Optio
 		hdr = jws.NewHeaders()
 	}
 
-	if err := hdr.Set(`typ`, `JWT`); err != nil {
-		return nil, errors.Wrap(err, `failed to sign payload`)
+	if _, ok := hdr.Get(`typ`); !ok {
+		if err := hdr.Set(`typ`, `JWT`); err != nil {
+			return nil, errors.Wrap(err, `failed to sign payload`)
+		}
 	}
+
 	sign, err := jws.Sign(buf, alg, key, jws.WithHeaders(hdr))
 	if err != nil {
 		return nil, errors.Wrap(err, `failed to sign payload`)

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -208,7 +208,8 @@ func lookupMatchingKey(data []byte, keyset jwk.Set, useDefault bool) (jwa.Signat
 // the type of key you provided, otherwise an error is returned.
 //
 // The protected header will also automatically have the `typ` field set
-// to the literal value `JWT`.
+// to the literal value `JWT`, unless you provide a custom value for it
+// by jwt.WithHeaders option.
 func Sign(t Token, alg jwa.SignatureAlgorithm, key interface{}, options ...Option) ([]byte, error) {
 	var hdr jws.Headers
 	for _, o := range options {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -229,7 +229,7 @@ func Sign(t Token, alg jwa.SignatureAlgorithm, key interface{}, options ...Optio
 
 	if _, ok := hdr.Get(`typ`); !ok {
 		if err := hdr.Set(`typ`, `JWT`); err != nil {
-			return nil, errors.Wrap(err, `failed to sign payload`)
+			return nil, errors.Wrap(err, `failed to set typ field`)
 		}
 	}
 

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -488,6 +488,9 @@ func TestSignTyp(t *testing.T) {
 			return
 		}
 		got, err := getJWTHeaders(signed)
+		if !assert.NoError(t, err) {
+			return
+		}
 		if !assert.Equal(t, `JWT`, got.Type(), `"typ" header parameter should be set to JWT`) {
 			return
 		}
@@ -503,6 +506,9 @@ func TestSignTyp(t *testing.T) {
 			return
 		}
 		got, err := getJWTHeaders(signed)
+		if !assert.NoError(t, err) {
+			return
+		}
 		if !assert.Equal(t, `custom-typ`, got.Type(), `"typ" header parameter should be set to the custom value`) {
 			return
 		}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -465,6 +465,28 @@ func TestSignJWK(t *testing.T) {
 	assert.Len(t, signatures, 1)
 }
 
+func TestSignWithTypHeader(t *testing.T) {
+	t.Parallel()
+	key, err := jwxtest.GenerateRsaKey()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	t1 := jwt.New()
+	hdrs := jws.NewHeaders()
+	hdrs.Set(`typ`, `custom-typ`)
+
+	signed, err := jwt.Sign(t1, jwa.RS256, key, jwt.WithHeaders(hdrs))
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	msg, err := jws.Parse(signed)
+	if !assert.Equal(t, `custom-typ`, msg.Signatures()[0].ProtectedHeaders().Type(), `jwt.WithHeaders option sholud allow setting "typ" header field`) {
+		return
+	}
+}
+
 func TestReadFile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`jwt.Sign` function automatically sets `"JWT"` to `typ` JOSE header parameter. Even though the user provides a custom value for `typ` using `WithHeaders` option, it's overwritten by `"JWT"`.

This pull-request changes the above behavior. Now `jwt.Sign` sets `"JWT"` to `typ` only if the user doesn't provide a custom value for it.

Tests are added to jwt_test.go
