### PR TITLE
Enable validate verify by default

### DIFF
--- a/Changes.v2
+++ b/Changes.v2
@@ -184,6 +184,10 @@ Changes
 
   # JWT
 
+  * [jwt] `jwt.Parse` now verifies the signature and validates the token
+    by default. You must disable it explicitly using `jwt.WithValidate(false)`
+    and/or `jwt.WithVerify(false)` if you only want to parse the JWT message.
+
   * [jwt] `jwt.Parse` can only parse raw JWT (JSON) or JWS (JSON or Compact).
     It no longer accepts JWE messages.
 

--- a/Changes.v2
+++ b/Changes.v2
@@ -188,6 +188,9 @@ Changes
     by default. You must disable it explicitly using `jwt.WithValidate(false)`
     and/or `jwt.WithVerify(false)` if you only want to parse the JWT message.
 
+    If you don't want either, a convenience function `jwt.ParseInsecure`
+    has been added.
+
   * [jwt] `jwt.Parse` can only parse raw JWT (JSON) or JWS (JSON or Compact).
     It no longer accepts JWE messages.
 

--- a/examples/jwt_example_test.go
+++ b/examples/jwt_example_test.go
@@ -288,7 +288,7 @@ func ExampleJWT_OpenIDToken() {
 	}
 	fmt.Printf("%s\n", buf)
 
-	t2, err := jwt.Parse(buf, jwt.WithToken(openid.New()))
+	t2, err := jwt.Parse(buf, jwt.WithToken(openid.New()), jwt.WithVerify(false), jwt.WithValidate(false))
 	if err != nil {
 		fmt.Printf("failed to parse JSON: %s\n", err)
 		return
@@ -313,88 +313,4 @@ func ExampleJWT_OpenIDToken() {
 	//   "privateClaimKey": "Hello, World!",
 	//   "sub": "https://github.com/lestrrat-go/jwx/v2/jwt"
 	// }
-}
-
-type TokenWithSource struct {
-	jwt.Token
-	undecoded []byte
-}
-
-func ParseTokenWithSource(serialized []byte, options ...jwt.ParseOption) (*TokenWithSource, error) {
-	tok := TokenWithSource{
-		Token: jwt.New(),
-	}
-
-	options = append(options, jwt.WithToken(&tok))
-
-	_, err := jwt.Parse(serialized, options...)
-	if err != nil {
-		return nil, fmt.Errorf(`failed to verify token: %w`, err)
-	}
-
-	tok.undecoded = serialized
-	return &tok, nil
-}
-
-func (t *TokenWithSource) Verify(options ...jws.VerifyOption) error {
-	if _, err := jws.Verify(t.undecoded, options...); err != nil {
-		return fmt.Errorf(`jws.Verify failed: %w`, err)
-	}
-	return nil
-}
-
-func (t *TokenWithSource) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, t.Token)
-}
-
-func (t *TokenWithSource) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Token)
-}
-
-// This example shows how you might want to customize a token without
-// verifying it, but carry the original serialized payload so that it can be
-// verified at a later point
-func ExampleJWT_Extended() {
-	key, err := jwk.FromRaw([]byte(`abracadavra`))
-	if err != nil {
-		fmt.Printf("failed to create key: %s\n", err)
-		return
-	}
-
-	var serialized []byte
-	{
-		t0, err := jwt.NewBuilder().
-			Issuer(`github.com/lestrrat-go/jwx`).
-			Audience([]string{`custom-token`}).
-			Build()
-		if err != nil {
-			fmt.Printf("failed to create token t0: %s\n", err)
-			return
-		}
-
-		v, err := jwt.Sign(t0, jwt.WithKey(jwa.HS256, key))
-		if err != nil {
-			fmt.Printf("failed to sign token t0: %s\n", err)
-			return
-		}
-		serialized = v
-	}
-
-	tok, err := ParseTokenWithSource(serialized)
-	if err != nil {
-		fmt.Printf("failed to parse custom token: %s\n", err)
-		return
-	}
-
-	if tok.Issuer() != `github.com/lestrrat-go/jwx` {
-		fmt.Printf("issuer did not match (got %q)\n", tok.Issuer())
-		return
-	}
-
-	if err := tok.Verify(jws.WithKey(jwa.HS256, key)); err != nil {
-		fmt.Printf("failed to verify token: %s\n", err)
-		return
-	}
-
-	// OUTPUT:
 }

--- a/examples/jwt_parse_example_test.go
+++ b/examples/jwt_parse_example_test.go
@@ -3,14 +3,12 @@ package examples_test
 import (
 	"fmt"
 
+	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 )
 
 func ExampleJWT_Parse() {
-	// Note: this JWT has NOT been verified because we have not
-	// passed jwt.WithKey() et al. You need to pass these values
-	// if you want the token to be parsed and verified in one go
-	tok, err := jwt.Parse([]byte(exampleJWTSignedHMAC))
+	tok, err := jwt.Parse(jwtSignedWithHS256, jwt.WithKey(jwa.HS256, jwkSymmetricKey))
 	if err != nil {
 		fmt.Printf("%s\n", err)
 		return

--- a/examples/jwt_parse_request_example_test.go
+++ b/examples/jwt_parse_request_example_test.go
@@ -43,10 +43,8 @@ func ExampleJWT_ParseRequest_Authorization() {
 	}
 
 	for _, tc := range testcases {
-		// Note: this JWT has NOT been verified because we have not
-		// passed jwt.WithKey() et al. You need to pass these values
-		// if you want the token to be parsed and verified in one go
-		tok, err := jwt.ParseRequest(req, tc.options...)
+		options := append(tc.options, []jwt.ParseOption{jwt.WithVerify(false), jwt.WithValidate(false)}...)
+		tok, err := jwt.ParseRequest(req, options...)
 		if err != nil {
 			fmt.Printf("jwt.ParseRequest with options %#v failed: %s\n", tc.options, err)
 			return

--- a/examples/jwt_parse_with_key_example_test.go
+++ b/examples/jwt_parse_with_key_example_test.go
@@ -17,7 +17,7 @@ func ExampleJWT_ParseWithKey() {
 		return
 	}
 
-	tok, err := jwt.Parse([]byte(exampleJWTSignedHMAC), jwt.WithKey(jwa.HS256, key))
+	tok, err := jwt.Parse([]byte(exampleJWTSignedHMAC), jwt.WithKey(jwa.HS256, key), jwt.WithValidate(false))
 	if err != nil {
 		fmt.Printf("jwt.Parse failed: %s\n", err)
 		return

--- a/examples/jwt_readfile_example_test.go
+++ b/examples/jwt_readfile_example_test.go
@@ -22,7 +22,7 @@ func ExampleJWT_ReadFile() {
 	// Note: this JWT has NOT been verified because we have not
 	// passed jwt.WithKey() et al. You need to pass these values
 	// if you want the token to be parsed and verified in one go
-	tok, err := jwt.ReadFile(f.Name())
+	tok, err := jwt.ReadFile(f.Name(), jwt.WithVerify(false), jwt.WithValidate(false))
 	if err != nil {
 		fmt.Printf("failed to read file %q: %s\n", f.Name(), err)
 		return

--- a/examples/jwt_validate_detect_error_type_example_test.go
+++ b/examples/jwt_validate_detect_error_type_example_test.go
@@ -29,7 +29,7 @@ func ExampleJWT_ValidateDetectErrorType() {
 		// Case 1: Parsing error. We're not showing verification faiure
 		// but it is about the same in the context of wanting to know
 		// if it's a validation error or not
-		_, err := jwt.Parse(buf[:len(buf)-1], jwt.WithValidate(true))
+		_, err := jwt.Parse(buf[:len(buf)-1], jwt.WithVerify(false), jwt.WithValidate(true))
 		if err == nil {
 			fmt.Printf("token should fail parsing\n")
 			return
@@ -45,7 +45,7 @@ func ExampleJWT_ValidateDetectErrorType() {
 		// Case 2: Parsing works, validation fails
 		// NOTE: This token has NOT been verified for demonstration
 		// purposes. Use `jwt.WithKey()` or the like in your production code
-		_, err = jwt.Parse(buf, jwt.WithValidate(true))
+		_, err = jwt.Parse(buf, jwt.WithVerify(false), jwt.WithValidate(true))
 		if err == nil {
 			fmt.Printf("token should fail parsing\n")
 			return

--- a/examples/jwt_validate_example_test.go
+++ b/examples/jwt_validate_example_test.go
@@ -38,7 +38,7 @@ func ExampleJWT_Validate() {
 
 		// NOTE: This token has NOT been verified for demonstration
 		// purposes. Use `jwt.WithKey()` or the like in your production code
-		_, err = jwt.Parse(buf, jwt.WithValidate(true))
+		_, err = jwt.Parse(buf, jwt.WithVerify(false), jwt.WithValidate(true))
 		if err == nil {
 			fmt.Printf("token should fail validation\n")
 			return

--- a/examples/jwx_example_test.go
+++ b/examples/jwx_example_test.go
@@ -4,16 +4,21 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
+	"time"
 
 	"github.com/lestrrat-go/jwx/v2/internal/json"
+	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 )
 
 var payloadLoremIpsum []byte
+var jwtSignedWithHS256 []byte
 var rawRSAPrivateKey *rsa.PrivateKey
 var rawRSAPublicKey *rsa.PublicKey
 var jwkRSAPrivateKey jwk.Key
 var jwkRSAPublicKey jwk.Key
+var jwkSymmetricKey jwk.Key
 var jsonRSAPrivateKey []byte
 var jsonRSAPublicKey []byte
 
@@ -26,6 +31,15 @@ func init() {
 // Create some variables that would be repeatedly used in the examples
 func Setup() error {
 	payloadLoremIpsum = []byte(`Lorem ipsum`)
+
+	tok, err := jwt.NewBuilder().
+		Issuer(`github.com/lestrrat-go/jwx`).
+		IssuedAt(time.Now().Add(-5 * time.Minute)).
+		Expiration(time.Now().Add(time.Hour)).
+		Build()
+	if err != nil {
+		return fmt.Errorf(`failed to build token: %w`, err)
+	}
 
 	{
 		v, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -67,6 +81,22 @@ func Setup() error {
 			return fmt.Errorf(`failed to marshal RSA public jwk.Key: %w`, err)
 		}
 		jsonRSAPublicKey = v
+	}
+
+	{
+		v, err := jwk.FromRaw([]byte(`abracadavra`))
+		if err != nil {
+			return fmt.Errorf(`failed to create jwk.Key from symmetric key: %w`, err)
+		}
+		jwkSymmetricKey = v
+	}
+
+	{
+		v, err := jwt.Sign(tok, jwt.WithKey(jwa.HS256, jwkSymmetricKey))
+		if err != nil {
+			return fmt.Errorf(`failed to sign token with HS256: %w`, err)
+		}
+		jwtSignedWithHS256 = v
 	}
 
 	return nil

--- a/examples/jwx_readme_example_test.go
+++ b/examples/jwx_readme_example_test.go
@@ -61,7 +61,7 @@ func ExampleJWX() {
 			req, err := http.NewRequest(http.MethodGet, `https://github.com/lestrrat-go/jwx`, nil)
 			req.Header.Set(`Authorization`, fmt.Sprintf(`Bearer %s`, signed))
 
-			verifiedToken, err := jwt.ParseRequest(req)
+			verifiedToken, err := jwt.ParseRequest(req, jwt.WithKey(jwa.RS256, pubkey))
 			if err != nil {
 				fmt.Printf("failed to verify token from HTTP request: %s\n", err)
 				return

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -155,9 +155,12 @@ func parseBytes(data []byte, options ...ParseOption) (Token, error) {
 		}
 	}
 
-	if len(verifyOpts) == 0 && verification {
+	lvo := len(verifyOpts)
+	if lvo == 0 && verification {
 		return nil, fmt.Errorf(`jwt.Parse: no keys for verification are provided (use jwt.WithVerify(false) to explicitly skip)`)
-	} else {
+	}
+
+	if lvo > 0 {
 		converted, err := toVerifyOptions(verifyOpts...)
 		if err != nil {
 			return nil, fmt.Errorf(`jwt.Parse: failed to convert options into jws.VerifyOption: %w`, err)

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -64,7 +64,7 @@ func TestJWTParse(t *testing.T) {
 
 	t.Run("Parse (no signature verification)", func(t *testing.T) {
 		t.Parallel()
-		t2, err := jwt.Parse(signed)
+		t2, err := jwt.ParseInsecure(signed)
 		if !assert.NoError(t, err, `jwt.Parse should succeed`) {
 			return
 		}
@@ -74,7 +74,7 @@ func TestJWTParse(t *testing.T) {
 	})
 	t.Run("ParseString (no signature verification)", func(t *testing.T) {
 		t.Parallel()
-		t2, err := jwt.ParseString(string(signed))
+		t2, err := jwt.ParseString(string(signed), jwt.WithVerify(false), jwt.WithValidate(false))
 		if !assert.NoError(t, err, `jwt.ParseString should succeed`) {
 			return
 		}
@@ -84,7 +84,7 @@ func TestJWTParse(t *testing.T) {
 	})
 	t.Run("ParseReader (no signature verification)", func(t *testing.T) {
 		t.Parallel()
-		t2, err := jwt.ParseReader(bytes.NewReader(signed))
+		t2, err := jwt.ParseReader(bytes.NewReader(signed), jwt.WithVerify(false), jwt.WithValidate(false))
 		if !assert.NoError(t, err, `jwt.ParseReader should succeed`) {
 			return
 		}
@@ -735,10 +735,10 @@ func TestReadFile(t *testing.T) {
 		return
 	}
 
-	if _, err := jwt.ReadFile(f.Name(), jwt.WithValidate(true), jwt.WithIssuer("lestrrat")); !assert.NoError(t, err, `jwt.ReadFile should succeed`) {
+	if _, err := jwt.ReadFile(f.Name(), jwt.WithVerify(false), jwt.WithValidate(true), jwt.WithIssuer("lestrrat")); !assert.NoError(t, err, `jwt.ReadFile should succeed`) {
 		return
 	}
-	if _, err := jwt.ReadFile(f.Name(), jwt.WithValidate(true), jwt.WithIssuer("lestrrrrrat")); !assert.Error(t, err, `jwt.ReadFile should fail`) {
+	if _, err := jwt.ReadFile(f.Name(), jwt.WithVerify(false), jwt.WithValidate(true), jwt.WithIssuer("lestrrrrrat")); !assert.Error(t, err, `jwt.ReadFile should fail`) {
 		return
 	}
 }
@@ -758,7 +758,7 @@ func TestCustomField(t *testing.T) {
 	src := b.String()
 
 	t.Run("jwt.Parse", func(t *testing.T) {
-		token, err := jwt.Parse([]byte(src))
+		token, err := jwt.ParseInsecure([]byte(src))
 		if !assert.NoError(t, err, `jwt.Parse should succeed`) {
 			t.Logf("%q", src)
 			return
@@ -1133,7 +1133,8 @@ func TestJWTParseWithTypedClaim(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
-			got, err := jwt.Parse(signed, tc.Options...)
+			options := append(tc.Options, jwt.WithVerify(false))
+			got, err := jwt.Parse(signed, options...)
 			if !assert.NoError(t, err, `jwt.Parse should succeed`) {
 				return
 			}

--- a/jwt/openid/openid_test.go
+++ b/jwt/openid/openid_test.go
@@ -455,7 +455,7 @@ func TestOpenIDClaims(t *testing.T) {
 				return
 			}
 
-			tokenTmp, err := jwt.Parse(signed, jwt.WithToken(openid.New()), jwt.WithKey(alg, &key.PublicKey))
+			tokenTmp, err := jwt.Parse(signed, jwt.WithToken(openid.New()), jwt.WithKey(alg, &key.PublicKey), jwt.WithValidate(false))
 			if !assert.NoError(t, err, `parsing the token via jwt.Parse should succeed`) {
 				return
 			}

--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -100,8 +100,28 @@ options:
     argument_type: bool
     comment: |
       WithValidate is passed to `Parse()` method to denote that the
-      validation of the JWT token should be performed after a successful
-      parsing of the incoming payload.
+      validation of the JWT token should be performed (or not) after
+      a successful parsing of the incoming payload.
+
+      This option is enabled by default. 
+
+      If you would like disable validation,
+      you must use `jwt.WithValidate(false)` or use `jwt.ParseInsecure()`
+  - ident: Verify
+    interface: ParseOption
+    argument_type: bool
+    comment: |
+      WithVerify is passed to `Parse()` method to denote that the
+      signature verification should be performed after a successful
+      deserialization of the incoming payload.
+
+      This option is enabled by default.
+
+      If you do not provide any verification key sources, `jwt.Parse()`
+      would return an error.
+      
+      If you would like to only parse the JWT payload and not verify it,
+      you must use `jwt.WithVerify(false)` or use `jwt.ParseInsecure()`
   - ident: KeyProvider
     interface: ParseOption
     argument_type: jws.KeyProvider

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -122,6 +122,7 @@ type identSignOption struct{}
 type identToken struct{}
 type identValidate struct{}
 type identValidator struct{}
+type identVerify struct{}
 
 func (identAcceptableSkew) String() string {
 	return "WithAcceptableSkew"
@@ -173,6 +174,10 @@ func (identValidate) String() string {
 
 func (identValidator) String() string {
 	return "WithValidator"
+}
+
+func (identVerify) String() string {
+	return "WithVerify"
 }
 
 // WithAcceptableSkew specifies the duration in which exp and nbf
@@ -260,8 +265,13 @@ func WithToken(v Token) ParseOption {
 }
 
 // WithValidate is passed to `Parse()` method to denote that the
-// validation of the JWT token should be performed after a successful
-// parsing of the incoming payload.
+// validation of the JWT token should be performed (or not) after
+// a successful parsing of the incoming payload.
+//
+// This option is enabled by default.
+//
+// If you would like disable validation,
+// you must use `jwt.WithValidate(false)` or use `jwt.ParseInsecure()`
 func WithValidate(v bool) ParseOption {
 	return &parseOption{option.New(identValidate{}, v)}
 }
@@ -279,4 +289,19 @@ func WithValidate(v bool) ParseOption {
 //    err := jwt.Validate(token, jwt.WithValidator(validator))
 func WithValidator(v Validator) ValidateOption {
 	return &validateOption{option.New(identValidator{}, v)}
+}
+
+// WithVerify is passed to `Parse()` method to denote that the
+// signature verification should be performed after a successful
+// deserialization of the incoming payload.
+//
+// This option is enabled by default.
+//
+// If you do not provide any verification key sources, `jwt.Parse()`
+// would return an error.
+//
+// If you would like to only parse the JWT payload and not verify it,
+// you must use `jwt.WithVerify(false)` or use `jwt.ParseInsecure()`
+func WithVerify(v bool) ParseOption {
+	return &parseOption{option.New(identVerify{}, v)}
 }

--- a/jwt/options_gen_test.go
+++ b/jwt/options_gen_test.go
@@ -22,4 +22,5 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithToken", identToken{}.String())
 	require.Equal(t, "WithValidate", identValidate{}.String())
 	require.Equal(t, "WithValidator", identValidator{}.String())
+	require.Equal(t, "WithVerify", identVerify{}.String())
 }

--- a/jwt/token_test.go
+++ b/jwt/token_test.go
@@ -237,7 +237,7 @@ func TestToken(t *testing.T) {
 			return
 		}
 
-		newtok, err := jwt.Parse(buf)
+		newtok, err := jwt.ParseInsecure(buf)
 		if !assert.NoError(t, err, `jwt.Parse should succeed`) {
 			return
 		}

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -338,13 +338,13 @@ func TestGHIssue10(t *testing.T) {
 			return
 		}
 
-		_, err = jwt.Parse(buf, jwt.WithValidate(true))
+		_, err = jwt.Parse(buf, jwt.WithVerify(false), jwt.WithValidate(true))
 		// This should fail, because exp is set in the past
 		if !assert.Error(t, err, "jwt.Parse should fail") {
 			return
 		}
 
-		_, err = jwt.Parse(buf, jwt.WithValidate(true), jwt.WithAcceptableSkew(time.Hour))
+		_, err = jwt.Parse(buf, jwt.WithVerify(false), jwt.WithValidate(true), jwt.WithAcceptableSkew(time.Hour))
 		// This should succeed, because we have given big skew
 		// that is well enough to get us accepted
 		if !assert.NoError(t, err, "jwt.Parse should succeed (1)") {
@@ -356,7 +356,7 @@ func TestGHIssue10(t *testing.T) {
 		clock := jwt.ClockFunc(func() time.Time {
 			return tm.Add(-59 * time.Minute)
 		})
-		_, err = jwt.Parse(buf, jwt.WithValidate(true), jwt.WithClock(clock))
+		_, err = jwt.Parse(buf, jwt.WithVerify(false), jwt.WithValidate(true), jwt.WithClock(clock))
 		if !assert.NoError(t, err, "jwt.Parse should succeed (2)") {
 			return
 		}


### PR DESCRIPTION
jwt.Parse no longer allows unverified and/or unvalidated tokens to be obtained by the caller by default. Allowing this had significant security problems.

Now you need to explicitly ask for it to be disabked to get the original behavior

