### PR TITLE
Implement generic AsMap

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,7 +5,7 @@ v3 has many incompatibilities with v2. To see the full list of differences betwe
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
 v3.0.2 UNRELEASED
-  * [transofmr] (EXPERIMENTAL) Add utility function `transform.AsMap` to convert a
+  * [transform] (EXPERIMENTAL) Add utility function `transform.AsMap` to convert a
     Mappable object to a map[string]interface{}. This is useful for converting
     objects such as `jws.Header`, `jwk.Key`, `jwt.Token`, etc. to a map that can
     be used with other libraries that expect a map.

--- a/Changes
+++ b/Changes
@@ -5,6 +5,10 @@ v3 has many incompatibilities with v2. To see the full list of differences betwe
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
 v3.0.2 UNRELEASED
+  * [transofmr] (EXPERIMENTAL) Add utility function `transform.AsMap` to convert a
+    Mappable object to a map[string]interface{}. This is useful for converting
+    objects such as `jws.Header`, `jwk.Key`, `jwt.Token`, etc. to a map that can
+    be used with other libraries that expect a map.
   * [jwt] (EXPERIMENTAL) Added token filtering functionality through the TokenFilter interface. 
   * [jwt/openid] (EXPERIMENTAL) Added StandardClaimsFilter() for filtering standard OpenID claims.
   * [jws] (EXPERIMENTAL) Added header filtering functionality through the HeaderFilter interface.

--- a/map.go
+++ b/map.go
@@ -1,0 +1,33 @@
+package jwx
+
+import "fmt"
+
+// Mappable is an interface that defines methods required when converting
+// a jwx structure into a map[string]interface{}.
+//
+// This feature is experimental and may change or be removed in the future.
+type Mappable interface {
+	Get(key string, dst interface{}) error
+	Keys() []string
+}
+
+// AsMap takes the specified Mappable object and populates the map
+// `dst` with the key-value pairs from the Mappable object.
+// If `dst` is nil, it will be initialized to a new map.
+//
+// This feature is experimental and may change or be removed in the future.
+func AsMap(m Mappable, dst map[string]interface{}) error {
+	if dst == nil {
+		dst = make(map[string]interface{})
+	}
+
+	for _, k := range m.Keys() {
+		var val interface{}
+		if err := m.Get(k, &val); err != nil {
+			return fmt.Errorf(`jwx.AsMap: failed to get key %q: %w`, k, err)
+		}
+		dst[k] = val
+	}
+
+	return nil
+}

--- a/transform/BUILD.bazel
+++ b/transform/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "transform",
@@ -8,6 +8,21 @@ go_library(
     ],
     importpath = "github.com/lestrrat-go/jwx/v3/transform",
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_lestrrat_go_blackmagic//:blackmagic",
+    ],
+)
+
+go_test(
+    name = "transform_test",
+    srcs = [
+        "map_test.go",
+    ],
+    deps = [
+        ":transform",
+        "//jwt",
+        "@com_github_stretchr_testify//require",
+    ],
 )
 
 alias(

--- a/transform/BUILD.bazel
+++ b/transform/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "transform",
-    srcs = ["filter.go"],
+    srcs = [
+        "filter.go",
+        "map.go",
+    ],
     importpath = "github.com/lestrrat-go/jwx/v3/transform",
     visibility = ["//visibility:public"],
 )

--- a/transform/map.go
+++ b/transform/map.go
@@ -1,6 +1,11 @@
 package transform
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/lestrrat-go/blackmagic"
+)
 
 // Mappable is an interface that defines methods required when converting
 // a jwx structure into a map[string]interface{}.
@@ -25,7 +30,10 @@ func AsMap(m Mappable, dst map[string]interface{}) error {
 	for _, k := range m.Keys() {
 		var val interface{}
 		if err := m.Get(k, &val); err != nil {
-			return fmt.Errorf(`jwx.AsMap: failed to get key %q: %w`, k, err)
+			// Allow invalid value errors. Assume they are just nil values.
+			if !errors.Is(err, blackmagic.InvalidValueError()) {
+				return fmt.Errorf(`jwx.AsMap: failed to get key %q: %w`, k, err)
+			}
 		}
 		dst[k] = val
 	}

--- a/transform/map.go
+++ b/transform/map.go
@@ -28,7 +28,7 @@ type Mappable interface {
 // compatibility guarantees.
 func AsMap(m Mappable, dst map[string]interface{}) error {
 	if dst == nil {
-		return fmt.Errorf("jwx.AsMap: destination map cannot be nil")
+		return fmt.Errorf("transform.AsMap: destination map cannot be nil")
 	}
 
 	for _, k := range m.Keys() {
@@ -36,7 +36,7 @@ func AsMap(m Mappable, dst map[string]interface{}) error {
 		if err := m.Get(k, &val); err != nil {
 			// Allow invalid value errors. Assume they are just nil values.
 			if !errors.Is(err, blackmagic.InvalidValueError()) {
-				return fmt.Errorf(`jwx.AsMap: failed to get key %q: %w`, k, err)
+				return fmt.Errorf(`transform.AsMap: failed to get key %q: %w`, k, err)
 			}
 		}
 		dst[k] = val

--- a/transform/map.go
+++ b/transform/map.go
@@ -1,4 +1,4 @@
-package jwx
+package transform
 
 import "fmt"
 
@@ -13,12 +13,13 @@ type Mappable interface {
 
 // AsMap takes the specified Mappable object and populates the map
 // `dst` with the key-value pairs from the Mappable object.
-// If `dst` is nil, it will be initialized to a new map.
+// Many objects in jwe, jwk, jws, and jwt packages including
+// `jwt.Token`, `jwk.Key`, `jws.Header`, etc.
 //
 // This feature is experimental and may change or be removed in the future.
 func AsMap(m Mappable, dst map[string]interface{}) error {
 	if dst == nil {
-		dst = make(map[string]interface{})
+		return fmt.Errorf("jwx.AsMap: destination map cannot be nil")
 	}
 
 	for _, k := range m.Keys() {

--- a/transform/map.go
+++ b/transform/map.go
@@ -10,7 +10,9 @@ import (
 // Mappable is an interface that defines methods required when converting
 // a jwx structure into a map[string]interface{}.
 //
-// This feature is experimental and may change or be removed in the future.
+// EXPERIMENTAL: This API is experimental and its interface and behavior is
+// subject to change in future releases. This API is not subject to semver
+// compatibility guarantees.
 type Mappable interface {
 	Get(key string, dst interface{}) error
 	Keys() []string
@@ -21,7 +23,9 @@ type Mappable interface {
 // Many objects in jwe, jwk, jws, and jwt packages including
 // `jwt.Token`, `jwk.Key`, `jws.Header`, etc.
 //
-// This feature is experimental and may change or be removed in the future.
+// EXPERIMENTAL: This API is experimental and its interface and behavior is
+// subject to change in future releases. This API is not subject to semver
+// compatibility guarantees.
 func AsMap(m Mappable, dst map[string]interface{}) error {
 	if dst == nil {
 		return fmt.Errorf("jwx.AsMap: destination map cannot be nil")

--- a/transform/map_test.go
+++ b/transform/map_test.go
@@ -1,0 +1,179 @@
+package transform_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v3/jwt"
+	"github.com/lestrrat-go/jwx/v3/transform"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsMapWithJWTToken(t *testing.T) {
+	t.Run("Basic JWT Token with standard claims", func(t *testing.T) {
+		// Create a JWT token with standard claims
+		token := jwt.New()
+		expectedTime := time.Unix(1234567890, 0).UTC()
+
+		require.NoError(t, token.Set(jwt.IssuerKey, "https://example.com"))
+		require.NoError(t, token.Set(jwt.SubjectKey, "user123"))
+		require.NoError(t, token.Set(jwt.AudienceKey, []string{"api", "web"}))
+		require.NoError(t, token.Set(jwt.IssuedAtKey, expectedTime))
+		require.NoError(t, token.Set(jwt.ExpirationKey, expectedTime.Add(time.Hour)))
+		require.NoError(t, token.Set(jwt.NotBeforeKey, expectedTime))
+		require.NoError(t, token.Set(jwt.JwtIDKey, "jwt-id-123"))
+
+		dst := make(map[string]interface{})
+		err := transform.AsMap(token, dst)
+		require.NoError(t, err, "AsMap should succeed")
+
+		// Verify all standard claims are present
+		require.Equal(t, "https://example.com", dst[jwt.IssuerKey])
+		require.Equal(t, "user123", dst[jwt.SubjectKey])
+		require.Equal(t, []string{"api", "web"}, dst[jwt.AudienceKey])
+		require.Equal(t, expectedTime, dst[jwt.IssuedAtKey])
+		require.Equal(t, expectedTime.Add(time.Hour), dst[jwt.ExpirationKey])
+		require.Equal(t, expectedTime, dst[jwt.NotBeforeKey])
+		require.Equal(t, "jwt-id-123", dst[jwt.JwtIDKey])
+	})
+
+	t.Run("JWT Token with private claims", func(t *testing.T) {
+		token := jwt.New()
+
+		// Set standard claims
+		require.NoError(t, token.Set(jwt.IssuerKey, "test-issuer"))
+		require.NoError(t, token.Set(jwt.SubjectKey, "test-subject"))
+
+		// Set private claims
+		require.NoError(t, token.Set("custom_claim", "custom_value"))
+		require.NoError(t, token.Set("user_role", "admin"))
+		require.NoError(t, token.Set("permissions", []string{"read", "write", "delete"}))
+		require.NoError(t, token.Set("metadata", map[string]interface{}{
+			"version": "1.0",
+			"source":  "test",
+		}))
+
+		dst := make(map[string]interface{})
+		err := transform.AsMap(token, dst)
+		require.NoError(t, err, "AsMap should succeed")
+
+		// Verify standard claims
+		require.Equal(t, "test-issuer", dst[jwt.IssuerKey])
+		require.Equal(t, "test-subject", dst[jwt.SubjectKey])
+
+		// Verify private claims
+		require.Equal(t, "custom_value", dst["custom_claim"])
+		require.Equal(t, "admin", dst["user_role"])
+		require.Equal(t, []string{"read", "write", "delete"}, dst["permissions"])
+
+		metadata, ok := dst["metadata"].(map[string]interface{})
+		require.True(t, ok, "metadata should be a map")
+		require.Equal(t, "1.0", metadata["version"])
+		require.Equal(t, "test", metadata["source"])
+	})
+
+	t.Run("Empty JWT Token", func(t *testing.T) {
+		token := jwt.New()
+
+		dst := make(map[string]interface{})
+		err := transform.AsMap(token, dst)
+		require.NoError(t, err, "AsMap should succeed for empty token")
+
+		// Should have no keys since no claims were set
+		require.Len(t, dst, 0, "Empty token should result in empty map")
+	})
+
+	t.Run("JWT Token with single claim", func(t *testing.T) {
+		token := jwt.New()
+		require.NoError(t, token.Set(jwt.IssuerKey, "single-issuer"))
+
+		dst := make(map[string]interface{})
+		err := transform.AsMap(token, dst)
+		require.NoError(t, err, "AsMap should succeed")
+
+		require.Len(t, dst, 1, "Should have exactly one key")
+		require.Equal(t, "single-issuer", dst[jwt.IssuerKey])
+	})
+
+	t.Run("JWT Token with various data types", func(t *testing.T) {
+		token := jwt.New()
+
+		// Test different data types
+		require.NoError(t, token.Set("string_claim", "string value"))
+		require.NoError(t, token.Set("int_claim", 42))
+		require.NoError(t, token.Set("bool_claim", true))
+		require.NoError(t, token.Set("float_claim", 3.14))
+		require.NoError(t, token.Set("array_claim", []interface{}{"a", "b", "c"}))
+		require.NoError(t, token.Set("null_claim", nil))
+
+		dst := make(map[string]interface{})
+		err := transform.AsMap(token, dst)
+		require.NoError(t, err, "AsMap should succeed")
+
+		require.Equal(t, "string value", dst["string_claim"])
+		require.Equal(t, 42, dst["int_claim"])
+		require.Equal(t, true, dst["bool_claim"])
+		require.Equal(t, 3.14, dst["float_claim"])
+		require.Equal(t, []interface{}{"a", "b", "c"}, dst["array_claim"])
+		require.Nil(t, dst["null_claim"])
+	})
+
+	t.Run("Nil destination map should return error", func(t *testing.T) {
+		token := jwt.New()
+		require.NoError(t, token.Set(jwt.IssuerKey, "test"))
+
+		err := transform.AsMap(token, nil)
+		require.Error(t, err, "AsMap should fail with nil destination")
+		require.Contains(t, err.Error(), "destination map cannot be nil")
+	})
+
+	t.Run("Pre-populated destination map should be extended", func(t *testing.T) {
+		token := jwt.New()
+		require.NoError(t, token.Set(jwt.IssuerKey, "token-issuer"))
+		require.NoError(t, token.Set("custom_claim", "token-value"))
+
+		// Pre-populate destination map
+		dst := map[string]interface{}{
+			"existing_key": "existing_value",
+			"another_key":  123,
+		}
+
+		err := transform.AsMap(token, dst)
+		require.NoError(t, err, "AsMap should succeed")
+
+		// Original keys should still be present
+		require.Equal(t, "existing_value", dst["existing_key"])
+		require.Equal(t, 123, dst["another_key"])
+
+		// New keys from token should be added
+		require.Equal(t, "token-issuer", dst[jwt.IssuerKey])
+		require.Equal(t, "token-value", dst["custom_claim"])
+
+		require.Len(t, dst, 4, "Should have 4 total keys")
+	})
+
+	t.Run("Overlapping keys should be overwritten", func(t *testing.T) {
+		token := jwt.New()
+		require.NoError(t, token.Set(jwt.IssuerKey, "token-issuer"))
+		require.NoError(t, token.Set("shared_key", "token-value"))
+
+		// Pre-populate with overlapping keys
+		dst := map[string]interface{}{
+			jwt.IssuerKey: "original-issuer",
+			"shared_key":  "original-value",
+			"unique_key":  "unique-value",
+		}
+
+		err := transform.AsMap(token, dst)
+		require.NoError(t, err, "AsMap should succeed")
+
+		// Overlapping keys should be overwritten with token values
+		require.Equal(t, "token-issuer", dst[jwt.IssuerKey])
+		require.Equal(t, "token-value", dst["shared_key"])
+
+		// Unique key should remain unchanged
+		require.Equal(t, "unique-value", dst["unique_key"])
+
+		require.Len(t, dst, 3, "Should have 3 total keys")
+	})
+}


### PR DESCRIPTION
fixes #1382

Adds ~jwx~`transform.AsMap`.

~As of 0f2ca066bc6df9ac97e9f88e852e1cbb0f701a63 the function resides in `jwx` package, but I'm not sure about the placement of this function at the top level package; I really would like to put it elsewhere where it's not as prevalent. So it should be considered a placeholder for now.~