### PR TITLE
Ensure http status is good before attempting to parse

### DIFF
--- a/jwk/fetch.go
+++ b/jwk/fetch.go
@@ -124,6 +124,10 @@ func Fetch(ctx context.Context, u string, options ...FetchOption) (Set, error) {
 		return nil, fmt.Errorf(`failed to fetch %q: %w`, u, err)
 	}
 
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf(`failed to fetch %q: %s`, u, res.Status)
+	}
+
 	buf, err := io.ReadAll(res.Body)
 	defer res.Body.Close()
 	if err != nil {


### PR DESCRIPTION
Saves some extra work if the provided url is returning bad data.