### PR TITLE
fix X25519 ECDH-ES to include apu/apv in KDF

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,6 +10,11 @@ v3.0.14 UNRELEASED
     header names in "crit", or "crit"-listed extensions not present in the protected
     header are now rejected.
 
+  * [jwe] Fixed X25519 ECDH-ES key agreement to include `apu` and `apv` parameters
+    in the Concat KDF derivation, matching the ECDSA path. Previously these values
+    were silently discarded during encryption, weakening the key derivation per
+    RFC 7518 Section 4.6.2.
+
   * [jwk] Fixed a deadlock in `jwk.Cache` that occurred when repeated `Refresh()` calls
     failed (e.g. HTTP 500 responses). Each failure killed an httprc worker goroutine,
     and after all workers were exhausted, subsequent `Refresh()` calls would block forever. (#1551)

--- a/jwe/internal/keygen/keygen.go
+++ b/jwe/internal/keygen/keygen.go
@@ -64,7 +64,7 @@ func Ecdhes(alg string, enc string, keysize int, pubkey *ecdsa.PublicKey, apu, a
 }
 
 // X25519 generates a new key using ECDH-ES with X25519
-func X25519(alg string, enc string, keysize int, pubkey *ecdh.PublicKey) (ByteSource, error) {
+func X25519(alg string, enc string, keysize int, pubkey *ecdh.PublicKey, apu, apv []byte) (ByteSource, error) {
 	priv, err := ecdh.X25519().GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf(`failed to generate key for X25519: %w`, err)
@@ -84,7 +84,7 @@ func X25519(alg string, enc string, keysize int, pubkey *ecdh.PublicKey) (ByteSo
 	if err != nil {
 		return nil, fmt.Errorf(`failed to compute Z: %w`, err)
 	}
-	kdf := concatkdf.New(crypto.SHA256, []byte(algorithm), zBytes, []byte{}, []byte{}, pubinfo, []byte{})
+	kdf := concatkdf.New(crypto.SHA256, []byte(algorithm), zBytes, apu, apv, pubinfo, []byte{})
 	kek := make([]byte, keysize)
 	if _, err := kdf.Read(kek); err != nil {
 		return nil, fmt.Errorf(`failed to read kdf: %w`, err)

--- a/jwe/jwebb/key_encrypt_asymmetric.go
+++ b/jwe/jwebb/key_encrypt_asymmetric.go
@@ -65,9 +65,9 @@ func generateECDHESKeyECDSA(alg string, calg string, keysize uint32, pubkey *ecd
 }
 
 // generateECDHESKeyX25519 generates the key material for X25519 keys using ECDH-ES
-func generateECDHESKeyX25519(alg string, calg string, keysize uint32, pubkey *ecdh.PublicKey) (keygen.ByteWithECPublicKey, error) {
+func generateECDHESKeyX25519(alg string, calg string, keysize uint32, pubkey *ecdh.PublicKey, apu, apv []byte) (keygen.ByteWithECPublicKey, error) {
 	// Generate the key directly
-	kg, err := keygen.X25519(alg, calg, int(keysize), pubkey)
+	kg, err := keygen.X25519(alg, calg, int(keysize), pubkey, apu, apv)
 	if err != nil {
 		return keygen.ByteWithECPublicKey{}, fmt.Errorf(`failed to generate X25519 key: %w`, err)
 	}
@@ -103,8 +103,8 @@ func KeyEncryptECDHESKeyWrapECDSA(cek []byte, alg string, apu, apv []byte, pubke
 }
 
 // KeyEncryptECDHESKeyWrapX25519 encrypts the CEK using ECDH-ES with key wrapping for X25519 keys
-func KeyEncryptECDHESKeyWrapX25519(cek []byte, alg string, _ []byte, _ []byte, pubkey *ecdh.PublicKey, keysize uint32, calg string) (keygen.ByteSource, error) {
-	bwpk, err := generateECDHESKeyX25519(alg, calg, keysize, pubkey)
+func KeyEncryptECDHESKeyWrapX25519(cek []byte, alg string, apu []byte, apv []byte, pubkey *ecdh.PublicKey, keysize uint32, calg string) (keygen.ByteSource, error) {
+	bwpk, err := generateECDHESKeyX25519(alg, calg, keysize, pubkey, apu, apv)
 	if err != nil {
 		return nil, err
 	}
@@ -136,8 +136,8 @@ func KeyEncryptECDHESECDSA(_ []byte, alg string, apu, apv []byte, pubkey *ecdsa.
 }
 
 // KeyEncryptECDHESX25519 encrypts using ECDH-ES direct (no key wrapping) for X25519 keys
-func KeyEncryptECDHESX25519(_ []byte, alg string, _, _ []byte, pubkey *ecdh.PublicKey, keysize uint32, calg string) (keygen.ByteSource, error) {
-	bwpk, err := generateECDHESKeyX25519(alg, calg, keysize, pubkey)
+func KeyEncryptECDHESX25519(_ []byte, alg string, apu, apv []byte, pubkey *ecdh.PublicKey, keysize uint32, calg string) (keygen.ByteSource, error) {
+	bwpk, err := generateECDHESKeyX25519(alg, calg, keysize, pubkey, apu, apv)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
X25519 ECDH-ES key agreement was silently discarding `apu` and `apv` parameters during encryption — the callers passed them but the functions used `_`. The ECDSA ECDH-ES path correctly included them in the Concat KDF. The decrypt side (`DeriveECDHES`) was already correct. This aligns both paths per RFC 7518 Section 4.6.2.