### PR TITLE
Generate rudimentary comments for Key interface

### DIFF
--- a/jwk/interface_gen.go
+++ b/jwk/interface_gen.go
@@ -82,20 +82,29 @@ type Key interface {
 	// Clone creates a new instance of the same type
 	Clone() (Key, error)
 
-	KeyType() jwa.KeyType
-
 	// PublicKey creates the corresponding PublicKey type for this object.
 	// All fields are copied onto the new public key, except for those that are not allowed.
 	//
 	// If the key is already a public key, it returns a new copy minus the disallowed fields as above.
 	PublicKey() (Key, error)
+
+	// KeyType returns the `kid` of a JWK
+	KeyType() jwa.KeyType
+	// KeyUsage returns `use` of a JWK
 	KeyUsage() string
+	// KeyOps returns `key_ops` of a JWK
 	KeyOps() KeyOperationList
+	// Algorithm returns `alg` of a JWK
 	Algorithm() string
+	// KeyID returns `kid` of a JWK
 	KeyID() string
+	// X509URL returns `x58` of a JWK
 	X509URL() string
+	// X509CertChain returns `x5c` of a JWK
 	X509CertChain() []*x509.Certificate
+	// X509CertThumbprint returns `x5t` of a JWK
 	X509CertThumbprint() string
+	// X509CertThumbprintS256 returns `x5t#S256` of a JWK
 	X509CertThumbprintS256() string
 
 	makePairs() []*HeaderPair

--- a/jwk/internal/cmd/genheader/main.go
+++ b/jwk/internal/cmd/genheader/main.go
@@ -739,12 +739,14 @@ func generateGenericHeaders(fields codegen.FieldList) error {
 	o.L("PrivateParams() map[string]interface{}")
 	o.LL("// Clone creates a new instance of the same type")
 	o.L("Clone() (Key, error)")
-	o.LL("KeyType() jwa.KeyType")
 	o.LL("// PublicKey creates the corresponding PublicKey type for this object.")
 	o.L("// All fields are copied onto the new public key, except for those that are not allowed.")
 	o.L("//\n// If the key is already a public key, it returns a new copy minus the disallowed fields as above.")
 	o.L("PublicKey() (Key, error)")
+	o.LL("// KeyType returns the `kid` of a JWK")
+	o.L("KeyType() jwa.KeyType")
 	for _, f := range fields {
+		o.L("// %s returns `%s` of a JWK", f.GetterMethod(true), f.JSON())
 		o.L("%s() ", f.GetterMethod(true))
 		if v := fieldGetterReturnValue(f); v != "" {
 			o.R("%s", v)


### PR DESCRIPTION
I suspect that the user could not find the relationship between the JSON field name and the corresponding jwk.Key method name in #565

This PR adds some rudimentary documentation to address this.