### PR TITLE
Fix link to openid

### DIFF
--- a/jwt/README.md
+++ b/jwt/README.md
@@ -8,7 +8,7 @@ Package jwt implements JSON Web Tokens as described in [RFC7519](https://tools.i
 * Conversion to and from JSON
 * Generate signed tokens
 * Verify signed tokens
-* Extra support for OpenID tokens via [github.com/lestrrat-go/jwx/jwt/openid](./jwt/openid)
+* Extra support for OpenID tokens via [github.com/lestrrat-go/jwx/jwt/openid](./openid)
 
 How-to style documentation can be found in the [docs directory](../docs).
 


### PR DESCRIPTION
This is in the `openid` subdirectory inside the `jwt` directory, but this file is already inside the latter.