### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,12 @@ For either bug reports or feature requests, failing tests are even better.
 
 Please make sure to include tests that excercise the changes you made.
 
+If you are editing auto-generated files (those files with the `_gen.go` prefix, please make sure that you do the following:
+
+1. Edit the generator, not the generated files (e.g. internal/cmd/genreadfile/main.go)
+2. Run `make generate` (or `go generate`) to generate the new code
+3. Commit _both_ the generator _and_ the generated files
+
 ## Discussions / Usage
 
 Please try [discussions](https://github.com/lestrrat-go/jwx/discussions) first.

--- a/jwt/internal/cmd/gentoken/main.go
+++ b/jwt/internal/cmd/gentoken/main.go
@@ -361,7 +361,7 @@ func generateToken(tt tokenType) error {
 		fmt.Fprintf(&buf, "\n// like the following")
 		fmt.Fprintf(&buf, "\n//\n// func SetFoo(tok jwt.Token) error")
 		fmt.Fprintf(&buf, "\n// func GetFoo(tok jwt.Token) (*Customtyp, error)")
-		fmt.Fprintf(&buf, "\n//\n// Embedding jwt.Token into another struct is not recommended, becase")
+		fmt.Fprintf(&buf, "\n//\n// Embedding jwt.Token into another struct is not recommended, because")
 		fmt.Fprintf(&buf, "\n// jwt.Token needs to handle private claims, and this really does not")
 		fmt.Fprintf(&buf, "\n// work well when it is embedded in other structure")
 	}

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -37,7 +37,7 @@ const (
 // func SetFoo(tok jwt.Token) error
 // func GetFoo(tok jwt.Token) (*Customtyp, error)
 //
-// Embedding jwt.Token into another struct is not recommended, becase
+// Embedding jwt.Token into another struct is not recommended, because
 // jwt.Token needs to handle private claims, and this really does not
 // work well when it is embedded in other structure
 type Token interface {


### PR DESCRIPTION
Take #433 and run make generate

Also add a note in the README that explains the process of fixing code in the generated files a bit better.