### PR TITLE
[jwe] Fix jwe encryption around apu/apv

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,22 @@ Changes
 v2 has many incompatibilities with v1. To see the full list of differences between
 v1 and v2, please read the Changes-v2.md file (https://github.com/lestrrat-go/jwx/blob/develop/v2/Changes-v2.md)
 
+v2.0.6 - UNRELEASED
+[Bug fixes][Security]
+  * [jwe] Agreement Party UInfo and VInfo (apv/apu) were not properly being
+    passed to the functions to compute the aad when encrypting using ECDH-ES
+    family of algorithms. Therefore, when using apu/apv, messages encrypted
+    via this module would have failed to be properly decrypted.
+
+    Please note that bogus encrypted messages would not have succeed being
+    decrypted (i.e. this problem does not allow spoofed messages to be decrypted).
+    Therefore this would not have caused unwanted data to to creep in --
+    however it did pose problems for data to be sent and decrypted from this module
+    when using ECDH-ES with apu/apv.
+
+    While not extensively tested, we believe this regression was introduced
+    with the v2 release.
+
 v2.0.5 - 11 Aug 2022
 [Bug fixes]
   * [jwt] Remove stray debug log

--- a/docs/03-jwe.md
+++ b/docs/03-jwe.md
@@ -270,9 +270,9 @@ source: [examples/jwe_encrypt_json_example_test.go](https://github.com/lestrrat-
 
 By default, only some header fields are included in the result from `jwe.Encrypt()`.
 
-For protected headers, you can use the jws.
+For global protected headers, you can use the `jwe.WithProtectedHeaders()` option.
 
-In order to provide extra headers to the encrypted message, you will need to use
+In order to provide extra headers to the encrypted message such as `apu` and `apv`, you will need to use
 `jwe.WithKey()` option with the `jwe.WithPerRecipientHeaders()` suboption.
 
 

--- a/jwe/internal/keyenc/interface.go
+++ b/jwe/internal/keyenc/interface.go
@@ -52,8 +52,6 @@ type ECDHESEncrypt struct {
 	algorithm jwa.KeyEncryptionAlgorithm
 	keyID     string
 	generator keygen.Generator
-	apu       []byte
-	apv       []byte
 }
 
 // ECDHESDecrypt decrypts keys using ECDH-ES.

--- a/jwe/internal/keyenc/interface.go
+++ b/jwe/internal/keyenc/interface.go
@@ -52,6 +52,8 @@ type ECDHESEncrypt struct {
 	algorithm jwa.KeyEncryptionAlgorithm
 	keyID     string
 	generator keygen.Generator
+	apu       []byte
+	apv       []byte
 }
 
 // ECDHESDecrypt decrypts keys using ECDH-ES.

--- a/jwe/internal/keyenc/keyenc.go
+++ b/jwe/internal/keyenc/keyenc.go
@@ -210,12 +210,12 @@ func (kw PBES2Encrypt) Encrypt(cek []byte) (keygen.ByteSource, error) {
 }
 
 // NewECDHESEncrypt creates a new key encrypter based on ECDH-ES
-func NewECDHESEncrypt(alg jwa.KeyEncryptionAlgorithm, enc jwa.ContentEncryptionAlgorithm, keysize int, keyif interface{}) (*ECDHESEncrypt, error) {
+func NewECDHESEncrypt(alg jwa.KeyEncryptionAlgorithm, enc jwa.ContentEncryptionAlgorithm, keysize int, keyif interface{}, apu, apv []byte) (*ECDHESEncrypt, error) {
 	var generator keygen.Generator
 	var err error
 	switch key := keyif.(type) {
 	case *ecdsa.PublicKey:
-		generator, err = keygen.NewEcdhes(alg, enc, keysize, key)
+		generator, err = keygen.NewEcdhes(alg, enc, keysize, key, apu, apv)
 	case x25519.PublicKey:
 		generator, err = keygen.NewX25519(alg, enc, keysize, key)
 	default:

--- a/jwe/internal/keygen/interface.go
+++ b/jwe/internal/keygen/interface.go
@@ -26,6 +26,8 @@ type Ecdhes struct {
 	keysize   int
 	algorithm jwa.KeyEncryptionAlgorithm
 	enc       jwa.ContentEncryptionAlgorithm
+	apu       []byte
+	apv       []byte
 }
 
 // X25519KeyGenerate generates keys using ECDH-ES algorithm / X25519 curve


### PR DESCRIPTION
fixes #803

* Add tests
* Add notes in the docs that apu/apv should be passed using
  `jwe.WithPerRecipientHeaders()` option along with the key
* Fix an omission where header values for apu/apv were not
  properly passed when encrypting