### PR TITLE
Inline ndata() in concatkdf New

### DIFF
--- a/jwe/internal/concatkdf/concatkdf.go
+++ b/jwe/internal/concatkdf/concatkdf.go
@@ -13,22 +13,25 @@ type KDF struct {
 	hash      crypto.Hash
 }
 
-func ndata(src []byte) []byte {
-	buf := make([]byte, 4+len(src))
-	binary.BigEndian.PutUint32(buf, uint32(len(src)))
-	copy(buf[4:], src)
-	return buf
-}
-
 func New(hash crypto.Hash, alg, Z, apu, apv, pubinfo, privinfo []byte) *KDF {
-	algbuf := ndata(alg)
-	apubuf := ndata(apu)
-	apvbuf := ndata(apv)
+	// Write length-prefixed fields directly into a single buffer,
+	// avoiding intermediate allocations from ndata().
+	totalSize := (4 + len(alg)) + (4 + len(apu)) + (4 + len(apv)) + len(pubinfo) + len(privinfo)
+	concat := make([]byte, totalSize)
 
-	concat := make([]byte, len(algbuf)+len(apubuf)+len(apvbuf)+len(pubinfo)+len(privinfo))
-	n := copy(concat, algbuf)
-	n += copy(concat[n:], apubuf)
-	n += copy(concat[n:], apvbuf)
+	n := 0
+	binary.BigEndian.PutUint32(concat[n:], uint32(len(alg)))
+	n += 4
+	n += copy(concat[n:], alg)
+
+	binary.BigEndian.PutUint32(concat[n:], uint32(len(apu)))
+	n += 4
+	n += copy(concat[n:], apu)
+
+	binary.BigEndian.PutUint32(concat[n:], uint32(len(apv)))
+	n += 4
+	n += copy(concat[n:], apv)
+
 	n += copy(concat[n:], pubinfo)
 	copy(concat[n:], privinfo)
 


### PR DESCRIPTION
Write length-prefixed fields directly into a single buffer, eliminating intermediate allocations from ndata().

No measurable perf change (compiler already optimized via inlining + escape analysis): 54.6 ns/op, 128 B/op, 2 allocs.