### PR TITLE
Implement per-object custom typed fields

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,23 @@
 Changes
 =======
 
+v1.2.1
+[New features]
+  * Option `jwt.WithTypedClaim()` and `jwk.WithTypedField()` have been added.
+    They allow a per-object custom conversion from their JSON representation
+    to a Go object, much like `RegisterCustomField`.
+    The difference is that whereas `RegisterCustomField` has global effect,
+    these typed fields only take effect in the call where the option was
+    explicitly passed.
+
+    `jws` and `jwe` does not have these options because
+    (1) JWS and JWE messages don't generally carry much in terms of custom data
+    (2) This requires changes in function signatures.
+
+    Only use these options when you absolutely need to. While it is a powerful
+    tool, they do have many caveats, and abusing these features will have
+    negative effects. See the documentation for details
+
 v1.2.0 30 Apr 2021
 
 This is a security fix release with minor incompatibilities from earlier version

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -77,3 +77,29 @@ func EncodeAudience(enc *Encoder, aud []string) error {
 	}
 	return enc.Encode(val)
 }
+
+// DecodeCtx is an interface for objects that needs that extra something
+// when decoding JSON into an object.
+type DecodeCtx interface {
+	Registry() *Registry
+}
+
+// DecodeCtxContainer is used to differentiate objects that can carry extra
+// decoding hints and those who can't.
+type DecodeCtxContainer interface {
+	DecodeCtx() DecodeCtx
+	SetDecodeCtx(DecodeCtx)
+}
+
+// stock decodeCtx. should cover 80% of the cases
+type decodeCtx struct {
+	registry *Registry
+}
+
+func NewDecodeCtx(r *Registry) DecodeCtx {
+	return &decodeCtx{registry: r}
+}
+
+func (dc *decodeCtx) Registry() *Registry {
+	return dc.registry
+}

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -51,6 +51,7 @@ type ecdsaPrivateKey struct {
 	y                      []byte
 	privateParams          map[string]interface{}
 	mu                     *sync.RWMutex
+	dc                     DecodeCtx
 }
 
 func NewECDSAPrivateKey() ECDSAPrivateKey {
@@ -412,6 +413,18 @@ func (k *ecdsaPrivateKey) Clone() (Key, error) {
 	return cloneKey(k)
 }
 
+func (k *ecdsaPrivateKey) DecodeCtx() DecodeCtx {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	return k.dc
+}
+
+func (k *ecdsaPrivateKey) SetDecodeCtx(dc DecodeCtx) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.dc = dc
+}
+
 func (h *ecdsaPrivateKey) UnmarshalJSON(buf []byte) error {
 	h.algorithm = nil
 	h.crv = nil
@@ -506,11 +519,21 @@ LOOP:
 					return errors.Wrapf(err, `failed to decode value for key %s`, ECDSAYKey)
 				}
 			default:
-				decoded, err := registry.Decode(dec, tok)
-				if err != nil {
-					return err
+				if dc := h.dc; dc != nil {
+					if localReg := dc.Registry(); localReg != nil {
+						decoded, err := localReg.Decode(dec, tok)
+						if err == nil {
+							h.setNoLock(tok, decoded)
+							continue
+						}
+					}
 				}
-				h.setNoLock(tok, decoded)
+				decoded, err := registry.Decode(dec, tok)
+				if err == nil {
+					h.setNoLock(tok, decoded)
+					continue
+				}
+				return errors.Wrapf(err, `could not decode field %s`, tok)
 			}
 		default:
 			return errors.Errorf(`invalid token %T`, tok)
@@ -619,6 +642,7 @@ type ecdsaPublicKey struct {
 	y                      []byte
 	privateParams          map[string]interface{}
 	mu                     *sync.RWMutex
+	dc                     DecodeCtx
 }
 
 func NewECDSAPublicKey() ECDSAPublicKey {
@@ -960,6 +984,18 @@ func (k *ecdsaPublicKey) Clone() (Key, error) {
 	return cloneKey(k)
 }
 
+func (k *ecdsaPublicKey) DecodeCtx() DecodeCtx {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	return k.dc
+}
+
+func (k *ecdsaPublicKey) SetDecodeCtx(dc DecodeCtx) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.dc = dc
+}
+
 func (h *ecdsaPublicKey) UnmarshalJSON(buf []byte) error {
 	h.algorithm = nil
 	h.crv = nil
@@ -1049,11 +1085,21 @@ LOOP:
 					return errors.Wrapf(err, `failed to decode value for key %s`, ECDSAYKey)
 				}
 			default:
-				decoded, err := registry.Decode(dec, tok)
-				if err != nil {
-					return err
+				if dc := h.dc; dc != nil {
+					if localReg := dc.Registry(); localReg != nil {
+						decoded, err := localReg.Decode(dec, tok)
+						if err == nil {
+							h.setNoLock(tok, decoded)
+							continue
+						}
+					}
 				}
-				h.setNoLock(tok, decoded)
+				decoded, err := registry.Decode(dec, tok)
+				if err == nil {
+					h.setNoLock(tok, decoded)
+					continue
+				}
+				return errors.Wrapf(err, `could not decode field %s`, tok)
 			}
 		default:
 			return errors.Errorf(`invalid token %T`, tok)

--- a/jwk/interface.go
+++ b/jwk/interface.go
@@ -106,23 +106,5 @@ type HTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
 }
 
-// DecodeCtx is an interface for objects that needs that extra something
-// when decoding JSON into an object.
-type DecodeCtx interface {
-	Registry() *json.Registry
-}
-
-// KeyWithDecodeCtx is used to differentiate objects that can carry extra
-// decoding hints and those who can't.
-type KeyWithDecodeCtx interface {
-	DecodeCtx() DecodeCtx
-	SetDecodeCtx(DecodeCtx)
-}
-
-type decodeCtx struct {
-	registry *json.Registry
-}
-
-func (c *decodeCtx) Registry() *json.Registry {
-	return c.registry
-}
+type DecodeCtx = json.DecodeCtx
+type KeyWithDecodeCtx = json.DecodeCtxContainer

--- a/jwk/interface.go
+++ b/jwk/interface.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lestrrat-go/iter/arrayiter"
 	"github.com/lestrrat-go/iter/mapiter"
 	"github.com/lestrrat-go/jwx/internal/iter"
+	"github.com/lestrrat-go/jwx/internal/json"
 )
 
 // KeyUsageType is used to denote what this key should be used for
@@ -82,6 +83,7 @@ type Set interface {
 type set struct {
 	keys []Key
 	mu   sync.RWMutex
+	dc   DecodeCtx
 }
 
 type HeaderVisitor = iter.MapVisitor
@@ -102,4 +104,25 @@ type PublicKeyer interface {
 // fetching tools.
 type HTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
+}
+
+// DecodeCtx is an interface for objects that needs that extra something
+// when decoding JSON into an object.
+type DecodeCtx interface {
+	Registry() *json.Registry
+}
+
+// KeyWithDecodeCtx is used to differentiate objects that can carry extra
+// decoding hints and those who can't.
+type KeyWithDecodeCtx interface {
+	DecodeCtx() DecodeCtx
+	SetDecodeCtx(DecodeCtx)
+}
+
+type decodeCtx struct {
+	registry *json.Registry
+}
+
+func (c *decodeCtx) Registry() *json.Registry {
+	return c.registry
 }

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1549,8 +1549,7 @@ func TestTypedFields(t *testing.T) {
 
 				for iter := got.Iterate(ctx); iter.Next(ctx); {
 					pair := iter.Pair()
-					key, ok := pair.Value.(jwk.Key)
-
+					key, _ := pair.Value.(jwk.Key)
 					v, ok := key.Get("typed-field")
 					if !assert.True(t, ok, `key.Get() should succeed`) {
 						return
@@ -1566,6 +1565,5 @@ func TestTypedFields(t *testing.T) {
 				}
 			})
 		}
-
 	})
 }

--- a/jwk/option.go
+++ b/jwk/option.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/lestrrat-go/backoff/v2"
+	"github.com/lestrrat-go/jwx/internal/json"
 	"github.com/lestrrat-go/option"
 )
 
@@ -16,6 +17,8 @@ type identRefreshInterval struct{}
 type identMinRefreshInterval struct{}
 type identFetchBackoff struct{}
 type identPEM struct{}
+type identTypedField struct{}
+type identLocalRegistry struct{}
 
 // AutoRefreshOption is a type of Option that can be passed to the
 // AutoRefresh object.
@@ -119,4 +122,40 @@ func WithPEM(v bool) ParseOption {
 	return &parseOption{
 		option.New(identPEM{}, v),
 	}
+}
+
+type typedFieldPair struct {
+	Name  string
+	Value interface{}
+}
+
+// WithTypedField allows a private field to be parsed into the object type of
+// your choice. It works much like the RegisterCustomField, but the effect
+// is only applicable to the jwt.Parse function call which receives this option.
+//
+// While this can be extremely useful, this option should be used with caution:
+// There are many caveats that your entire team/user-base needs to be aware of,
+// and therefore in general its use is discouraged. Only use it when you know
+// what you are doing, and you document its use clearly for others.
+//
+// First and foremost, this is a "per-object" option. Meaning that given the same
+// serialized format, it is possible to generate two objects whose internal
+// representations may differ. That is, if you parse one _WITH_ the option,
+// and the other _WITHOUT_, their internal representation may completely differ.
+// This could potentially lead to problems.
+//
+// Second, specifying this option will slightly slow down the decoding process
+// as it needs to consult multiple definitions sources (global and local), so
+// be careful if you are decoding a large number of tokens, as the effects will stack up.
+func WithTypedField(name string, object interface{}) ParseOption {
+	return &parseOption{
+		option.New(identTypedField{},
+			typedFieldPair{Name: name, Value: object},
+		),
+	}
+}
+
+// This option is only available for internal code. Users don't get to play with it
+func withLocalRegistry(r *json.Registry) ParseOption {
+	return &parseOption{option.New(identLocalRegistry{}, r)}
 }

--- a/jwk/set.go
+++ b/jwk/set.go
@@ -180,3 +180,15 @@ func (s *set) LookupKeyID(kid string) (Key, bool) {
 	}
 	return nil, false
 }
+
+func (s *set) DecodeCtx() DecodeCtx {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.dc
+}
+
+func (s *set) SetDecodeCtx(dc DecodeCtx) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dc = dc
+}

--- a/jwk/set.go
+++ b/jwk/set.go
@@ -142,15 +142,22 @@ func (s *set) UnmarshalJSON(data []byte) error {
 		return errors.Wrap(err, `failed to unmarshal into Key (proxy)`)
 	}
 
+	var options []ParseOption
+	if dc := s.dc; dc != nil {
+		if localReg := dc.Registry(); localReg != nil {
+			options = append(options, withLocalRegistry(localReg))
+		}
+	}
+
 	if len(proxy.Keys) == 0 {
-		k, err := ParseKey(data)
+		k, err := ParseKey(data, options...)
 		if err != nil {
 			return errors.Wrap(err, `failed to unmarshal key from JSON headers`)
 		}
 		s.keys = append(s.keys, k)
 	} else {
 		for i, buf := range proxy.Keys {
-			k, err := ParseKey([]byte(buf))
+			k, err := ParseKey([]byte(buf), options...)
 			if err != nil {
 				return errors.Wrapf(err, `failed to unmarshal key #%d (total %d) from multi-key JWK set`, i+1, len(proxy.Keys))
 			}

--- a/jwt/interface.go
+++ b/jwt/interface.go
@@ -3,9 +3,23 @@ package jwt
 import (
 	"github.com/lestrrat-go/iter/mapiter"
 	"github.com/lestrrat-go/jwx/internal/iter"
+	"github.com/lestrrat-go/jwx/internal/json"
 )
 
 type ClaimPair = mapiter.Pair
 type Iterator = mapiter.Iterator
 type Visitor = iter.MapVisitor
 type VisitorFunc iter.MapVisitorFunc
+
+// DecodeCtx is an interface for objects that needs that extra something
+// when decoding JSON into an object.
+type DecodeCtx interface {
+	Registry() *json.Registry
+}
+
+// TokenWithDecodeCtx is used to differentiate objects that can carry extra
+// decoding hints and those who can't.
+type TokenWithDecodeCtx interface {
+	DecodeCtx() DecodeCtx
+	SetDecodeCtx(DecodeCtx)
+}

--- a/jwt/interface.go
+++ b/jwt/interface.go
@@ -9,17 +9,6 @@ import (
 type ClaimPair = mapiter.Pair
 type Iterator = mapiter.Iterator
 type Visitor = iter.MapVisitor
-type VisitorFunc iter.MapVisitorFunc
-
-// DecodeCtx is an interface for objects that needs that extra something
-// when decoding JSON into an object.
-type DecodeCtx interface {
-	Registry() *json.Registry
-}
-
-// TokenWithDecodeCtx is used to differentiate objects that can carry extra
-// decoding hints and those who can't.
-type TokenWithDecodeCtx interface {
-	DecodeCtx() DecodeCtx
-	SetDecodeCtx(DecodeCtx)
-}
+type VisitorFunc = iter.MapVisitorFunc
+type DecodeCtx = json.DecodeCtx
+type TokenWithDecodeCtx = json.DecodeCtxContainer

--- a/jwt/internal/cmd/gentoken/main.go
+++ b/jwt/internal/cmd/gentoken/main.go
@@ -384,13 +384,6 @@ func generateToken(tt tokenType) error {
 	fmt.Fprintf(&buf, "\nAsMap(context.Context) (map[string]interface{}, error)")
 	fmt.Fprintf(&buf, "\n}")
 
-	fmt.Fprintf(&buf, "\ntype decodeCtx struct {")
-	fmt.Fprintf(&buf, "\nregistry *json.Registry")
-	fmt.Fprintf(&buf, "\n}")
-	fmt.Fprintf(&buf, "\n\nfunc(c *decodeCtx) Registry() *json.Registry {")
-	fmt.Fprintf(&buf, "\nreturn c.registry")
-	fmt.Fprintf(&buf, "\n}")
-
 	fmt.Fprintf(&buf, "\ntype %s struct {", tt.structName)
 	fmt.Fprintf(&buf, "\nmu *sync.RWMutex")
 	fmt.Fprintf(&buf, "\ndc DecodeCtx // per-object context for decoding")

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -175,14 +175,16 @@ func parse(token Token, data []byte, verify bool, alg jwa.SignatureAlgorithm, ke
 		}
 	}
 
-	if pcToken, ok := token.(TokenWithDecodeCtx); ok {
-		if localReg != nil {
-			pc := &decodeCtx{
-				registry: localReg,
-			}
-			pcToken.SetDecodeCtx(pc)
-			defer func() { pcToken.SetDecodeCtx(nil) }()
+	if localReg != nil {
+		dcToken, ok := token.(TokenWithDecodeCtx)
+		if !ok {
+			return nil, errors.Errorf(`typed claim was requested, but the token (%T) does not support DecodeCtx`, token)
 		}
+		dc := &decodeCtx{
+			registry: localReg,
+		}
+		dcToken.SetDecodeCtx(dc)
+		defer func() { dcToken.SetDecodeCtx(nil) }()
 	}
 
 	if err := json.Unmarshal(payload, token); err != nil {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -168,6 +168,7 @@ func parse(token Token, data []byte, verify bool, alg jwa.SignatureAlgorithm, ke
 	}
 
 	var typedClaims map[string]interface{}
+	//nolint:forcetypeassert
 	for _, option := range options {
 		switch option.Ident() {
 		case identTypedClaim{}:

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -125,6 +125,11 @@ func parseBytes(data []byte, options ...ParseOption) (Token, error) {
 	return parse(token, data, false, "", nil, validate, options...)
 }
 
+type tokenWithParseCtx interface {
+	parseCtx() *parseCtx
+	setParseCtx(*parseCtx)
+}
+
 // verify parameter exists to make sure that we don't accidentally skip
 // over verification just because alg == ""  or key == nil or something.
 func parse(token Token, data []byte, verify bool, alg jwa.SignatureAlgorithm, key interface{}, validate bool, options ...ParseOption) (Token, error) {
@@ -161,6 +166,35 @@ func parse(token Token, data []byte, verify bool, alg jwa.SignatureAlgorithm, ke
 	if token == nil {
 		token = New()
 	}
+
+	var typedClaims map[string]interface{}
+	for _, option := range options {
+		switch option.Ident() {
+		case identTypedClaim{}:
+			pair := option.Value().(typedClaimPair)
+			if typedClaims == nil {
+				typedClaims = make(map[string]interface{})
+			}
+			typedClaims[pair.Name] = pair.Value
+		}
+	}
+
+	if pcToken, ok := token.(tokenWithParseCtx); ok {
+		if len(typedClaims) > 0 {
+			pc := &parseCtx{
+				registry: json.NewRegistry(),
+			}
+			pcToken.setParseCtx(pc)
+			for name, obj := range typedClaims {
+				pc.registry.Register(name, obj)
+			}
+		}
+
+		if pcToken.parseCtx() != nil {
+			defer func() { pcToken.setParseCtx(nil) }()
+		}
+	}
+
 	if err := json.Unmarshal(payload, token); err != nil {
 		return nil, errors.Wrap(err, `failed to parse token`)
 	}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -125,11 +125,6 @@ func parseBytes(data []byte, options ...ParseOption) (Token, error) {
 	return parse(token, data, false, "", nil, validate, options...)
 }
 
-type tokenWithParseCtx interface {
-	parseCtx() *parseCtx
-	setParseCtx(*parseCtx)
-}
-
 // verify parameter exists to make sure that we don't accidentally skip
 // over verification just because alg == ""  or key == nil or something.
 func parse(token Token, data []byte, verify bool, alg jwa.SignatureAlgorithm, key interface{}, validate bool, options ...ParseOption) (Token, error) {
@@ -180,19 +175,19 @@ func parse(token Token, data []byte, verify bool, alg jwa.SignatureAlgorithm, ke
 		}
 	}
 
-	if pcToken, ok := token.(tokenWithParseCtx); ok {
+	if pcToken, ok := token.(TokenWithDecodeCtx); ok {
 		if len(typedClaims) > 0 {
-			pc := &parseCtx{
+			pc := &decodeCtx{
 				registry: json.NewRegistry(),
 			}
-			pcToken.setParseCtx(pc)
+			pcToken.SetDecodeCtx(pc)
 			for name, obj := range typedClaims {
 				pc.registry.Register(name, obj)
 			}
 		}
 
-		if pcToken.parseCtx() != nil {
-			defer func() { pcToken.setParseCtx(nil) }()
+		if pcToken.DecodeCtx() != nil {
+			defer func() { pcToken.SetDecodeCtx(nil) }()
 		}
 	}
 

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -180,9 +180,7 @@ func parse(token Token, data []byte, verify bool, alg jwa.SignatureAlgorithm, ke
 		if !ok {
 			return nil, errors.Errorf(`typed claim was requested, but the token (%T) does not support DecodeCtx`, token)
 		}
-		dc := &decodeCtx{
-			registry: localReg,
-		}
+		dc := json.NewDecodeCtx(localReg)
 		dcToken.SetDecodeCtx(dc)
 		defer func() { dcToken.SetDecodeCtx(nil) }()
 	}

--- a/jwt/openid/interface.go
+++ b/jwt/openid/interface.go
@@ -3,9 +3,23 @@ package openid
 import (
 	"github.com/lestrrat-go/iter/mapiter"
 	"github.com/lestrrat-go/jwx/internal/iter"
+	"github.com/lestrrat-go/jwx/internal/json"
 )
 
 type ClaimPair = mapiter.Pair
 type Iterator = mapiter.Iterator
 type Visitor = iter.MapVisitor
 type VisitorFunc = iter.MapVisitorFunc
+
+// DecodeCtx is an interface for objects that needs that extra something
+// when decoding JSON into an object.
+type DecodeCtx interface {
+	Registry() *json.Registry
+}
+
+// TokenWithDecodeCtx is used to differentiate objects that can carry extra
+// decoding hints and those who can't.
+type TokenWithDecodeCtx interface {
+	DecodeCtx() DecodeCtx
+	SetDecodeCtx(DecodeCtx)
+}

--- a/jwt/openid/interface.go
+++ b/jwt/openid/interface.go
@@ -12,4 +12,3 @@ type Visitor = iter.MapVisitor
 type VisitorFunc = iter.MapVisitorFunc
 type DecodeCtx = json.DecodeCtx
 type TokenWithDecodeCtx = json.DecodeCtxContainer
-

--- a/jwt/openid/interface.go
+++ b/jwt/openid/interface.go
@@ -10,16 +10,6 @@ type ClaimPair = mapiter.Pair
 type Iterator = mapiter.Iterator
 type Visitor = iter.MapVisitor
 type VisitorFunc = iter.MapVisitorFunc
+type DecodeCtx = json.DecodeCtx
+type TokenWithDecodeCtx = json.DecodeCtxContainer
 
-// DecodeCtx is an interface for objects that needs that extra something
-// when decoding JSON into an object.
-type DecodeCtx interface {
-	Registry() *json.Registry
-}
-
-// TokenWithDecodeCtx is used to differentiate objects that can carry extra
-// decoding hints and those who can't.
-type TokenWithDecodeCtx interface {
-	DecodeCtx() DecodeCtx
-	SetDecodeCtx(DecodeCtx)
-}

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -84,14 +84,6 @@ type Token interface {
 	Walk(context.Context, Visitor) error
 	AsMap(context.Context) (map[string]interface{}, error)
 }
-type decodeCtx struct {
-	registry *json.Registry
-}
-
-func (c *decodeCtx) Registry() *json.Registry {
-	return c.registry
-}
-
 type stdToken struct {
 	mu                  *sync.RWMutex
 	dc                  DecodeCtx          // per-object context for decoding

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -84,8 +84,12 @@ type Token interface {
 	Walk(context.Context, Visitor) error
 	AsMap(context.Context) (map[string]interface{}, error)
 }
+type parseCtx struct {
+	registry *json.Registry
+}
 type stdToken struct {
 	mu                  *sync.RWMutex
+	pc                  *parseCtx          // per-object context for parsing
 	audience            types.StringList   // https://tools.ietf.org/html/rfc7519#section-4.1.3
 	expiration          *types.NumericDate // https://tools.ietf.org/html/rfc7519#section-4.1.4
 	issuedAt            *types.NumericDate // https://tools.ietf.org/html/rfc7519#section-4.1.6
@@ -357,6 +361,18 @@ func (t *stdToken) Set(name string, value interface{}) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.setNoLock(name, value)
+}
+
+func (t *stdToken) parseCtx() *parseCtx {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.pc
+}
+
+func (t *stdToken) setParseCtx(v *parseCtx) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pc = v
 }
 
 func (t *stdToken) setNoLock(name string, value interface{}) error {
@@ -1052,11 +1068,25 @@ LOOP:
 				}
 				t.updatedAt = &decoded
 			default:
-				decoded, err := registry.Decode(dec, tok)
-				if err != nil {
-					return err
+				registries := make([]*json.Registry, 0, 2)
+				if pc := t.pc; pc != nil {
+					registries = append(registries, pc.registry)
 				}
-				t.setNoLock(tok, decoded)
+				registries = append(registries, registry)
+				var lastError error
+				for _, reg := range registries {
+					decoded, err := reg.Decode(dec, tok)
+					if err != nil {
+						lastError = err
+						continue
+					}
+					lastError = nil
+					t.setNoLock(tok, decoded)
+					break
+				}
+				if lastError != nil {
+					return errors.Wrapf(err, `could not decode field %s`, tok)
+				}
 			}
 		default:
 			return errors.Errorf(`invalid token %T`, tok)

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -84,12 +84,17 @@ type Token interface {
 	Walk(context.Context, Visitor) error
 	AsMap(context.Context) (map[string]interface{}, error)
 }
-type parseCtx struct {
+type decodeCtx struct {
 	registry *json.Registry
 }
+
+func (c *decodeCtx) Registry() *json.Registry {
+	return c.registry
+}
+
 type stdToken struct {
 	mu                  *sync.RWMutex
-	pc                  *parseCtx          // per-object context for parsing
+	dc                  DecodeCtx          // per-object context for decoding
 	audience            types.StringList   // https://tools.ietf.org/html/rfc7519#section-4.1.3
 	expiration          *types.NumericDate // https://tools.ietf.org/html/rfc7519#section-4.1.4
 	issuedAt            *types.NumericDate // https://tools.ietf.org/html/rfc7519#section-4.1.6
@@ -363,16 +368,16 @@ func (t *stdToken) Set(name string, value interface{}) error {
 	return t.setNoLock(name, value)
 }
 
-func (t *stdToken) parseCtx() *parseCtx {
+func (t *stdToken) DecodeCtx() DecodeCtx {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	return t.pc
+	return t.dc
 }
 
-func (t *stdToken) setParseCtx(v *parseCtx) {
+func (t *stdToken) SetDecodeCtx(v DecodeCtx) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.pc = v
+	t.dc = v
 }
 
 func (t *stdToken) setNoLock(name string, value interface{}) error {
@@ -1068,25 +1073,21 @@ LOOP:
 				}
 				t.updatedAt = &decoded
 			default:
-				registries := make([]*json.Registry, 0, 2)
-				if pc := t.pc; pc != nil {
-					registries = append(registries, pc.registry)
-				}
-				registries = append(registries, registry)
-				var lastError error
-				for _, reg := range registries {
-					decoded, err := reg.Decode(dec, tok)
-					if err != nil {
-						lastError = err
-						continue
+				if dc := t.dc; dc != nil {
+					if localReg := dc.Registry(); localReg != nil {
+						decoded, err := localReg.Decode(dec, tok)
+						if err == nil {
+							t.setNoLock(tok, decoded)
+							continue
+						}
 					}
-					lastError = nil
+				}
+				decoded, err := registry.Decode(dec, tok)
+				if err == nil {
 					t.setNoLock(tok, decoded)
-					break
+					continue
 				}
-				if lastError != nil {
-					return errors.Wrapf(err, `could not decode field %s`, tok)
-				}
+				return errors.Wrapf(err, `could not decode field %s`, tok)
 			}
 		default:
 			return errors.Errorf(`invalid token %T`, tok)

--- a/jwt/options.go
+++ b/jwt/options.go
@@ -84,6 +84,7 @@ type identJwtid struct{}
 type identKeySet struct{}
 type identSubject struct{}
 type identToken struct{}
+type identTypedClaim struct{}
 type identValidate struct{}
 type identVerify struct{}
 
@@ -233,4 +234,19 @@ func WithFormKey(v string) ParseRequestOption {
 // and will change the behavior for all JWT serialization.
 func WithFlattenAudience(v bool) GlobalOption {
 	return &globalOption{option.New(identFlattenAudience{}, v)}
+}
+
+type typedClaimPair struct {
+	Name  string
+	Value interface{}
+}
+
+// WithTypedClaim allows a private claim to be parsed into the object type of
+// your choice. It works much like the RegisterCustomField, but the effect
+// is only applicable to the jwt.Parse function call which recieves this option.
+//
+// Providing this option will slightly slow down the decoding process, so be careful
+// if you are decoding a large number of tokens
+func WithTypedClaim(name string, object interface{}) ParseOption {
+	return newParseOption(identTypedClaim{}, typedClaimPair{Name: name, Value: object})
 }

--- a/jwt/options.go
+++ b/jwt/options.go
@@ -248,6 +248,11 @@ type typedClaimPair struct {
 // Providing this option will slightly slow down the decoding process as it needs
 // to consult multiple definitions sources (global and local), so be careful
 // if you are decoding a large number of tokens, as the effects will stack up.
+//
+// This option will also NOT work unless the tokens themselves support such
+// parsing mechanism. For example, while tokens obtained from `jwt.New()` and
+// `openid.New()` will respect this option, if you provide your own custom
+// token type, it will need to implement the TokenWithDecodeCtx interface.
 func WithTypedClaim(name string, object interface{}) ParseOption {
 	return newParseOption(identTypedClaim{}, typedClaimPair{Name: name, Value: object})
 }

--- a/jwt/options.go
+++ b/jwt/options.go
@@ -245,11 +245,22 @@ type typedClaimPair struct {
 // your choice. It works much like the RegisterCustomField, but the effect
 // is only applicable to the jwt.Parse function call which receives this option.
 //
-// Providing this option will slightly slow down the decoding process as it needs
-// to consult multiple definitions sources (global and local), so be careful
-// if you are decoding a large number of tokens, as the effects will stack up.
+// While this can be extremely useful, this option should be used with caution:
+// There are many caveats that your entire team/user-base needs to be aware of,
+// and therefore in general its use is discouraged. Only use it when you know
+// what you are doing, and you document its use clearly for others.
 //
-// This option will also NOT work unless the tokens themselves support such
+// First and foremost, this is a "per-object" option. Meaning that given the same
+// serialized format, it is possible to generate two objects whose internal
+// representations may differ. That is, if you parse one _WITH_ the option,
+// and the other _WITHOUT_, their internal representation may completely differ.
+// This could potentially lead to problems.
+//
+// Second, specifying this option will slightly slow down the decoding process
+// as it needs to consult multiple definitions sources (global and local), so
+// be careful if you are decoding a large number of tokens, as the effects will stack up.
+//
+// Finally, this option will also NOT work unless the tokens themselves support such
 // parsing mechanism. For example, while tokens obtained from `jwt.New()` and
 // `openid.New()` will respect this option, if you provide your own custom
 // token type, it will need to implement the TokenWithDecodeCtx interface.

--- a/jwt/options.go
+++ b/jwt/options.go
@@ -243,10 +243,11 @@ type typedClaimPair struct {
 
 // WithTypedClaim allows a private claim to be parsed into the object type of
 // your choice. It works much like the RegisterCustomField, but the effect
-// is only applicable to the jwt.Parse function call which recieves this option.
+// is only applicable to the jwt.Parse function call which receives this option.
 //
-// Providing this option will slightly slow down the decoding process, so be careful
-// if you are decoding a large number of tokens
+// Providing this option will slightly slow down the decoding process as it needs
+// to consult multiple definitions sources (global and local), so be careful
+// if you are decoding a large number of tokens, as the effects will stack up.
 func WithTypedClaim(name string, object interface{}) ParseOption {
 	return newParseOption(identTypedClaim{}, typedClaimPair{Name: name, Value: object})
 }

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -57,14 +57,6 @@ type Token interface {
 	Walk(context.Context, Visitor) error
 	AsMap(context.Context) (map[string]interface{}, error)
 }
-type decodeCtx struct {
-	registry *json.Registry
-}
-
-func (c *decodeCtx) Registry() *json.Registry {
-	return c.registry
-}
-
 type stdToken struct {
 	mu            *sync.RWMutex
 	dc            DecodeCtx          // per-object context for decoding


### PR DESCRIPTION
fixes #384 

I'm still a bit weary of this feature, but perhaps this is the only solution to a problem described in the above issue.

This PR allows something like this:

```go
type Foo struct {
   ....
}
token, _ := jwt.Parse(..., jwt.WithTypedClaim("foo", Foo{}))
token.Get("foo") // returns an instance of Foo. otherwise something like a map[string]interface{} is returned
```

