### PR TITLE
Allow resetting the default jwt validators

### DIFF
--- a/Changes
+++ b/Changes
@@ -32,6 +32,9 @@ v2.0.22 UNRELEASED
     default validators (`iat`, `exp`, and `nbf`), so that you can completely customize
     the validation with the validators you specify using `jwt.WithValidator()`.
 
+    This sort of behavior is useful for special cases such as 
+    https://openid.net/specs/openid-connect-rpinitiated-1_0.html
+
 v2.0.21 07 Mar 2024
 [Security]
   * [jwe] Added `jwe.Settings(jwe.WithMaxDecompressBufferSize(int64))` to specify the

--- a/Changes
+++ b/Changes
@@ -6,15 +6,15 @@ v1 and v2, please read the Changes-v2.md file (https://github.com/lestrrat-go/jw
 
 v2.0.22 UNRELEASED
 [New Features]
-  * [jwt] Added jwt.ParseCookie() function
-  * [jwt] jwt.ParseRequest() can now accept a new option, jwt.WithCookieKey() to
+  * [jwt] Added `jwt.ParseCookie()` function
+  * [jwt] `jwt.ParseRequest()` can now accept a new option, jwt.WithCookieKey() to
     specify a cookie name to extract the token from.
-  * [jwt] jwt.ParseRequest() and jwt.ParseCookie can accept the jwt.WithCookie() option,
+  * [jwt] `jwt.ParseRequest()` and `jwt.ParseCookie()` can accept the `jwt.WithCookie()` option,
     which will, upon successful token parsing, make the functions assign the *http.Cookie
     used to parse the token. This allows users to further inspect the cookie where the
     token came from, should the need arise.
-  * [jwt] jwt.ParseRequest() no longer automatically looks for "Authorization" header when
-    only jwt.WithFormKey() is used. This behavior is the same for jwt.WithCookieKey() and
+  * [jwt] `jwt.ParseRequest()` no longer automatically looks for "Authorization" header when
+    only `jwt.WithFormKey()` is used. This behavior is the same for `jwt.WithCookieKey()` and
     any similar options that may be implemented in the future.
 
       # previously
@@ -26,7 +26,12 @@ v2.0.22 UNRELEASED
       jwt.ParseRequest(req) // same as before
       jwt.ParseRequest(req, jwt.WithFormKey("foo")) // looks under foo
       jwt.ParseReuqest(req, jwt.WithHeaderKey("Authorization"), jwt.WithFormKey("foo")) // looks under foo AND Authorization
-      
+
+  * [jwt] Add `jwt.WithResetValidators()` option to `jwt.Validate()`. This option
+    will allow you to tell `jwt.Validate()` to NOT automatically check the
+    default validators (`iat`, `exp`, and `nbf`), so that you can completely customize
+    the validation with the validators you specify using `jwt.WithValidator()`.
+
 v2.0.21 07 Mar 2024
 [Security]
   * [jwe] Added `jwe.Settings(jwe.WithMaxDecompressBufferSize(int64))` to specify the

--- a/Changes
+++ b/Changes
@@ -33,7 +33,9 @@ v2.0.22 UNRELEASED
     the validation with the validators you specify using `jwt.WithValidator()`.
 
     This sort of behavior is useful for special cases such as 
-    https://openid.net/specs/openid-connect-rpinitiated-1_0.html
+    https://openid.net/specs/openid-connect-rpinitiated-1_0.html. However, you SHOULD NOT
+    use this option unless you know exactly what you are doing, as this will pose
+    significant security issues when used incorrectly.
 
 v2.0.21 07 Mar 2024
 [Security]

--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -72,6 +72,23 @@ options:
       Please be aware that in the next major release of this library,
       `jwt.Validate()`'s signature will change to include an explicit
       `context.Context` object.
+  - ident: ResetValidators
+    interface: ValidateOption
+    argument_type: bool
+    comment: |
+      WithResetValidators specifies that the default validators should be
+      reset before applying the custom validators. By default `jwt.Validate()`
+      checks for the validity of JWT by checking `exp`, `nbf`, and `iat`, even
+      when you specify more validators through other options.
+
+      Using this option with the value `true` will remove all default checks, 
+      and will expect you to specify validators as options. This is useful when you
+      want to skip the default validators and only use specific validators.
+
+      If you set this option to true and you do not specify any validators,
+      `jwt.Validate()` will return an error.
+
+      The default value is `false`.
   - ident: FlattenAudience
     interface: GlobalOption
     argument_type: bool

--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -81,6 +81,9 @@ options:
       checks for the validity of JWT by checking `exp`, `nbf`, and `iat`, even
       when you specify more validators through other options.
 
+      You SHOULD NOT use this option unless you know exactly what you are doing,
+      as this will pose significant security issues when used incorrectly.
+
       Using this option with the value `true` will remove all default checks, 
       and will expect you to specify validators as options. This is useful when you
       want to skip the default validators and only use specific validators, such as
@@ -90,7 +93,7 @@ options:
       If you set this option to true and you do not specify any validators,
       `jwt.Validate()` will return an error.
 
-      The default value is `false`.
+      The default value is `false` (`iat`, `exp`, and `nbf` are automatically checked).
   - ident: FlattenAudience
     interface: GlobalOption
     argument_type: bool

--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -83,7 +83,9 @@ options:
 
       Using this option with the value `true` will remove all default checks, 
       and will expect you to specify validators as options. This is useful when you
-      want to skip the default validators and only use specific validators.
+      want to skip the default validators and only use specific validators, such as
+      for https://openid.net/specs/openid-connect-rpinitiated-1_0.html, where
+      the token could be accepted even if the token is expired.
 
       If you set this option to true and you do not specify any validators,
       `jwt.Validate()` will return an error.

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -139,6 +139,7 @@ type identNumericDateFormatPrecision struct{}
 type identNumericDateParsePedantic struct{}
 type identNumericDateParsePrecision struct{}
 type identPedantic struct{}
+type identResetValidators struct{}
 type identSignOption struct{}
 type identToken struct{}
 type identTruncation struct{}
@@ -208,6 +209,10 @@ func (identNumericDateParsePrecision) String() string {
 
 func (identPedantic) String() string {
 	return "WithPedantic"
+}
+
+func (identResetValidators) String() string {
+	return "WithResetValidators"
 }
 
 func (identSignOption) String() string {
@@ -360,6 +365,23 @@ func WithNumericDateParsePrecision(v int) GlobalOption {
 // applies to checking for the correct `typ` and/or `cty` when necessary.
 func WithPedantic(v bool) ParseOption {
 	return &parseOption{option.New(identPedantic{}, v)}
+}
+
+// WithResetValidators specifies that the default validators should be
+// reset before applying the custom validators. By default `jwt.Validate()`
+// checks for the validity of JWT by checking `exp`, `nbf`, and `iat`, even
+// when you specify more validators through other options.
+//
+// Using this option with the value `true` will remove all default checks,
+// and will expect you to specify validators as options. This is useful when you
+// want to skip the default validators and only use specific validators.
+//
+// If you set this option to true and you do not specify any validators,
+// `jwt.Validate()` will return an error.
+//
+// The default value is `false`.
+func WithResetValidators(v bool) ValidateOption {
+	return &validateOption{option.New(identResetValidators{}, v)}
 }
 
 // WithSignOption provides an escape hatch for cases where extra options to

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -372,14 +372,19 @@ func WithPedantic(v bool) ParseOption {
 // checks for the validity of JWT by checking `exp`, `nbf`, and `iat`, even
 // when you specify more validators through other options.
 //
+// You SHOULD NOT use this option unless you know exactly what you are doing,
+// as this will pose significant security issues when used incorrectly.
+//
 // Using this option with the value `true` will remove all default checks,
 // and will expect you to specify validators as options. This is useful when you
-// want to skip the default validators and only use specific validators.
+// want to skip the default validators and only use specific validators, such as
+// for https://openid.net/specs/openid-connect-rpinitiated-1_0.html, where
+// the token could be accepted even if the token is expired.
 //
 // If you set this option to true and you do not specify any validators,
 // `jwt.Validate()` will return an error.
 //
-// The default value is `false`.
+// The default value is `false` (`iat`, `exp`, and `nbf` are automatically checked).
 func WithResetValidators(v bool) ValidateOption {
 	return &validateOption{option.New(identResetValidators{}, v)}
 }

--- a/jwt/options_gen_test.go
+++ b/jwt/options_gen_test.go
@@ -25,6 +25,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithNumericDateParsePedantic", identNumericDateParsePedantic{}.String())
 	require.Equal(t, "WithNumericDateParsePrecision", identNumericDateParsePrecision{}.String())
 	require.Equal(t, "WithPedantic", identPedantic{}.String())
+	require.Equal(t, "WithResetValidators", identResetValidators{}.String())
 	require.Equal(t, "WithSignOption", identSignOption{}.String())
 	require.Equal(t, "WithToken", identToken{}.String())
 	require.Equal(t, "WithTruncation", identTruncation{}.String())

--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -48,11 +48,13 @@ func Validate(t Token, options ...ValidateOption) error {
 
 	var clock Clock = ClockFunc(time.Now)
 	var skew time.Duration
-	var validators = []Validator{
+	var baseValidators = []Validator{
 		IsIssuedAtValid(),
 		IsExpirationValid(),
 		IsNbfValid(),
 	}
+	var extraValidators []Validator
+	var resetValidators bool
 	for _, o := range options {
 		//nolint:forcetypeassert
 		switch o.Ident() {
@@ -64,6 +66,8 @@ func Validate(t Token, options ...ValidateOption) error {
 			trunc = o.Value().(time.Duration)
 		case identContext{}:
 			ctx = o.Value().(context.Context)
+		case identResetValidators{}:
+			resetValidators = o.Value().(bool)
 		case identValidator{}:
 			v := o.Value().(Validator)
 			switch v := v.(type) {
@@ -72,22 +76,33 @@ func Validate(t Token, options ...ValidateOption) error {
 					if err := isSupportedTimeClaim(v.c1); err != nil {
 						return err
 					}
-					validators = append(validators, IsRequired(v.c1))
+					extraValidators = append(extraValidators, IsRequired(v.c1))
 				}
 				if v.c2 != "" {
 					if err := isSupportedTimeClaim(v.c2); err != nil {
 						return err
 					}
-					validators = append(validators, IsRequired(v.c2))
+					extraValidators = append(extraValidators, IsRequired(v.c2))
 				}
 			}
-			validators = append(validators, v)
+			extraValidators = append(extraValidators, v)
 		}
 	}
 
 	ctx = SetValidationCtxSkew(ctx, skew)
 	ctx = SetValidationCtxClock(ctx, clock)
 	ctx = SetValidationCtxTruncation(ctx, trunc)
+
+	var validators []Validator
+	if !resetValidators {
+		validators = append(baseValidators, extraValidators...)
+	} else {
+		if len(extraValidators) == 0 {
+			return fmt.Errorf(`no validators specified: jwt.WithResetValidators(true) and no jwt.WithValidator() specified`)
+		}
+		validators = extraValidators
+	}
+
 	for _, v := range validators {
 		if err := v.Validate(ctx, t); err != nil {
 			return err


### PR DESCRIPTION
```go
// does NOT check for iat, exp, and nbf, but checks for iss
jwt.Validate(token, jwt.WithResetValidators(true), jwt.WithIssuer("foo"))
```