### PR TITLE
fix typos

### DIFF
--- a/docs/04-jwk.md
+++ b/docs/04-jwk.md
@@ -485,7 +485,7 @@ func ExampleJWK_FromRaw() {
   {
     raw, err := rsa.GenerateKey(rand.Reader, 2048)
     if err != nil {
-      fmt.Printf("failed to generate new RSA privatre key: %s\n", err)
+      fmt.Printf("failed to generate new RSA private key: %s\n", err)
       return
     }
 
@@ -506,7 +506,7 @@ func ExampleJWK_FromRaw() {
   {
     raw, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
     if err != nil {
-      fmt.Printf("failed to generate new ECDSA privatre key: %s\n", err)
+      fmt.Printf("failed to generate new ECDSA private key: %s\n", err)
       return
     }
 

--- a/examples/jwk_from_raw_example_test.go
+++ b/examples/jwk_from_raw_example_test.go
@@ -50,7 +50,7 @@ func ExampleJWK_FromRaw() {
 	{
 		raw, err := rsa.GenerateKey(rand.Reader, 2048)
 		if err != nil {
-			fmt.Printf("failed to generate new RSA privatre key: %s\n", err)
+			fmt.Printf("failed to generate new RSA private key: %s\n", err)
 			return
 		}
 
@@ -71,7 +71,7 @@ func ExampleJWK_FromRaw() {
 	{
 		raw, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 		if err != nil {
-			fmt.Printf("failed to generate new ECDSA privatre key: %s\n", err)
+			fmt.Printf("failed to generate new ECDSA private key: %s\n", err)
 			return
 		}
 


### PR DESCRIPTION
I found a couple of typos using this amazing library so I fixed it.
I wonder I don't have to fix typos under `docs/`.