### PR TITLE
Accept multiple keys given a key ID

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,9 +4,12 @@ Changes
 v2 has many incompatibilities with v1. To see the full list of differences between
 v1 and v2, please read the Changes-v2.md file (https://github.com/lestrrat-go/jwx/blob/develop/v2/Changes-v2.md)
 
-unreleased
-[Changes]
-  * [jws] Add handling of not unique kid when verifying signatures.
+v2.0.4 - UNRELEASED
+[New Features]
+  * [jws] Add `jws.WithMultipleKeysPerKeyID()` sub-option to allow non-unique
+    key IDs in a given JWK set. By default we assume that a key ID is unique
+    within a key set, but enabling this option allows you to handle JWK sets
+    that contain multiple keys that contain the same key ID.
 
 v2.0.3 - 13 Jun 2022
 [Bug Fixes]

--- a/Changes
+++ b/Changes
@@ -4,6 +4,10 @@ Changes
 v2 has many incompatibilities with v1. To see the full list of differences between
 v1 and v2, please read the Changes-v2.md file (https://github.com/lestrrat-go/jwx/blob/develop/v2/Changes-v2.md)
 
+unreleased
+[Changes]
+  * [jws] Add handling of not unique kid when verifying signatures.
+
 v2.0.3 - 13 Jun 2022
 [Bug Fixes]
   * [jwk] Update dependency on github.com/lestrrat-go/httprc to v1.0.2 to

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1142,7 +1142,7 @@ func TestVerifyNonUniqueKid(t *testing.T) {
 			// Try matching in different orders
 			for _, set := range []jwk.Set{makeSet(wrongKey, correctKey), makeSet(correctKey, wrongKey)} {
 				var usedKey jwk.Key
-				_, err = jws.Verify(signed, jws.WithKeySet(set), jws.WithKeyUsed(&usedKey))
+				_, err = jws.Verify(signed, jws.WithKeySet(set, jws.WithMultipleKeysPerKeyID(true)), jws.WithKeyUsed(&usedKey))
 				if !assert.NoError(t, err, `jws.Verify should succeed`) {
 					return
 				}

--- a/jws/options.go
+++ b/jws/options.go
@@ -119,7 +119,7 @@ func WithKey(alg jwa.KeyAlgorithm, key interface{}, options ...WithKeySuboption)
 // suboption types.
 func WithKeySet(set jwk.Set, options ...WithKeySetSuboption) VerifyOption {
 	requireKid := true
-	var useDefault, inferAlgorithm bool
+	var useDefault, inferAlgorithm, multipleKeysPerKeyID bool
 	for _, option := range options {
 		//nolint:forcetypeassert
 		switch option.Ident() {
@@ -127,16 +127,19 @@ func WithKeySet(set jwk.Set, options ...WithKeySetSuboption) VerifyOption {
 			requireKid = option.Value().(bool)
 		case identUseDefault{}:
 			useDefault = option.Value().(bool)
+		case identMultipleKeysPerKeyID{}:
+			multipleKeysPerKeyID = option.Value().(bool)
 		case identInferAlgorithmFromKey{}:
 			inferAlgorithm = option.Value().(bool)
 		}
 	}
 
 	return WithKeyProvider(&keySetProvider{
-		set:            set,
-		requireKid:     requireKid,
-		useDefault:     useDefault,
-		inferAlgorithm: inferAlgorithm,
+		set:                  set,
+		requireKid:           requireKid,
+		useDefault:           useDefault,
+		multipleKeysPerKeyID: multipleKeysPerKeyID,
+		inferAlgorithm:       inferAlgorithm,
 	})
 }
 

--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -117,9 +117,18 @@ options:
     interface: WithKeySetSuboption
     argument_type: bool
     comment: |
-      WithrequiredKid specifies whether the keys in the jwk.Set should
+      WithRequiredKid specifies whether the keys in the jwk.Set should
       only be matched if the target JWS message's Key ID and the Key ID
       in the given key matches.
+  - ident: MultipleKeysPerKeyID
+    interface: WithKeySetSuboption
+    argument_type: bool
+    comment: |
+      WithMultipleKeysPerKeyID specifies if we should expect multiple keys
+      to match against a key ID. By default it is assumed that key IDs are
+      unique, i.e. for a given key ID, the key set only contains a single
+      key that has the matching ID. When this option is set to true,
+      multiple keys that match the same key ID in the set can be tried.
   - ident: Pretty
     interface: WithJSONSuboption
     argument_type: bool

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -132,6 +132,7 @@ type identKey struct{}
 type identKeyProvider struct{}
 type identKeyUsed struct{}
 type identMessage struct{}
+type identMultipleKeysPerKeyID struct{}
 type identPretty struct{}
 type identProtectedHeaders struct{}
 type identPublicHeaders struct{}
@@ -173,6 +174,10 @@ func (identKeyUsed) String() string {
 
 func (identMessage) String() string {
 	return "WithMessage"
+}
+
+func (identMultipleKeysPerKeyID) String() string {
+	return "WithMultipleKeysPerKeyID"
 }
 
 func (identPretty) String() string {
@@ -268,6 +273,15 @@ func WithMessage(v *Message) VerifyOption {
 	return &verifyOption{option.New(identMessage{}, v)}
 }
 
+// WithMultipleKeysPerKeyID specifies if we should expect multiple keys
+// to match against a key ID. By default it is assumed that key IDs are
+// unique, i.e. for a given key ID, the key set only contains a single
+// key that has the matching ID. When this option is set to true,
+// multiple keys that match the same key ID in the set can be tried.
+func WithMultipleKeysPerKeyID(v bool) WithKeySetSuboption {
+	return &withKeySetSuboption{option.New(identMultipleKeysPerKeyID{}, v)}
+}
+
 // WithPretty specifies whether the JSON output should be formatted and
 // indented
 func WithPretty(v bool) WithJSONSuboption {
@@ -293,7 +307,7 @@ func WithPublicHeaders(v Headers) WithKeySuboption {
 	return &withKeySuboption{option.New(identPublicHeaders{}, v)}
 }
 
-// WithrequiredKid specifies whether the keys in the jwk.Set should
+// WithRequiredKid specifies whether the keys in the jwk.Set should
 // only be matched if the target JWS message's Key ID and the Key ID
 // in the given key matches.
 func WithRequireKid(v bool) WithKeySetSuboption {

--- a/jws/options_gen_test.go
+++ b/jws/options_gen_test.go
@@ -18,6 +18,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithKeyProvider", identKeyProvider{}.String())
 	require.Equal(t, "WithKeyUsed", identKeyUsed{}.String())
 	require.Equal(t, "WithMessage", identMessage{}.String())
+	require.Equal(t, "WithMultipleKeysPerKeyID", identMultipleKeysPerKeyID{}.String())
 	require.Equal(t, "WithPretty", identPretty{}.String())
 	require.Equal(t, "WithProtectedHeaders", identProtectedHeaders{}.String())
 	require.Equal(t, "WithPublicHeaders", identPublicHeaders{}.String())

--- a/tools/cmd/genoptions/main.go
+++ b/tools/cmd/genoptions/main.go
@@ -121,6 +121,7 @@ func genOptions(objects *Objects) error {
 	o.LL(`package %s`, objects.PackageName)
 
 	imports := append(objects.Imports, []string{
+		`io/fs`, // for some reason without this the goimports in my environment tries to import a differnet package
 		`github.com/lestrrat-go/jwx/v2/jwa`,
 		`github.com/lestrrat-go/jwx/v2/jwe`,
 		`github.com/lestrrat-go/jwx/v2/jwk`,


### PR DESCRIPTION
Builds on top of #757 
* Refactor and add tests
* Refactor code
* Add `WithMultipleKeysPerKeyID` to preserve old behavior

I think the last bit is necessary because we should keep new behavior opt-in as much as possible so that people upgrading do not get surprised.