### PR TITLE
fix typo for error message if signature is invalid

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -241,7 +241,7 @@ func lookupMatchingKey(data []byte, keyset jwk.Set, useDefault bool) (jwa.Signat
 
 	var alg jwa.SignatureAlgorithm
 	if err := alg.Accept(key.Algorithm()); err != nil {
-		return "", nil, errors.Wrapf(err, `invalid signatre algorithm %s`, key.Algorithm())
+		return "", nil, errors.Wrapf(err, `invalid signature algorithm %s`, key.Algorithm())
 	}
 
 	return alg, rawKey, nil


### PR DESCRIPTION
Not sure if this is the only typo, but this stands out to me in my error messages and would be nice to fix.