### PR TITLE
enforce minimum PBES2 iteration count

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,12 @@ v3.0.14 UNRELEASED
     were silently discarded during encryption, weakening the key derivation per
     RFC 7518 Section 4.6.2.
 
+  * [jwe] POTENTIALLY BREAKING: `jwe.Decrypt()` now rejects PBES2 messages with
+    a `p2c` (iteration count) below 1,000 by default. This prevents accepting
+    tokens with trivially low iteration counts that eliminate PBKDF2 brute-force
+    protection. To restore the previous behavior or adjust the threshold, call
+    `jwe.Settings(jwe.WithMinPBES2Count(0))`.
+
   * [jwk] Fixed a deadlock in `jwk.Cache` that occurred when repeated `Refresh()` calls
     failed (e.g. HTTP 500 responses). Each failure killed an httprc worker goroutine,
     and after all workers were exhausted, subsequent `Refresh()` calls would block forever. (#1551)

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -30,6 +30,7 @@ import (
 
 var muSettings sync.RWMutex
 var maxPBES2Count = 10000
+var minPBES2Count = 1000
 var maxDecompressBufferSize int64 = 10 * 1024 * 1024 // 10MB
 
 func Settings(options ...GlobalOption) {
@@ -40,6 +41,10 @@ func Settings(options ...GlobalOption) {
 		case identMaxPBES2Count{}:
 			if err := option.Value(&maxPBES2Count); err != nil {
 				panic(fmt.Sprintf("jwe.Settings: value for option WithMaxPBES2Count must be an int: %s", err))
+			}
+		case identMinPBES2Count{}:
+			if err := option.Value(&minPBES2Count); err != nil {
+				panic(fmt.Sprintf("jwe.Settings: value for option WithMinPBES2Count must be an int: %s", err))
 			}
 		case identMaxDecompressBufferSize{}:
 			if err := option.Value(&maxDecompressBufferSize); err != nil {
@@ -525,8 +530,12 @@ func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgo
 
 		muSettings.RLock()
 		maxCount := maxPBES2Count
+		minCount := minPBES2Count
 		muSettings.RUnlock()
 		if countFlt > float64(maxCount) {
+			return nil, fmt.Errorf("invalid 'p2c' value")
+		}
+		if countFlt < float64(minCount) {
 			return nil, fmt.Errorf("invalid 'p2c' value")
 		}
 		salt, err := base64.DecodeString(saltB64)

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -859,6 +859,41 @@ func TestGHSA_7f9x_gw85_8grf(t *testing.T) {
 	}
 }
 
+func TestMinPBES2Count(t *testing.T) {
+	// Encrypt a message using PBES2 (default p2c=10000)
+	password := []byte(`supersecret`)
+	key, err := jwk.Import(password)
+	require.NoError(t, err, `jwk.Import should succeed`)
+
+	payload := []byte(`hello world`)
+	encrypted, err := jwe.Encrypt(payload, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+	require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+	t.Run("default min rejects nothing at default p2c", func(t *testing.T) {
+		// Default min is 1000, default p2c is 10000 — should succeed
+		_, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+		require.NoError(t, err, `jwe.Decrypt should succeed with default settings`)
+	})
+
+	t.Run("high min rejects default p2c", func(t *testing.T) {
+		// NOTE: HAS GLOBAL EFFECT
+		jwe.Settings(jwe.WithMinPBES2Count(20000))
+		defer jwe.Settings(jwe.WithMinPBES2Count(1000))
+
+		_, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+		require.Error(t, err, `jwe.Decrypt should fail when p2c < min`)
+	})
+
+	t.Run("min of zero disables check", func(t *testing.T) {
+		// NOTE: HAS GLOBAL EFFECT
+		jwe.Settings(jwe.WithMinPBES2Count(0))
+		defer jwe.Settings(jwe.WithMinPBES2Count(1000))
+
+		_, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+		require.NoError(t, err, `jwe.Decrypt should succeed when min is 0`)
+	})
+}
+
 func TestCBCBufferSize(t *testing.T) {
 	// NOTE: This has GLOBAL EFFECT
 	jwe.Settings(jwe.WithCBCBufferSize(1))

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -148,6 +148,15 @@ options:
       value of 10,000 is used.
 
       This option has a global effect.
+  - ident: MinPBES2Count
+    interface: GlobalOption
+    argument_type: int
+    comment: |
+      WithMinPBES2Count specifies the minimum number of PBES2 iterations
+      to accept when decrypting a message. If not specified, the default
+      value of 1,000 is used. Set to 0 to disable the minimum check.
+
+      This option has a global effect.
   - ident: MaxDecompressBufferSize
     interface: GlobalDecryptOption
     argument_type: int64

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -152,6 +152,7 @@ type identMaxDecompressBufferSize struct{}
 type identMaxPBES2Count struct{}
 type identMergeProtectedHeaders struct{}
 type identMessage struct{}
+type identMinPBES2Count struct{}
 type identPerRecipientHeaders struct{}
 type identPretty struct{}
 type identProtectedHeaders struct{}
@@ -212,6 +213,10 @@ func (identMergeProtectedHeaders) String() string {
 
 func (identMessage) String() string {
 	return "WithMessage"
+}
+
+func (identMinPBES2Count) String() string {
+	return "WithMinPBES2Count"
 }
 
 func (identPerRecipientHeaders) String() string {
@@ -367,6 +372,15 @@ func WithMergeProtectedHeaders(v bool) EncryptOption {
 // in one go.
 func WithMessage(v *Message) DecryptOption {
 	return &decryptOption{option.New(identMessage{}, v)}
+}
+
+// WithMinPBES2Count specifies the minimum number of PBES2 iterations
+// to accept when decrypting a message. If not specified, the default
+// value of 1,000 is used. Set to 0 to disable the minimum check.
+//
+// This option has a global effect.
+func WithMinPBES2Count(v int) GlobalOption {
+	return &globalOption{option.New(identMinPBES2Count{}, v)}
 }
 
 // WithPretty specifies whether the JSON output should be formatted and

--- a/jwe/options_gen_test.go
+++ b/jwe/options_gen_test.go
@@ -23,6 +23,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithMaxPBES2Count", identMaxPBES2Count{}.String())
 	require.Equal(t, "WithMergeProtectedHeaders", identMergeProtectedHeaders{}.String())
 	require.Equal(t, "WithMessage", identMessage{}.String())
+	require.Equal(t, "WithMinPBES2Count", identMinPBES2Count{}.String())
 	require.Equal(t, "WithPerRecipientHeaders", identPerRecipientHeaders{}.String())
 	require.Equal(t, "WithPretty", identPretty{}.String())
 	require.Equal(t, "WithProtectedHeaders", identProtectedHeaders{}.String())


### PR DESCRIPTION
PBES2 `p2c` was checked against a max (default 10000) but had no minimum, accepting values like 0 or 1 that eliminate brute-force protection. Adds `WithMinPBES2Count` (default 1000) mirroring the existing `WithMaxPBES2Count` pattern. Set to 0 to disable.