### PR TITLE
fix panic from empty seed

### DIFF
--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -81,6 +81,9 @@ func (k *okpPublicKey) Raw(v interface{}) error {
 }
 
 func buildOKPPrivateKey(alg jwa.EllipticCurveAlgorithm, xbuf []byte, dbuf []byte) (interface{}, error) {
+	if len(dbuf) == 0 {
+		return nil, fmt.Errorf(`cannot use empty seed`)
+	}
 	switch alg {
 	case jwa.Ed25519:
 		ret := ed25519.NewKeyFromSeed(dbuf)


### PR DESCRIPTION
`ed25519.NewKeyFromSeed()` will panic if its parameter is 0 length. Avoid the panic.

To reproduce, run this test:

```go
package main

import (
        "github.com/lestrrat-go/jwx/v2/jwk"
        "testing"
)

func TestIt(t *testing.T) {
        raw := []byte("{\"crv\":\"Ed25519\",\"d\":\"\",\"x\":\"\",\"KtY\":\"OKP\"}")
        k, err := jwk.ParseKey(raw)
        if err != nil {
                return
        }
        var exported []byte
        k.Raw(&exported)
}
```