### PR TITLE
Return `RequiredClaimValidationError` error when required claim is missing

### DIFF
--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1291,6 +1291,13 @@ func TestGH430(t *testing.T) {
 	}
 }
 
+func TestGH706(t *testing.T) {
+	tok := jwt.New()
+	if !assert.ErrorIs(t, jwt.Validate(tok, jwt.WithRequiredClaim("foo")), &jwt.RequiredClaimValidationError{}, `jwt.Validate should fail`) {
+		return
+	}
+}
+
 func TestBenHigginsByPassRegression(t *testing.T) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {

--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -159,6 +159,19 @@ func (err *validationError) Unwrap() error {
 	return err.error
 }
 
+type RequiredClaimValidationError struct {
+	claim string
+}
+
+func (err *RequiredClaimValidationError) Error() string {
+	return fmt.Sprintf("%q not satisfied: required claim not found", err.claim)
+}
+
+func (err *RequiredClaimValidationError) Is(target error) bool {
+	_, ok := target.(*RequiredClaimValidationError)
+	return ok
+}
+
 var errTokenExpired = NewValidationError(fmt.Errorf(`"exp" not satisfied`))
 var errInvalidIssuedAt = NewValidationError(fmt.Errorf(`"iat" not satisfied`))
 var errTokenNotYetValid = NewValidationError(fmt.Errorf(`"nbf" not satisfied`))
@@ -379,7 +392,7 @@ type isRequired string
 func (ir isRequired) Validate(_ context.Context, t Token) ValidationError {
 	_, ok := t.Get(string(ir))
 	if !ok {
-		return NewValidationError(fmt.Errorf(`%q not satisfied: required claim not found`, string(ir)))
+		return NewValidationError(&RequiredClaimValidationError{claim: string(ir)})
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #706: when a required claim is missing after parsing the JWT token, a `RequiredClaimValidationError` error is returned in place of the generic `ValidationError`