### PR TITLE
jws: improve performance for SplitCompact/SplitCompactString

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -632,17 +632,26 @@ func parseJSON(data []byte) (result *Message, err error) {
 	return &m, nil
 }
 
+const tokenDelim = "."
+
 // SplitCompact splits a JWT and returns its three parts
 // separately: protected headers, payload and signature.
 //
 // On error, returns a jws.ParseError.
 func SplitCompact(src []byte) ([]byte, []byte, []byte, error) {
-	// Three parts is two separators
-	if bytes.Count(src, []byte(".")) != 2 {
+	protected, s, ok := bytes.Cut(src, []byte(tokenDelim))
+	if !ok { // no period found
 		return nil, nil, nil, parseerr(`invalid number of segments`)
 	}
-	parts := bytes.SplitN(src, []byte("."), 3)
-	return parts[0], parts[1], parts[2], nil
+	payload, s, ok := bytes.Cut(s, []byte(tokenDelim))
+	if !ok { // only one period found
+		return nil, nil, nil, parseerr(`invalid number of segments`)
+	}
+	signature, _, ok := bytes.Cut(s, []byte(tokenDelim))
+	if ok { // three periods found
+		return nil, nil, nil, parseerr(`invalid number of segments`)
+	}
+	return protected, payload, signature, nil
 }
 
 // SplitCompactString splits a JWT and returns its three parts
@@ -650,12 +659,7 @@ func SplitCompact(src []byte) ([]byte, []byte, []byte, error) {
 //
 // On error, returns a jws.ParseError.
 func SplitCompactString(src string) ([]byte, []byte, []byte, error) {
-	// Three parts is two separators
-	if strings.Count(src, ".") != 2 {
-		return nil, nil, nil, parseerr(`invalid number of segments`)
-	}
-	parts := strings.SplitN(src, ".", 3)
-	return []byte(parts[0]), []byte(parts[1]), []byte(parts[2]), nil
+	return SplitCompact([]byte(src))
 }
 
 // SplitCompactReader splits a JWT and returns its three parts

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1314,7 +1314,7 @@ func TestRFC7797(t *testing.T) {
 				            "signature": "A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"
 						},
 						{
-							"protected": "eyJhbGciOiJIUzI1NiIsImI2NCI6dHJ1ZSwiY3JpdCI6WyJiNjQiXX0", 
+							"protected": "eyJhbGciOiJIUzI1NiIsImI2NCI6dHJ1ZSwiY3JpdCI6WyJiNjQiXX0",
 							"signature": "6BjugbC8MfrT_yy5WxWVFZrEHVPDtpdsV9u-wbzQDV8"
 						}
 					],
@@ -2050,4 +2050,22 @@ func TestParseFormat(t *testing.T) {
 	require.NoError(t, err, `jws.Parse should succeed`)
 	_, err = jws.Parse(signedJSON, jws.WithJSON(), jws.WithCompact())
 	require.NoError(t, err, `jws.Parse should succeed`)
+}
+
+func BenchmarkSplitCompat(b *testing.B) {
+	for range b.N {
+		_, _, _, err := jws.SplitCompact([]byte(exampleCompactSerialization))
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkSplitCompatString(b *testing.B) {
+	for range b.N {
+		_, _, _, err := jws.SplitCompactString(exampleCompactSerialization)
+		if err != nil {
+			panic(err)
+		}
+	}
 }


### PR DESCRIPTION
name            old time/op    new time/op    delta
SplitCompat-16    76.5ns ± 5%    21.1ns ± 1%   -72.40%  (p=0.000 n=10+10)

name            old alloc/op   new alloc/op   delta
SplitCompat-16      272B ± 0%        0B       -100.00%  (p=0.000 n=10+10)

name            old allocs/op  new allocs/op  delta
SplitCompat-16      2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)