### PR TITLE
Use io.ReadFull to ensure that generated jwk match the expected keysize

### DIFF
--- a/cmd/jwx/jwk.go
+++ b/cmd/jwx/jwk.go
@@ -156,7 +156,7 @@ func makeJwkGenerateCmd() *cli.Command {
 			rawkey = v
 		case jwa.OctetSeq:
 			octets := make([]byte, c.Int("keysize"))
-			rand.Reader.Read(octets)
+			io.ReadFull(rand.Reader, octets)
 
 			rawkey = octets
 		case jwa.OKP:


### PR DESCRIPTION
`io.Reader.Read` docs say the following: 

```
If some data is available but not len(p) bytes, Read conventionally returns what is available instead of waiting for more.
```

We need to use `io.ReadFull` or `rand.Read` (which in turn calls `ReadFull`) to ensure that we fill the entire buffer.
