### PR TITLE
Use base64.Encode instead of EncodeToString in JWS marshal

### DIFF
--- a/jws/bench_marshal_test.go
+++ b/jws/bench_marshal_test.go
@@ -30,7 +30,7 @@ func BenchmarkMarshalFlattened(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := msg.MarshalJSON()
 		if err != nil {
 			b.Fatal(err)
@@ -66,7 +66,7 @@ func BenchmarkMarshalFull(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := msg.MarshalJSON()
 		if err != nil {
 			b.Fatal(err)

--- a/jws/bench_marshal_test.go
+++ b/jws/bench_marshal_test.go
@@ -1,0 +1,75 @@
+package jws_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jws"
+)
+
+func BenchmarkMarshalFlattened(b *testing.B) {
+	b.ReportAllocs()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	payload := []byte(`{"iss":"bench","sub":"test","aud":"perf","exp":9999999999}`)
+	signed, err := jws.Sign(payload, jws.WithKey(jwa.ES256(), key))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	msg, err := jws.Parse(signed)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := msg.MarshalJSON()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshalFull(b *testing.B) {
+	b.ReportAllocs()
+
+	key1, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		b.Fatal(err)
+	}
+	key2, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	payload := []byte(`{"iss":"bench","sub":"test","aud":"perf","exp":9999999999}`)
+	signed, err := jws.Sign(payload,
+		jws.WithJSON(),
+		jws.WithKey(jwa.ES256(), key1),
+		jws.WithKey(jwa.ES256(), key2),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	msg, err := jws.Parse(signed)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := msg.MarshalJSON()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/jws/message.go
+++ b/jws/message.go
@@ -409,7 +409,7 @@ func (m Message) marshalFlattened() ([]byte, error) {
 		buf.WriteRune(tokens.Comma)
 	}
 	buf.WriteString(`"payload":"`)
-	buf.WriteString(base64.EncodeToString(m.payload))
+	buf.Write(base64.Encode(m.payload))
 	buf.WriteRune('"')
 
 	if protected := sig.protected; protected != nil {
@@ -418,12 +418,12 @@ func (m Message) marshalFlattened() ([]byte, error) {
 			return nil, fmt.Errorf(`failed to marshal "protected" (flattened format): %w`, err)
 		}
 		buf.WriteString(`,"protected":"`)
-		buf.WriteString(base64.EncodeToString(protectedbuf))
+		buf.Write(base64.Encode(protectedbuf))
 		buf.WriteRune('"')
 	}
 
 	buf.WriteString(`,"signature":"`)
-	buf.WriteString(base64.EncodeToString(sig.signature))
+	buf.Write(base64.Encode(sig.signature))
 	buf.WriteRune('"')
 	buf.WriteRune(tokens.CloseCurlyBracket)
 
@@ -437,7 +437,7 @@ func (m Message) marshalFull() ([]byte, error) {
 	defer pool.BytesBuffer().Put(buf)
 
 	buf.WriteString(`{"payload":"`)
-	buf.WriteString(base64.EncodeToString(m.payload))
+	buf.Write(base64.Encode(m.payload))
 	buf.WriteString(`","signatures":[`)
 	for i, sig := range m.signatures {
 		if i > 0 {
@@ -465,7 +465,7 @@ func (m Message) marshalFull() ([]byte, error) {
 				buf.WriteRune(tokens.Comma)
 			}
 			buf.WriteString(`"protected":"`)
-			buf.WriteString(base64.EncodeToString(protectedbuf))
+			buf.Write(base64.Encode(protectedbuf))
 			buf.WriteRune('"')
 			wrote = true
 		}
@@ -476,7 +476,7 @@ func (m Message) marshalFull() ([]byte, error) {
 				buf.WriteRune(tokens.Comma)
 			}
 			buf.WriteString(`"signature":"`)
-			buf.WriteString(base64.EncodeToString(sig.signature))
+			buf.Write(base64.Encode(sig.signature))
 			buf.WriteString(`"`)
 		}
 		buf.WriteString(`}`)


### PR DESCRIPTION
Write []byte directly to buffer instead of converting to string.

MarshalFlattened: -20% mem (875→699 B/op), -17% allocs (12→10)
MarshalFull: -14% mem (1913→1639 B/op), -11% allocs (27→24)