### PR TITLE
jwk: "invalid memory address or nil pointer dereference" error when create new jwk.Key from empty RSA private  key

### DIFF
--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1027,6 +1027,12 @@ func TestRSA(t *testing.T) {
 				Value:  "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
 			}),
 		})
+		t.Run("New", func(t *testing.T) {
+			_, err := jwk.New(rsa.PublicKey{})
+			if !assert.Error(t, err, `jwk.New should fail for empty key`) {
+				return
+			}
+		})
 	})
 	t.Run("Private Key", func(t *testing.T) {
 		t.Parallel()
@@ -1067,6 +1073,12 @@ func TestRSA(t *testing.T) {
 				Method: "QI",
 				Value:  "GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU",
 			}),
+		})
+		t.Run("New", func(t *testing.T) {
+			_, err := jwk.New(rsa.PrivateKey{})
+			if !assert.Error(t, err, `jwk.New should fail for empty key`) {
+				return
+			}
 		})
 	})
 	t.Run("Thumbprint", func(t *testing.T) {

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -17,6 +17,9 @@ func (k *rsaPrivateKey) FromRaw(rawKey *rsa.PrivateKey) error {
 	k.mu.Lock()
 	defer k.mu.Unlock()
 
+	if rawKey.D == nil {
+		return errors.Errorf(`invalid rsa.PrivateKey`)
+	}
 	k.d = rawKey.D.Bytes()
 	if len(rawKey.Primes) < 2 {
 		return errors.Errorf(`invalid number of primes in rsa.PrivateKey: need 2, got %d`, len(rawKey.Primes))
@@ -53,6 +56,9 @@ func (k *rsaPublicKey) FromRaw(rawKey *rsa.PublicKey) error {
 	k.mu.Lock()
 	defer k.mu.Unlock()
 
+	if rawKey.N == nil {
+		return errors.Errorf(`invalid rsa.PublicKey`)
+	}
 	k.n = rawKey.N.Bytes()
 	data := make([]byte, 8)
 	binary.BigEndian.PutUint64(data, uint64(rawKey.E))


### PR DESCRIPTION
Hi,
we upgraded to 1.6.2 and now getting an panic error in our unit tests while creating a new `jwk.Key` from an empty rsa private or public key:
```
Test Panicked
    runtime error: invalid memory address or nil pointer dereference
    /usr/local/go/src/runtime/panic.go:212

    Full Stack Trace
    math/big.(*Int).Bytes(...)
    github.com/lestrrat-go/jwx/jwk.(*rsaPublicKey).FromRaw(0xc0002fed00, 0xc0003ec1d0, 0x0, 0x0)
    github.com/lestrrat-go/jwx/jwk.New(0xa6fd60, 0xc0003ec070, 0x0, 0x0, 0xc0000f6fb0, 0x1)
....
```
So I added a validatation that at least an error is thrown.