### PR TITLE
Add the claim name to error messages produced by ClaimValueIs()

### DIFF
--- a/docs/01-jwt.md
+++ b/docs/01-jwt.md
@@ -2,35 +2,34 @@
 
 In this document we describe how to work with JWT using `github.com/lestrrat-go/jwx/v3/jwt`
 
-* [Terminology](#terminology)
-  * [Verification](#verification)
-  * [Validation](#validation)
-* [Parsing](#parsing)
-  * [Parse a JWT](#parse-a-jwt)
-  * [Parse a JWT from file](#parse-a-jwt-from-file)
-  * [Parse a JWT from a *http.Request](#parse-a-jwt-from-a-httprequest)
-* [Programmatically Creating a JWT](#programmatically-creating-a-jwt)
-  * [Using jwt.New](#using-jwtnew)
-  * [Using Builder](#using-builder)
-* [Verification](#jwt-verification)
-  * [Parse and Verify a JWT (with a single key)](#parse-and-verify-a-jwt-with-single-key)
-  * [Parse and Verify a JWT (with a key set, matching `kid`)](#parse-and-verify-a-jwt-with-a-key-set-matching-kid)
-  * [Parse and Verify a JWT (using arbitrary keys)](#parse-and-verify-a-jwt-using-arbitrary-keys)
-  * [Parse and Verify a JWT (using key specified in `jku`)](#parse-and-verify-a-jwt-using-key-specified-in-jku)
-* [Validation](#jwt-validation)
-  * [Validate for specific claim values](#validate-for-specific-claim-values)
-  * [Use a custom validator](#use-a-custom-validator)
-  * [Detecting error types](#detecting-error-types)
-* [Serialization](#jwt-serialization)
-  * [Serialize using JWS](#serialize-using-jws)
-  * [Serialize using JWE and JWS](#serialize-using-jwe-and-jws)
-  * [Serialize the `aud` field as a single string](#serialize-the-aud-field-as-a-single-string)
-* [Working with JWT](#working-with-jwt-1)
-  * [Performance](#performance)
-  * [Access JWS headers](#access-jws-headers)
-  * [Get/Set fields](#getset-fields)
-  * [Using a custom base64 encoder](#using-a-custom-base64-encoder)
-
+- [Terminology](#terminology)
+  - [Verification](#verification)
+  - [Validation](#validation)
+- [Parsing](#parsing)
+  - [Parse a JWT](#parse-a-jwt)
+  - [Parse a JWT from file](#parse-a-jwt-from-file)
+  - [Parse a JWT from a \*http.Request](#parse-a-jwt-from-a-httprequest)
+- [Programmatically Creating a JWT](#programmatically-creating-a-jwt)
+  - [Using jwt.New](#using-jwtnew)
+  - [Using Builder](#using-builder)
+- [Verification](#jwt-verification)
+  - [Parse and Verify a JWT (with a single key)](#parse-and-verify-a-jwt-with-single-key)
+  - [Parse and Verify a JWT (with a key set, matching `kid`)](#parse-and-verify-a-jwt-with-a-key-set-matching-kid)
+  - [Parse and Verify a JWT (using arbitrary keys)](#parse-and-verify-a-jwt-using-arbitrary-keys)
+  - [Parse and Verify a JWT (using key specified in `jku`)](#parse-and-verify-a-jwt-using-key-specified-in-jku)
+- [Validation](#jwt-validation)
+  - [Validate for specific claim values](#validate-for-specific-claim-values)
+  - [Use a custom validator](#use-a-custom-validator)
+  - [Detecting error types](#detecting-error-types)
+- [Serialization](#jwt-serialization)
+  - [Serialize using JWS](#serialize-using-jws)
+  - [Serialize using JWE and JWS](#serialize-using-jwe-and-jws)
+  - [Serialize the `aud` field as a single string](#serialize-the-aud-field-as-a-single-string)
+- [Working with JWT](#working-with-jwt-1)
+  - [Performance](#performance)
+  - [Access JWS headers](#access-jws-headers)
+  - [Get/Set fields](#getset-fields)
+  - [Using a custom base64 encoder](#using-a-custom-base64-encoder)
 
 ---
 
@@ -54,9 +53,9 @@ eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTk
 
 This message consists of three data segments encoded in `base64`, concatenated with a `.`. Each part reads as follows:
 
-* **Part 1**: The JWS protected headers. These are metadata required to verify the signed payload.
-* **Part 2**: The JWS payload. This can be any arbitrary data, but in our case it would be a JWT object.
-* **Part 3**: The JWS signature. This is the signature generated from the signing key, the headers, and the payload.
+- **Part 1**: The JWS protected headers. These are metadata required to verify the signed payload.
+- **Part 2**: The JWS payload. This can be any arbitrary data, but in our case it would be a JWT object.
+- **Part 3**: The JWS signature. This is the signature generated from the signing key, the headers, and the payload.
 
 It is important to realize that JWS in itself has nothing to do with JWT. The envelope and therefore the JWS mechanism itself does not care that the payload is JWT or not.
 
@@ -73,6 +72,7 @@ as well as validating the contents of the JWT object after it has been decoded.
 To parse a JWT in either raw JSON or JWS compact serialization format, use [`jwt.Parse()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwt#Parse)
 
 <!-- INCLUDE(examples/jwt_parse_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -93,7 +93,9 @@ func Example_jwt_parse() {
   // OUTPUT:
 }
 ```
+
 source: [examples/jwt_parse_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_parse_example_test.go)
+
 <!-- END INCLUDE -->
 
 Note that the above form performs only signature verification and no validation of the JWT token itself.
@@ -104,6 +106,7 @@ In order to perform validation, please use `Validate()`.
 To parsea JWT stored in a file, use [`jwt.ReadFile()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwt#ReadFile). [`jwt.ReadFile()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwt#ReadFile) accepts the same options as [`jwt.Parse()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwt#Parse).
 
 <!-- INCLUDE(examples/jwt_readfile_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -137,14 +140,17 @@ func Example_jwt_readfile() {
   // OUTPUT:
 }
 ```
+
 source: [examples/jwt_readfile_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_readfile_example_test.go)
+
 <!-- END INCLUDE -->
 
-## Parse a JWT from a *http.Request
+## Parse a JWT from a \*http.Request
 
-To parse a JWT stored within a *http.Request object, use [`jwt.ParseRequest()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwt#ParseRequest). It by default looks for JWTs stored in the "Authorization" header, but can be configured to look under other headers and within the form fields.
+To parse a JWT stored within a \*http.Request object, use [`jwt.ParseRequest()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwt#ParseRequest). It by default looks for JWTs stored in the "Authorization" header, but can be configured to look under other headers and within the form fields.
 
 <!-- INCLUDE(examples/jwt_parse_request_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -220,7 +226,9 @@ func Example_jwt_parse_request_authorization() {
   // OUTPUT:
 }
 ```
+
 source: [examples/jwt_parse_request_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_parse_request_example_test.go)
+
 <!-- END INCLUDE -->
 
 # Programmatically Creating a JWT
@@ -230,6 +238,7 @@ source: [examples/jwt_parse_request_example_test.go](https://github.com/lestrrat
 The most straight forward way is to use the constructor `jwt.New()` and use `(jwt.Token).Set()`:
 
 <!-- INCLUDE(examples/jwt_construct_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -260,7 +269,9 @@ func Example_jwt_construct() {
   // {"aud":["users"],"iss":"github.com/lestrrat-go/jwx"}
 }
 ```
+
 source: [examples/jwt_construct_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_construct_example_test.go)
+
 <!-- END INCLUDE -->
 
 If repeatedly checking for errors in `Set()` sounds like too much trouble, consider using the builder.
@@ -275,6 +286,7 @@ One caveat that you should be aware about is that all calls to set a claim in th
 operation. If you set the same claim multiple times, the last value is used.
 
 <!-- INCLUDE(examples/jwt_builder_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -305,16 +317,19 @@ func Example_jwt_builder() {
   // {"aud":["users"],"claim1":"value1","claim2":"value2","iss":"github.com/lestrrat-go/jwx"}
 }
 ```
+
 source: [examples/jwt_builder_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_builder_example_test.go)
+
 <!-- END INCLUDE -->
 
 # JWT Verification
 
 ## Parse and Verify a JWT (with single key)
 
-To parse a JWT *and* verify that its content matches the signature as described in the JWS message, you need to add some options when calling the [`jwt.Parse()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwt#Parse) function.
+To parse a JWT _and_ verify that its content matches the signature as described in the JWS message, you need to add some options when calling the [`jwt.Parse()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwt#Parse) function.
 
 <!-- INCLUDE(examples/jwt_parse_with_key_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -344,20 +359,23 @@ func Example_jwt_parse_with_key() {
   // OUTPUT:
 }
 ```
+
 source: [examples/jwt_parse_with_key_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_parse_with_key_example_test.go)
+
 <!-- END INCLUDE -->
 
 In the above example, `key` may either be the raw key (i.e. "crypto/ecdsa".PublicKey, "crypto/ecdsa".PrivateKey) or an instance of [`jwk.Key`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwk#Key) (i.e. [`jwk.ECDSAPrivateKey`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwk#ECDSAPrivateKey), [`jwk.ECDSAPublicKey`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwk#ECDSAPublicKey)). The key type must match the algorithm being used.
 
 ## Parse and Verify a JWT (with a key set, matching `kid`)
 
-To parse a JWT *and* verify that its content matches the signature as described in the JWS message using a [`jwk.Set`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwk#Set), you need to add some options when calling the [`jwt.Parse()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwt#Parse) function.
+To parse a JWT _and_ verify that its content matches the signature as described in the JWS message using a [`jwk.Set`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwk#Set), you need to add some options when calling the [`jwt.Parse()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwt#Parse) function.
 
 The following code does a lot of preparation to mimic a real JWKS signed JWT, but the code required in the user side is located towards the end.
 
 In real life, the location of JWKS files are specified by the service that provided you with the signed JWT. The URL for these JWKS files often (but are not always guaranteed to be) take the form `https://DOMAIN/.well-known/jwks.json` and the like. If you need to fetch these in your code, [refer to the documentation on `jwk` package](04-jwk.md#fetching-jwk-sets).
 
 <!-- INCLUDE(examples/jwt_parse_with_keyset_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -459,7 +477,9 @@ func Example_jwt_parse_with_key_set() {
   // OUTPUT:
 }
 ```
+
 source: [examples/jwt_parse_with_keyset_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_parse_with_keyset_example_test.go)
+
 <!-- END INCLUDE -->
 
 There are a couple of things to note.
@@ -499,6 +519,7 @@ If you must switch the key to use for verification dynamically, you can load you
 arbitrary location using `jwt.WithKeySetProvider()` option:
 
 <!-- INCLUDE(examples/jwt_parse_with_key_provider_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -649,7 +670,9 @@ func Example_jwt_parse_with_key_provider() {
   // OUTPUT:
 }
 ```
+
 source: [examples/jwt_parse_with_key_provider_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_parse_with_key_provider_example_test.go)
+
 <!-- END INCLUDE -->
 
 ## Parse and Verify a JWT (using key specified in `jku`)
@@ -659,6 +682,7 @@ use `jws.VerifyAuto()` instead of `jws.Verify()`. This would effectively allow a
 self-validating.
 
 <!-- INCLUDE(examples/jwt_parse_with_jku_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -741,7 +765,9 @@ func Example_jwt_parse_with_jku() {
   // OUTPUT:
 }
 ```
+
 source: [examples/jwt_parse_with_jku_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_parse_with_jku_example_test.go)
+
 <!-- END INCLUDE -->
 
 This feature must be used with extreme caution. Please see the caveats and fine prints
@@ -752,6 +778,7 @@ in the documentation for `jws.VerifyAuto()`
 To validate if the JWT's contents, such as if the JWT contains the proper "iss","sub","aut", etc, or the expiration information and such, use the [`jwt.Validate()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwt#Validate) function.
 
 <!-- INCLUDE(examples/jwt_validate_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -805,7 +832,9 @@ func Example_jwt_validate() {
   // jwt.Parse: failed to parse token: jwt.Validate: validation failed: "exp" not satisfied: token is expired
 }
 ```
+
 source: [examples/jwt_validate_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_validate_example_test.go)
+
 <!-- END INCLUDE -->
 
 ## Validate for specific claim values
@@ -813,6 +842,7 @@ source: [examples/jwt_validate_example_test.go](https://github.com/lestrrat-go/j
 By default we only check for the time-related components of a token, such as "iat", "exp", and "nbf". To tell [`jwt.Validate()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwt#Validate) to check for other fields, use one of the various [`jwt.ValidateOption`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwt#ValidateOption) values, such as `jwt.WithClaimValue()`, `jwt.WithRequiredClaim()`, etc.
 
 <!-- INCLUDE(examples/jwt_validate_issuer_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -840,10 +870,12 @@ func Example_jwt_validate_issuer() {
   }
   fmt.Printf("%s\n", err)
   // OUTPUT:
-  // jwt.Validate: validation failed: "iss" not satisfied: values do not match
+  // jwt.Validate: validation failed: "iss" not satisfied: claim "iss" does not have the expected value
 }
 ```
+
 source: [examples/jwt_validate_issuer_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_validate_issuer_example_test.go)
+
 <!-- END INCLUDE -->
 
 ## Use a custom validator
@@ -851,6 +883,7 @@ source: [examples/jwt_validate_issuer_example_test.go](https://github.com/lestrr
 You may also create a custom validator that implements the `jwt.Validator` interface. These validators can be added as an option to `jwt.Validate()` using `jwt.WithValidator()`. Multiple validators can be specified. The error should be of type `jwt.ValidationError`. Use `jwt.NewValidationError` to create an error of appropriate type.
 
 <!-- INCLUDE(examples/jwt_validate_validator_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -894,7 +927,9 @@ func Example_jwt_validate_validator() {
   // jwt.Validate: validation failed: tokens are only valid if issued during August!
 }
 ```
+
 source: [examples/jwt_validate_validator_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_validate_validator_example_test.go)
+
 <!-- END INCLUDE -->
 
 ## Detecting error types
@@ -902,6 +937,7 @@ source: [examples/jwt_validate_validator_example_test.go](https://github.com/les
 If you enable validation during `jwt.Parse()`, you might sometimes want to differentiate between parsing errors and validation errors. To do this, you can use the function `jwt.IsValidationError()`. To further differentiate between specific errors, you can use `errors.Is()`:
 
 <!-- INCLUDE(examples/jwt_validate_detect_error_type_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -971,7 +1007,9 @@ func Example_jwt_validate_detect_error_type() {
   // jwt.Parse: failed to parse token: jwt.Validate: validation failed: "exp" not satisfied: token is expired
 }
 ```
+
 source: [examples/jwt_validate_detect_error_type_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_validate_detect_error_type_example_test.go)
+
 <!-- END INCLUDE -->
 
 # JWT Serialization
@@ -984,6 +1022,7 @@ In this case it will be marshaled as a JSON object rather than in the compact fo
 Since it will be just the raw token, no signing or encryption will be performed.
 
 <!-- INCLUDE(examples/jwt_serialize_json_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -1011,7 +1050,9 @@ func Example_jwt_serialize_json() {
   // {"iat":233431200,"iss":"github.com/lestrrat-go/jwx"}
 }
 ```
+
 source: [examples/jwt_serialize_json_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_serialize_json_example_test.go)
+
 <!-- END INCLUDE -->
 
 ## Serialize using JWS
@@ -1021,6 +1062,7 @@ The `jwt` package provides a convenience function `jwt.Sign()` to serialize a to
 If you need even further customization, consider using the `jws` package directly.
 
 <!-- INCLUDE(examples/jwt_serialize_jws_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -1073,18 +1115,21 @@ func Example_jwt_serialize_jws() {
   // eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjIzMzQzMTIwMCwiaXNzIjoiZ2l0aHViLmNvbS9sZXN0cnJhdC1nby9qd3gifQ.K1WVWaM6Dww9aNNFMjnyUfjaaHIs08-3Qb1b8eSEHOk
 }
 ```
+
 source: [examples/jwt_serialize_jws_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_serialize_jws_example_test.go)
+
 <!-- END INCLUDE -->
 
 ## Serialize using JWE and JWS
 
-The `jwt` package provides a `Serializer` object to allow users to serialize a token using an arbitrary combination of processors. 
+The `jwt` package provides a `Serializer` object to allow users to serialize a token using an arbitrary combination of processors.
 
 If for whatever reason the built-in `(jwt.Serializer).Sign()` and `(jwt.Serializer).Encrypt()` do not work for you, you may choose to provider a custom serialization step using `(jwt.Serialize).Step()` -- but at this point it may just be easier if you hand-rolled your own serialization.
 
 The following example, encrypts a token using JWE, then uses JWS to sign the encrypted payload:
 
 <!-- INCLUDE(examples/jwt_serialize_jwe_jws_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -1141,7 +1186,9 @@ func Example_jwt_serialize_jwe_jws() {
   // OUTPUT:
 }
 ```
+
 source: [examples/jwt_serialize_jwe_jws_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_serialize_jwe_jws_example_test.go)
+
 <!-- END INCLUDE -->
 
 ## Serialize the `aud` field as a single string
@@ -1167,6 +1214,7 @@ The examples below should both be valid, but apparently there are systems that d
 To work around these problematic parsers, you may use enable the option `jwt.FlattenAudience` on each token that you would like to see this behavior. If you do this for _all_ (or most) tokens, you may opt to change the global default value by settings `jwt.WithFlattenAudience(true)` option via `jwt.Settings()`.
 
 <!-- INCLUDE(examples/jwt_flatten_audience_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -1253,7 +1301,9 @@ func Example_jwt_flatten_Audience() {
   // {"aud":"foo"}
 }
 ```
+
 source: [examples/jwt_flatten_audience_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_flatten_audience_example_test.go)
+
 <!-- END INCLUDE -->
 
 # Working with JWT
@@ -1263,6 +1313,7 @@ source: [examples/jwt_flatten_audience_example_test.go](https://github.com/lestr
 github.com/lestrrat-go/jwx is focused on usability / stable API. If you are worried about performance while processing JWTs, the best path is just to use a plain struct after handling JWS yourself:
 
 <!-- INCLUDE(examples/jwt_raw_struct_example_test.go) -->
+
 ```go
 package examples
 
@@ -1313,7 +1364,9 @@ func Example_jwt_plain_struct() {
   // foobar
 }
 ```
+
 source: [examples/jwt_raw_struct_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_raw_struct_example_test.go)
+
 <!-- END INCLUDE -->
 
 This makes sure that you do not go through any extra layers of abstraction that causes performance penalties, and you get exactly the type of field that you want.
@@ -1324,8 +1377,8 @@ The RFC defines JWS as an envelope to JWT (JWS can carry any payload, you just h
 
 If you need to access these JWS headers while parsing JWS signed JWT, you will need to reach into the tools defined in the `jws` package.
 
-* If you are considering using JWS header fields to decide on which key to use for verification, consider [using a `jwt.KeyProvider`](#parse-and-verify-a-jwt-using-arbitrary-keys).
-* If you are looking for ways to 
+- If you are considering using JWS header fields to decide on which key to use for verification, consider [using a `jwt.KeyProvider`](#parse-and-verify-a-jwt-using-arbitrary-keys).
+- If you are looking for ways to
 
 Please [look at the JWS documentation for it](./02-jws.md#parse-a-jws-message-and-access-jws-headers) .
 
@@ -1360,12 +1413,12 @@ For pre-defined fields, `Set()` will return an error when the value cannot be co
 
 ## Using a custom base64 encoder
 
-
 Per specification JWT should be using URL base64 encoding with no padding when generating (and by nature of the process when verifying as well) signatures. However, some systems do not necessarily adhere to the standards ([there have been reports that AWS ALB is one such system, generating User Claims JWT with padding](https://github.com/lestrrat-go/jwx/discussions/1324))
 
 In these situations, you will need to specify the base64 encoder to your `jwt.Sign` and `jwt.Parse` calls. Please note that this feature is available on v3 onwards only.
 
 <!-- INCLUDE(examples/jwt_sign_with_custom_base64_example_test.go) -->
+
 ```go
 package examples_test
 
@@ -1421,7 +1474,9 @@ func Example_jwt_sign_with_custom_base64_encoder() {
   // {"iat":233431200,"sub":"github.com/lestrrat-go/jwx"}
 }
 ```
+
 source: [examples/jwt_sign_with_custom_base64_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwt_sign_with_custom_base64_example_test.go)
+
 <!-- END INCLUDE -->
 
 You can use these option for `jws.Sign` and `jws.Verify` as well. See the [JWS docs for an example](./02-jwt.md#using-a-custom-base64-encoder).

--- a/examples/jwt_validate_issuer_example_test.go
+++ b/examples/jwt_validate_issuer_example_test.go
@@ -24,5 +24,5 @@ func Example_jwt_validate_issuer() {
 	}
 	fmt.Printf("%s\n", err)
 	// OUTPUT:
-	// jwt.Validate: validation failed: "iss" not satisfied: values do not match
+	// jwt.Validate: validation failed: "iss" not satisfied: claim "iss" does not have the expected value
 }

--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -373,7 +373,7 @@ func (cv *claimValueIs) Validate(_ context.Context, t Token) error {
 		return cv.makeErr(`claim %[1]q does not exist or is not a []string: %[2]w`, cv.name, err)
 	}
 	if v != cv.value {
-		return cv.makeErr(`values do not match`)
+		return cv.makeErr(`claim %[1]q does not have the expected value`, cv.name)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR adds changes the behaviour of `ClaimValueIs` to include the claim name in the error message produced when the claim key is present, but the value does not match the required value. The message produced when the claim is absent already included the name.

The existing test cases cover this scenario by checking that the error is non-nil, but as there were no existing assertions about the message _content_, I chose to leave these as is.