### PR TITLE
jws/jwe: split token into fixed number of parts

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -886,10 +886,11 @@ func parseJSON(buf []byte, storeProtectedHeaders bool) (*Message, error) {
 }
 
 func parseCompact(buf []byte, storeProtectedHeaders bool) (*Message, error) {
-	parts := bytes.Split(buf, []byte{'.'})
-	if len(parts) != 5 {
-		return nil, fmt.Errorf(`compact JWE format must have five parts (%d)`, len(parts))
+	// Five parts is four separators
+	if count := bytes.Count(buf, []byte{'.'}); count != 4 {
+		return nil, fmt.Errorf(`compact JWE format must have five parts (%d)`, count)
 	}
+	parts := bytes.SplitN(buf, []byte{'.'}, 5)
 
 	hdrbuf, err := base64.Decode(parts[0])
 	if err != nil {

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -625,10 +625,11 @@ func parseJSON(data []byte) (result *Message, err error) {
 //
 // On error, returns a jws.ParseError.
 func SplitCompact(src []byte) ([]byte, []byte, []byte, error) {
-	parts := bytes.Split(src, []byte("."))
-	if len(parts) < 3 {
+	// Three parts is two separators
+	if bytes.Count(src, []byte(".")) != 2 {
 		return nil, nil, nil, parseerr(`invalid number of segments`)
 	}
+	parts := bytes.SplitN(src, []byte("."), 3)
 	return parts[0], parts[1], parts[2], nil
 }
 
@@ -637,10 +638,11 @@ func SplitCompact(src []byte) ([]byte, []byte, []byte, error) {
 //
 // On error, returns a jws.ParseError.
 func SplitCompactString(src string) ([]byte, []byte, []byte, error) {
-	parts := strings.Split(src, ".")
-	if len(parts) < 3 {
+	// Three parts is two separators
+	if strings.Count(src, ".") != 2 {
 		return nil, nil, nil, parseerr(`invalid number of segments`)
 	}
+	parts := strings.SplitN(src, ".", 3)
 	return []byte(parts[0]), []byte(parts[1]), []byte(parts[2]), nil
 }
 


### PR DESCRIPTION
this avoid to use eccessive memory when processing maliciously crafted tokens with a large number of '.' characters.

See also:

https://github.com/golang/go/issues/71490
https://github.com/go-jose/go-jose/security/advisories/GHSA-c6gw-w398-hv78