### PR TITLE
Fix link to parse-a-key-or-a-set-in-pem-format

### DIFF
--- a/docs/04-jwk.md
+++ b/docs/04-jwk.md
@@ -9,7 +9,7 @@ In this document we describe how to work with JWK using `github.com/lestrrat-go/
 * [Parsing](#parsing)
   * [Parse a set](#parse-a-set)
   * [Parse a key](#parse-a-key)
-  * [Parse a key or set in PEM format](#parse-a-key-or-set-in-pem-format)
+  * [Parse a key or set in PEM format](#parse-a-key-or-a-set-in-pem-format)
   * [Parse a key from a file](#parse-a-key-from-a-file)
   * [Parse a key from a remote resource](#parse-a-key-from-a-remote-resource)
 * [Construction](#construction)

--- a/docs/99-faq.md
+++ b/docs/99-faq.md
@@ -46,7 +46,7 @@ See ["Using jwk.New()"](./04-jwk.md#using-jwknew) for more details.
 
 When you read from a PEM encoded file (e.g. `key.pem`), you cannot just parse it using `jwk.Parse()` as by default we do not expect the data to be PEM encoded. Use `jwk.WithPEM(true)` for this.
 
-See ["Parse a key or set in PEM format"](./04-jwk.md#parse-a-key-or-set-in-pem-format) for more details.
+See ["Parse a key or set in PEM format"](./04-jwk.md#parse-a-key-or-a-set-in-pem-format) for more details.
 
 ## "Why is my code to call `jwt.Sign()`/`jws.Verify()` failing?"
 


### PR DESCRIPTION
References to `Parse a key or set in PEM format` are broken.  This is a minor fix for that.