### PR TITLE
docs: align package name in ParseRequest examples

### DIFF
--- a/jwt/http.go
+++ b/jwt/http.go
@@ -50,13 +50,13 @@ func ParseForm(values url.Values, name string, options ...ParseOption) (Token, e
 // If WithHeaderKey() is used, you must explicitly re-enable searching for "Authorization" header.
 //
 //   # searches for "Authorization"
-//   jwthttp.ParseRequest(req)
+//   jwt.ParseRequest(req)
 //
 //   # searches for "x-my-token" ONLY.
-//   jwthttp.ParseRequest(req, http.WithHeaderKey("x-my-token"))
+//   jwt.ParseRequest(req, http.WithHeaderKey("x-my-token"))
 //
 //   # searches for "Authorization" AND "x-my-token"
-//   jwthttp.ParseRequest(req, http.WithHeaderKey("Authorization"), http.WithHeaderKey("x-my-token"))
+//   jwt.ParseRequest(req, http.WithHeaderKey("Authorization"), http.WithHeaderKey("x-my-token"))
 func ParseRequest(req *http.Request, options ...ParseOption) (Token, error) {
 	var hdrkeys []string
 	var formkeys []string


### PR DESCRIPTION
This PR changes the package in the examples for `ParseRequest` from `jwthttp` to `jwt`.

Not sure if using `jwthttp` is intended or not but I think that it will be clearer to users if we change this since they belong in the `jwt` package.