### PR TITLE
Change text in error message to base64url encoding

### DIFF
--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -34,7 +34,7 @@ func AssignNextBytesToken(dst *[]byte, dec *Decoder) error {
 
 	buf, err := base64.DecodeString(val)
 	if err != nil {
-		return errors.Errorf(`expected base64 encoded []byte (%T)`, val)
+		return errors.Errorf(`expected base64url encoded []byte (%T)`, val)
 	}
 	*dst = buf
 	return nil


### PR DESCRIPTION
I would suggesting changing the text in this error message to `base64url encoding`.

to match the terminology in RFC7515
https://datatracker.ietf.org/doc/html/rfc7515#section-2

`base64` and `base64url` are not exactly the same.  For people trying to diagnose problems by reading this error message, and not 100% familiar with JWX, they may go down the wrong path of trying to use `base64` decoders for solving their problem instead of a `base64url` decoder.  (I did).

The code internally uses `internal/base64/base64.go` for encoding/decoding which already implements base64url.

