### PR TITLE
fix probe field name in panic message

### DIFF
--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -41,7 +41,7 @@ func init() {
 		Type: reflect.TypeFor[json.RawMessage](),
 		Tag:  `json:"d,omitempty"`,
 	}); err != nil {
-		panic(fmt.Errorf("failed to register mandatory probe for 'kty' field: %w", err))
+		panic(fmt.Errorf("failed to register mandatory probe for 'd' field: %w", err))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix copy-paste error in `jwk/jwk.go` `init()`: panic message for the `d` probe field incorrectly said `'kty'`

## Test plan
- No behavior change — only affects a panic message in an `init()` guard that fires on duplicate field registration
