### PR TITLE
Fix building on 32-bit systems

### DIFF
--- a/jwt/openid/birthdate.go
+++ b/jwt/openid/birthdate.go
@@ -60,7 +60,7 @@ func (b *BirthdateClaim) UnmarshalJSON(data []byte) error {
 
 func parseBirthdayInt(s string) int {
 	i, _ := strconv.ParseInt(s, 10, 64)
-	if math.MaxInt == math.MaxInt32 && i > math.MaxInt32 {
+	if i < 0 || (math.MaxInt == math.MaxInt32 && i > math.MaxInt32) {
 		return 0
 	}
 	return int(i)

--- a/jwt/openid/birthdate.go
+++ b/jwt/openid/birthdate.go
@@ -59,11 +59,9 @@ func (b *BirthdateClaim) UnmarshalJSON(data []byte) error {
 }
 
 func parseBirthdayInt(s string) int {
-	var i int64
-	if math.MaxInt == math.MaxInt32 {
-		i, _ = strconv.ParseInt(s, 10, 32)
-	} else {
-		i, _ = strconv.ParseInt(s, 10, 64)
+	i, _ := strconv.ParseInt(s, 10, 64)
+	if math.MaxInt == math.MaxInt32 && i > math.MaxInt32 {
+		return 0
 	}
 	return int(i)
 }

--- a/jwt/openid/birthdate.go
+++ b/jwt/openid/birthdate.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"math"
 	"regexp"
 	"strconv"
 
@@ -58,21 +57,17 @@ func (b *BirthdateClaim) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-var intSize int
-
-func init() {
-	switch math.MaxInt {
-	case math.MaxInt16:
-		intSize = 16
-	case math.MaxInt32:
-		intSize = 32
-	case math.MaxInt64:
-		intSize = 64
-	}
-}
+// This is true if the app is running on a 64-bit system
+// See: https://stackoverflow.com/a/60319709/192024
+const is64bit = uint64(^uintptr(0)) == ^uint64(0)
 
 func parseBirthdayInt(s string) int {
-	i, _ := strconv.ParseInt(s, 10, intSize)
+	var i int64
+	if is64bit {
+		i, _ = strconv.ParseInt(s, 10, 64)
+	} else {
+		i, _ = strconv.ParseInt(s, 10, 32)
+	}
 	return int(i)
 }
 

--- a/jwt/openid/birthdate.go
+++ b/jwt/openid/birthdate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"regexp"
 	"strconv"
 
@@ -57,16 +58,12 @@ func (b *BirthdateClaim) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// This is true if the app is running on a 64-bit system
-// See: https://stackoverflow.com/a/60319709/192024
-const is64bit = uint64(^uintptr(0)) == ^uint64(0)
-
 func parseBirthdayInt(s string) int {
 	var i int64
-	if is64bit {
-		i, _ = strconv.ParseInt(s, 10, 64)
-	} else {
+	if math.MaxInt == math.MaxInt32 {
 		i, _ = strconv.ParseInt(s, 10, 32)
+	} else {
+		i, _ = strconv.ParseInt(s, 10, 64)
 	}
 	return int(i)
 }


### PR DESCRIPTION
Builds on 32-bit systems are failing:

```
 /go/pkg/mod/github.com/lestrrat-go/jwx/v2@v2.0.21/jwt/openid/birthdate.go:69:7: math.MaxInt64 (untyped int constant 9223372036854775807) overflows int
```

This changes how 32-bit systems are detected in a way that doesn't cause the error. Although this does remove 16-bit systems from the `case`, the Go compiler does not support any 16-bit system at present (and it's very unlikely it ever will).