### PR TITLE
Replace make+copy with bytes.Clone

### DIFF
--- a/jwe/compress.go
+++ b/jwe/compress.go
@@ -56,7 +56,6 @@ func compress(plaintext []byte) ([]byte, error) {
 		return nil, fmt.Errorf(`failed to close compression writer: %w`, err)
 	}
 
-	ret := make([]byte, buf.Len())
-	copy(ret, buf.Bytes())
+	ret := bytes.Clone(buf.Bytes())
 	return ret, nil
 }

--- a/jwe/message.go
+++ b/jwe/message.go
@@ -1,6 +1,7 @@
 package jwe
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"strings"
@@ -71,8 +72,7 @@ func (r *stdRecipient) MarshalJSON() ([]byte, error) {
 	buf.WriteString(base64.EncodeToString(r.encryptedKey))
 	buf.WriteString(`"}`)
 
-	ret := make([]byte, buf.Len())
-	copy(ret, buf.Bytes())
+	ret := bytes.Clone(buf.Bytes())
 	return ret, nil
 }
 
@@ -344,8 +344,7 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 	}
 	fmt.Fprintf(buf, `}`)
 
-	ret := make([]byte, buf.Len())
-	copy(ret, buf.Bytes())
+	ret := bytes.Clone(buf.Bytes())
 	return ret, nil
 }
 
@@ -554,7 +553,6 @@ func Compact(m *Message, _ ...CompactOption) ([]byte, error) {
 	buf.WriteByte(tokens.Period)
 	buf.Write(tag)
 
-	result := make([]byte, buf.Len())
-	copy(result, buf.Bytes())
+	result := bytes.Clone(buf.Bytes())
 	return result, nil
 }

--- a/jws/bench_serialize_test.go
+++ b/jws/bench_serialize_test.go
@@ -1,0 +1,82 @@
+package jws_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/internal/jwxtest"
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jws"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkCompact(b *testing.B) {
+	b.ReportAllocs()
+
+	key, err := jwxtest.GenerateRsaKey()
+	require.NoError(b, err)
+
+	payload := []byte(`{"iss":"bench","sub":"perf","aud":"test","exp":9999999999}`)
+	signed, err := jws.Sign(payload, jws.WithKey(jwa.RS256(), key))
+	require.NoError(b, err)
+
+	msg, err := jws.Parse(signed)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := jws.Compact(msg)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshalJSON(b *testing.B) {
+	b.ReportAllocs()
+
+	key, err := jwxtest.GenerateRsaKey()
+	require.NoError(b, err)
+
+	payload := []byte(`{"iss":"bench","sub":"perf","aud":"test","exp":9999999999}`)
+	signed, err := jws.Sign(payload, jws.WithKey(jwa.RS256(), key))
+	require.NoError(b, err)
+
+	msg, err := jws.Parse(signed)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := msg.MarshalJSON()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshalJSONMultiSig(b *testing.B) {
+	b.ReportAllocs()
+
+	rsaKey, err := jwxtest.GenerateRsaKey()
+	require.NoError(b, err)
+	ecKey, err := jwxtest.GenerateEcdsaKey(jwa.P256())
+	require.NoError(b, err)
+
+	payload := []byte(`{"iss":"bench","sub":"perf","aud":"test","exp":9999999999}`)
+	signed, err := jws.Sign(payload,
+		jws.WithJSON(),
+		jws.WithKey(jwa.RS256(), rsaKey),
+		jws.WithKey(jwa.ES256(), ecKey),
+	)
+	require.NoError(b, err)
+
+	msg, err := jws.Parse(signed)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := msg.MarshalJSON()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/jws/message.go
+++ b/jws/message.go
@@ -194,8 +194,7 @@ func (s *Signature) sign2(payload []byte, signer interface{ Algorithm() jwa.Sign
 
 	buf.WriteByte(tokens.Period)
 	buf.WriteString(encoder.EncodeToString(s.signature))
-	ret := make([]byte, buf.Len())
-	copy(ret, buf.Bytes())
+	ret := bytes.Clone(buf.Bytes())
 
 	return s.signature, ret, nil
 }
@@ -427,8 +426,7 @@ func (m Message) marshalFlattened() ([]byte, error) {
 	buf.WriteRune('"')
 	buf.WriteRune(tokens.CloseCurlyBracket)
 
-	ret := make([]byte, buf.Len())
-	copy(ret, buf.Bytes())
+	ret := bytes.Clone(buf.Bytes())
 	return ret, nil
 }
 
@@ -483,8 +481,7 @@ func (m Message) marshalFull() ([]byte, error) {
 	}
 	buf.WriteString(`]}`)
 
-	ret := make([]byte, buf.Len())
-	copy(ret, buf.Bytes())
+	ret := bytes.Clone(buf.Bytes())
 	return ret, nil
 }
 
@@ -544,7 +541,6 @@ func Compact(msg *Message, options ...CompactOption) ([]byte, error) {
 
 	buf.WriteByte(tokens.Period)
 	buf.WriteString(encoder.EncodeToString(s.signature))
-	ret := make([]byte, buf.Len())
-	copy(ret, buf.Bytes())
+	ret := bytes.Clone(buf.Bytes())
 	return ret, nil
 }


### PR DESCRIPTION
Idiomatic single-call replacement for the two-line make([]byte, buf.Len()) + copy pattern.
No performance change; readability improvement.