### PR TITLE
Allows 0 to be valid token expiration instead of -62135596800

### DIFF
--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -151,7 +151,7 @@ func Validate(t Token, options ...ValidateOption) error {
 	}
 
 	// check for exp
-	if tv := t.Expiration(); !tv.IsZero() {
+	if tv := t.Expiration(); !tv.IsZero() && tv.Unix() != 0 {
 		now := clock.Now().Truncate(time.Second)
 		ttv := tv.Truncate(time.Second)
 		if !now.Before(ttv.Add(skew)) {
@@ -160,7 +160,7 @@ func Validate(t Token, options ...ValidateOption) error {
 	}
 
 	// check for iat
-	if tv := t.IssuedAt(); !tv.IsZero() {
+	if tv := t.IssuedAt(); !tv.IsZero() && tv.Unix() != 0 {
 		now := clock.Now().Truncate(time.Second)
 		ttv := tv.Truncate(time.Second)
 		if now.Before(ttv.Add(-1 * skew)) {
@@ -169,7 +169,7 @@ func Validate(t Token, options ...ValidateOption) error {
 	}
 
 	// check for nbf
-	if tv := t.NotBefore(); !tv.IsZero() {
+	if tv := t.NotBefore(); !tv.IsZero() && tv.Unix() != 0 {
 		now := clock.Now().Truncate(time.Second)
 		ttv := tv.Truncate(time.Second)
 		// now cannot be before t, so we check for now > t - skew

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -160,6 +160,36 @@ func TestGHIssue10(t *testing.T) {
 			return
 		}
 	})
+	t.Run("Unix zero times", func(t *testing.T) {
+		t.Parallel()
+		t1 := jwt.New()
+
+		tm := time.Unix(0, 0)
+
+		t1.Set(jwt.NotBeforeKey, tm)
+		t1.Set(jwt.IssuedAtKey, tm)
+		t1.Set(jwt.ExpirationKey, tm)
+
+		// This should pass because the unix zero times should be ignored
+		if assert.NoError(t, jwt.Validate(t1), "token.Validate should pass") {
+			return
+		}
+	})
+	t.Run("Go zero times", func(t *testing.T) {
+		t.Parallel()
+		t1 := jwt.New()
+
+		tm := time.Time{}
+
+		t1.Set(jwt.NotBeforeKey, tm)
+		t1.Set(jwt.IssuedAtKey, tm)
+		t1.Set(jwt.ExpirationKey, tm)
+
+		// This should pass because the go zero times should be ignored
+		if assert.NoError(t, jwt.Validate(t1), "token.Validate should pass") {
+			return
+		}
+	})
 	t.Run("Parse and validate", func(t *testing.T) {
 		t.Parallel()
 		t1 := jwt.New()


### PR DESCRIPTION
If you have a `0` as a token expiration, issued at, or not before claim, validation will fail.  Currently you have to set it to be -62135596800 to pass the `time.IsZero()` check, this pull would allow unix time 0 to pass.