### PR TITLE
[jwe] Add option to explicitly clear per-recipient headers (`"header"`) for flattened JSON serialization

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,9 @@ v3 has many incompatibilities with v2. To see the full list of differences betwe
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
 v3.0.12 UNRELEASED
+  * [jwe] As part of the next change, now per-recipient headers that are empty
+    are no longer serialized in flattened JSON serialization.
+
   * [jwe] Introduce `jwe.WithLegacyHeaderMerging(bool)` option to control header
     merging behavior in during JWE encryption. This only applies to flattened
     JSON serialization.

--- a/Changes
+++ b/Changes
@@ -5,6 +5,27 @@ v3 has many incompatibilities with v2. To see the full list of differences betwe
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
 v3.0.12 UNRELEASED
+  * [jwe] Introduce `jwe.WithLegacyHeaderMerging(bool)` option to control header
+    merging behavior in during JWE encryption. This only applies to flattened
+    JSON serialization.
+
+    Previously, when using flattened JSON serialization (i.e. you specified
+    JSON serialization via `jwe.WithJSON()` and only supplied one key), per-recipient
+    headers were merged into the protected headers during encryption, and then
+    were left to be included in the final serialization as-is. This caused duplicate
+    headers to be present in both the protected headers and the per-recipient headers.
+
+    Since there maybe users who rely on this behavior already, instead of changing the
+    default behavior to fix this duplication, a new option to `jwe.Encrypt()` was added
+    to allow clearing the per-recipient headers after merging to leave the `"headers"`
+    field empty. This in effect makes the flattened JSON serialization more similar to
+    the compact serialization, where there are no per-recipient headers present, and
+    leaves the headers disjoint.
+    
+    Note that in compact mode, there are no per-recipient headers and thus the
+    headers need to be merged regardless. In full JSON serialization, we never
+    merge the headers, so it is left up to the user to keep the headers disjoint.
+
   * [jws] Calling the deprecated `jws.NewSigner()` function for the time will cause
     legacy signers to be loaded automatically. Previously, you had to explicitly
     call `jws.Settings(jws.WithLegacySigners(true))` to enable legacy signers.

--- a/examples/jwe_encrypt_json_example_test.go
+++ b/examples/jwe_encrypt_json_example_test.go
@@ -29,7 +29,12 @@ func Example_jwe_encrypt_json() {
 	}
 
 	const payload = `Lorem ipsum`
-	encrypted, err := jwe.Encrypt([]byte(payload), jwe.WithJSON(), jwe.WithKey(jwa.RSA_OAEP(), pubkey))
+	encrypted, err := jwe.Encrypt(
+		[]byte(payload),
+		jwe.WithJSON(),                      // Toggle JSON serialization. Because there's only one key (recipient), this will produce Flattened JSON serialization
+		jwe.WithLegacyHeaderMerging(false),  // Disable legacy header merging
+		jwe.WithKey(jwa.RSA_OAEP(), pubkey), // Public key for encryption
+	)
 	if err != nil {
 		fmt.Printf("failed to encrypt payload: %s\n", err)
 		return

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -106,16 +106,13 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 	if hdr == nil {
 		hdr = NewHeaders()
 	}
-	if apu == nil {
-		if val, ok := hdr.AgreementPartyUInfo(); ok {
-			apu = val
-		}
+
+	if val, ok := hdr.AgreementPartyUInfo(); ok {
+		apu = val
 	}
 
-	if apv == nil {
-		if val, ok := hdr.AgreementPartyVInfo(); ok {
-			apv = val
-		}
+	if val, ok := hdr.AgreementPartyVInfo(); ok {
+		apv = val
 	}
 
 	// Create the encrypter using the new jwebb pattern

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -99,13 +99,21 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 		rawKey = raw
 	}
 
-	// Extract ECDH-ES specific parameters if needed
+	// Extract ECDH-ES specific parameters if needed.
 	var apu, apv []byte
-	if b.headers != nil {
-		if val, ok := b.headers.AgreementPartyUInfo(); ok {
+
+	hdr := b.headers
+	if hdr == nil {
+		hdr = NewHeaders()
+	}
+	if apu == nil {
+		if val, ok := hdr.AgreementPartyUInfo(); ok {
 			apu = val
 		}
-		if val, ok := b.headers.AgreementPartyVInfo(); ok {
+	}
+
+	if apv == nil {
+		if val, ok := hdr.AgreementPartyVInfo(); ok {
 			apv = val
 		}
 	}
@@ -116,20 +124,20 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 		return nil, fmt.Errorf(`jwe.Encrypt: recipientBuilder: failed to create encrypter: %w`, err)
 	}
 
-	if hdrs := b.headers; hdrs != nil {
-		_ = r.SetHeaders(hdrs)
-	}
+	_ = r.SetHeaders(hdr)
 
-	if err := r.Headers().Set(AlgorithmKey, b.alg); err != nil {
+	// Populate headers with stuff that we automatically set
+	if err := hdr.Set(AlgorithmKey, b.alg); err != nil {
 		return nil, fmt.Errorf(`failed to set header: %w`, err)
 	}
 
 	if keyID != "" {
-		if err := r.Headers().Set(KeyIDKey, keyID); err != nil {
+		if err := hdr.Set(KeyIDKey, keyID); err != nil {
 			return nil, fmt.Errorf(`failed to set header: %w`, err)
 		}
 	}
 
+	// Handle the encrypted key
 	var rawCEK []byte
 	enckey, err := enc.EncryptKey(cek)
 	if err != nil {
@@ -143,8 +151,9 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 		}
 	}
 
+	// finally, anything specific should go here
 	if hp, ok := enckey.(populater); ok {
-		if err := hp.Populate(r.Headers()); err != nil {
+		if err := hp.Populate(hdr); err != nil {
 			return nil, fmt.Errorf(`failed to populate: %w`, err)
 		}
 	}
@@ -177,17 +186,7 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 //
 // As of v3.0.12, users can specify `jwe.WithLegacyHeaderMerging()` to
 // disable header merging behavior that was the default prior to v3.0.12.
-// Before v3.0.12, per-recipient headers were merged into the protected header
-// when there was only one recipient. This would not be a problem when
-// per-recipient headers are not used, but could result in results that
-// vaiolate RFC 7516. When this option is explicitly set to `false`,
-// the per-recipient headers and protected headers are left as-is.
-// Users are responsible for ensuring that the protected headers contain
-// the correct values, except for those that are automatically set by this library
-// (e.g. `alg` and `enc`).
-//
-// This behavior will become the default in a future major release. New users
-// are encouraged to explicitly set this option to `false`.
+// Read the documentation for `jwe.WithLegacyHeaderMerging()` for more information.
 func Encrypt(payload []byte, options ...EncryptOption) ([]byte, error) {
 	ec := encryptContextPool.Get()
 	defer encryptContextPool.Put(ec)
@@ -426,9 +425,25 @@ func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgo
 		Tag(msg.tag).
 		CEK(dc.cek)
 
-	if v, ok := recipient.Headers().Algorithm(); !ok || v != alg {
-		// algorithms don't match
+	// The "alg" header can be in either protected/unprotected headers.
+	// prefer per-recipient headers (as it might be the case that the algorithm differs
+	// by each recipient), then look at protected headers.
+	var algMatched bool
+	for _, hdr := range []Headers{recipient.Headers(), protectedHeaders} {
+		v, ok := hdr.Algorithm()
+		if !ok {
+			continue
+		}
+
+		if v == alg {
+			algMatched = true
+			break
+		}
+		// if we found something but didn't match, it's a failure
 		return nil, fmt.Errorf(`jwe.Decrypt: key (%q) and recipient (%q) algorithms do not match`, alg, v)
+	}
+	if !algMatched {
+		return nil, fmt.Errorf(`jwe.Decrypt: failed to find "alg" header in either protected or per-recipient headers`)
 	}
 
 	h2, err := protectedHeaders.Clone()
@@ -555,7 +570,7 @@ type encryptContext struct {
 	format              int
 	builders            []*recipientBuilder
 	protected           Headers
-	legacyHeaderMerging *bool
+	legacyHeaderMerging bool
 }
 
 var encryptContextPool = pool.New(allocEncryptContext, freeEncryptContext)
@@ -578,6 +593,7 @@ func freeEncryptContext(ec *encryptContext) *encryptContext {
 }
 
 func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
+	ec.legacyHeaderMerging = true
 	var mergeProtected bool
 	var useRawCEK bool
 	for _, option := range options {
@@ -594,7 +610,11 @@ func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
 			if v == jwa.DIRECT() || v == jwa.ECDH_ES() {
 				useRawCEK = true
 			}
-			ec.builders = append(ec.builders, &recipientBuilder{alg: v, key: wk.key, headers: wk.headers})
+			ec.builders = append(ec.builders, &recipientBuilder{
+				alg:     v,
+				key:     wk.key,
+				headers: wk.headers,
+			})
 		case identContentEncryptionAlgorithm{}:
 			var c jwa.ContentEncryptionAlgorithm
 			if err := option.Value(&c); err != nil {
@@ -638,7 +658,7 @@ func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
 			if err := option.Value(&v); err != nil {
 				return err
 			}
-			ec.legacyHeaderMerging = &v
+			ec.legacyHeaderMerging = v
 		}
 	}
 
@@ -755,7 +775,8 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 		}
 	}
 
-	recipients := recipientSlicePool.GetCapacity(len(ec.builders))
+	lbuilders := len(ec.builders)
+	recipients := recipientSlicePool.GetCapacity(lbuilders)
 	defer recipientSlicePool.Put(recipients)
 
 	for i, builder := range ec.builders {
@@ -790,19 +811,54 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 		}
 	}
 
-	// For backwards compatibility, we do the legacy header merging
-	// by default, or when the user explicitly asks for it. If the
-	// user explicitly asks to NOT do legacy header merging, we just
-	// skip this process
-	if lhm := ec.legacyHeaderMerging; lhm == nil || *lhm {
-		// If there's only one recipient, you want to include that in the
-		// protected header
-		if len(recipients) == 1 {
+	// fmtCompact does not have per-recipient headers, nor a "header" field.
+	// In this mode, we're going to have to merge everything to the protected
+	// header.
+	if ec.format == fmtCompact {
+		// We have already established that the number of builders is 1 in
+		// ec.ProcessOptions(). But we're going to be pedantic
+		if lbuilders != 1 {
+			return nil, fmt.Errorf(`internal error: expected exactly one recipient builder (got %d)`, lbuilders)
+		}
+
+		// when we're using compact format, we can safely merge per-recipient
+		// headers into the protected header, if any
+		h, err := protected.Merge(recipients[0].Headers())
+		if err != nil {
+			return nil, fmt.Errorf(`failed to merge protected headers for compact serialization: %w`, err)
+		}
+		protected = h
+		// per-recipient headers, if any, will be ignored in compact format
+	} else {
+		// If it got here, it's JSON (could be pretty mode, too).
+		if lbuilders == 1 {
+			// If it got here, then we're doing flattened JSON serialization.
+			// In this mode, we should merge per-recipient headers into the protected header,
+			// but we also need to make sure that the "header" field is reset so that
+			// it does not contain the same fields as the protected header.
+			//
+			// However, old behavior was to merge per-recipient headers into the
+			// protected header when there was only one recipient, AND leave the
+			// original "header" field as is, so we need to support that for backwards compatibility.
+			//
+			// The legacy merging only takes effect when there is exactly one recipient.
+			//
+			// This behavior can be disabled by passing jwe.WithLegacyHeaderMerging(false)
+			// If the user has explicitly asked for merging, do it
 			h, err := protected.Merge(recipients[0].Headers())
 			if err != nil {
-				return nil, fmt.Errorf(`failed to merge protected headers: %w`, err)
+				return nil, fmt.Errorf(`failed to merge protected headers for flattenend JSON format: %w`, err)
 			}
 			protected = h
+
+			if !ec.legacyHeaderMerging {
+				// Clear per-recipient headers, since they have been merged.
+				// But we only do it when legacy merging is disabled.
+				// Note: we should probably introduce a Reset() method in v4
+				if err := recipients[0].SetHeaders(NewHeaders()); err != nil {
+					return nil, fmt.Errorf(`failed to clear per-recipient headers after merging: %w`, err)
+				}
+			}
 		}
 	}
 

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -154,7 +154,9 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 
 // Encrypt generates a JWE message for the given payload and returns
 // it in serialized form, which can be in either compact or
-// JSON format. Default is compact.
+// JSON format. Default is compact. When JSON format is specified and
+// and there is only one recipient, the resulting serialization is
+// automatically converted to flattened JSON serialization format.
 //
 // You must pass at least one key to `jwe.Encrypt()` by using `jwe.WithKey()`
 // option.
@@ -172,6 +174,20 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 //
 // Look for options that return `jwe.EncryptOption` or `jws.EncryptDecryptOption`
 // for a complete list of options that can be passed to this function.
+//
+// As of v3.0.12, users can specify `jwe.WithLegacyHeaderMerging()` to
+// disable header merging behavior that was the default prior to v3.0.12.
+// Before v3.0.12, per-recipient headers were merged into the protected header
+// when there was only one recipient. This would not be a problem when
+// per-recipient headers are not used, but could result in results that
+// vaiolate RFC 7516. When this option is explicitly set to `false`,
+// the per-recipient headers and protected headers are left as-is.
+// Users are responsible for ensuring that the protected headers contain
+// the correct values, except for those that are automatically set by this library
+// (e.g. `alg` and `enc`).
+//
+// This behavior will become the default in a future major release. New users
+// are encouraged to explicitly set this option to `false`.
 func Encrypt(payload []byte, options ...EncryptOption) ([]byte, error) {
 	ec := encryptContextPool.Get()
 	defer encryptContextPool.Put(ec)
@@ -534,11 +550,12 @@ func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgo
 
 // encryptContext holds the state during JWE encryption, similar to JWS signContext
 type encryptContext struct {
-	calg        jwa.ContentEncryptionAlgorithm
-	compression jwa.CompressionAlgorithm
-	format      int
-	builders    []*recipientBuilder
-	protected   Headers
+	calg                jwa.ContentEncryptionAlgorithm
+	compression         jwa.CompressionAlgorithm
+	format              int
+	builders            []*recipientBuilder
+	protected           Headers
+	legacyHeaderMerging *bool
 }
 
 var encryptContextPool = pool.New(allocEncryptContext, freeEncryptContext)
@@ -616,6 +633,12 @@ func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
 				return err
 			}
 			ec.format = fmtOpt
+		case identLegacyHeaderMerging{}:
+			var v bool
+			if err := option.Value(&v); err != nil {
+				return err
+			}
+			ec.legacyHeaderMerging = &v
 		}
 	}
 
@@ -767,14 +790,20 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 		}
 	}
 
-	// If there's only one recipient, you want to include that in the
-	// protected header
-	if len(recipients) == 1 {
-		h, err := protected.Merge(recipients[0].Headers())
-		if err != nil {
-			return nil, fmt.Errorf(`failed to merge protected headers: %w`, err)
+	// For backwards compatibility, we do the legacy header merging
+	// by default, or when the user explicitly asks for it. If the
+	// user explicitly asks to NOT do legacy header merging, we just
+	// skip this process
+	if lhm := ec.legacyHeaderMerging; lhm == nil || *lhm {
+		// If there's only one recipient, you want to include that in the
+		// protected header
+		if len(recipients) == 1 {
+			h, err := protected.Merge(recipients[0].Headers())
+			if err != nil {
+				return nil, fmt.Errorf(`failed to merge protected headers: %w`, err)
+			}
+			protected = h
 		}
-		protected = h
 	}
 
 	aad, err := protected.Encode()

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -164,7 +164,7 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 // Encrypt generates a JWE message for the given payload and returns
 // it in serialized form, which can be in either compact or
 // JSON format. Default is compact. When JSON format is specified and
-// and there is only one recipient, the resulting serialization is
+// there is only one recipient, the resulting serialization is
 // automatically converted to flattened JSON serialization format.
 //
 // You must pass at least one key to `jwe.Encrypt()` by using `jwe.WithKey()`

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1139,4 +1139,29 @@ func TestGH1470(t *testing.T) {
 			}
 		}
 	})
+
+	// Check for empty "`headers"`, for both parsing and serializing to
+	// flattened JSON serialization
+	t.Run("Make sure flattened JSON serialization with non-legacy header merging does not contain `headers`", func(t *testing.T) {
+		const payload = "Lorem ipsum"
+		privkey, err := jwxtest.GenerateRsaKey()
+		require.NoError(t, err, `jwxtest.GenerateRsaJwk should succeed`)
+
+		encrypted, err := jwe.Encrypt([]byte(payload), jwe.WithJSON(), jwe.WithLegacyHeaderMerging(false), jwe.WithKey(jwa.RSA_OAEP_256(), privkey.PublicKey))
+		require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+		require.NotContains(t, string(encrypted), `"header":`, `flattened JSON serialization should NOT contain "header"`)
+	})
+	t.Run("Parse Without Header for Flatted Token", func(t *testing.T) {
+		token := `{
+    "ciphertext": "NR5BBCPc",
+    "encrypted_key": "PENNLqJYzXYbKgiZCTe61Qhasls8wrqGQ7ytsvvm5_E6Yya79QyrtDaX_lYm2FitLPMkw4K-63NJf1Ltp9Ur-zZUJB2rQmGkhB4toBO-SkLSkSPhUr6lILKIFWrnbBjjy63g_Awfqb7tsWT1kD0rqO_xPhhN9s0xoHMpgFYY80QQxUBVYiADiu01H_o9tsh66Npch3HAI6t6bxUfVwyMjpWK7N6k74vc95l3-ZcAGxl6aeWAtUTD37bE5bVbvILfcb6HdK0Z81fmPcRe2o9W4wZ_SP2fEV67I-jrsx73rgL1a1c_9TB4vZX3XxppvBhwKHUBAksaq3aWQXr8gkWt-g",
+    "iv": "TPrbYWe0oUeC9Eop",
+    "protected": "eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIiwia2lkIjoicmVjaXBpZW50MSJ9",
+    "tag": "tOk33fmFy80qZVNyb22s0g"
+}`
+
+		_, err := jwe.Parse([]byte(token))
+		require.NoError(t, err)
+	})
 }

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1023,3 +1023,71 @@ func TestGH1434(t *testing.T) {
 	require.NoError(t, err, `jwe.Decrypt should succeed`)
 	require.Equal(t, []byte(payload), decrypted, `decrypted payload should match original payload`)
 }
+
+type GH1470JWEFlattened struct {
+	Protected   string         `json:"protected,omitempty"`
+	Unprotected map[string]any `json:"unprotected,omitempty"`
+	Header      map[string]any `json:"header,omitempty"`
+}
+
+func TestGH1470(t *testing.T) {
+	privkey, err := jwxtest.GenerateRsaJwk()
+	require.NoError(t, err)
+
+	pubkey, err := jwk.PublicKeyOf(privkey)
+	require.NoError(t, err)
+
+	// Per-recipient unprotected header includes kid
+	recipientHeaders := jwe.NewHeaders()
+	require.NoError(t, recipientHeaders.Set("kid", "recipient1"))
+
+	recipient := jwe.WithKey(
+		jwa.RSA_OAEP_256(),
+		pubkey,
+		jwe.WithPerRecipientHeaders(recipientHeaders),
+	)
+
+	TRUE := true
+	FALSE := false
+	for _, lhm := range []*bool{nil, &TRUE, &FALSE} {
+		var title string
+		if lhm == nil {
+			title = "legacy header merging left as default (nil)"
+		} else if *lhm {
+			title = "legacy header merging explicitly set to true"
+		} else {
+			title = "legacy header merging explicitly set to false"
+		}
+		t.Run(title, func(t *testing.T) {
+			options := []jwe.EncryptOption{jwe.WithJSON(), recipient}
+			if lhm != nil {
+				options = append(options, jwe.WithLegacyHeaderMerging(*lhm))
+			}
+
+			// Produce JSON Serialization (flattened for single recipient)
+			encrypted, err := jwe.Encrypt([]byte("Hello!"), options...)
+			require.NoError(t, err)
+
+			var object GH1470JWEFlattened
+			require.NoError(t, json.Unmarshal(encrypted, &object), `json.Unmarshal should succeed`)
+
+			protectedJSON, err := base64.RawURLEncoding.DecodeString(object.Protected)
+			require.NoError(t, err)
+
+			var protected map[string]any
+			require.NoError(t, json.Unmarshal(protectedJSON, &protected))
+
+			for _, key := range []string{"alg", "kid"} {
+				// Fail if the same names appear in both places (violates RFC 7516 §7.2.1)
+				if _, has := protected[key]; has {
+					_, also := object.Header[key]
+					if lhm == nil || *lhm {
+						require.True(t, also, `lhm = true, %q should exist`, key)
+					} else {
+						require.False(t, also, `lhm = false, %q should NOT exist`, key)
+					}
+				}
+			}
+		})
+	}
+}

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1037,57 +1037,106 @@ func TestGH1470(t *testing.T) {
 	pubkey, err := jwk.PublicKeyOf(privkey)
 	require.NoError(t, err)
 
-	// Per-recipient unprotected header includes kid
-	recipientHeaders := jwe.NewHeaders()
-	require.NoError(t, recipientHeaders.Set("kid", "recipient1"))
-
-	recipient := jwe.WithKey(
-		jwa.RSA_OAEP_256(),
-		pubkey,
-		jwe.WithPerRecipientHeaders(recipientHeaders),
-	)
+	const payload = "Lorem ipsum"
 
 	TRUE := true
 	FALSE := false
-	for _, lhm := range []*bool{nil, &TRUE, &FALSE} {
-		var title string
-		if lhm == nil {
-			title = "legacy header merging left as default (nil)"
-		} else if *lhm {
-			title = "legacy header merging explicitly set to true"
-		} else {
-			title = "legacy header merging explicitly set to false"
-		}
-		t.Run(title, func(t *testing.T) {
-			options := []jwe.EncryptOption{jwe.WithJSON(), recipient}
-			if lhm != nil {
-				options = append(options, jwe.WithLegacyHeaderMerging(*lhm))
+
+	t.Run("Flattened JSON serialization", func(t *testing.T) {
+		// Per-recipient unprotected header includes kid
+		recipientHeaders := jwe.NewHeaders()
+		require.NoError(t, recipientHeaders.Set("kid", "recipient1"))
+
+		recipient := jwe.WithKey(
+			jwa.RSA_OAEP_256(),
+			pubkey,
+			jwe.WithPerRecipientHeaders(recipientHeaders),
+		)
+
+		for _, lhm := range []*bool{nil, &TRUE, &FALSE} {
+			var title string
+			if lhm == nil {
+				title = "legacy header merging left as default (nil)"
+			} else if *lhm {
+				title = "legacy header merging explicitly set to true"
+			} else {
+				title = "legacy header merging explicitly set to false"
 			}
+			t.Run(title, func(t *testing.T) {
+				options := []jwe.EncryptOption{jwe.WithJSON(), recipient}
+				if lhm != nil {
+					options = append(options, jwe.WithLegacyHeaderMerging(*lhm))
+				}
 
-			// Produce JSON Serialization (flattened for single recipient)
-			encrypted, err := jwe.Encrypt([]byte("Hello!"), options...)
-			require.NoError(t, err)
+				// Produce JSON Serialization (flattened for single recipient)
+				encrypted, err := jwe.Encrypt([]byte(payload), options...)
+				require.NoError(t, err)
 
-			var object GH1470JWEFlattened
-			require.NoError(t, json.Unmarshal(encrypted, &object), `json.Unmarshal should succeed`)
+				var object GH1470JWEFlattened
+				require.NoError(t, json.Unmarshal(encrypted, &object), `json.Unmarshal should succeed`)
 
-			protectedJSON, err := base64.RawURLEncoding.DecodeString(object.Protected)
-			require.NoError(t, err)
+				protectedJSON, err := base64.RawURLEncoding.DecodeString(object.Protected)
+				require.NoError(t, err)
 
-			var protected map[string]any
-			require.NoError(t, json.Unmarshal(protectedJSON, &protected))
+				var protected map[string]any
+				require.NoError(t, json.Unmarshal(protectedJSON, &protected))
 
-			for _, key := range []string{"alg", "kid"} {
-				// Fail if the same names appear in both places (violates RFC 7516 §7.2.1)
-				if _, has := protected[key]; has {
-					_, also := object.Header[key]
-					if lhm == nil || *lhm {
-						require.True(t, also, `lhm = true, %q should exist`, key)
-					} else {
-						require.False(t, also, `lhm = false, %q should NOT exist`, key)
+				for _, key := range []string{"alg", "kid"} {
+					// Fail if the same names appear in both places (violates RFC 7516 §7.2.1)
+					if _, has := protected[key]; has {
+						_, also := object.Header[key]
+						if lhm == nil || *lhm {
+							require.True(t, also, `lhm = true, %q should exist`, key)
+						} else {
+							require.False(t, also, `lhm = false, %q should NOT exist`, key)
+						}
 					}
 				}
+			})
+		}
+	})
+
+	// one more test: we need to make sure what happens when we're using compact serialization
+	t.Run("Compact serialization", func(t *testing.T) {
+		for _, lhm := range []*bool{nil, &TRUE, &FALSE} {
+			var title string
+			if lhm == nil {
+				title = "legacy header merging left as default (nil)"
+			} else if *lhm {
+				title = "legacy header merging explicitly set to true"
+			} else {
+				title = "legacy header merging explicitly set to false"
 			}
-		})
-	}
+
+			for _, prh := range []bool{true, false} {
+				if prh {
+					title += " + per-recipient header is set"
+				} else {
+					title += " + per-recipient header is NOT set"
+				}
+
+				t.Run(title, func(t *testing.T) {
+					var options []jwe.EncryptOption
+					if prh {
+						hdr := jwe.NewHeaders()
+						_ = hdr.Set(jwe.KeyIDKey, "recipient1")
+						options = append(options, jwe.WithKey(
+							jwa.RSA_OAEP_256(),
+							pubkey,
+							jwe.WithPerRecipientHeaders(hdr),
+						))
+					} else {
+						options = append(options, jwe.WithKey(jwa.RSA_OAEP_256(), pubkey))
+					}
+
+					if lhm != nil {
+						options = append(options, jwe.WithLegacyHeaderMerging(*lhm))
+					}
+
+					_, err := jwe.Encrypt([]byte(payload), options...)
+					require.NoError(t, err, `jwe.Encrypt should succeed regardless`)
+				})
+			}
+		}
+	})
 }

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -176,16 +176,35 @@ options:
     option_name: WithLegacyHeaderMerging
     comment: |
       WithLegacyHeaderMerging specifies whether to perform legacy header merging
-      when encrypting a JWE message. This is enabled by default for backwards compatibility.
-      
-      Legacy header merging means that when there's only one recipient,
-      the recipient's headers are merged into the protected headers.
-      However, this behavior is problematic, as it modifies the ending result
-      depending on the serialization format. 
+      when encrypting a JWE message in JSON serialization, when there is a single recipient.
+      This behavior is enabled by default for backwards compatibility.
 
-      When this option is set to false, the recipient headers are NOT merged
-      into the protected headers, regardless of the number of recipients. The
-      protected headers will be used as-is for computing AAD.
+      When a JWE message is encrypted in JSON serialization, and there is only
+      one recipient, this library automatically serializes the message in
+      flattened JSON serialization format. In older versions of this library,
+      the protected headers and the per-recipient headers were merged together
+      before computing the AAD (Additional Authenticated Data), but the per-recipient
+      headers were kept as-is in the `header` field of the recipient object.
 
-      In future versions, this option will default to false. New users are
+      This behavior is not compliant with the JWE specification, which states that
+      the headers must be disjoint.
+
+      Passing this option with a value of `false` disables this legacy behavior,
+      and while the per-recipient headers and protected headers are still merged
+      for the purpose of computing AAD, the per-recipient headers are cleared
+      after merging, so that the resulting JWE message is compliant with the
+      specification.
+
+      This option has no effect when there are multiple recipients, or when
+      the serialization format is compact serialization. For multiple recipients
+      (i.e. full JSON serialization), the protected headers and per-recipient
+      headers are never merged, and it is the caller's responsibility to ensure
+      that the headers are disjoint. In compact serialization, there are no per-recipient
+      headers; in fact, the protected headers are the only headers that exist,
+      and therefore there is no possibility of header collision after merging
+      (note: while per-recipient headers do not make sense in compact serialization,
+      this library does not prevent you from setting them -- they are all just
+      merged into the protected headers).
+
+      In future versions, the new behavior will be the default. New users are
       encouraged to set this option to `false` now to avoid future issues.

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -170,3 +170,22 @@ options:
       In v2, this option was called MaxBufferSize.
 
       This option has a global effect.
+  - ident: LegacyHeaderMerging
+    interface: EncryptOption
+    argument_type: bool
+    option_name: WithLegacyHeaderMerging
+    comment: |
+      WithLegacyHeaderMerging specifies whether to perform legacy header merging
+      when encrypting a JWE message. This is enabled by default for backwards compatibility.
+      
+      Legacy header merging means that when there's only one recipient,
+      the recipient's headers are merged into the protected headers.
+      However, this behavior is problematic, as it modifies the ending result
+      depending on the serialization format. 
+
+      When this option is set to false, the recipient headers are NOT merged
+      into the protected headers, regardless of the number of recipients. The
+      protected headers will be used as-is for computing AAD.
+
+      In future versions, this option will default to false. New users are
+      encouraged to set this option to `false` now to avoid future issues.

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -147,6 +147,7 @@ type identFS struct{}
 type identKey struct{}
 type identKeyProvider struct{}
 type identKeyUsed struct{}
+type identLegacyHeaderMerging struct{}
 type identMaxDecompressBufferSize struct{}
 type identMaxPBES2Count struct{}
 type identMergeProtectedHeaders struct{}
@@ -191,6 +192,10 @@ func (identKeyProvider) String() string {
 
 func (identKeyUsed) String() string {
 	return "WithKeyUsed"
+}
+
+func (identLegacyHeaderMerging) String() string {
+	return "WithLegacyHeaderMerging"
 }
 
 func (identMaxDecompressBufferSize) String() string {
@@ -290,6 +295,23 @@ func WithKeyProvider(v KeyProvider) DecryptOption {
 // jwx API allows users to specify a raw key such as *rsa.PublicKey)
 func WithKeyUsed(v any) DecryptOption {
 	return &decryptOption{option.New(identKeyUsed{}, v)}
+}
+
+// WithLegacyHeaderMerging specifies whether to perform legacy header merging
+// when encrypting a JWE message. This is enabled by default for backwards compatibility.
+//
+// Legacy header merging means that when there's only one recipient,
+// the recipient's headers are merged into the protected headers.
+// However, this behavior is problematic, as it modifies the ending result
+// depending on the serialization format.
+//
+// When this option is set to false, the recipient headers are NOT merged
+// into the protected headers, regardless of the number of recipients. The
+// protected headers will be used as-is for computing AAD.
+//
+// In future versions, this option will default to false.
+func WithLegacyHeaderMerging(v bool) EncryptOption {
+	return &encryptOption{option.New(identLegacyHeaderMerging{}, v)}
 }
 
 // WithMaxDecompressBufferSize specifies the maximum buffer size for used when

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -298,18 +298,38 @@ func WithKeyUsed(v any) DecryptOption {
 }
 
 // WithLegacyHeaderMerging specifies whether to perform legacy header merging
-// when encrypting a JWE message. This is enabled by default for backwards compatibility.
+// when encrypting a JWE message in JSON serialization, when there is a single recipient.
+// This behavior is enabled by default for backwards compatibility.
 //
-// Legacy header merging means that when there's only one recipient,
-// the recipient's headers are merged into the protected headers.
-// However, this behavior is problematic, as it modifies the ending result
-// depending on the serialization format.
+// When a JWE message is encrypted in JSON serialization, and there is only
+// one recipient, this library automatically serializes the message in
+// flattened JSON serialization format. In older versions of this library,
+// the protected headers and the per-recipient headers were merged together
+// before computing the AAD (Additional Authenticated Data), but the per-recipient
+// headers were kept as-is in the `header` field of the recipient object.
 //
-// When this option is set to false, the recipient headers are NOT merged
-// into the protected headers, regardless of the number of recipients. The
-// protected headers will be used as-is for computing AAD.
+// This behavior is not compliant with the JWE specification, which states that
+// the headers must be disjoint.
 //
-// In future versions, this option will default to false.
+// Passing this option with a value of `false` disables this legacy behavior,
+// and while the per-recipient headers and protected headers are still merged
+// for the purpose of computing AAD, the per-recipient headers are cleared
+// after merging, so that the resulting JWE message is compliant with the
+// specification.
+//
+// This option has no effect when there are multiple recipients, or when
+// the serialization format is compact serialization. For multiple recipients
+// (i.e. full JSON serialization), the protected headers and per-recipient
+// headers are never merged, and it is the caller's responsibility to ensure
+// that the headers are disjoint. In compact serialization, there are no per-recipient
+// headers; in fact, the protected headers are the only headers that exist,
+// and therefore there is no possibility of header collision after merging
+// (note: while per-recipient headers do not make sense in compact serialization,
+// this library does not prevent you from setting them -- they are all just
+// merged into the protected headers).
+//
+// In future versions, the new behavior will be the default. New users are
+// encouraged to set this option to `false` now to avoid future issues.
 func WithLegacyHeaderMerging(v bool) EncryptOption {
 	return &encryptOption{option.New(identLegacyHeaderMerging{}, v)}
 }

--- a/jwe/options_gen_test.go
+++ b/jwe/options_gen_test.go
@@ -18,6 +18,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithKey", identKey{}.String())
 	require.Equal(t, "WithKeyProvider", identKeyProvider{}.String())
 	require.Equal(t, "WithKeyUsed", identKeyUsed{}.String())
+	require.Equal(t, "WithLegacyHeaderMerging", identLegacyHeaderMerging{}.String())
 	require.Equal(t, "WithMaxDecompressBufferSize", identMaxDecompressBufferSize{}.String())
 	require.Equal(t, "WithMaxPBES2Count", identMaxPBES2Count{}.String())
 	require.Equal(t, "WithMergeProtectedHeaders", identMergeProtectedHeaders{}.String())


### PR DESCRIPTION
fixes #1470

After much going back and forth, I have nailed down that the ONLY time the current implementation creates duplicate entries (that matter) are when flattened JSON serialization is used.

For full JSON serialization, we didn't merge anything to start with. This was fine. It's the user's responsibility to figure out how to create headers that are completely disjoint. But for flattened JSON, we merged the per-recipient headers and the protected header, and yet kept the per-recipient headers in tact. The fix is to nuke the headers stored in the per-recipient headers after merging -- the merge is NOT necessary, but it is my understanding that we would be erring on the safer side if we merged everything into the protected header so that the entirety of this metadata is used as AAD, thus making the flattened JSON serialization that we produce analogous to the compact format.

Now, I'm sure there is code somewhere that already relies on this behavior, so instead of just "fixing" this, we introduced an option to explicitly enable the new behavior. Code that wants to generate a flattened JSON serialization that clears the `"header"` value should call `jwe.Encrypt()` with `jwe.WithLegacyHeaderMerging(false)`.