### PR TITLE
fix incorrect example code.

### DIFF
--- a/jwk/README.md
+++ b/jwk/README.md
@@ -260,7 +260,7 @@ func main() {
     // jwk.Key, which can't be used as the first argument to json.Unmarshal
     //
     // In this case, use jwk.Parse()
-    fromJsonKey, err := jwk.ParseBytes(jsonbuf)
+    fromJsonKey, err := jwk.Parse(jsonbuf)
     if err != nil {
       log.Printf("failed to parse json: %s", err)
       return

--- a/jwt/README.md
+++ b/jwt/README.md
@@ -117,7 +117,7 @@ func Example_openid() {
   }
   fmt.Printf("%s\n", buf)
 
-  t2, err := jwt.ParseBytes(buf, jwt.WithToken(openid.New())
+  t2, err := jwt.Parse(buf, jwt.WithToken(openid.New()))
   if err != nil {
     fmt.Printf("failed to parse JSON: %s\n", err)
     return

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -80,7 +80,7 @@ func TestJWTParse(t *testing.T) {
 	t.Run("ParseReader (no signature verification)", func(t *testing.T) {
 		t.Parallel()
 		t2, err := jwt.ParseReader(bytes.NewReader(signed))
-		if !assert.NoError(t, err, `jwt.ParseBytes should succeed`) {
+		if !assert.NoError(t, err, `jwt.ParseReader should succeed`) {
 			return
 		}
 		if !assert.True(t, jwt.Equal(t1, t2), `t1 == t2`) {


### PR DESCRIPTION
`ParseBytes` is a non-existent function.