### PR TITLE
Optimize iteration

### DIFF
--- a/jwe/headers.go
+++ b/jwe/headers.go
@@ -70,8 +70,7 @@ func (h *stdHeaders) Clone(ctx context.Context) (Headers, error) {
 }
 
 func (h *stdHeaders) Copy(ctx context.Context, dst Headers) error {
-	for iter := h.Iterate(ctx); iter.Next(ctx); {
-		pair := iter.Pair()
+	for _, pair := range h.makePairs() {
 		if err := dst.Set(pair.Key.(string), pair.Value); err != nil {
 			return errors.Wrapf(err, `failed to set header`)
 		}

--- a/jwe/headers_gen.go
+++ b/jwe/headers_gen.go
@@ -675,12 +675,9 @@ LOOP:
 }
 
 func (h stdHeaders) MarshalJSON() ([]byte, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	data := make(map[string]interface{})
 	fields := make([]string, 0, 16)
-	for iter := h.Iterate(ctx); iter.Next(ctx); {
-		pair := iter.Pair()
+	for _, pair := range h.makePairs() {
 		fields = append(fields, pair.Key.(string))
 		data[pair.Key.(string)] = pair.Value
 	}

--- a/jwe/internal/cmd/genheader/main.go
+++ b/jwe/internal/cmd/genheader/main.go
@@ -475,12 +475,9 @@ func generateHeaders() error {
 	fmt.Fprintf(&buf, "\n}")
 
 	fmt.Fprintf(&buf, "\n\nfunc (h stdHeaders) MarshalJSON() ([]byte, error) {")
-	fmt.Fprintf(&buf, "\nctx, cancel := context.WithCancel(context.Background())")
-	fmt.Fprintf(&buf, "\ndefer cancel()")
 	fmt.Fprintf(&buf, "\ndata := make(map[string]interface{})")
 	fmt.Fprintf(&buf, "\nfields := make([]string, 0, %d)", len(fields))
-	fmt.Fprintf(&buf, "\nfor iter := h.Iterate(ctx); iter.Next(ctx); {")
-	fmt.Fprintf(&buf, "\npair := iter.Pair()")
+	fmt.Fprintf(&buf, "\nfor _, pair := range h.makePairs() {")
 	fmt.Fprintf(&buf, "\nfields = append(fields, pair.Key.(string))")
 	fmt.Fprintf(&buf, "\ndata[pair.Key.(string)] = pair.Value")
 	fmt.Fprintf(&buf, "\n}")

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -1,7 +1,6 @@
 package jwk
 
 import (
-	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -140,13 +139,12 @@ func (k *ecdsaPrivateKey) Raw(v interface{}) error {
 }
 
 func makeECDSAPublicKey(v interface {
-	Iterate(context.Context) HeaderIterator
+	makePairs() []*HeaderPair
 }) (Key, error) {
 	newKey := NewECDSAPublicKey()
 
 	// Iterate and copy everything except for the bits that should not be in the public key
-	for iter := v.Iterate(context.TODO()); iter.Next(context.TODO()); {
-		pair := iter.Pair()
+	for _, pair := range v.makePairs() {
 		switch pair.Key {
 		case ECDSADKey:
 			continue

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -555,12 +555,9 @@ LOOP:
 }
 
 func (h ecdsaPrivateKey) MarshalJSON() ([]byte, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	data := make(map[string]interface{})
 	fields := make([]string, 0, 12)
-	for iter := h.Iterate(ctx); iter.Next(ctx); {
-		pair := iter.Pair()
+	for _, pair := range h.makePairs() {
 		fields = append(fields, pair.Key.(string))
 		data[pair.Key.(string)] = pair.Value
 	}
@@ -1118,12 +1115,9 @@ LOOP:
 }
 
 func (h ecdsaPublicKey) MarshalJSON() ([]byte, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	data := make(map[string]interface{})
 	fields := make([]string, 0, 11)
-	for iter := h.Iterate(ctx); iter.Next(ctx); {
-		pair := iter.Pair()
+	for _, pair := range h.makePairs() {
 		fields = append(fields, pair.Key.(string))
 		data[pair.Key.(string)] = pair.Value
 	}

--- a/jwk/interface_gen.go
+++ b/jwk/interface_gen.go
@@ -91,4 +91,6 @@ type Key interface {
 	X509CertChain() []*x509.Certificate
 	X509CertThumbprint() string
 	X509CertThumbprintS256() string
+
+	makePairs() []*HeaderPair
 }

--- a/jwk/internal/cmd/genheader/main.go
+++ b/jwk/internal/cmd/genheader/main.go
@@ -494,6 +494,7 @@ func generateGenericHeaders() error {
 			fmt.Fprintf(&buf, "%s", f.PointerElem())
 		}
 	}
+	fmt.Fprintf(&buf, "\n\nmakePairs() []*HeaderPair")
 	fmt.Fprintf(&buf, "\n}")
 
 	if err := codegen.WriteFile("interface_gen.go", &buf, codegen.WithFormatCode(true)); err != nil {
@@ -925,12 +926,9 @@ func generateHeader(kt keyType) error {
 		fmt.Fprintf(&buf, "\n}")
 
 		fmt.Fprintf(&buf, "\n\nfunc (h %s) MarshalJSON() ([]byte, error) {", structName)
-		fmt.Fprintf(&buf, "\nctx, cancel := context.WithCancel(context.Background())")
-		fmt.Fprintf(&buf, "\ndefer cancel()")
 		fmt.Fprintf(&buf, "\ndata := make(map[string]interface{})")
 		fmt.Fprintf(&buf, "\nfields := make([]string, 0, %d)", len(ht.allHeaders))
-		fmt.Fprintf(&buf, "\nfor iter := h.Iterate(ctx); iter.Next(ctx); {")
-		fmt.Fprintf(&buf, "\npair := iter.Pair()")
+		fmt.Fprintf(&buf, "\nfor _, pair := range h.makePairs() {")
 		fmt.Fprintf(&buf, "\nfields = append(fields, pair.Key.(string))")
 		fmt.Fprintf(&buf, "\ndata[pair.Key.(string)] = pair.Value")
 		fmt.Fprintf(&buf, "\n}")

--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -2,7 +2,6 @@ package jwk
 
 import (
 	"bytes"
-	"context"
 	"crypto"
 	"crypto/ed25519"
 	"fmt"
@@ -117,13 +116,12 @@ func (k *okpPrivateKey) Raw(v interface{}) error {
 }
 
 func makeOKPPublicKey(v interface {
-	Iterate(context.Context) HeaderIterator
+	makePairs() []*HeaderPair
 }) (Key, error) {
 	newKey := NewOKPPublicKey()
 
 	// Iterate and copy everything except for the bits that should not be in the public key
-	for iter := v.Iterate(context.TODO()); iter.Next(context.TODO()); {
-		pair := iter.Pair()
+	for _, pair := range v.makePairs() {
 		switch pair.Key {
 		case OKPDKey:
 			continue

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -523,12 +523,9 @@ LOOP:
 }
 
 func (h okpPrivateKey) MarshalJSON() ([]byte, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	data := make(map[string]interface{})
 	fields := make([]string, 0, 11)
-	for iter := h.Iterate(ctx); iter.Next(ctx); {
-		pair := iter.Pair()
+	for _, pair := range h.makePairs() {
 		fields = append(fields, pair.Key.(string))
 		data[pair.Key.(string)] = pair.Value
 	}
@@ -1056,12 +1053,9 @@ LOOP:
 }
 
 func (h okpPublicKey) MarshalJSON() ([]byte, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	data := make(map[string]interface{})
 	fields := make([]string, 0, 10)
-	for iter := h.Iterate(ctx); iter.Next(ctx); {
-		pair := iter.Pair()
+	for _, pair := range h.makePairs() {
 		fields = append(fields, pair.Key.(string))
 		data[pair.Key.(string)] = pair.Value
 	}

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -1,7 +1,6 @@
 package jwk
 
 import (
-	"context"
 	"crypto"
 	"crypto/rsa"
 	"encoding/binary"
@@ -167,13 +166,12 @@ func (k *rsaPublicKey) Raw(v interface{}) error {
 }
 
 func makeRSAPublicKey(v interface {
-	Iterate(context.Context) HeaderIterator
+	makePairs() []*HeaderPair
 }) (Key, error) {
 	newKey := NewRSAPublicKey()
 
 	// Iterate and copy everything except for the bits that should not be in the public key
-	for iter := v.Iterate(context.TODO()); iter.Next(context.TODO()); {
-		pair := iter.Pair()
+	for _, pair := range v.makePairs() {
 		switch pair.Key {
 		case RSADKey, RSADPKey, RSADQKey, RSAPKey, RSAQKey, RSAQIKey:
 			continue

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -665,12 +665,9 @@ LOOP:
 }
 
 func (h rsaPrivateKey) MarshalJSON() ([]byte, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	data := make(map[string]interface{})
 	fields := make([]string, 0, 16)
-	for iter := h.Iterate(ctx); iter.Next(ctx); {
-		pair := iter.Pair()
+	for _, pair := range h.makePairs() {
 		fields = append(fields, pair.Key.(string))
 		data[pair.Key.(string)] = pair.Value
 	}
@@ -1193,12 +1190,9 @@ LOOP:
 }
 
 func (h rsaPublicKey) MarshalJSON() ([]byte, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	data := make(map[string]interface{})
 	fields := make([]string, 0, 10)
-	for iter := h.Iterate(ctx); iter.Next(ctx); {
-		pair := iter.Pair()
+	for _, pair := range h.makePairs() {
 		fields = append(fields, pair.Key.(string))
 		data[pair.Key.(string)] = pair.Value
 	}

--- a/jwk/set.go
+++ b/jwk/set.go
@@ -171,9 +171,12 @@ func (s *set) LookupKeyID(kid string) (Key, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	for iter := s.Iterate(context.TODO()); iter.Next(context.TODO()); {
-		pair := iter.Pair()
-		key := pair.Value.(Key) //nolint:forcetypeassert
+	n := s.Len()
+	for i := 0; i < n; i++ {
+		key, ok := s.Get(i)
+		if !ok {
+			return nil, false
+		}
 		if key.KeyID() == kid {
 			return key, true
 		}

--- a/jwk/symmetric.go
+++ b/jwk/symmetric.go
@@ -1,7 +1,6 @@
 package jwk
 
 import (
-	"context"
 	"crypto"
 	"fmt"
 
@@ -51,8 +50,7 @@ func (k *symmetricKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 func (k *symmetricKey) PublicKey() (Key, error) {
 	newKey := NewSymmetricKey()
 
-	for iter := k.Iterate(context.TODO()); iter.Next(context.TODO()); {
-		pair := iter.Pair()
+	for _, pair := range k.makePairs() {
 		if err := newKey.Set(pair.Key.(string), pair.Value); err != nil {
 			return nil, errors.Wrapf(err, `failed to set field %s`, pair.Key)
 		}

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -456,12 +456,9 @@ LOOP:
 }
 
 func (h symmetricKey) MarshalJSON() ([]byte, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	data := make(map[string]interface{})
 	fields := make([]string, 0, 9)
-	for iter := h.Iterate(ctx); iter.Next(ctx); {
-		pair := iter.Pair()
+	for _, pair := range h.makePairs() {
 		fields = append(fields, pair.Key.(string))
 		data[pair.Key.(string)] = pair.Value
 	}

--- a/jws/headers.go
+++ b/jws/headers.go
@@ -35,8 +35,7 @@ func (h *stdHeaders) AsMap(ctx context.Context) (map[string]interface{}, error) 
 }
 
 func (h *stdHeaders) Copy(ctx context.Context, dst Headers) error {
-	for iter := h.Iterate(ctx); iter.Next(ctx); {
-		pair := iter.Pair()
+	for _, pair := range h.makePairs() {
 		if err := dst.Set(pair.Key.(string), pair.Value); err != nil {
 			return errors.Wrapf(err, `failed to set header`)
 		}

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -24,7 +24,6 @@ package jws
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -220,13 +219,12 @@ func Verify(buf []byte, alg jwa.SignatureAlgorithm, key interface{}, options ...
 // Furthermore if the JWS signature asks for a spefici "kid", the
 // `jwk.Key` must have the same "kid" as the signature.
 func VerifySet(buf []byte, set jwk.Set) ([]byte, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	//nolint:forcetypeassert
-	for iter := set.Iterate(ctx); iter.Next(ctx); {
-		pair := iter.Pair()
-		key := pair.Value.(jwk.Key)
+	n := set.Len()
+	for i := 0; i < n; i++ {
+		key, ok := set.Get(i)
+		if !ok {
+			continue
+		}
 		if key.Algorithm() == "" { // algorithm is not
 			continue
 		}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -5,7 +5,6 @@ package jwt
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -389,9 +388,7 @@ func Equal(t1, t2 Token) bool {
 func (t *stdToken) Clone() (Token, error) {
 	dst := New()
 
-	ctx := context.Background()
-	for iter := t.Iterate(ctx); iter.Next(ctx); {
-		pair := iter.Pair()
+	for _, pair := range t.makePairs() {
 		if err := dst.Set(pair.Key.(string), pair.Value); err != nil {
 			return nil, errors.Wrapf(err, `failed to set %s`, pair.Key.(string))
 		}

--- a/jwt/openid/openid.go
+++ b/jwt/openid/openid.go
@@ -8,8 +8,6 @@
 package openid
 
 import (
-	"context"
-
 	"github.com/lestrrat-go/jwx/internal/json"
 	"github.com/lestrrat-go/jwx/jwt"
 	"github.com/pkg/errors"
@@ -20,9 +18,7 @@ var registry = json.NewRegistry()
 func (t *stdToken) Clone() (jwt.Token, error) {
 	var dst jwt.Token = New()
 
-	ctx := context.Background()
-	for iter := t.Iterate(ctx); iter.Next(ctx); {
-		pair := iter.Pair()
+	for _, pair := range t.makePairs() {
 		if err := dst.Set(pair.Key.(string), pair.Value); err != nil {
 			return nil, errors.Wrapf(err, `failed to set %s`, pair.Key.(string))
 		}


### PR DESCRIPTION
Iteration of lestrrat-go/iter using goroutine and channel is sometimes useful with a generic interface, but it can be slow.

I tried the benchmark for `LookupKey`, it has been improved.

```go
package jwk_test

import (
	"context"
	"testing"

	"github.com/lestrrat-go/jwx/jwk"
)

const u = "https://www.googleapis.com/oauth2/v3/certs"

func BenchmarkVerifySet(b *testing.B) {
	ctx := context.Background()
	ar := jwk.NewAutoRefresh(ctx)
	ar.Configure(u)
	set, err := ar.Fetch(ctx, u)
	if err != nil {
		b.Fatal(err)
	}
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_, ok := set.LookupKeyID("REPLACE_THE_REAL_KEY_ID")
		if !ok {
			b.Fatal("no key")
		}
	}
}
```


before
```
goos: linux
goarch: amd64
pkg: github.com/lestrrat-go/jwx/jwk
cpu: 11th Gen Intel(R) Core(TM) i3-1115G4 @ 3.00GHz
BenchmarkVerifySet-4   	 1214281	       982.7 ns/op	     304 B/op	       7 allocs/op
PASS
ok  	github.com/lestrrat-go/jwx/jwk	2.028s
```

after
```
goos: linux
goarch: amd64
pkg: github.com/lestrrat-go/jwx/jwk
cpu: 11th Gen Intel(R) Core(TM) i3-1115G4 @ 3.00GHz
BenchmarkVerifySet-4   	14858936	        71.80 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/lestrrat-go/jwx/jwk	1.296s
```