### PR TITLE
Remove unused variables in ReadFile

### DIFF
--- a/jwe/io.go
+++ b/jwe/io.go
@@ -14,15 +14,6 @@ func (sysFS) Open(path string) (fs.File, error) {
 }
 
 func ReadFile(path string, options ...ReadFileOption) (*Message, error) {
-	var parseOptions []ParseOption
-	var readFileOptions []ReadFileOption
-	for _, option := range options {
-		if po, ok := option.(ParseOption); ok {
-			parseOptions = append(parseOptions, po)
-		} else {
-			readFileOptions = append(readFileOptions, option)
-		}
-	}
 
 	var srcFS fs.FS = sysFS{}
 	for _, option := range options {

--- a/jwk/io.go
+++ b/jwk/io.go
@@ -15,12 +15,9 @@ func (sysFS) Open(path string) (fs.File, error) {
 
 func ReadFile(path string, options ...ReadFileOption) (Set, error) {
 	var parseOptions []ParseOption
-	var readFileOptions []ReadFileOption
 	for _, option := range options {
 		if po, ok := option.(ParseOption); ok {
 			parseOptions = append(parseOptions, po)
-		} else {
-			readFileOptions = append(readFileOptions, option)
 		}
 	}
 

--- a/jws/io.go
+++ b/jws/io.go
@@ -14,15 +14,6 @@ func (sysFS) Open(path string) (fs.File, error) {
 }
 
 func ReadFile(path string, options ...ReadFileOption) (*Message, error) {
-	var parseOptions []ParseOption
-	var readFileOptions []ReadFileOption
-	for _, option := range options {
-		if po, ok := option.(ParseOption); ok {
-			parseOptions = append(parseOptions, po)
-		} else {
-			readFileOptions = append(readFileOptions, option)
-		}
-	}
 
 	var srcFS fs.FS = sysFS{}
 	for _, option := range options {

--- a/jwt/io.go
+++ b/jwt/io.go
@@ -15,12 +15,9 @@ func (sysFS) Open(path string) (fs.File, error) {
 
 func ReadFile(path string, options ...ReadFileOption) (Token, error) {
 	var parseOptions []ParseOption
-	var readFileOptions []ReadFileOption
 	for _, option := range options {
 		if po, ok := option.(ParseOption); ok {
 			parseOptions = append(parseOptions, po)
-		} else {
-			readFileOptions = append(readFileOptions, option)
 		}
 	}
 

--- a/tools/cmd/genreadfile/main.go
+++ b/tools/cmd/genreadfile/main.go
@@ -71,15 +71,14 @@ func generateFile(def definition) error {
 	o.L(`}`)
 
 	o.LL("func ReadFile(path string, options ...ReadFileOption) (%s, error) {", def.ReturnType)
-	o.L("var parseOptions []ParseOption")
-	o.L(`var readFileOptions []ReadFileOption`)
-	o.L(`for _, option := range options {`)
-	o.L(`if po, ok := option.(ParseOption); ok {`)
-	o.L(`parseOptions = append(parseOptions, po)`)
-	o.L(`} else {`)
-	o.L(`readFileOptions = append(readFileOptions, option)`)
-	o.L(`}`)
-	o.L(`}`)
+	if def.ParseOptions {
+		o.L("var parseOptions []ParseOption")
+		o.L(`for _, option := range options {`)
+		o.L(`if po, ok := option.(ParseOption); ok {`)
+		o.L(`parseOptions = append(parseOptions, po)`)
+		o.L(`}`)
+		o.L(`}`)
+	}
 	o.LL(`var srcFS fs.FS = sysFS{}`)
 	o.L("for _, option := range options {")
 	o.L(`switch option.Ident() {`)


### PR DESCRIPTION
`var readFileOptions []ReadFileOption` are never used. （something mistake?）

Generate `var parseOptions []ParseOption` only when needs.
