### PR TITLE
enforce crit header validation in jws.Verify per RFC 7515

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,11 @@ v3 has many incompatibilities with v2. To see the full list of differences betwe
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
 v3.0.14 UNRELEASED
+  * [jws] `jws.Verify()` now validates the "crit" (Critical) header parameter per
+    RFC 7515 Section 4.1.11. Signatures with an empty "crit" array, standard JOSE
+    header names in "crit", or "crit"-listed extensions not present in the protected
+    header are now rejected.
+
   * [jwk] Fixed a deadlock in `jwk.Cache` that occurred when repeated `Refresh()` calls
     failed (e.g. HTTP 500 responses). Each failure killed an httprc worker goroutine,
     and after all workers were exhausted, subsequent `Refresh()` calls would block forever. (#1551)

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -615,6 +615,10 @@ func Settings(options ...GlobalOption) {
 //
 // Since this function avoids doing many checks that jws.Verify would perform,
 // you must ensure to perform the necessary checks including ensuring that algorithm is safe to use for your payload yourself.
+//
+// Note: this function does NOT validate the "crit" (Critical) header
+// parameter (RFC 7515 Section 4.1.11). If you need "crit" validation,
+// use jws.Verify() instead.
 func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]byte, error) {
 	algstr := alg.String()
 

--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -1,0 +1,106 @@
+package jws_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/internal/jwxtest"
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jws"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCriticalHeaderValidation(t *testing.T) {
+	payload := []byte(`hello world`)
+
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+
+	// Helper to sign with given protected headers
+	sign := func(t *testing.T, hdrs jws.Headers) []byte {
+		t.Helper()
+		signed, err := jws.Sign(payload, jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)))
+		require.NoError(t, err, `jws.Sign should succeed`)
+		return signed
+	}
+
+	t.Run("No crit header", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		signed := sign(t, hdrs)
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
+		require.NoError(t, err, `jws.Verify should succeed without crit header`)
+	})
+
+	t.Run("crit with b64 present in header", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set("b64", false))
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"b64"}))
+
+		signed, err := jws.Sign(nil, jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)), jws.WithDetachedPayload(payload))
+		require.NoError(t, err, `jws.Sign should succeed`)
+
+		_, err = jws.Verify(signed, jws.WithKey(jwa.HS256(), key), jws.WithDetachedPayload(payload))
+		require.NoError(t, err, `jws.Verify should succeed when crit-listed header is present`)
+	})
+
+	t.Run("crit with custom header present succeeds", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set("x-custom", "custom-value"))
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-custom"}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
+		require.NoError(t, err, `jws.Verify should succeed when crit-listed header is present`)
+	})
+
+	t.Run("crit references header not present fails", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-missing"}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
+		require.Error(t, err, `jws.Verify should fail when crit references absent header`)
+		require.ErrorContains(t, err, `not present in the protected header`)
+	})
+
+	t.Run("crit with standard header name fails", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"alg"}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
+		require.Error(t, err, `jws.Verify should fail when crit contains standard header name`)
+		require.ErrorContains(t, err, `standard header parameter`)
+	})
+
+	t.Run("crit with empty array fails", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
+		require.Error(t, err, `jws.Verify should fail when crit is empty`)
+		require.ErrorContains(t, err, `must not be empty`)
+	})
+
+	t.Run("crit with multiple headers all present succeeds", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set("x-one", "v1"))
+		require.NoError(t, hdrs.Set("x-two", "v2"))
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-one", "x-two"}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
+		require.NoError(t, err, `jws.Verify should succeed when all crit-listed headers are present`)
+	})
+
+	t.Run("crit with multiple headers one missing fails", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set("x-present", "value"))
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-present", "x-absent"}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
+		require.Error(t, err, `jws.Verify should fail when any crit-listed header is missing`)
+		require.ErrorContains(t, err, `x-absent`)
+	})
+}

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -151,6 +151,13 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 			rawHeaders = protected
 		}
 
+		// Validate the "crit" header per RFC 7515 Section 4.1.11 before
+		// attempting signature verification with any keys.
+		if err := validateCritical(sig.protected); err != nil {
+			errs = append(errs, makeVerifyError(`signature #%d has invalid "crit" header: %w`, idx+1, err))
+			continue
+		}
+
 		verifyBuf = verifyBuf[:0]
 		verifyBuf = jwsbb.SignBuffer(verifyBuf, rawHeaders, msg.payload, vc.encoder, msg.b64)
 		for i, kp := range vc.keyProviders {
@@ -205,6 +212,37 @@ func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, ke
 
 	if vc.dst != nil {
 		*(vc.dst) = *msg
+	}
+
+	return nil
+}
+
+// validateCritical checks the "crit" header per RFC 7515 Section 4.1.11.
+// It verifies that all header names listed in "crit" are present in the
+// protected header and are not standard JWS header parameters.
+func validateCritical(protected Headers) error {
+	if !protected.Has(CriticalKey) {
+		return nil
+	}
+
+	crit, _ := protected.Critical()
+	if len(crit) == 0 {
+		return makeVerifyError(`"crit" header must not be empty`)
+	}
+
+	for _, name := range crit {
+		// RFC 7515 Section 4.1.11: "crit" MUST NOT include names defined
+		// by the JOSE Header specification itself.
+		for _, std := range stdHeaderNames {
+			if name == std {
+				return makeVerifyError(`"crit" header must not contain standard header parameter %q`, name)
+			}
+		}
+
+		// The extension must be present in the protected header
+		if !protected.Has(name) {
+			return makeVerifyError(`"crit" header references extension %q, but it is not present in the protected header`, name)
+		}
 	}
 
 	return nil

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/lestrrat-go/blackmagic"
@@ -233,10 +234,8 @@ func validateCritical(protected Headers) error {
 	for _, name := range crit {
 		// RFC 7515 Section 4.1.11: "crit" MUST NOT include names defined
 		// by the JOSE Header specification itself.
-		for _, std := range stdHeaderNames {
-			if name == std {
-				return makeVerifyError(`"crit" header must not contain standard header parameter %q`, name)
-			}
+		if slices.Contains(stdHeaderNames, name) {
+			return makeVerifyError(`"crit" header must not contain standard header parameter %q`, name)
 		}
 
 		// The extension must be present in the protected header


### PR DESCRIPTION
Adds validateCritical() in jws.Verify to enforce RFC 7515 Section 4.1.11: rejects empty crit, standard JOSE header names in crit, and extensions not present in the protected header. VerifyCompactFast is unchanged (documented as not validating crit).