### PR TITLE
Change go.mod version requirements to go 1.24.0 and introduce toolchain directive

### DIFF
--- a/bench/comparison/go.mod
+++ b/bench/comparison/go.mod
@@ -1,6 +1,8 @@
 module github.com/lestrrat-go/jwx/bench/comparison
 
-go 1.24.4
+go 1.24.0
+
+toolchain go1.24.4
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.2.2

--- a/bench/performance/go.mod
+++ b/bench/performance/go.mod
@@ -1,6 +1,8 @@
 module github.com/lestrrat-go/jwx/v3/bench/performance
 
-go 1.24.4
+go 1.24.0
+
+toolchain go1.24.4
 
 require github.com/lestrrat-go/jwx/v3 v3.0.0
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,8 @@
 module github.com/lestrrat-go/jwx/v3/examples
 
-go 1.24.4
+go 1.24.0
+
+toolchain go1.24.4
 
 require (
 	github.com/cloudflare/circl v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/lestrrat-go/jwx/v3
 
-go 1.24.4
+go 1.24.0
+
+toolchain 1.24.4
 
 require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/lestrrat-go/jwx/v3
 
 go 1.24.0
 
-toolchain 1.24.4
+toolchain go1.24.4
 
 require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0


### PR DESCRIPTION
Currently the go version is 1.24.4 which sets a minimum version of 1.24.4 where 1.24.0 should be sufficient. This downgrades the go version in all go.mod files and introduces the `toolchain` directive to maintain a consistent build version.