### PR TITLE
Fix verification bypass when passed a raw JSON object with specific attributes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,13 @@
 Changes
 =======
 
+v1.2.11 UNRELEASED
+[Security Fix]
+  * Since v1.2.6, it was possible to craft a special JSON object to
+    bypass JWT verification via `jwt.Parse`.
+    If you relied on this module to perform all the verification,
+    upgrade is strongly recommended
+
 v1.2.10 09 Nov 2021
 [Bug fixes]
   * Parsing OpenID claims were not working for some fields.

--- a/Changes
+++ b/Changes
@@ -3,10 +3,10 @@ Changes
 
 v1.2.11 UNRELEASED
 [Security Fix]
-  * Since v1.2.6, it was possible to craft a special JSON object to
-    bypass JWT verification via `jwt.Parse`.
+  * It was reported that since v1.2.6, it was possible to craft
+    a special JSON object to bypass JWT verification via `jwt.Parse`.
     If you relied on this module to perform all the verification,
-    upgrade is strongly recommended
+    upgrade is strongly recommended.
 
 v1.2.10 09 Nov 2021
 [Bug fixes]


### PR DESCRIPTION
if the payload passed to `jwt.Parse` is a JSON object *looks* like JWT, e.g. has an `"aud"` field, but otherwise has fields that does not verify, e.g. `"exp"` is invalid, the current code silently bypasses verification.