### PR TITLE
docs: fix outdated links for related libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,8 @@ the `"x-foo-bar"` key will decode in the same way. If you need this behavior fro
 
 * https://github.com/dgrijalva/jwt-go
 * https://github.com/square/go-jose
-* https://github.com/coreos/oidc
-* https://golang.org/x/oauth2
+* https://github.com/coreos/go-oidc
+* https://pkg.go.dev/golang.org/x/oauth2
 
 # Contributions
 


### PR DESCRIPTION
This PR updates the `github.com/coreos/go-oidc` library to the updated repository link and uses the redirected docs link for `golang.org/x/oauth2`.