### PR TITLE
Allow matching of JWKS keys with not unique kid for signature verification

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,10 @@ Changes
 v2 has many incompatibilities with v1. To see the full list of differences between
 v1 and v2, please read the Changes-v2.md file (https://github.com/lestrrat-go/jwx/blob/develop/v2/Changes-v2.md)
 
+unreleased
+[Changes]
+  * [jws] Add handling of not unique kid when verifying signatures.
+
 v2.0.3 - 13 Jun 2022
 [Bug Fixes]
   * [jwk] Update dependency on github.com/lestrrat-go/httprc to v1.0.2 to


### PR DESCRIPTION
**What this PR does / why we need it**
This changes the matching of JWKS keys with not unique kid for signature verification.
In case a JWKS store contains keys with not unique kid, all matching keys are selected. The selected keys are then tried to see if one produces a correct signature.
Not unique kid are allowed by the standard
https://datatracker.ietf.org/doc/html/rfc7517#section-4.5

Please have a look this PR and tell me what you think.
The code changes are intentionally kept minimal.
So this changes the standard behavior.
Putting this behavior behind an option would also be possible.

###### Michael Mueller [michael.ab.mueller@mercedes-benz.com](mailto:michael.ab.mueller@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/LEGAL_IMPRINT.md)