### PR TITLE
fix doc bug in Key interface

### DIFF
--- a/formatkind_string_gen.go
+++ b/formatkind_string_gen.go
@@ -4,6 +4,18 @@ package jwx
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[UnknownFormat-0]
+	_ = x[JWE-1]
+	_ = x[JWS-2]
+	_ = x[JWK-3]
+	_ = x[JWKS-4]
+	_ = x[JWT-5]
+}
+
 const _FormatKind_name = "UnknownFormatJWEJWSJWKJWKSJWT"
 
 var _FormatKind_index = [...]uint8{0, 13, 16, 19, 22, 26, 29}

--- a/formatkind_string_gen.go
+++ b/formatkind_string_gen.go
@@ -4,18 +4,6 @@ package jwx
 
 import "strconv"
 
-func _() {
-	// An "invalid array index" compiler error signifies that the constant values have changed.
-	// Re-run the stringer command to generate them again.
-	var x [1]struct{}
-	_ = x[UnknownFormat-0]
-	_ = x[JWE-1]
-	_ = x[JWS-2]
-	_ = x[JWK-3]
-	_ = x[JWKS-4]
-	_ = x[JWT-5]
-}
-
 const _FormatKind_name = "UnknownFormatJWEJWSJWKJWKSJWT"
 
 var _FormatKind_index = [...]uint8{0, 13, 16, 19, 22, 26, 29}

--- a/jwk/interface_gen.go
+++ b/jwk/interface_gen.go
@@ -88,7 +88,7 @@ type Key interface {
 	// If the key is already a public key, it returns a new copy minus the disallowed fields as above.
 	PublicKey() (Key, error)
 
-	// KeyType returns the `kid` of a JWK
+	// KeyType returns the `kty` of a JWK
 	KeyType() jwa.KeyType
 	// KeyUsage returns `use` of a JWK
 	KeyUsage() string

--- a/tools/cmd/genjwk/main.go
+++ b/tools/cmd/genjwk/main.go
@@ -669,7 +669,7 @@ func generateGenericHeaders(fields codegen.FieldList) error {
 	o.L("// All fields are copied onto the new public key, except for those that are not allowed.")
 	o.L("//\n// If the key is already a public key, it returns a new copy minus the disallowed fields as above.")
 	o.L("PublicKey() (Key, error)")
-	o.LL("// KeyType returns the `kid` of a JWK")
+	o.LL("// KeyType returns the `kty` of a JWK")
 	o.L("KeyType() jwa.KeyType")
 	for _, f := range fields {
 		o.L("// %s returns `%s` of a JWK", f.GetterMethod(true), f.JSON())


### PR DESCRIPTION
I rather suspect KeyType() returns the `kty` rather than the `kid`.