### PR TITLE
[jwe] Work with non X25519 ECDH encryption

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,10 @@ Changes
 v3 has many incompatibilities with v2. To see the full list of differences between
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
+v3.0.11 UNRELEASED
+  * [jwe] Previously, ecdh.PrivateKey/ecdh.PublicKey were not properly handled
+    when used for encryption, which has been fixed.
+
 v3.0.10 04 Aug 2025
   * [jws/jwsbb] Add `jwsbb.ErrHeaderNotFound()` to return the same error type as when
     a non-existent header is requested. via `HeaderGetXXX()` functions. Previously, this

--- a/internal/keyconv/keyconv.go
+++ b/internal/keyconv/keyconv.go
@@ -336,7 +336,7 @@ func ECDHToECDSA(dst, src any) error {
 	// convert the public key
 	ecdsaPubKey, err := ecdhPublicKeyToECDSA(pubkey)
 	if err != nil {
-		return fmt.Errorf(`keyconv.ECDHToECDSA: failed to convert ECDH public key to ECDSA publick key: %w`, err)
+		return fmt.Errorf(`keyconv.ECDHToECDSA: failed to convert ECDH public key to ECDSA public key: %w`, err)
 	}
 
 	// return if we were being asked to convert *ecdh.PublicKey

--- a/internal/keyconv/keyconv.go
+++ b/internal/keyconv/keyconv.go
@@ -263,3 +263,8 @@ func ECDHPublicKey(dst, src any) error {
 
 	return blackmagic.AssignIfCompatible(dst, pubECDH)
 }
+
+func ECDHToECDSA(dst, src any) error {
+	// convert ecdh.PublicKey to ecdsa.PublicKey, ecdh.PrivateKey to ecdsa.PrivateKey
+
+}

--- a/internal/keyconv/keyconv.go
+++ b/internal/keyconv/keyconv.go
@@ -5,8 +5,10 @@ import (
 	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rsa"
 	"fmt"
+	"math/big"
 
 	"github.com/lestrrat-go/blackmagic"
 	"github.com/lestrrat-go/jwx/v3/jwk"
@@ -264,7 +266,89 @@ func ECDHPublicKey(dst, src any) error {
 	return blackmagic.AssignIfCompatible(dst, pubECDH)
 }
 
+// ecdhCurveToElliptic maps ECDH curves to elliptic curves
+func ecdhCurveToElliptic(ecdhCurve ecdh.Curve) (elliptic.Curve, error) {
+	switch ecdhCurve {
+	case ecdh.P256():
+		return elliptic.P256(), nil
+	case ecdh.P384():
+		return elliptic.P384(), nil
+	case ecdh.P521():
+		return elliptic.P521(), nil
+	default:
+		return nil, fmt.Errorf(`keyconv: unsupported ECDH curve: %v`, ecdhCurve)
+	}
+}
+
+// ecdhPublicKeyToECDSA converts an ECDH public key to an ECDSA public key
+func ecdhPublicKeyToECDSA(ecdhPubKey *ecdh.PublicKey) (*ecdsa.PublicKey, error) {
+	curve, err := ecdhCurveToElliptic(ecdhPubKey.Curve())
+	if err != nil {
+		return nil, err
+	}
+
+	pubBytes := ecdhPubKey.Bytes()
+
+	// Parse the uncompressed point format (0x04 prefix + X + Y coordinates)
+	if len(pubBytes) == 0 || pubBytes[0] != 0x04 {
+		return nil, fmt.Errorf(`keyconv: invalid ECDH public key format`)
+	}
+
+	keyLen := (len(pubBytes) - 1) / 2
+	if len(pubBytes) != 1+2*keyLen {
+		return nil, fmt.Errorf(`keyconv: invalid ECDH public key length`)
+	}
+
+	x := new(big.Int).SetBytes(pubBytes[1 : 1+keyLen])
+	y := new(big.Int).SetBytes(pubBytes[1+keyLen:])
+
+	return &ecdsa.PublicKey{
+		Curve: curve,
+		X:     x,
+		Y:     y,
+	}, nil
+}
+
 func ECDHToECDSA(dst, src any) error {
 	// convert ecdh.PublicKey to ecdsa.PublicKey, ecdh.PrivateKey to ecdsa.PrivateKey
 
+	// First, handle value types by converting to pointers
+	switch s := src.(type) {
+	case ecdh.PrivateKey:
+		src = &s
+	case ecdh.PublicKey:
+		src = &s
+	}
+
+	var privBytes []byte
+	var pubkey *ecdh.PublicKey
+	// Now handle the actual conversion with pointer types
+	switch src := src.(type) {
+	case *ecdh.PrivateKey:
+		pubkey = src.PublicKey()
+		privBytes = src.Bytes()
+	case *ecdh.PublicKey:
+		pubkey = src
+	default:
+		return fmt.Errorf(`keyconv: expected ecdh.PrivateKey, *ecdh.PrivateKey, ecdh.PublicKey, or *ecdh.PublicKey, got %T`, src)
+	}
+
+	// convert the public key
+	ecdsaPubKey, err := ecdhPublicKeyToECDSA(pubkey)
+	if err != nil {
+		return fmt.Errorf(`keyconv.ECDHToECDSA: failed to convert ECDH public key to ECDSA publick key: %w`, err)
+	}
+
+	// return if we were being asked to convert *ecdh.PublicKey
+	if privBytes == nil {
+		return blackmagic.AssignIfCompatible(dst, ecdsaPubKey)
+	}
+
+	// Then create the private key with the public key embedded
+	ecdsaPrivKey := &ecdsa.PrivateKey{
+		D:         new(big.Int).SetBytes(privBytes),
+		PublicKey: *ecdsaPubKey,
+	}
+
+	return blackmagic.AssignIfCompatible(dst, ecdsaPrivKey)
 }

--- a/internal/keyconv/keyconv_test.go
+++ b/internal/keyconv/keyconv_test.go
@@ -238,7 +238,6 @@ func TestECDHToECDSA(t *testing.T) {
 					error bool
 				}{
 					{"*ecdh.PrivateKey", ecdhPrivKey, false},
-					{"ecdh.PrivateKey", *ecdhPrivKey, false},
 					{"invalid type", "not a key", true},
 				}
 

--- a/internal/keyconv/keyconv_test.go
+++ b/internal/keyconv/keyconv_test.go
@@ -1,7 +1,9 @@
 package keyconv_test
 
 import (
+	"crypto/ecdh"
 	"crypto/ecdsa"
+	"crypto/rand"
 	"crypto/rsa"
 	"testing"
 
@@ -203,5 +205,129 @@ func TestKeyconv(t *testing.T) {
 				})
 			}
 		})
+	})
+}
+
+func TestECDHToECDSA(t *testing.T) {
+	curves := []struct {
+		name      string
+		ecdhCurve ecdh.Curve
+		jwaAlg    jwa.EllipticCurveAlgorithm
+	}{
+		{"P256", ecdh.P256(), jwa.P256()},
+		{"P384", ecdh.P384(), jwa.P384()},
+		{"P521", ecdh.P521(), jwa.P521()},
+	}
+
+	for _, curve := range curves {
+		t.Run(curve.name, func(t *testing.T) {
+			// Generate an ECDSA key for comparison
+			ecdsaKey, err := jwxtest.GenerateEcdsaKey(curve.jwaAlg)
+			require.NoError(t, err, `ecdsa.GenerateKey should succeed`)
+
+			// Convert ECDSA key to ECDH key
+			ecdhPrivKey, err := ecdsaKey.ECDH()
+			require.NoError(t, err, `ECDSA to ECDH conversion should succeed`)
+
+			ecdhPubKey := ecdhPrivKey.PublicKey()
+
+			t.Run("PrivateKey", func(t *testing.T) {
+				testcases := []struct {
+					name  string
+					src   any
+					error bool
+				}{
+					{"*ecdh.PrivateKey", ecdhPrivKey, false},
+					{"ecdh.PrivateKey", *ecdhPrivKey, false},
+					{"invalid type", "not a key", true},
+				}
+
+				for _, tc := range testcases {
+					t.Run(tc.name, func(t *testing.T) {
+						var dst *ecdsa.PrivateKey
+						err := keyconv.ECDHToECDSA(&dst, tc.src)
+
+						if tc.error {
+							require.Error(t, err, `ECDHToECDSA should fail for invalid input`)
+						} else {
+							require.NoError(t, err, `ECDHToECDSA should succeed`)
+							require.NotNil(t, dst, `destination should not be nil`)
+
+							// Verify the converted key has the same curve
+							require.Equal(t, ecdsaKey.Curve, dst.Curve, `curves should match`)
+
+							// Verify the private key values match
+							require.Equal(t, ecdsaKey.D, dst.D, `private key values should match`)
+
+							// Verify the public key coordinates match
+							require.Equal(t, ecdsaKey.PublicKey.X, dst.PublicKey.X, `X coordinates should match`)
+							require.Equal(t, ecdsaKey.PublicKey.Y, dst.PublicKey.Y, `Y coordinates should match`)
+						}
+					})
+				}
+			})
+
+			t.Run("PublicKey", func(t *testing.T) {
+				testcases := []struct {
+					name  string
+					src   any
+					error bool
+				}{
+					{"*ecdh.PublicKey", ecdhPubKey, false},
+					{"ecdh.PublicKey", *ecdhPubKey, false},
+					{"invalid type", "not a key", true},
+				}
+
+				for _, tc := range testcases {
+					t.Run(tc.name, func(t *testing.T) {
+						var dst *ecdsa.PublicKey
+						err := keyconv.ECDHToECDSA(&dst, tc.src)
+
+						if tc.error {
+							require.Error(t, err, `ECDHToECDSA should fail for invalid input`)
+						} else {
+							require.NoError(t, err, `ECDHToECDSA should succeed`)
+							require.NotNil(t, dst, `destination should not be nil`)
+
+							// Verify the converted key has the same curve
+							require.Equal(t, ecdsaKey.PublicKey.Curve, dst.Curve, `curves should match`)
+
+							// Verify the public key coordinates match
+							require.Equal(t, ecdsaKey.PublicKey.X, dst.X, `X coordinates should match`)
+							require.Equal(t, ecdsaKey.PublicKey.Y, dst.Y, `Y coordinates should match`)
+						}
+					})
+				}
+			})
+
+			t.Run("RoundTrip", func(t *testing.T) {
+				// Test that ECDSA -> ECDH -> ECDSA produces the same key
+				var convertedPrivKey *ecdsa.PrivateKey
+				err := keyconv.ECDHToECDSA(&convertedPrivKey, ecdhPrivKey)
+				require.NoError(t, err, `ECDHToECDSA should succeed`)
+
+				var convertedPubKey *ecdsa.PublicKey
+				err = keyconv.ECDHToECDSA(&convertedPubKey, ecdhPubKey)
+				require.NoError(t, err, `ECDHToECDSA should succeed`)
+
+				// Verify the keys are equivalent
+				require.Equal(t, ecdsaKey.D, convertedPrivKey.D, `private key values should match`)
+				require.Equal(t, ecdsaKey.PublicKey.X, convertedPrivKey.PublicKey.X, `private key X coordinates should match`)
+				require.Equal(t, ecdsaKey.PublicKey.Y, convertedPrivKey.PublicKey.Y, `private key Y coordinates should match`)
+				require.Equal(t, ecdsaKey.PublicKey.X, convertedPubKey.X, `public key X coordinates should match`)
+				require.Equal(t, ecdsaKey.PublicKey.Y, convertedPubKey.Y, `public key Y coordinates should match`)
+			})
+		})
+	}
+
+	t.Run("UnsupportedCurve", func(t *testing.T) {
+		// Create a mock ECDH key with X25519 curve (not supported for ECDSA)
+		x25519Key, err := ecdh.X25519().GenerateKey(rand.Reader)
+		require.NoError(t, err, `X25519 key generation should succeed`)
+
+		var dst *ecdsa.PrivateKey
+		err = keyconv.ECDHToECDSA(&dst, x25519Key)
+		require.Error(t, err, `ECDHToECDSA should fail for unsupported curve`)
+		require.Contains(t, err.Error(), "unsupported ECDH curve", `error should mention unsupported curve`)
 	})
 }

--- a/jwe/encrypt.go
+++ b/jwe/encrypt.go
@@ -129,11 +129,10 @@ func (e *encrypter) EncryptKey(cek []byte) (keygen.ByteSource, error) {
 			if err := keyconv.ECDHToECDSA(&ecdsaKey, key); err != nil {
 				return nil, fmt.Errorf(`encrypt: failed to convert ECDH public key to ECDSA: %w`, err)
 			}
+			keyToUse = ecdsaKey
+		}
 
-			if !keywrap {
-				return jwebb.KeyEncryptECDHESECDSA(cek, e.keyalg.String(), e.apu, e.apv, ecdsaKey, keysize, e.ctalg.String())
-			}
-			return jwebb.KeyEncryptECDHESKeyWrapECDSA(cek, e.keyalg.String(), e.apu, e.apv, ecdsaKey, keysize, e.ctalg.String())
+		switch key := keyToUse.(type) {
 		case *ecdsa.PublicKey:
 			if !keywrap {
 				return jwebb.KeyEncryptECDHESECDSA(cek, e.keyalg.String(), e.apu, e.apv, key, keysize, e.ctalg.String())

--- a/jwe/encrypt.go
+++ b/jwe/encrypt.go
@@ -96,10 +96,23 @@ func (e *encrypter) EncryptKey(cek []byte) (keygen.ByteSource, error) {
 			keyToUse = e.pubkey
 		}
 
-		// Handle ecdsa.PublicKey by value - convert to pointer
-		if pk, ok := keyToUse.(ecdsa.PublicKey); ok {
-			keyToUse = &pk
+		switch key := keyToUse.(type) {
+		case *ecdsa.PublicKey, *ecdh.PublicKey:
+			// no op
+		case ecdsa.PublicKey:
+			keyToUse = &key
+		case ecdh.PublicKey:
+			keyToUse = &key
+		case *ecdsa.PrivateKey:
+			keyToUse = &key.PublicKey
+		case ecdsa.PrivateKey:
+			keyToUse = &key.PublicKey
+		case ecdh.PrivateKey:
+			keyToUse = key.PublicKey()
+		case *ecdh.PrivateKey:
+			keyToUse = key.PublicKey()
 		}
+		fmt.Printf("keyToUse: %T\n", keyToUse)
 
 		// Determine key type and call appropriate function
 		switch key := keyToUse.(type) {

--- a/jwe/encrypt.go
+++ b/jwe/encrypt.go
@@ -97,35 +97,48 @@ func (e *encrypter) EncryptKey(cek []byte) (keygen.ByteSource, error) {
 		}
 
 		switch key := keyToUse.(type) {
-		case *ecdsa.PublicKey, *ecdh.PublicKey:
+		case *ecdsa.PublicKey:
 			// no op
 		case ecdsa.PublicKey:
-			keyToUse = &key
-		case ecdh.PublicKey:
 			keyToUse = &key
 		case *ecdsa.PrivateKey:
 			keyToUse = &key.PublicKey
 		case ecdsa.PrivateKey:
 			keyToUse = &key.PublicKey
+		case *ecdh.PublicKey:
+			// no op
+		case ecdh.PublicKey:
+			keyToUse = &key
 		case ecdh.PrivateKey:
 			keyToUse = key.PublicKey()
 		case *ecdh.PrivateKey:
 			keyToUse = key.PublicKey()
 		}
-		fmt.Printf("keyToUse: %T\n", keyToUse)
 
 		// Determine key type and call appropriate function
 		switch key := keyToUse.(type) {
+		case *ecdh.PublicKey:
+			if key.Curve() == ecdh.X25519() {
+				if !keywrap {
+					return jwebb.KeyEncryptECDHESX25519(cek, e.keyalg.String(), e.apu, e.apv, key, keysize, e.ctalg.String())
+				}
+				return jwebb.KeyEncryptECDHESKeyWrapX25519(cek, e.keyalg.String(), e.apu, e.apv, key, keysize, e.ctalg.String())
+			}
+
+			var ecdsaKey *ecdsa.PublicKey
+			if err := keyconv.ECDHToECDSA(&ecdsaKey, key); err != nil {
+				return nil, fmt.Errorf(`encrypt: failed to convert ECDH public key to ECDSA: %w`, err)
+			}
+
+			if !keywrap {
+				return jwebb.KeyEncryptECDHESECDSA(cek, e.keyalg.String(), e.apu, e.apv, ecdsaKey, keysize, e.ctalg.String())
+			}
+			return jwebb.KeyEncryptECDHESKeyWrapECDSA(cek, e.keyalg.String(), e.apu, e.apv, ecdsaKey, keysize, e.ctalg.String())
 		case *ecdsa.PublicKey:
 			if !keywrap {
 				return jwebb.KeyEncryptECDHESECDSA(cek, e.keyalg.String(), e.apu, e.apv, key, keysize, e.ctalg.String())
 			}
 			return jwebb.KeyEncryptECDHESKeyWrapECDSA(cek, e.keyalg.String(), e.apu, e.apv, key, keysize, e.ctalg.String())
-		case *ecdh.PublicKey:
-			if !keywrap {
-				return jwebb.KeyEncryptECDHESX25519(cek, e.keyalg.String(), e.apu, e.apv, key, keysize, e.ctalg.String())
-			}
-			return jwebb.KeyEncryptECDHESKeyWrapX25519(cek, e.keyalg.String(), e.apu, e.apv, key, keysize, e.ctalg.String())
 		default:
 			return nil, fmt.Errorf(`encrypt: unsupported key type for ECDH-ES: %T`, keyToUse)
 		}

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1008,3 +1008,18 @@ func BenchmarkParseCompat(b *testing.B) {
 		}
 	}
 }
+
+func TestGH1434(t *testing.T) {
+	// Test if we can use ecdh.PrivateKey to encrypt and decrypt
+
+	key, err := ecdh.P256().GenerateKey(rand.Reader)
+	require.NoError(t, err, `ecdh.P256().GenerateKey should succeed`)
+
+	const payload = `hello, world!`
+	encrypted, err := jwe.Encrypt([]byte(payload), jwe.WithKey(jwa.ECDH_ES_A256KW(), key))
+	require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+	decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.ECDH_ES_A256KW(), key))
+	require.NoError(t, err, `jwe.Decrypt should succeed`)
+	require.Equal(t, []byte(payload), decrypted, `decrypted payload should match original payload`)
+}

--- a/jwx_test.go
+++ b/jwx_test.go
@@ -1,8 +1,11 @@
 package jwx_test
 
 import (
+	"bytes"
 	"context"
+	"crypto/ecdh"
 	"crypto/ecdsa"
+	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
 	"strings"
@@ -558,4 +561,109 @@ func TestGH1140(t *testing.T) {
 
 	_, err = jwe.Decrypt(encrypted, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
 	require.NoError(t, err, `jwe.Decrypt should succeed`)
+}
+
+func TestGH1434(t *testing.T) {
+	if testing.Short() {
+		t.Logf("Skipped during short tests")
+		return
+	}
+
+	if !jose.Available() {
+		t.Logf("`jose` binary not available, skipping tests")
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Check if jose supports ECDH-ES algorithm
+	set, err := jose.Algorithms(ctx, t)
+	require.NoError(t, err)
+	if !set.Has("ECDH-ES") {
+		t.Logf("jose does not support ECDH-ES algorithm: skipping")
+		return
+	}
+
+	expected := []byte("Hello, World! This tests ECDH-ES interoperability.")
+	
+	// Test with different elliptic curves and their corresponding ECDH-ES+KW algorithms
+	curves := []struct {
+		name     string
+		crv      string
+		ecdhCurve ecdh.Curve
+		keyAlg   jwa.KeyEncryptionAlgorithm
+	}{
+		{"P256", "P-256", ecdh.P256(), jwa.ECDH_ES_A128KW()},
+		{"P384", "P-384", ecdh.P384(), jwa.ECDH_ES_A192KW()},
+		{"P521", "P-521", ecdh.P521(), jwa.ECDH_ES_A256KW()},
+	}
+
+	for _, curve := range curves {
+		t.Run(curve.name, func(t *testing.T) {
+			// Check if jose supports this key encryption algorithm
+			if !set.Has(curve.keyAlg.String()) {
+				t.Logf("jose does not support %s algorithm: skipping", curve.keyAlg.String())
+				return
+			}
+
+			// Generate an ECDH private key directly
+			ecdhPrivKey, err := curve.ecdhCurve.GenerateKey(rand.Reader)
+			require.NoError(t, err, `ECDH key generation should succeed`)
+
+			// Create a JWK from the ECDH private key
+			jwxJwk, err := jwk.Import(ecdhPrivKey)
+			require.NoError(t, err, `jwk.Import should succeed`)
+
+			// Write the JWK to a temporary file for jose to use
+			jwkBytes, err := json.Marshal(jwxJwk)
+			require.NoError(t, err, `jwk JSON marshaling should succeed`)
+			
+			joseJwkFile, joseJwkCleanup, err := jwxtest.WriteFile(t.TempDir(), "ecdh-key-*.jwk", bytes.NewReader(jwkBytes))
+			require.NoError(t, err, `writing JWK file should succeed`)
+			defer joseJwkCleanup()
+
+			t.Run("Parse ECDH JWK via jwx", func(t *testing.T) {
+				// Test exporting as ECDH key (should work directly)
+				var ecdhKey ecdh.PrivateKey
+				require.NoError(t, jwk.Export(jwxJwk, &ecdhKey), `jwk.Export to ECDH should succeed`)
+				
+				// Test exporting as ECDSA key (should use ECDHToECDSA conversion)
+				var ecdsaKey ecdsa.PrivateKey
+				require.NoError(t, jwk.Export(jwxJwk, &ecdsaKey), `jwk.Export to ECDSA should succeed via ECDHToECDSA conversion`)
+			})
+
+			t.Run("Encrypt with jose using ECDH key, Decrypt with jwx", func(t *testing.T) {
+				// let jose encrypt payload using ECDH-ES with key wrapping
+				joseCryptFile, joseCryptCleanup, err := jose.EncryptJwe(ctx, t, expected, curve.keyAlg.String(), joseJwkFile, jwa.A256GCM().String(), true)
+				require.NoError(t, err, `jose.EncryptJwe should succeed`)
+				defer joseCryptCleanup()
+
+				jwxtest.DumpFile(t, joseCryptFile)
+
+				// let jwx decrypt using the ECDH key (which internally should convert to ECDSA if needed)
+				encryptedData, err := jwxtest.ReadFile(joseCryptFile)
+				require.NoError(t, err, `reading encrypted file should succeed`)
+				
+				payload, err := jwe.Decrypt(encryptedData, jwe.WithKey(curve.keyAlg, ecdhPrivKey))
+				require.NoError(t, err, `jwe.Decrypt with ECDH key should succeed`)
+				require.Equal(t, expected, payload, `decrypted payloads should match`)
+			})
+
+			t.Run("Encrypt with jwx using ECDH key, Decrypt with jose", func(t *testing.T) {
+				// Encrypt using jwx with the ECDH key directly
+				encrypted, err := jwe.Encrypt(expected, jwe.WithKey(curve.keyAlg, ecdhPrivKey.PublicKey()), jwe.WithContentEncryption(jwa.A256GCM()))
+				require.NoError(t, err, `jwe.Encrypt with ECDH key should succeed`)
+
+				// Write encrypted data to file for jose
+				jwxCryptFile, jwxCryptCleanup, err := jwxtest.WriteFile(t.TempDir(), "jwx-encrypted-*.jwe", bytes.NewReader(encrypted))
+				require.NoError(t, err, `writing encrypted file should succeed`)
+				defer jwxCryptCleanup()
+
+				payload, err := jose.DecryptJwe(ctx, t, jwxCryptFile, joseJwkFile)
+				require.NoError(t, err, `jose.DecryptJwe should succeed`)
+				require.Equal(t, expected, payload, `decrypted payloads should match`)
+			})
+		})
+	}
 }

--- a/jwx_test.go
+++ b/jwx_test.go
@@ -586,13 +586,13 @@ func TestGH1434(t *testing.T) {
 	}
 
 	expected := []byte("Hello, World! This tests ECDH-ES interoperability.")
-	
+
 	// Test with different elliptic curves and their corresponding ECDH-ES+KW algorithms
 	curves := []struct {
-		name     string
-		crv      string
+		name      string
+		crv       string
 		ecdhCurve ecdh.Curve
-		keyAlg   jwa.KeyEncryptionAlgorithm
+		keyAlg    jwa.KeyEncryptionAlgorithm
 	}{
 		{"P256", "P-256", ecdh.P256(), jwa.ECDH_ES_A128KW()},
 		{"P384", "P-384", ecdh.P384(), jwa.ECDH_ES_A192KW()},
@@ -618,7 +618,7 @@ func TestGH1434(t *testing.T) {
 			// Write the JWK to a temporary file for jose to use
 			jwkBytes, err := json.Marshal(jwxJwk)
 			require.NoError(t, err, `jwk JSON marshaling should succeed`)
-			
+
 			joseJwkFile, joseJwkCleanup, err := jwxtest.WriteFile(t.TempDir(), "ecdh-key-*.jwk", bytes.NewReader(jwkBytes))
 			require.NoError(t, err, `writing JWK file should succeed`)
 			defer joseJwkCleanup()
@@ -627,7 +627,7 @@ func TestGH1434(t *testing.T) {
 				// Test exporting as ECDH key (should work directly)
 				var ecdhKey ecdh.PrivateKey
 				require.NoError(t, jwk.Export(jwxJwk, &ecdhKey), `jwk.Export to ECDH should succeed`)
-				
+
 				// Test exporting as ECDSA key (should use ECDHToECDSA conversion)
 				var ecdsaKey ecdsa.PrivateKey
 				require.NoError(t, jwk.Export(jwxJwk, &ecdsaKey), `jwk.Export to ECDSA should succeed via ECDHToECDSA conversion`)
@@ -644,7 +644,7 @@ func TestGH1434(t *testing.T) {
 				// let jwx decrypt using the ECDH key (which internally should convert to ECDSA if needed)
 				encryptedData, err := jwxtest.ReadFile(joseCryptFile)
 				require.NoError(t, err, `reading encrypted file should succeed`)
-				
+
 				payload, err := jwe.Decrypt(encryptedData, jwe.WithKey(curve.keyAlg, ecdhPrivKey))
 				require.NoError(t, err, `jwe.Decrypt with ECDH key should succeed`)
 				require.Equal(t, expected, payload, `decrypted payloads should match`)


### PR DESCRIPTION
fixes #1434

This change introduces conversion from ECDH keys to ECDSA keys such that JWE encryption works for both types of raw keys.