### PR TITLE
Fix `jwt.isValidationError()` false negative for `ErrMissingRequiredClaim`

### DIFF
--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1292,8 +1292,12 @@ func TestGH430(t *testing.T) {
 }
 
 func TestGH706(t *testing.T) {
-	tok := jwt.New()
-	if !assert.ErrorIs(t, jwt.ErrMissingRequiredClaim(""), jwt.Validate(tok, jwt.WithRequiredClaim("foo")), `jwt.Validate should fail`) {
+	err := jwt.Validate(jwt.New(), jwt.WithRequiredClaim("foo"))
+	if !assert.True(t, jwt.IsValidationError(err), `error should be a validation error`) {
+		return
+	}
+
+	if !assert.ErrorIs(t, err, jwt.ErrMissingRequiredClaim(""), `jwt.Validate should fail`) {
 		return
 	}
 }

--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -389,6 +389,8 @@ func IsValidationError(err error) bool {
 			return true
 		case *invalidIssuerError:
 			return true
+		case *missingRequiredClaimError:
+			return true
 		default:
 			return false
 		}


### PR DESCRIPTION
Fixes #719: I simply added a new case to detect whether the target error is an instance of `missingRequiredClaimError` and changed the test to avoid a regression in the future