### PR TITLE
Protect jws.Verify() and jwe.Encrypt() from panic on go1.19+

### DIFF
--- a/jwe/internal/keygen/keygen.go
+++ b/jwe/internal/keygen/keygen.go
@@ -88,6 +88,9 @@ func (g Ecdhes) Generate() (ByteSource, error) {
 	pubinfo := make([]byte, 4)
 	binary.BigEndian.PutUint32(pubinfo, uint32(g.keysize)*8)
 
+	if !priv.PublicKey.Curve.IsOnCurve(g.pubkey.X, g.pubkey.Y) {
+		return nil, fmt.Errorf(`public key used does not contain a point (X,Y) on the curve`)
+	}
 	z, _ := priv.PublicKey.Curve.ScalarMult(g.pubkey.X, g.pubkey.Y, priv.D.Bytes())
 	zBytes := ecutil.AllocECPointBuffer(z, priv.PublicKey.Curve)
 	defer ecutil.ReleaseECPointBuffer(zBytes)

--- a/jws/ecdsa.go
+++ b/jws/ecdsa.go
@@ -172,6 +172,10 @@ func (v *ecdsaVerifier) Verify(payload []byte, signature []byte, key interface{}
 		}
 	}
 
+	if !pubkey.Curve.IsOnCurve(pubkey.X, pubkey.Y) {
+		return fmt.Errorf(`public key used does not contain a point (X,Y) on the curve`)
+	}
+
 	r := pool.GetBigInt()
 	s := pool.GetBigInt()
 	defer pool.ReleaseBigInt(r)


### PR DESCRIPTION
fixes #840