### PR TITLE
Infer JWK "alg" from cert chain

### DIFF
--- a/jwa/signature_gen.go
+++ b/jwa/signature_gen.go
@@ -3,6 +3,7 @@
 package jwa
 
 import (
+	"crypto/x509"
 	"fmt"
 	"sort"
 	"sync"
@@ -50,6 +51,18 @@ var allSignatureAlgorithms = map[SignatureAlgorithm]struct{}{
 	RS512:       {},
 }
 
+var cryptoSignatureMap = map[x509.SignatureAlgorithm]SignatureAlgorithm {
+	x509.SHA256WithRSA: RS256,
+	x509.SHA384WithRSA: RS384,
+	x509.SHA512WithRSA: RS512,
+	x509.ECDSAWithSHA256: ES256,
+	x509.ECDSAWithSHA384: ES384,
+	x509.ECDSAWithSHA512: ES512,
+	x509.SHA256WithRSAPSS: PS256,
+	x509.SHA384WithRSAPSS: PS384,
+	x509.SHA512WithRSAPSS: PS512,
+}
+
 var listSignatureAlgorithmOnce sync.Once
 var listSignatureAlgorithm []SignatureAlgorithm
 
@@ -65,6 +78,14 @@ func SignatureAlgorithms() []SignatureAlgorithm {
 		})
 	})
 	return listSignatureAlgorithm
+}
+
+func NewFromCrypto(cryptoAlg x509.SignatureAlgorithm) (SignatureAlgorithm, error) {
+	if alg, ok := cryptoSignatureMap[cryptoAlg]; ok {
+		return alg, nil
+	} else {
+		return "", errors.Errorf(`unknown algorithm: %s`, cryptoAlg.String())
+	}
 }
 
 // Accept is used when conversion from values given by

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -768,6 +768,11 @@ func (h rsaPublicKey) KeyType() jwa.KeyType {
 func (h *rsaPublicKey) Algorithm() string {
 	if h.algorithm != nil {
 		return *(h.algorithm)
+	} else if len(h.X509CertChain()) > 0 {
+		cryptoAlg := h.X509CertChain()[0].SignatureAlgorithm
+		if alg, err := jwa.NewFromCrypto(cryptoAlg); err == nil {
+			return alg.String()
+		}
 	}
 	return ""
 }


### PR DESCRIPTION
### Abstract

The "alg" fields for JWKs is optional. This change tries to infer its value from the certificate chain.

### Notes

I just saw that another PR (#470 by @lestrrat) resolves the same issue.

Motivation for this patch is exactly the reason from the original issue — to parse JWKs from Microsoft.

Fixes #469.