### PR TITLE
update comments to include iat

### DIFF
--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -45,7 +45,7 @@ options:
     interface: ValidateOption
     argument_type: time.Duration
     comment: |
-      WithAcceptableSkew specifies the duration in which exp and nbf
+      WithAcceptableSkew specifies the duration in which exp, iat and nbf
       claims may differ by. This value should be positive
   - ident: Truncation
     interface: ValidateOption
@@ -61,7 +61,7 @@ options:
     argument_type: Clock
     comment: |
       WithClock specifies the `Clock` to be used when verifying
-      exp and nbf claims.
+      exp, iat and nbf claims.
   - ident: Context
     interface: ValidateOption
     argument_type: context.Context

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -239,14 +239,14 @@ func (identVerify) String() string {
 	return "WithVerify"
 }
 
-// WithAcceptableSkew specifies the duration in which exp and nbf
+// WithAcceptableSkew specifies the duration in which exp, iat and nbf
 // claims may differ by. This value should be positive
 func WithAcceptableSkew(v time.Duration) ValidateOption {
 	return &validateOption{option.New(identAcceptableSkew{}, v)}
 }
 
 // WithClock specifies the `Clock` to be used when verifying
-// exp and nbf claims.
+// exp, iat and nbf claims.
 func WithClock(v Clock) ValidateOption {
 	return &validateOption{option.New(identClock{}, v)}
 }


### PR DESCRIPTION
`WithAcceptableSkew()` and `WithClock()` both apply to `iat` as well as `nbf` and `exp` - update comments to reflect that.