### PR TITLE
validate crit header in VerifyCompactFast

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -615,10 +615,6 @@ func Settings(options ...GlobalOption) {
 //
 // Since this function avoids doing many checks that jws.Verify would perform,
 // you must ensure to perform the necessary checks including ensuring that algorithm is safe to use for your payload yourself.
-//
-// Note: this function does NOT validate the "crit" (Critical) header
-// parameter (RFC 7515 Section 4.1.11). If you need "crit" validation,
-// use jws.Verify() instead.
 func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]byte, error) {
 	algstr := alg.String()
 
@@ -626,6 +622,12 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	hdr, payload, encodedSig, err := jwsbb.SplitCompact(compact)
 	if err != nil {
 		return nil, fmt.Errorf("jwt.verifyFast: failed to split compact: %w", err)
+	}
+
+	// Validate the "crit" header per RFC 7515 Section 4.1.11
+	parsedHdr := jwsbb.HeaderParseCompact(hdr)
+	if err := validateCriticalFast(parsedHdr); err != nil {
+		return nil, err
 	}
 
 	signature, err := base64.Decode(encodedSig)

--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -104,3 +104,86 @@ func TestCriticalHeaderValidation(t *testing.T) {
 		require.ErrorContains(t, err, `x-absent`)
 	})
 }
+
+func TestCriticalHeaderValidationFastPath(t *testing.T) {
+	payload := []byte(`hello world`)
+
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+
+	sign := func(t *testing.T, hdrs jws.Headers) []byte {
+		t.Helper()
+		signed, err := jws.Sign(payload, jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)))
+		require.NoError(t, err, `jws.Sign should succeed`)
+		return signed
+	}
+
+	t.Run("No crit header", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		signed := sign(t, hdrs)
+		_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
+		require.NoError(t, err, `VerifyCompactFast should succeed without crit header`)
+	})
+
+	t.Run("crit with custom header present succeeds", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set("x-custom", "custom-value"))
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-custom"}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
+		require.NoError(t, err, `VerifyCompactFast should succeed when crit-listed header is present`)
+	})
+
+	t.Run("crit references header not present fails", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-missing"}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
+		require.Error(t, err, `VerifyCompactFast should fail when crit references absent header`)
+		require.ErrorContains(t, err, `not present in the protected header`)
+	})
+
+	t.Run("crit with standard header name fails", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"alg"}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
+		require.Error(t, err, `VerifyCompactFast should fail when crit contains standard header name`)
+		require.ErrorContains(t, err, `standard header parameter`)
+	})
+
+	t.Run("crit with empty array fails", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
+		require.Error(t, err, `VerifyCompactFast should fail when crit is empty`)
+		require.ErrorContains(t, err, `must not be empty`)
+	})
+
+	t.Run("crit with multiple headers all present succeeds", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set("x-one", "v1"))
+		require.NoError(t, hdrs.Set("x-two", "v2"))
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-one", "x-two"}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
+		require.NoError(t, err, `VerifyCompactFast should succeed when all crit-listed headers are present`)
+	})
+
+	t.Run("crit with multiple headers one missing fails", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set("x-present", "value"))
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-present", "x-absent"}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
+		require.Error(t, err, `VerifyCompactFast should fail when any crit-listed header is missing`)
+		require.ErrorContains(t, err, `x-absent`)
+	})
+}

--- a/jws/jwsbb/BUILD.bazel
+++ b/jws/jwsbb/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "ecdsa.go",
         "eddsa.go",
         "format.go",
+        "header.go",
         "hmac.go",
         "jwsbb.go",
         "rsa.go",
@@ -24,6 +25,7 @@ go_library(
         "//internal/tokens",
         "//jws/internal/keytype",
         "@com_github_lestrrat_go_dsig//:dsig",
+        "@com_github_valyala_fastjson//:fastjson",
     ],
 )
 

--- a/jws/jwsbb/header.go
+++ b/jws/jwsbb/header.go
@@ -194,6 +194,41 @@ func HeaderGetStringBytes(h Header, key string) ([]byte, error) {
 	return v.StringBytes()
 }
 
+// HeaderHas returns true if the given key exists in the JWS header.
+//
+// This function is experimental and may change or be removed in the future.
+func HeaderHas(h Header, key string) bool {
+	_, err := headerGet(h, key)
+	return err == nil
+}
+
+// HeaderGetStringArray returns a string array for the given key from the JWS header.
+// An error is returned if the JSON was not valid, if the key does not exist,
+// or if the value is not a JSON array of strings.
+//
+// This function is experimental and may change or be removed in the future.
+func HeaderGetStringArray(h Header, key string) ([]string, error) {
+	v, err := headerGet(h, key)
+	if err != nil {
+		return nil, err
+	}
+
+	arr, err := v.Array()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]string, len(arr))
+	for i, item := range arr {
+		sb, err := item.StringBytes()
+		if err != nil {
+			return nil, err
+		}
+		result[i] = string(sb)
+	}
+	return result, nil
+}
+
 // HeaderGetUint returns the uint value for the given key from the JWS header.
 // An error is returned if the JSON was not valid, if the key does not exist,
 // or if the value is not a uint.

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -246,3 +246,32 @@ func validateCritical(protected Headers) error {
 
 	return nil
 }
+
+// validateCriticalFast is the fastjson-based equivalent of validateCritical,
+// used by VerifyCompactFast to validate the "crit" header without full
+// message parsing.
+func validateCriticalFast(hdr jwsbb.Header) error {
+	crit, err := jwsbb.HeaderGetStringArray(hdr, CriticalKey)
+	if err != nil {
+		if errors.Is(err, jwsbb.ErrHeaderNotFound()) {
+			return nil
+		}
+		return makeVerifyError(`failed to read "crit" header: %w`, err)
+	}
+
+	if len(crit) == 0 {
+		return makeVerifyError(`"crit" header must not be empty`)
+	}
+
+	for _, name := range crit {
+		if slices.Contains(stdHeaderNames, name) {
+			return makeVerifyError(`"crit" header must not contain standard header parameter %q`, name)
+		}
+
+		if !jwsbb.HeaderHas(hdr, name) {
+			return makeVerifyError(`"crit" header references extension %q, but it is not present in the protected header`, name)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Extends crit header validation (from #1601) to `VerifyCompactFast` using fastjson-based header parsing. Adds `HeaderHas` and `HeaderGetStringArray` helpers to `jwsbb`. The JWT fast path (`jwt.Parse` with single `WithKey`) now also validates crit.