### PR TITLE
[v3] Explcitly check key sizes before passing to aes.NewCipher

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,31 @@ Changes
 v3 has many incompatibilities with v2. To see the full list of differences between
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
+v3.0.1 29 Apr 2025
+  * [jwe] Fixed a long standing that occurred when a pair of specific content encryption
+    algorithm and a specific wrong key was used.
+
+    This problem only manifested itself when alg=A256CBC_HS512 was specified and
+    the key was erronously constructed with a 32-byte content encryption key (CEK)
+    in DIRECT mode.
+
+    In this case, the user would be passing a mis-constructed key of 32-bytes instead
+    of the intended 64-bytes. In all other cases, this construction would cause
+    an error because `crypto/aes.NewCipher` would return an error when a key with length
+    not matching 16, 24, and 32 bytes is used. However, due to use using a the provided
+    32-bytes as half CEK and half the hash, the `crypto/aes.NewCipher` was passed
+    a 16-byte key, which is fine for AES-128. So internally `crypto/aes.NewCipher` would
+    choose to use AES-128 instead of AES-256, and happily continue. Note that no other
+    key lengths such as 48 and 128 would have worked. It had to be exactly 32.
+
+    This does indeed result in a downgraded encryption, but we believe it is unlikely that this would cause a problem in the real world,
+    as you would have to very specifically choose to use DIRECT mode, choose
+    the specific content encryption algorithm, AND also use the wrong key size of
+    exactly 32 bytes.
+
+    However, in abandunce of caution, we recommend that you upgrade to v3.0.1 or later,
+    or v2.1.6 or later if you are still on v2 series.
+
 v3.0.0 1 Apr 2025
   * Release initial v3.0.0 series. Code is identical to v3.0.0-beta2, except
     for minor documentation changes.

--- a/Changes
+++ b/Changes
@@ -5,12 +5,15 @@ v3 has many incompatibilities with v2. To see the full list of differences betwe
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
 v3.0.1 29 Apr 2025
-  * [jwe] Fixed a long standing bug that occurred when a pair of specific content encryption
-    algorithm and a specific wrong key was used.
+  * [jwe] Fixed a long standing bug that could lead to degraded encryption or failure to
+    decrypt JWE messages when a very specific combination of inputs were used for
+    JWE operations.
 
-    This problem only manifested itself when alg=A256CBC_HS512 was specified and
-    the key was erronously constructed with a 32-byte content encryption key (CEK)
-    in DIRECT mode.
+    This problem only manifested itself when the following conditions in content encryption or decryption
+    were met:
+      - Content encryption was specified to use DIRECT mode.
+      - Algorithm is specified as A256CBC_HS512
+      - The key was erronously constructed with a 32-byte content encryption key (CEK)
 
     In this case, the user would be passing a mis-constructed key of 32-bytes instead
     of the intended 64-bytes. In all other cases, this construction would cause

--- a/Changes
+++ b/Changes
@@ -12,7 +12,7 @@ v3.0.1 29 Apr 2025
     This problem only manifested itself when the following conditions in content encryption or decryption
     were met:
       - Content encryption was specified to use DIRECT mode.
-      - Algorithm is specified as A256CBC_HS512
+      - Contentn encryption algorithm is specified as A256CBC_HS512
       - The key was erronously constructed with a 32-byte content encryption key (CEK)
 
     In this case, the user would be passing a mis-constructed key of 32-bytes instead

--- a/Changes
+++ b/Changes
@@ -5,7 +5,7 @@ v3 has many incompatibilities with v2. To see the full list of differences betwe
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
 v3.0.1 29 Apr 2025
-  * [jwe] Fixed a long standing that occurred when a pair of specific content encryption
+  * [jwe] Fixed a long standing bug that occurred when a pair of specific content encryption
     algorithm and a specific wrong key was used.
 
     This problem only manifested itself when alg=A256CBC_HS512 was specified and

--- a/jwe/internal/cipher/interface.go
+++ b/jwe/internal/cipher/interface.go
@@ -19,7 +19,7 @@ type ContentCipher interface {
 }
 
 type Fetcher interface {
-	Fetch([]byte) (cipher.AEAD, error)
+	Fetch([]byte, int) (cipher.AEAD, error)
 }
 
 type gcmFetcher struct{}

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -457,7 +457,7 @@ func TestEncode_Direct(t *testing.T) {
 		// code was doing `actual_keysize/2` and passing 16 bytes out of the total
 		// 32 bytes, resulting in the aes.NewCipher function using AES-128 instead of AES-256.
 		//
-		// It wouldn't have worked for for A192CBC_HS384, because if you
+		// It wouldn't have worked for A192CBC_HS384, because if you
 		// provided 24 bytes instead of 48, the key size would be 12, and
 		// aes.NewCipher would barf.
 		{

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -421,32 +421,73 @@ func Test_GHIssue207(t *testing.T) {
 
 // tests direct key encryption by encrypting-decrypting a plaintext
 func TestEncode_Direct(t *testing.T) {
-	var testcases = []struct {
+	testcases := []*struct {
 		Algorithm jwa.ContentEncryptionAlgorithm
 		KeySize   int // in bytes
+		Error     bool
 	}{
-		{jwa.A128CBC_HS256(), 32},
-		{jwa.A128GCM(), 16},
-		{jwa.A192CBC_HS384(), 48},
-		{jwa.A192GCM(), 24},
-		{jwa.A256CBC_HS512(), 64},
-		{jwa.A256GCM(), 32},
+		{
+			Algorithm: jwa.A128CBC_HS256(),
+			KeySize:   32,
+		},
+		{
+			Algorithm: jwa.A128GCM(),
+			KeySize:   16,
+		},
+		{
+			Algorithm: jwa.A192CBC_HS384(),
+			KeySize:   48,
+		},
+		{
+			Algorithm: jwa.A192GCM(),
+			KeySize:   24,
+		},
+		{
+			Algorithm: jwa.A256CBC_HS512(),
+			KeySize:   64,
+		},
+		{
+			Algorithm: jwa.A256GCM(),
+			KeySize:   32,
+		},
+		// Test with wrong alg <-> key size combinations.
+
+		// Test for gh-1366
+		// Prior to v3.0.1, this did not error. It only passed because the original
+		// code was doing `actual_keysize/2` and passing 16 bytes out of the total
+		// 32 bytes, resulting in the aes.NewCipher function using AES-128 instead of AES-256.
+		//
+		// It wouldn't have worked for for A192CBC_HS384, because if you
+		// provided 24 bytes instead of 48, the key size would be 12, and
+		// aes.NewCipher would barf.
+		{
+			Algorithm: jwa.A256CBC_HS512(),
+			KeySize:   32,
+			Error:     true,
+		},
+		// Sanity for HS384. This never went through, but just in case
+		{
+			Algorithm: jwa.A192CBC_HS384(),
+			KeySize:   24,
+			Error:     true,
+		},
 	}
 	plaintext := []byte("Lorem ipsum")
 
 	for _, tc := range testcases {
 		t.Run(tc.Algorithm.String(), func(t *testing.T) {
 			key := make([]byte, tc.KeySize)
-			/*
-				_, err := rand.Read(key)
-				require.NoError(t, err, "Key generation succeeds")
-			*/
 			for n := 0; n < len(key); {
 				w := copy(key[n:], []byte(`12345678`))
 				n += w
 			}
 
 			encrypted, err := jwe.Encrypt(plaintext, jwe.WithKey(jwa.DIRECT(), key), jwe.WithContentEncryption(tc.Algorithm))
+			if tc.Error {
+				require.Error(t, err, `jwe.Encrypt should fail`)
+				// we can't continue
+				return
+			}
 			require.NoError(t, err, `jwe.Encrypt should succeed`)
 			decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.DIRECT(), key))
 			require.NoError(t, err, `jwe.Decrypt should succeed`)


### PR DESCRIPTION
ONLY in the case where the content encryption is done in DIRECT mode, algorithm was A256CBC_HS512,  _and_ the key used for this operation errornously had key size = 32 (half of the expected 64), this operation went through by `aes.NewCipher` picking up to use AES-128 instead of AES-256.

fixes problem uncovered in #1366