### PR TITLE
v2: jws/jwe: split token into fixed number of parts (#1308)

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -846,10 +846,11 @@ func parseJSON(buf []byte, storeProtectedHeaders bool) (*Message, error) {
 }
 
 func parseCompact(buf []byte, storeProtectedHeaders bool) (*Message, error) {
-	parts := bytes.Split(buf, []byte{'.'})
-	if len(parts) != 5 {
-		return nil, fmt.Errorf(`compact JWE format must have five parts (%d)`, len(parts))
+	// Five parts is four separators
+	if count := bytes.Count(buf, []byte{'.'}); count != 4 {
+		return nil, fmt.Errorf(`compact JWE format must have five parts (%d)`, count)
 	}
+	parts := bytes.SplitN(buf, []byte{'.'}, 5)
 
 	hdrbuf, err := base64.Decode(parts[0])
 	if err != nil {

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -635,20 +635,22 @@ func parseJSON(data []byte) (result *Message, err error) {
 // SplitCompact splits a JWT and returns its three parts
 // separately: protected headers, payload and signature.
 func SplitCompact(src []byte) ([]byte, []byte, []byte, error) {
-	parts := bytes.Split(src, []byte("."))
-	if len(parts) < 3 {
+	// Three parts is two separators
+	if bytes.Count(src, []byte(".")) != 2 {
 		return nil, nil, nil, fmt.Errorf(`invalid number of segments`)
 	}
+	parts := bytes.SplitN(src, []byte("."), 3)
 	return parts[0], parts[1], parts[2], nil
 }
 
 // SplitCompactString splits a JWT and returns its three parts
 // separately: protected headers, payload and signature.
 func SplitCompactString(src string) ([]byte, []byte, []byte, error) {
-	parts := strings.Split(src, ".")
-	if len(parts) < 3 {
+	// Three parts is two separators
+	if strings.Count(src, ".") != 2 {
 		return nil, nil, nil, fmt.Errorf(`invalid number of segments`)
 	}
+	parts := strings.SplitN(src, ".", 3)
 	return []byte(parts[0]), []byte(parts[1]), []byte(parts[2]), nil
 }
 


### PR DESCRIPTION
belated backport of #1308 to v2 

---

this avoid to use eccessive memory when processing maliciously crafted tokens with a large number of '.' characters