### PR TITLE
reject null JSON values for string claims (#1484)

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,12 @@ v3 has many incompatibilities with v2. To see the full list of differences betwe
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
 v3.0.14 UNRELEASED
+  * [jwt] `jwt.Parse()` now rejects JSON `null` for string registered claims
+    (`iss`, `sub`, `jti`). Previously, null was silently accepted as an empty
+    string due to Go's default JSON decoding behavior. This is a correctness fix
+    per the RFC type definitions (StringOrURI) rather than a security fix —
+    legitimate token issuers do not emit null for these claims. (#1484)
+
   * [jws] `jws.Verify()` now validates the "crit" (Critical) header parameter per
     RFC 7515 Section 4.1.11. Signatures with an empty "crit" array, standard JOSE
     header names in "crit", or "crit"-listed extensions not present in the protected

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -45,12 +45,25 @@ func AssignNextBytesToken(dst *[]byte, dec *Decoder) error {
 	return nil
 }
 
+// ReadNextStringToken reads the next JSON token from the decoder and
+// returns it as a string. JSON null is explicitly rejected: while Go's
+// json.Decoder silently converts null to "", the JSON spec treats null
+// as a distinct type from string. In practice this is low-risk — legitimate
+// issuers rarely emit null for string claims — but rejecting null is the
+// correct behavior per the RFC type definitions (e.g. StringOrURI).
 func ReadNextStringToken(dec *Decoder) (string, error) {
-	var val string
+	var val any
 	if err := dec.Decode(&val); err != nil {
 		return "", fmt.Errorf(`error reading next value: %w`, err)
 	}
-	return val, nil
+	if val == nil {
+		return "", fmt.Errorf(`error reading next value: expected string, got null`)
+	}
+	s, ok := val.(string)
+	if !ok {
+		return "", fmt.Errorf(`error reading next value: expected string, got %T`, val)
+	}
+	return s, nil
 }
 
 func AssignNextStringToken(dst **string, dec *Decoder) error {

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1639,3 +1639,35 @@ func TestGH1482(t *testing.T) {
 	require.NoError(t, err, `jwt.Parse should succeed`)
 	require.NotEmpty(t, markerValue, "context value 'marker' should be present")
 }
+
+// TestGH1484 tests that jwt.Parse rejects JSON null for string registered
+// claims (iss, sub, jti). Go's json.Decoder silently converts null to ""
+// for string targets, so the library must explicitly check for this.
+// Low real-world risk — legitimate issuers don't emit null — but correct
+// per the RFC StringOrURI type definitions.
+func TestGH1484(t *testing.T) {
+	// Tokens signed with HS256 key "abracadabra".
+	// null_sub generated from issue report; null_iss and null_jti
+	// constructed by signing matching payloads with the same key.
+	testcases := []struct {
+		Name    string
+		Payload string
+	}{
+		{Name: "null_sub", Payload: `{"sub":null}`},
+		{Name: "null_iss", Payload: `{"iss":null}`},
+		{Name: "null_jti", Payload: `{"jti":null}`},
+	}
+
+	key, err := jwk.Import([]byte("abracadabra"))
+	require.NoError(t, err, `jwk.Import should succeed`)
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			signed, err := jws.Sign([]byte(tc.Payload), jws.WithKey(jwa.HS256(), key))
+			require.NoError(t, err, `jws.Sign should succeed`)
+
+			_, err = jwt.Parse(signed, jwt.WithKey(jwa.HS256(), key))
+			require.Error(t, err, `jwt.Parse should reject null claim`)
+		})
+	}
+}


### PR DESCRIPTION
Reject JSON null for string registered claims (iss, sub, jti) during parsing. Go's json.Decoder silently converts null to empty string; now explicitly decoded via any and checked. Low real-world risk — correctness fix per RFC StringOrURI type definitions, not a security fix.

fixes #1484