### PR TITLE
Allow escape hatch for those who (incorrectly) use RFC3339 in Numeric Date fields

### DIFF
--- a/jwt/internal/types/date.go
+++ b/jwt/internal/types/date.go
@@ -14,7 +14,7 @@ const (
 	MaxPrecision     uint32 = 9 // nanosecond level
 )
 
-var Pedantic uint32 = 0
+var Pedantic uint32
 var ParsePrecision = DefaultPrecision
 var FormatPrecision = DefaultPrecision
 

--- a/jwt/internal/types/date.go
+++ b/jwt/internal/types/date.go
@@ -14,6 +14,7 @@ const (
 	MaxPrecision     uint32 = 9 // nanosecond level
 )
 
+var Pedantic uint32 = 0
 var ParsePrecision = DefaultPrecision
 var FormatPrecision = DefaultPrecision
 
@@ -52,6 +53,27 @@ func intToTime(v interface{}, t *time.Time) bool {
 
 func parseNumericString(x string) (time.Time, error) {
 	var t time.Time // empty time for empty return value
+
+	// Only check for the escape hatch if it's the pedantic
+	// flag is off
+	if Pedantic != 1 {
+		// This is an escape hatch for non-conformant providers
+		// that gives us RFC3339 instead of epoch time
+		for _, r := range x {
+			// 0x30 = '0', 0x39 = '9', 0x2E = '.'
+			if (r >= 0x30 && r <= 0x39) || r == 0x2E {
+				continue
+			}
+
+			// if it got here, then it probably isn't epoch time
+			tv, err := time.Parse(time.RFC3339, x)
+			if err != nil {
+				return t, fmt.Errorf(`value is not number of seconds since the epoch, and attempt to parse it as RFC3339 timestamp failed: %w`, err)
+			}
+			return tv, nil
+		}
+	}
+
 	var fractional string
 	whole := x
 	if i := strings.IndexRune(x, '.'); i > 0 {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -18,6 +18,7 @@ import (
 // Settings controls global settings that are specific to JWTs.
 func Settings(options ...GlobalOption) {
 	var flattenAudienceBool bool
+	var parsePedantic bool
 	var parsePrecision = types.MaxPrecision + 1  // illegal value, so we can detect nothing was set
 	var formatPrecision = types.MaxPrecision + 1 // illegal value, so we can detect nothing was set
 
@@ -26,6 +27,8 @@ func Settings(options ...GlobalOption) {
 		switch option.Ident() {
 		case identFlattenAudience{}:
 			flattenAudienceBool = option.Value().(bool)
+		case identNumericDateParsePedantic{}:
+			parsePedantic = option.Value().(bool)
 		case identNumericDateParsePrecision{}:
 			v := option.Value().(int)
 			// only accept this value if it's in our desired range
@@ -52,6 +55,17 @@ func Settings(options ...GlobalOption) {
 		v := atomic.LoadUint32(&types.FormatPrecision)
 		if v != formatPrecision {
 			atomic.CompareAndSwapUint32(&types.FormatPrecision, v, formatPrecision)
+		}
+	}
+
+	{
+		v := atomic.LoadUint32(&types.Pedantic)
+		if (v == 1) != parsePedantic {
+			var newVal uint32
+			if parsePedantic {
+				newVal = 1
+			}
+			atomic.CompareAndSwapUint32(&types.Pedantic, v, newVal)
 		}
 	}
 

--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -186,4 +186,16 @@ options:
       WithNumericDateFormatPrecision sets the precision up to which the
       library uses to format fractional dates found in the numeric date
       fields. Default is 0 (second, no fractionals), max is 9 (nanosecond)
+  - ident: NumericDateParsePedantic
+    interface: GlobalOption
+    argument_type: bool
+    comment: |
+      WithNumericDateParsePedantic specifies if the parser should behave
+      in a pedantic manner when parsing numeric dates. Normally fields that
+      are defined to have `numeric date` type expect seconds since epoch
+      (with an optional fraction part), but by setting this to `false`
+      the parser tries to parse it as RFC3339 when unexpected characters
+      are found in the value.  Default is `false`, and RFC3339 timestamps are
+      also parsed along with seconds since epoch.
+
 

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -132,6 +132,7 @@ type identFormKey struct{}
 type identHeaderKey struct{}
 type identKeyProvider struct{}
 type identNumericDateFormatPrecision struct{}
+type identNumericDateParsePedantic struct{}
 type identNumericDateParsePrecision struct{}
 type identPedantic struct{}
 type identSignOption struct{}
@@ -178,6 +179,10 @@ func (identKeyProvider) String() string {
 
 func (identNumericDateFormatPrecision) String() string {
 	return "WithNumericDateFormatPrecision"
+}
+
+func (identNumericDateParsePedantic) String() string {
+	return "WithNumericDateParsePedantic"
 }
 
 func (identNumericDateParsePrecision) String() string {
@@ -283,6 +288,17 @@ func WithKeyProvider(v jws.KeyProvider) ParseOption {
 // fields. Default is 0 (second, no fractionals), max is 9 (nanosecond)
 func WithNumericDateFormatPrecision(v int) GlobalOption {
 	return &globalOption{option.New(identNumericDateFormatPrecision{}, v)}
+}
+
+// WithNumericDateParsePedantic specifies if the parser should behave
+// in a pedantic manner when parsing numeric dates. Normally fields that
+// are defined to have `numeric date` type expect seconds since epoch
+// (with an optional fraction part), but by setting this to `false`
+// the parser tries to parse it as RFC3339 when unexpected characters
+// are found in the value.  Default is `false`, and RFC3339 timestamps are
+// also parsed along with seconds since epoch.
+func WithNumericDateParsePedantic(v bool) GlobalOption {
+	return &globalOption{option.New(identNumericDateParsePedantic{}, v)}
 }
 
 // WithNumericDateParsePrecision sets the precision up to which the

--- a/jwt/options_gen_test.go
+++ b/jwt/options_gen_test.go
@@ -19,6 +19,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithHeaderKey", identHeaderKey{}.String())
 	require.Equal(t, "WithKeyProvider", identKeyProvider{}.String())
 	require.Equal(t, "WithNumericDateFormatPrecision", identNumericDateFormatPrecision{}.String())
+	require.Equal(t, "WithNumericDateParsePedantic", identNumericDateParsePedantic{}.String())
 	require.Equal(t, "WithNumericDateParsePrecision", identNumericDateParsePrecision{}.String())
 	require.Equal(t, "WithPedantic", identPedantic{}.String())
 	require.Equal(t, "WithSignOption", identSignOption{}.String())


### PR DESCRIPTION
fixes #734