### PR TITLE
Add `b64: false` header to detached example

### DIFF
--- a/examples/jws_sign_detached_payload_example_test.go
+++ b/examples/jws_sign_detached_payload_example_test.go
@@ -24,7 +24,7 @@ func Example_jws_sign_detached_payload() {
 	hdrs := jws.NewHeaders()
 	hdrs.Set("b64", false)
 	hdrs.Set("crit", []string{"b64"})
-	
+
 	serialized, err := jws.Sign(nil, jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)), jws.WithDetachedPayload([]byte(payload)))
 	if err != nil {
 		fmt.Printf("failed to sign payload: %s\n", err)
@@ -33,5 +33,5 @@ func Example_jws_sign_detached_payload() {
 
 	fmt.Printf("%s\n", serialized)
 	// OUTPUT:
-	// eyJhbGciOiJIUzI1NiJ9..H14oXKwyvAsl0IbBLjw9tLxNIoYisuIyb_oDV4-30Vk
+	// eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..lnRw_MSpQjARa5LWqPcu8Qls9p3wYGrC6tz4-nr0rkA
 }

--- a/examples/jws_sign_detached_payload_example_test.go
+++ b/examples/jws_sign_detached_payload_example_test.go
@@ -23,7 +23,7 @@ func Example_jws_sign_detached_payload() {
 	// a plaintext payload.
 	hdrs := jws.NewHeaders()
 	hdrs.Set("b64", false)
-	hdrs.Set("crit", "b64")
+	hdrs.Set("crit", []string{"b64"})
 	
 	serialized, err := jws.Sign(nil, jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)), jws.WithDetachedPayload([]byte(payload)))
 	if err != nil {

--- a/examples/jws_sign_detached_payload_example_test.go
+++ b/examples/jws_sign_detached_payload_example_test.go
@@ -17,7 +17,15 @@ func Example_jws_sign_detached_payload() {
 		return
 	}
 
-	serialized, err := jws.Sign(nil, jws.WithKey(jwa.HS256(), key), jws.WithDetachedPayload([]byte(payload)))
+	// If you plan to transmit your payload without base64-encoding (RFC 7797),
+	// it's best to set `b64: false` so libraries can act accordingly (e.g. the
+	// popular NodeJS `jose` library requires it set to false in order to verify
+	// a plaintext payload.
+	hdrs := jws.NewHeaders()
+	hdrs.Set("b64", false)
+	hdrs.Set("crit", "b64")
+	
+	serialized, err := jws.Sign(nil, jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)), jws.WithDetachedPayload([]byte(payload)))
 	if err != nil {
 		fmt.Printf("failed to sign payload: %s\n", err)
 		return

--- a/examples/jws_verify_detached_payload_example_test.go
+++ b/examples/jws_verify_detached_payload_example_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Example_jws_verify_detached_payload() {
-	serialized := `eyJhbGciOiJIUzI1NiJ9..H14oXKwyvAsl0IbBLjw9tLxNIoYisuIyb_oDV4-30Vk`
+	serialized := `eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..lnRw_MSpQjARa5LWqPcu8Qls9p3wYGrC6tz4-nr0rkA`
 	payload := `$.02`
 
 	key, err := jwk.Import([]byte(`abracadabra`))


### PR DESCRIPTION
When using JWS to sign a detached webhook payload I intend to transmit in the clear, I found the receiving service written in NodeJS (using the very popular `jose` library) assumed the payload was base64-encoded. It demanded the `b64: false` header be sent in order to treat it as plaintext.

While RFC 7797 states this header is OPTIONAL, in order to maximize compatibility with other software and libraries, this example should endeavour to use it. I'm going on the assumption that detached payloads are not likely manually base64-encoded