### PR TITLE
Add way to serialize JWT "aud" claim into a single string token

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,22 @@
 Changes
 =======
 
+v1.1.8 (not yet released)
+[New features]
+  * `jwt.Settings()` and `jwt.WithFlattenAudience(bool)` has been added
+    to control how the "aud" claim is serialized into JSON. When this
+    is enabled, all JWTs with a single "aud" claim will serialize
+    the field as a single string, instead of an array of strings with
+    a single element, i.e.:
+
+    // jwt.WithFlattenAudience(true)
+    {"aud": "foo"}
+
+    // jwt.WithFlattenAudience(false)
+    {"aud": ["foo"]}
+
+    This setting has a global effect.
+
 v1.1.7 2 Apr 2021
 [New features]
   * `jwk.New` `jwk.Parse`, `jwk.ParseKey` can now take a Certificate in

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test-cmd:
 	go test -v -race $(TESTOPTS)
 
 test:
-	$(MAKE) test-cmd TESOPTS=./...
+	$(MAKE) TESTOPTS=./... test-cmd
 	$(MAKE) -f $(PWD)/Makefile -C examples test-cmd
 	$(MAKE) -f $(PWD)/Makefile -C bench test-cmd
 

--- a/examples/jwt_example_test.go
+++ b/examples/jwt_example_test.go
@@ -227,7 +227,9 @@ func ExampleJWT_Token() {
 
 	// OUTPUT:
 	// {
-	//   "aud": "Golang Users",
+	//   "aud": [
+  //     "Golang Users"
+  //   ],
 	//   "iat": 233431200,
 	//   "privateClaimKey": "Hello, World!",
 	//   "sub": "https://github.com/lestrrat-go/jwx/jwt"
@@ -319,7 +321,9 @@ func ExampleJWT_OpenIDToken() {
 	//     "region": "東京都",
 	//     "street_address": "芝公園 4-2-8"
 	//   },
-	//   "aud": "Golang Users",
+	//   "aud": [
+  //     "Golang Users"
+  //   ],
 	//   "iat": 233431200,
 	//   "privateClaimKey": "Hello, World!",
 	//   "sub": "https://github.com/lestrrat-go/jwx/jwt"

--- a/examples/jwt_example_test.go
+++ b/examples/jwt_example_test.go
@@ -227,9 +227,7 @@ func ExampleJWT_Token() {
 
 	// OUTPUT:
 	// {
-	//   "aud": [
-	//     "Golang Users"
-	//   ],
+	//   "aud": "Golang Users",
 	//   "iat": 233431200,
 	//   "privateClaimKey": "Hello, World!",
 	//   "sub": "https://github.com/lestrrat-go/jwx/jwt"
@@ -321,9 +319,7 @@ func ExampleJWT_OpenIDToken() {
 	//     "region": "東京都",
 	//     "street_address": "芝公園 4-2-8"
 	//   },
-	//   "aud": [
-	//     "Golang Users"
-	//   ],
+	//   "aud": "Golang Users",
 	//   "iat": 233431200,
 	//   "privateClaimKey": "Hello, World!",
 	//   "sub": "https://github.com/lestrrat-go/jwx/jwt"

--- a/examples/jwt_example_test.go
+++ b/examples/jwt_example_test.go
@@ -228,8 +228,8 @@ func ExampleJWT_Token() {
 	// OUTPUT:
 	// {
 	//   "aud": [
-  //     "Golang Users"
-  //   ],
+	//     "Golang Users"
+	//   ],
 	//   "iat": 233431200,
 	//   "privateClaimKey": "Hello, World!",
 	//   "sub": "https://github.com/lestrrat-go/jwx/jwt"
@@ -322,8 +322,8 @@ func ExampleJWT_OpenIDToken() {
 	//     "street_address": "芝公園 4-2-8"
 	//   },
 	//   "aud": [
-  //     "Golang Users"
-  //   ],
+	//     "Golang Users"
+	//   ],
 	//   "iat": 233431200,
 	//   "privateClaimKey": "Hello, World!",
 	//   "sub": "https://github.com/lestrrat-go/jwx/jwt"

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -57,8 +57,8 @@ func AssignNextStringToken(dst **string, dec *Decoder) error {
 	return nil
 }
 
-// Flag to specify if we should flatten the "aud" entry to a string
-// when there's only one entry.
+// FlattenAudience is a flag to specify if we should flatten the "aud"
+// entry to a string when there's only one entry.
 // In jwx < 1.1.8 we just dumped everything as an array of strings,
 // but apparently AWS Cognito doesn't handle this well.
 //

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -3,6 +3,7 @@ package json
 import (
 	"bytes"
 	"sync"
+	"sync/atomic"
 
 	"github.com/lestrrat-go/jwx/internal/base64"
 	"github.com/pkg/errors"
@@ -54,4 +55,25 @@ func AssignNextStringToken(dst **string, dec *Decoder) error {
 	}
 	*dst = &val
 	return nil
+}
+
+// Flag to specify if we should flatten the "aud" entry to a string
+// when there's only one entry.
+// In jwx < 1.1.8 we just dumped everything as an array of strings,
+// but apparently AWS Cognito doesn't handle this well.
+//
+// So now we have the ability to dump "aud" as a string if there's
+// only one entry, but we need to retain the old behavior so that
+// we don't accidentally break somebody else's code. (e.g. messing
+// up how signatures are calculated)
+var FlattenAudience uint32
+
+func EncodeAudience(enc *Encoder, aud []string) error {
+	var val interface{}
+	if len(aud) == 1 && atomic.LoadUint32(&FlattenAudience) == 1 {
+		val = aud[0]
+	} else {
+		val = aud
+	}
+	return enc.Encode(val)
 }

--- a/jwt/internal/cmd/gentoken/main.go
+++ b/jwt/internal/cmd/gentoken/main.go
@@ -688,7 +688,7 @@ func generateToken(tt tokenType) error {
 	fmt.Fprintf(&buf, "\nswitch f {")
 	fmt.Fprintf(&buf, "\ncase AudienceKey:")
 	fmt.Fprintf(&buf, "\nvar val interface{}")
-	fmt.Fprintf(&buf, "\nif v := data[f].([]string); len(v) == 1 {")
+	fmt.Fprintf(&buf, "\nif v := data[f].([]string); len(v) == 1 && atomic.LoadUint32(&flattenAudience) == 1 {")
 	fmt.Fprintf(&buf, "\nval = v[0]")
 	fmt.Fprintf(&buf, "\n} else {")
 	fmt.Fprintf(&buf, "\nval = data[f]")

--- a/jwt/internal/cmd/gentoken/main.go
+++ b/jwt/internal/cmd/gentoken/main.go
@@ -687,13 +687,9 @@ func generateToken(tt tokenType) error {
 	// Handle cases that need specialized handling
 	fmt.Fprintf(&buf, "\nswitch f {")
 	fmt.Fprintf(&buf, "\ncase AudienceKey:")
-	fmt.Fprintf(&buf, "\nvar val interface{}")
-	fmt.Fprintf(&buf, "\nif v := data[f].([]string); len(v) == 1 && atomic.LoadUint32(&flattenAudience) == 1 {")
-	fmt.Fprintf(&buf, "\nval = v[0]")
-	fmt.Fprintf(&buf, "\n} else {")
-	fmt.Fprintf(&buf, "\nval = data[f]")
+	fmt.Fprintf(&buf, "\nif err := json.EncodeAudience(enc, data[f].([]string)); err != nil {")
+	fmt.Fprintf(&buf, "\nreturn nil, errors.Wrap(err, `failed to encode \"aud\"`)")
 	fmt.Fprintf(&buf, "\n}")
-	fmt.Fprintf(&buf, "\nenc.Encode(val)")
 	fmt.Fprintf(&buf, "\ncontinue")
 	if lndf := len(numericDateFields); lndf > 0 {
 		fmt.Fprintf(&buf, "\ncase ")

--- a/jwt/internal/cmd/gentoken/main.go
+++ b/jwt/internal/cmd/gentoken/main.go
@@ -683,15 +683,19 @@ func generateToken(tt tokenType) error {
 	fmt.Fprintf(&buf, "\nbuf.WriteRune('\"')")
 	fmt.Fprintf(&buf, "\nbuf.WriteString(f)")
 	fmt.Fprintf(&buf, "\nbuf.WriteString(`\":`)")
-	fmt.Fprintf(&buf, "\nv := data[f]")
-	fmt.Fprintf(&buf, "\nswitch v := v.(type) {")
-	fmt.Fprintf(&buf, "\ncase []byte:")
-	fmt.Fprintf(&buf, "\nbuf.WriteRune('\"')")
-	fmt.Fprintf(&buf, "\nbuf.WriteString(base64.EncodeToString(v))")
-	fmt.Fprintf(&buf, "\nbuf.WriteRune('\"')")
+
+	// Handle cases that need specialized handling
+	fmt.Fprintf(&buf, "\nswitch f {")
+	fmt.Fprintf(&buf, "\ncase AudienceKey:")
+	fmt.Fprintf(&buf, "\nvar val interface{}")
+	fmt.Fprintf(&buf, "\nif v := data[f].([]string); len(v) == 1 {")
+	fmt.Fprintf(&buf, "\nval = v[0]")
+	fmt.Fprintf(&buf, "\n} else {")
+	fmt.Fprintf(&buf, "\nval = data[f]")
+	fmt.Fprintf(&buf, "\n}")
+	fmt.Fprintf(&buf, "\nenc.Encode(val)")
+	fmt.Fprintf(&buf, "\ncontinue")
 	if lndf := len(numericDateFields); lndf > 0 {
-		fmt.Fprintf(&buf, "\ncase time.Time:")
-		fmt.Fprintf(&buf, "\nswitch f {")
 		fmt.Fprintf(&buf, "\ncase ")
 		for i, ndf := range numericDateFields {
 			fmt.Fprintf(&buf, "%sKey", ndf.method)
@@ -700,14 +704,17 @@ func generateToken(tt tokenType) error {
 			}
 		}
 		fmt.Fprintf(&buf, ":")
-		fmt.Fprintf(&buf, "\nenc.Encode(v.Unix())")
-		fmt.Fprintf(&buf, "\ndefault:")
-		fmt.Fprintf(&buf, "\nif err := enc.Encode(v); err != nil {")
-		fmt.Fprintf(&buf, "\nreturn nil, errors.Wrapf(err, `failed to marshal field %%s`, f)")
-		fmt.Fprintf(&buf, "\n}")
-		fmt.Fprintf(&buf, "\nbuf.Truncate(buf.Len()-1)")
-		fmt.Fprintf(&buf, "\n}")
+		fmt.Fprintf(&buf, "\nenc.Encode(data[f].(time.Time).Unix())")
+		fmt.Fprintf(&buf, "\ncontinue")
 	}
+	fmt.Fprintf(&buf, "\n}")
+
+	fmt.Fprintf(&buf, "\nv := data[f]")
+	fmt.Fprintf(&buf, "\nswitch v := v.(type) {")
+	fmt.Fprintf(&buf, "\ncase []byte:")
+	fmt.Fprintf(&buf, "\nbuf.WriteRune('\"')")
+	fmt.Fprintf(&buf, "\nbuf.WriteString(base64.EncodeToString(v))")
+	fmt.Fprintf(&buf, "\nbuf.WriteRune('\"')")
 	fmt.Fprintf(&buf, "\ndefault:")
 	fmt.Fprintf(&buf, "\nif err := enc.Encode(v); err != nil {")
 	fmt.Fprintf(&buf, "\nreturn nil, errors.Wrapf(err, `failed to marshal field %%s`, f)")

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -19,16 +19,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Flatten the "aud" entry to a string if there's only one entry.
-// In jwx < 1.1.8 we just dumped everything as an array of strings,
-// but apparently AWS Cognito doesn't handle this well.
-//
-// So now we have the ability to dump "aud" as a string if there's
-// only one entry, but we need to retain the old behavior so that
-// we don't accidentally break somebody else's code. (e.g. messing
-// up how signatures are calculated)
-var flattenAudience uint32
-
 // Settings controls global settings that are specific to JWTs.
 func Settings(options ...GlobalOption) {
 	var flattenAudienceBool bool
@@ -39,13 +29,13 @@ func Settings(options ...GlobalOption) {
 		}
 	}
 
-	v := atomic.LoadUint32(&flattenAudience)
+	v := atomic.LoadUint32(&json.FlattenAudience)
 	if (v == 1) != flattenAudienceBool {
 		var newVal uint32
 		if flattenAudienceBool {
 			newVal = 1
 		}
-		atomic.CompareAndSwapUint32(&flattenAudience, v, newVal)
+		atomic.CompareAndSwapUint32(&json.FlattenAudience, v, newVal)
 	}
 }
 

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -22,6 +22,8 @@ import (
 // Settings controls global settings that are specific to JWTs.
 func Settings(options ...GlobalOption) {
 	var flattenAudienceBool bool
+
+	//nolint:forcetypeassert
 	for _, option := range options {
 		switch option.Ident() {
 		case identFlattenAudience{}:

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -326,7 +326,7 @@ func TestUnmarshal(t *testing.T) {
 				t.Set("aud", "foo")
 				return t
 			},
-			ExpectedJSON: `{"aud":["foo"]}`,
+			ExpectedJSON: `{"aud":"foo"}`,
 		},
 		{
 			Title:  "multiple aud's",
@@ -736,19 +736,43 @@ func TestParseRequest(t *testing.T) {
 }
 
 func TestGHIssue368(t *testing.T) {
-	tok := jwt.New()
-	_ = tok.Set(jwt.AudienceKey, "hello")
+	t.Parallel()
+	t.Run("Single Key", func(t *testing.T) {
+		t.Parallel()
+		tok := jwt.New()
+		_ = tok.Set(jwt.AudienceKey, "hello")
 
-	buf, err := json.MarshalIndent(tok, "", "  ")
-	if !assert.NoError(t, err, `json.MarshalIndent should succeed`) {
-		return
-	}
+		buf, err := json.MarshalIndent(tok, "", "  ")
+		if !assert.NoError(t, err, `json.MarshalIndent should succeed`) {
+			return
+		}
 
-	const expected = `{
+		const expected = `{
   "aud": "hello"
 }`
 
-	if !assert.Equal(t, expected, string(buf), `output should match`) {
-		return
-	}
+		if !assert.Equal(t, expected, string(buf), `output should match`) {
+			return
+		}
+	})
+	t.Run("Multiple Keys", func(t *testing.T) {
+		tok := jwt.New()
+		_ = tok.Set(jwt.AudienceKey, []string{"hello", "world"})
+
+		buf, err := json.MarshalIndent(tok, "", "  ")
+		if !assert.NoError(t, err, `json.MarshalIndent should succeed`) {
+			return
+		}
+
+		const expected = `{
+  "aud": [
+    "hello",
+    "world"
+  ]
+}`
+
+		if !assert.Equal(t, expected, string(buf), `output should match`) {
+			return
+		}
+	})
 }

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -734,3 +734,21 @@ func TestParseRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestGHIssue368(t *testing.T) {
+	tok := jwt.New()
+	_ = tok.Set(jwt.AudienceKey, "hello")
+
+	buf, err := json.MarshalIndent(tok, "", "  ")
+	if !assert.NoError(t, err, `json.MarshalIndent should succeed`) {
+		return
+	}
+
+	const expected = `{
+  "aud": "hello"
+}`
+
+	if !assert.Equal(t, expected, string(buf), `output should match`) {
+		return
+	}
+}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -754,16 +754,16 @@ func TestGHIssue368(t *testing.T) {
 
 				var expected string
 				if flatten {
-				expected = `{
+					expected = `{
   "aud": "hello"
 }`
 				} else {
-				expected = `{
+					expected = `{
   "aud": [
     "hello"
   ]
 }`
-	}
+				}
 
 				if !assert.Equal(t, expected, string(buf), `output should match`) {
 					return

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -1090,22 +1090,26 @@ func (t stdToken) MarshalJSON() ([]byte, error) {
 		buf.WriteRune('"')
 		buf.WriteString(f)
 		buf.WriteString(`":`)
+		switch f {
+		case AudienceKey:
+			var val interface{}
+			if v := data[f].([]string); len(v) == 1 {
+				val = v[0]
+			} else {
+				val = data[f]
+			}
+			enc.Encode(val)
+			continue
+		case ExpirationKey, IssuedAtKey, NotBeforeKey, UpdatedAtKey:
+			enc.Encode(data[f].(time.Time).Unix())
+			continue
+		}
 		v := data[f]
 		switch v := v.(type) {
 		case []byte:
 			buf.WriteRune('"')
 			buf.WriteString(base64.EncodeToString(v))
 			buf.WriteRune('"')
-		case time.Time:
-			switch f {
-			case ExpirationKey, IssuedAtKey, NotBeforeKey, UpdatedAtKey:
-				enc.Encode(v.Unix())
-			default:
-				if err := enc.Encode(v); err != nil {
-					return nil, errors.Wrapf(err, `failed to marshal field %s`, f)
-				}
-				buf.Truncate(buf.Len() - 1)
-			}
 		default:
 			if err := enc.Encode(v); err != nil {
 				return nil, errors.Wrapf(err, `failed to marshal field %s`, f)

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/lestrrat-go/iter/mapiter"
@@ -1093,7 +1094,7 @@ func (t stdToken) MarshalJSON() ([]byte, error) {
 		switch f {
 		case AudienceKey:
 			var val interface{}
-			if v := data[f].([]string); len(v) == 1 {
+			if v := data[f].([]string); len(v) == 1 && atomic.LoadUint32(&flattenAudience) == 1 {
 				val = v[0]
 			} else {
 				val = data[f]

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"sort"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/lestrrat-go/iter/mapiter"
@@ -1093,13 +1092,9 @@ func (t stdToken) MarshalJSON() ([]byte, error) {
 		buf.WriteString(`":`)
 		switch f {
 		case AudienceKey:
-			var val interface{}
-			if v := data[f].([]string); len(v) == 1 && atomic.LoadUint32(&flattenAudience) == 1 {
-				val = v[0]
-			} else {
-				val = data[f]
+			if err := json.EncodeAudience(enc, data[f].([]string)); err != nil {
+				return nil, errors.Wrap(err, `failed to encode "aud"`)
 			}
-			enc.Encode(val)
 			continue
 		case ExpirationKey, IssuedAtKey, NotBeforeKey, UpdatedAtKey:
 			enc.Encode(data[f].(time.Time).Unix())

--- a/jwt/options.go
+++ b/jwt/options.go
@@ -222,6 +222,10 @@ func WithFormKey(v string) ParseRequestOption {
 //
 // This is sometimes important when a JWT consumer does not understand that
 // the "aud" claim can actually take the form of an array of strings.
+//
+// The default value is `false`, which means that "aud" claims are always
+// rendered as a arrays of strings. This setting has a global effect,
+// and will change the behavior for all JWT serialization.
 func WithFlattenAudience(v bool) GlobalOption {
 	return &globalOption{option.New(identFlattenAudience{}, v)}
 }

--- a/jwt/options.go
+++ b/jwt/options.go
@@ -11,6 +11,18 @@ import (
 
 type Option = option.Interface
 
+// GlobalOption describes an Option that can be passed to `Settings()`.
+type GlobalOption interface {
+	Option
+	globalOption()
+}
+
+type globalOption struct {
+	Option
+}
+
+func (*globalOption) globalOption() {}
+
 // ParseRequestOption describes an Option that can be passed to `ParseRequest()`.
 type ParseRequestOption interface {
 	ParseOption
@@ -65,6 +77,7 @@ type identAudience struct{}
 type identClaim struct{}
 type identClock struct{}
 type identDefault struct{}
+type identFlattenAudience struct{}
 type identHeaders struct{}
 type identIssuer struct{}
 type identJwtid struct{}
@@ -202,4 +215,13 @@ func WithHeaderKey(v string) ParseRequestOption {
 // doing so will have no effect. Only use it for HTTP request parsing functions
 func WithFormKey(v string) ParseRequestOption {
 	return &httpParseOption{newParseOption(identFormKey{}, v)}
+}
+
+// WithFlattenAudience specifies if the "aud" claim should be flattened
+// to a single string upon the token being serialized to JSON.
+//
+// This is sometimes important when a JWT consumer does not understand that
+// the "aud" claim can actually take the form of an array of strings.
+func WithFlattenAudience(v bool) GlobalOption {
+	return &globalOption{option.New(identFlattenAudience{}, v)}
 }

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"sort"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/lestrrat-go/iter/mapiter"
@@ -432,13 +431,9 @@ func (t stdToken) MarshalJSON() ([]byte, error) {
 		buf.WriteString(`":`)
 		switch f {
 		case AudienceKey:
-			var val interface{}
-			if v := data[f].([]string); len(v) == 1 && atomic.LoadUint32(&flattenAudience) == 1 {
-				val = v[0]
-			} else {
-				val = data[f]
+			if err := json.EncodeAudience(enc, data[f].([]string)); err != nil {
+				return nil, errors.Wrap(err, `failed to encode "aud"`)
 			}
-			enc.Encode(val)
 			continue
 		case ExpirationKey, IssuedAtKey, NotBeforeKey:
 			enc.Encode(data[f].(time.Time).Unix())

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/lestrrat-go/iter/mapiter"
@@ -432,7 +433,7 @@ func (t stdToken) MarshalJSON() ([]byte, error) {
 		switch f {
 		case AudienceKey:
 			var val interface{}
-			if v := data[f].([]string); len(v) == 1 {
+			if v := data[f].([]string); len(v) == 1 && atomic.LoadUint32(&flattenAudience) == 1 {
 				val = v[0]
 			} else {
 				val = data[f]

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -429,22 +429,26 @@ func (t stdToken) MarshalJSON() ([]byte, error) {
 		buf.WriteRune('"')
 		buf.WriteString(f)
 		buf.WriteString(`":`)
+		switch f {
+		case AudienceKey:
+			var val interface{}
+			if v := data[f].([]string); len(v) == 1 {
+				val = v[0]
+			} else {
+				val = data[f]
+			}
+			enc.Encode(val)
+			continue
+		case ExpirationKey, IssuedAtKey, NotBeforeKey:
+			enc.Encode(data[f].(time.Time).Unix())
+			continue
+		}
 		v := data[f]
 		switch v := v.(type) {
 		case []byte:
 			buf.WriteRune('"')
 			buf.WriteString(base64.EncodeToString(v))
 			buf.WriteRune('"')
-		case time.Time:
-			switch f {
-			case ExpirationKey, IssuedAtKey, NotBeforeKey:
-				enc.Encode(v.Unix())
-			default:
-				if err := enc.Encode(v); err != nil {
-					return nil, errors.Wrapf(err, `failed to marshal field %s`, f)
-				}
-				buf.Truncate(buf.Len() - 1)
-			}
 		default:
 			if err := enc.Encode(v); err != nil {
 				return nil, errors.Wrapf(err, `failed to marshal field %s`, f)


### PR DESCRIPTION
I have been informed that apparently AWS Cognito doesn't play well when the "aud" claim of a JWT is in the array-of-strings format.

This PR adds the optional ability to change the behavior of JWT serialization such that when you only have a single "aud" claim, the field is rendered as a string.

So where previously it would have rendered as follows:

```json
{ "aud": ["foo"] }
```

Now it is possible to have it serialized as:

```json
{ "aud": "foo" }
```

This behavior is turned on by opting in, and you need to explicitly call a method that triggers a global effect:

```go
jwt.Settings(jwt.WithFlattenAudience(true))
```