### PR TITLE
codecov: update to v3 action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,9 @@ jobs:
         run: make cover-${{ matrix.go_tags }}
       - name: Upload code coverage to codecov
         if: matrix.go == '1.18'
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          file: ./coverage.out
+          files: ./coverage.out
       - name: Check difference between generation code and commit code
         run: make check_diffs
  


### PR DESCRIPTION
v1 is deprecated and no longer works. Update to v3.

Fixes #743