### PR TITLE
add RFC 9864 fully-specified EdDSA signature algorithms

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,8 +15,25 @@ v3.0.14 UNRELEASED
     RFC 9864. The polymorphic `EdDSA` algorithm is now marked as deprecated.
     New Go accessors: `jwa.EdDSAEd25519()` and `jwa.EdDSAEd448()` (function names
     are tentative and may change in future releases).
-    Note: Ed448 is registered as an algorithm identifier but is not usable for
-    signing or verification because Go's standard library does not support Ed448.
+    Ed448 signing/verification requires `github.com/cloudflare/circl` because
+    Go's standard library does not support Ed448. To avoid pulling in this
+    extra dependency for all users, Ed448 support is provided as a separate
+    module (`github.com/lestrrat-go/jwx-circl-ed448`). Import it for side
+    effects to enable Ed448:
+      import _ "github.com/lestrrat-go/jwx-circl-ed448"
+    Without this import, Ed448 is registered as an algorithm identifier but
+    will return an error at sign/verify time.
+
+  * [jwk] Add `jwk/jwkunsafe` package with `NewKey(kty)` and `NewPublicKey(kty)`
+    functions for creating empty, unpopulated JWK key objects. This is intended
+    for extension module authors who need to register custom KeyImporter
+    implementations for new key types.
+
+  * [jws] Add `jws.RegisterAlgorithmForKeyType()` for external modules to register
+    additional algorithm-to-key-type mappings.
+
+  * [jws/jwsbb] Add `jwsbb.RegisterEdDSAAlgorithm()` for external modules to
+    register custom EdDSA algorithm implementations (e.g. Ed448).
 
   * [jws] `jws.Verify()` now validates the "crit" (Critical) header parameter per
     RFC 7515 Section 4.1.11. Signatures with an empty "crit" array, standard JOSE

--- a/Changes
+++ b/Changes
@@ -11,6 +11,13 @@ v3.0.14 UNRELEASED
     per the RFC type definitions (StringOrURI) rather than a security fix —
     legitimate token issuers do not emit null for these claims. (#1484)
 
+  * [jwa] Add fully-specified EdDSA signature algorithms `Ed25519` and `Ed448` per
+    RFC 9864. The polymorphic `EdDSA` algorithm is now marked as deprecated.
+    New Go accessors: `jwa.EdDSAEd25519()` and `jwa.EdDSAEd448()` (function names
+    are tentative and may change in future releases).
+    Note: Ed448 is registered as an algorithm identifier but is not usable for
+    signing or verification because Go's standard library does not support Ed448.
+
   * [jws] `jws.Verify()` now validates the "crit" (Critical) header parameter per
     RFC 7515 Section 4.1.11. Signatures with an empty "crit" array, standard JOSE
     header names in "crit", or "crit"-listed extensions not present in the protected

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cloudflare/circl v1.6.3
 	github.com/emmansun/gmsm v0.41.1
 	github.com/lestrrat-go/httprc/v3 v3.0.5
+	github.com/lestrrat-go/jwx-circl-ed448 v0.0.0
 	github.com/lestrrat-go/jwx/v3 v3.0.0
 )
 

--- a/examples/jws_ed448_example_test.go
+++ b/examples/jws_ed448_example_test.go
@@ -1,0 +1,41 @@
+package examples_test
+
+import (
+	"fmt"
+
+	"github.com/cloudflare/circl/sign/ed448"
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jws"
+
+	// Importing the ed448 module registers Ed448 signing, verification,
+	// and JWK key import/export. This is all that's needed to enable Ed448.
+	_ "github.com/lestrrat-go/jwx-circl-ed448"
+)
+
+func Example_jws_sign_verify_ed448() {
+	pubkey, privkey, err := ed448.GenerateKey(nil)
+	if err != nil {
+		fmt.Printf("failed to generate Ed448 key: %s\n", err)
+		return
+	}
+
+	const payload = "Hello, Ed448!"
+
+	// Sign using the fully-specified Ed448 algorithm (RFC 9864)
+	signed, err := jws.Sign([]byte(payload), jws.WithKey(jwa.EdDSAEd448(), privkey))
+	if err != nil {
+		fmt.Printf("failed to sign: %s\n", err)
+		return
+	}
+
+	// Verify
+	verified, err := jws.Verify(signed, jws.WithKey(jwa.EdDSAEd448(), pubkey))
+	if err != nil {
+		fmt.Printf("failed to verify: %s\n", err)
+		return
+	}
+
+	fmt.Println(string(verified))
+	// OUTPUT:
+	// Hello, Ed448!
+}

--- a/jwa/jwa_test.go
+++ b/jwa/jwa_test.go
@@ -22,6 +22,43 @@ func TestSanity(t *testing.T) {
 	require.True(t, ok, `converting k2 to jws.KeyEncryptionAlgorithm should succeed`)
 }
 
+func TestRFC9864(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EdDSA is deprecated", func(t *testing.T) {
+		t.Parallel()
+		require.True(t, jwa.EdDSA().IsDeprecated(), `EdDSA should be deprecated`)
+	})
+	t.Run("EdDSAEd25519 is not deprecated", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, jwa.EdDSAEd25519().IsDeprecated(), `EdDSAEd25519 should not be deprecated`)
+	})
+	t.Run("EdDSAEd448 is not deprecated", func(t *testing.T) {
+		t.Parallel()
+		require.False(t, jwa.EdDSAEd448().IsDeprecated(), `EdDSAEd448 should not be deprecated`)
+	})
+	t.Run("EdDSAEd25519 string value", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "Ed25519", jwa.EdDSAEd25519().String(), `EdDSAEd25519 should have string value Ed25519`)
+	})
+	t.Run("EdDSAEd448 string value", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "Ed448", jwa.EdDSAEd448().String(), `EdDSAEd448 should have string value Ed448`)
+	})
+	t.Run("LookupSignatureAlgorithm for Ed25519", func(t *testing.T) {
+		t.Parallel()
+		v, ok := jwa.LookupSignatureAlgorithm("Ed25519")
+		require.True(t, ok, `LookupSignatureAlgorithm("Ed25519") should succeed`)
+		require.Equal(t, jwa.EdDSAEd25519(), v)
+	})
+	t.Run("LookupEllipticCurveAlgorithm for Ed25519 still works", func(t *testing.T) {
+		t.Parallel()
+		v, ok := jwa.LookupEllipticCurveAlgorithm("Ed25519")
+		require.True(t, ok, `LookupEllipticCurveAlgorithm("Ed25519") should still succeed`)
+		require.Equal(t, jwa.Ed25519(), v)
+	})
+}
+
 func TestKeyAlgorithmFrom(t *testing.T) {
 	testcases := []struct {
 		Input any

--- a/jwa/signature_gen.go
+++ b/jwa/signature_gen.go
@@ -17,22 +17,24 @@ var builtinSignatureAlgorithm = map[string]struct{}{}
 
 func init() {
 	// builtin values for SignatureAlgorithm
-	algorithms := make([]SignatureAlgorithm, 15)
+	algorithms := make([]SignatureAlgorithm, 17)
 	algorithms[0] = NewSignatureAlgorithm("ES256")
 	algorithms[1] = NewSignatureAlgorithm("ES256K")
 	algorithms[2] = NewSignatureAlgorithm("ES384")
 	algorithms[3] = NewSignatureAlgorithm("ES512")
-	algorithms[4] = NewSignatureAlgorithm("EdDSA")
-	algorithms[5] = NewSignatureAlgorithm("HS256", WithIsSymmetric(true))
-	algorithms[6] = NewSignatureAlgorithm("HS384", WithIsSymmetric(true))
-	algorithms[7] = NewSignatureAlgorithm("HS512", WithIsSymmetric(true))
-	algorithms[8] = NewSignatureAlgorithm("none")
-	algorithms[9] = NewSignatureAlgorithm("PS256")
-	algorithms[10] = NewSignatureAlgorithm("PS384")
-	algorithms[11] = NewSignatureAlgorithm("PS512")
-	algorithms[12] = NewSignatureAlgorithm("RS256")
-	algorithms[13] = NewSignatureAlgorithm("RS384")
-	algorithms[14] = NewSignatureAlgorithm("RS512")
+	algorithms[4] = NewSignatureAlgorithm("EdDSA", WithDeprecated(true))
+	algorithms[5] = NewSignatureAlgorithm("Ed25519")
+	algorithms[6] = NewSignatureAlgorithm("Ed448")
+	algorithms[7] = NewSignatureAlgorithm("HS256", WithIsSymmetric(true))
+	algorithms[8] = NewSignatureAlgorithm("HS384", WithIsSymmetric(true))
+	algorithms[9] = NewSignatureAlgorithm("HS512", WithIsSymmetric(true))
+	algorithms[10] = NewSignatureAlgorithm("none")
+	algorithms[11] = NewSignatureAlgorithm("PS256")
+	algorithms[12] = NewSignatureAlgorithm("PS384")
+	algorithms[13] = NewSignatureAlgorithm("PS512")
+	algorithms[14] = NewSignatureAlgorithm("RS256")
+	algorithms[15] = NewSignatureAlgorithm("RS384")
+	algorithms[16] = NewSignatureAlgorithm("RS512")
 
 	RegisterSignatureAlgorithm(algorithms...)
 }
@@ -57,9 +59,19 @@ func ES512() SignatureAlgorithm {
 	return lookupBuiltinSignatureAlgorithm("ES512")
 }
 
-// EdDSA returns an object representing EdDSA signature algorithms.
+// EdDSA returns an object representing EdDSA signature algorithms (deprecated by RFC 9864, use EdDSAEd25519 or EdDSAEd448).
 func EdDSA() SignatureAlgorithm {
 	return lookupBuiltinSignatureAlgorithm("EdDSA")
+}
+
+// EdDSAEd25519 returns an object representing EdDSA signature algorithm using Ed25519 (RFC 9864). The function name is tentative and may change in future releases.
+func EdDSAEd25519() SignatureAlgorithm {
+	return lookupBuiltinSignatureAlgorithm("Ed25519")
+}
+
+// EdDSAEd448 returns an object representing EdDSA signature algorithm using Ed448 (RFC 9864). The function name is tentative and may change in future releases.
+func EdDSAEd448() SignatureAlgorithm {
+	return lookupBuiltinSignatureAlgorithm("Ed448")
 }
 
 // HS256 returns an object representing HMAC signature algorithm using SHA-256.

--- a/jwa/signature_gen_test.go
+++ b/jwa/signature_gen_test.go
@@ -95,6 +95,38 @@ func TestSignatureAlgorithm(t *testing.T) {
 	})
 	t.Run(`Lookup the object`, func(t *testing.T) {
 		t.Parallel()
+		v, ok := jwa.LookupSignatureAlgorithm("Ed25519")
+		require.True(t, ok, `Lookup should succeed`)
+		require.Equal(t, jwa.EdDSAEd25519(), v, `Lookup value should be equal to constant`)
+	})
+	t.Run(`Unmarshal the string Ed25519`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.SignatureAlgorithm
+		require.NoError(t, json.Unmarshal([]byte(strconv.Quote("Ed25519")), &dst), `UnmarshalJSON is successful`)
+		require.Equal(t, jwa.EdDSAEd25519(), dst, `unmarshaled value should be equal to constant`)
+	})
+	t.Run(`stringification for Ed25519`, func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "Ed25519", jwa.EdDSAEd25519().String(), `stringified value matches`)
+	})
+	t.Run(`Lookup the object`, func(t *testing.T) {
+		t.Parallel()
+		v, ok := jwa.LookupSignatureAlgorithm("Ed448")
+		require.True(t, ok, `Lookup should succeed`)
+		require.Equal(t, jwa.EdDSAEd448(), v, `Lookup value should be equal to constant`)
+	})
+	t.Run(`Unmarshal the string Ed448`, func(t *testing.T) {
+		t.Parallel()
+		var dst jwa.SignatureAlgorithm
+		require.NoError(t, json.Unmarshal([]byte(strconv.Quote("Ed448")), &dst), `UnmarshalJSON is successful`)
+		require.Equal(t, jwa.EdDSAEd448(), dst, `unmarshaled value should be equal to constant`)
+	})
+	t.Run(`stringification for Ed448`, func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "Ed448", jwa.EdDSAEd448().String(), `stringified value matches`)
+	})
+	t.Run(`Lookup the object`, func(t *testing.T) {
+		t.Parallel()
 		v, ok := jwa.LookupSignatureAlgorithm("HS256")
 		require.True(t, ok, `Lookup should succeed`)
 		require.Equal(t, jwa.HS256(), v, `Lookup value should be equal to constant`)
@@ -275,6 +307,12 @@ func TestSignatureAlgorithm(t *testing.T) {
 		t.Run(`EdDSA`, func(t *testing.T) {
 			require.False(t, jwa.EdDSA().IsSymmetric(), `jwa.EdDSA returns expected value`)
 		})
+		t.Run(`EdDSAEd25519`, func(t *testing.T) {
+			require.False(t, jwa.EdDSAEd25519().IsSymmetric(), `jwa.EdDSAEd25519 returns expected value`)
+		})
+		t.Run(`EdDSAEd448`, func(t *testing.T) {
+			require.False(t, jwa.EdDSAEd448().IsSymmetric(), `jwa.EdDSAEd448 returns expected value`)
+		})
 		t.Run(`HS256`, func(t *testing.T) {
 			require.True(t, jwa.HS256().IsSymmetric(), `jwa.HS256 returns expected value`)
 		})
@@ -309,21 +347,23 @@ func TestSignatureAlgorithm(t *testing.T) {
 	t.Run(`check list of elements`, func(t *testing.T) {
 		t.Parallel()
 		var expected = map[jwa.SignatureAlgorithm]struct{}{
-			jwa.ES256():       {},
-			jwa.ES256K():      {},
-			jwa.ES384():       {},
-			jwa.ES512():       {},
-			jwa.EdDSA():       {},
-			jwa.HS256():       {},
-			jwa.HS384():       {},
-			jwa.HS512():       {},
-			jwa.NoSignature(): {},
-			jwa.PS256():       {},
-			jwa.PS384():       {},
-			jwa.PS512():       {},
-			jwa.RS256():       {},
-			jwa.RS384():       {},
-			jwa.RS512():       {},
+			jwa.ES256():        {},
+			jwa.ES256K():       {},
+			jwa.ES384():        {},
+			jwa.ES512():        {},
+			jwa.EdDSA():        {},
+			jwa.EdDSAEd25519(): {},
+			jwa.EdDSAEd448():   {},
+			jwa.HS256():        {},
+			jwa.HS384():        {},
+			jwa.HS512():        {},
+			jwa.NoSignature():  {},
+			jwa.PS256():        {},
+			jwa.PS384():        {},
+			jwa.PS512():        {},
+			jwa.RS256():        {},
+			jwa.RS384():        {},
+			jwa.RS512():        {},
 		}
 		for _, v := range jwa.SignatureAlgorithms() {
 			_, ok := expected[v]

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lestrrat-go/jwx/v3/internal/pool"
 	"github.com/lestrrat-go/jwx/v3/internal/tokens"
 	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk/internal/registry"
 )
 
 const (
@@ -549,7 +550,7 @@ LOOP:
 						}
 					}
 				}
-				decoded, err := registry.Decode(dec, tok)
+				decoded, err := fieldRegistry.Decode(dec, tok)
 				if err == nil {
 					h.setNoLock(tok, decoded)
 					continue
@@ -1258,7 +1259,7 @@ LOOP:
 						}
 					}
 				}
-				decoded, err := registry.Decode(dec, tok)
+				decoded, err := fieldRegistry.Decode(dec, tok)
 				if err == nil {
 					h.setNoLock(tok, decoded)
 					continue
@@ -1429,4 +1430,11 @@ func init() {
 // ECDSAStandardFieldsFilter returns a KeyFilter that filters out standard ECDSA fields.
 func ECDSAStandardFieldsFilter() KeyFilter {
 	return ecdsaStandardFields
+}
+
+func init() {
+	registry.Register(jwa.EC().String(), registry.Constructor{
+		Public:  func() any { return newECDSAPublicKey() },
+		Private: func() any { return newECDSAPrivateKey() },
+	})
 }

--- a/jwk/internal/registry/registry.go
+++ b/jwk/internal/registry/registry.go
@@ -1,0 +1,43 @@
+// Package registry provides an internal registry of JWK key constructors.
+// It exists so that both jwk and jwk/jwkunsafe can access the same set of
+// constructors without exporting them from the jwk package.
+package registry
+
+import "fmt"
+
+// Constructor holds factory functions for creating empty JWK keys.
+// Public may be nil for key types without a public/private distinction
+// (e.g. symmetric keys).
+type Constructor struct {
+	Public  func() any // returns jwk.Key
+	Private func() any // returns jwk.Key
+}
+
+var constructors = map[string]Constructor{}
+
+// Register adds a constructor for the given key type name.
+func Register(kty string, c Constructor) {
+	constructors[kty] = c
+}
+
+// NewKey creates a new empty private (or symmetric) key for the given key type.
+func NewKey(kty string) (any, error) {
+	c, ok := constructors[kty]
+	if !ok {
+		return nil, fmt.Errorf(`registry: unknown key type %q`, kty)
+	}
+	return c.Private(), nil
+}
+
+// NewPublicKey creates a new empty public key for the given key type.
+// Returns an error for key types that have no public/private distinction.
+func NewPublicKey(kty string) (any, error) {
+	c, ok := constructors[kty]
+	if !ok {
+		return nil, fmt.Errorf(`registry: unknown key type %q`, kty)
+	}
+	if c.Public == nil {
+		return nil, fmt.Errorf(`registry: key type %q has no public key variant`, kty)
+	}
+	return c.Public(), nil
+}

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -19,7 +19,7 @@ import (
 	"github.com/lestrrat-go/jwx/v3/internal/json"
 )
 
-var registry = json.NewRegistry()
+var fieldRegistry = json.NewRegistry()
 
 func bigIntToBytes(n *big.Int) ([]byte, error) {
 	if n == nil {
@@ -574,7 +574,7 @@ type CustomDecodeFunc = json.CustomDecodeFunc
 // that wraps your desired type (in this case `time.Time`) and implement
 // MarshalJSON and UnmashalJSON.
 func RegisterCustomField(name string, object any) {
-	registry.Register(name, object)
+	fieldRegistry.Register(name, object)
 }
 
 // Equal compares two keys and returns true if they are equal. The comparison

--- a/jwk/jwkunsafe/jwkunsafe.go
+++ b/jwk/jwkunsafe/jwkunsafe.go
@@ -1,0 +1,46 @@
+// Package jwkunsafe provides low-level JWK key construction functions.
+//
+// These functions create empty, unpopulated key objects. In most cases you
+// should use [jwk.Import] or [jwk.ParseKey] instead. This package exists
+// for extension module authors who need to register custom [jwk.KeyImporter]
+// implementations for new key types (e.g. Ed448).
+package jwkunsafe
+
+import (
+	"fmt"
+
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/lestrrat-go/jwx/v3/jwk/internal/registry"
+)
+
+// NewKey creates a new empty private (or symmetric) key for the given key type.
+// The returned key has no fields set — the caller must populate it via
+// [jwk.Key.Set] before use.
+func NewKey(kty jwa.KeyType) (jwk.Key, error) {
+	v, err := registry.NewKey(kty.String())
+	if err != nil {
+		return nil, fmt.Errorf(`jwkunsafe.NewKey: %w`, err)
+	}
+	key, ok := v.(jwk.Key)
+	if !ok {
+		return nil, fmt.Errorf(`jwkunsafe.NewKey: internal error: constructor for %q returned %T, not jwk.Key`, kty, v)
+	}
+	return key, nil
+}
+
+// NewPublicKey creates a new empty public key for the given key type.
+// Returns an error for key types that have no public/private distinction
+// (e.g. symmetric keys). The returned key has no fields set — the caller
+// must populate it via [jwk.Key.Set] before use.
+func NewPublicKey(kty jwa.KeyType) (jwk.Key, error) {
+	v, err := registry.NewPublicKey(kty.String())
+	if err != nil {
+		return nil, fmt.Errorf(`jwkunsafe.NewPublicKey: %w`, err)
+	}
+	key, ok := v.(jwk.Key)
+	if !ok {
+		return nil, fmt.Errorf(`jwkunsafe.NewPublicKey: internal error: constructor for %q returned %T, not jwk.Key`, kty, v)
+	}
+	return key, nil
+}

--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -48,6 +48,15 @@ func (k *okpPublicKey) Import(rawKeyIf any) error {
 		crv = jwa.X25519()
 		k.crv = &crv
 	default:
+		for _, fn := range okpRawKeyImporters {
+			c, x, _, ok := fn(rawKeyIf)
+			if ok {
+				k.x = x
+				crv = c
+				k.crv = &crv
+				return nil
+			}
+		}
 		return fmt.Errorf(`unknown key type %T`, rawKeyIf)
 	}
 
@@ -72,10 +81,45 @@ func (k *okpPrivateKey) Import(rawKeyIf any) error {
 		crv = jwa.X25519()
 		k.crv = &crv
 	default:
+		for _, fn := range okpRawKeyImporters {
+			c, x, d, ok := fn(rawKeyIf)
+			if ok {
+				k.x = x
+				k.d = d
+				crv = c
+				k.crv = &crv
+				return nil
+			}
+		}
 		return fmt.Errorf(`unknown key type %T`, rawKeyIf)
 	}
 
 	return nil
+}
+
+// OKPCurveBuilder provides curve-specific key construction for OKP keys.
+// Build-tagged files (e.g. ed448.go) register additional curves via init().
+type OKPCurveBuilder struct {
+	BuildPublicKey  func(xbuf []byte) (any, error)
+	BuildPrivateKey func(xbuf, dbuf []byte) (any, error)
+}
+
+var okpCurveBuilders = map[jwa.EllipticCurveAlgorithm]OKPCurveBuilder{}
+
+// RegisterOKPCurveBuilder registers curve-specific key builders for OKP keys.
+func RegisterOKPCurveBuilder(alg jwa.EllipticCurveAlgorithm, b OKPCurveBuilder) {
+	okpCurveBuilders[alg] = b
+}
+
+// OKPRawKeyImporter tries to import a raw key as an OKP key.
+// Returns the curve, x, d (nil for public), and true if handled.
+type OKPRawKeyImporter func(key any) (crv jwa.EllipticCurveAlgorithm, x, d []byte, ok bool)
+
+var okpRawKeyImporters []OKPRawKeyImporter
+
+// RegisterOKPRawKeyImporter registers a function that can import raw keys as OKP keys.
+func RegisterOKPRawKeyImporter(fn OKPRawKeyImporter) {
+	okpRawKeyImporters = append(okpRawKeyImporters, fn)
 }
 
 func buildOKPPublicKey(alg jwa.EllipticCurveAlgorithm, xbuf []byte) (any, error) {
@@ -89,6 +133,9 @@ func buildOKPPublicKey(alg jwa.EllipticCurveAlgorithm, xbuf []byte) (any, error)
 		}
 		return ret, nil
 	default:
+		if b, ok := okpCurveBuilders[alg]; ok {
+			return b.BuildPublicKey(xbuf)
+		}
 		return nil, fmt.Errorf(`invalid curve algorithm %s`, alg)
 	}
 }
@@ -136,6 +183,9 @@ func buildOKPPrivateKey(alg jwa.EllipticCurveAlgorithm, xbuf []byte, dbuf []byte
 		}
 		return ret, nil
 	default:
+		if b, ok := okpCurveBuilders[alg]; ok {
+			return b.BuildPrivateKey(xbuf, dbuf)
+		}
 		return nil, fmt.Errorf(`invalid curve algorithm %s`, alg)
 	}
 }

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lestrrat-go/jwx/v3/internal/pool"
 	"github.com/lestrrat-go/jwx/v3/internal/tokens"
 	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk/internal/registry"
 )
 
 const (
@@ -516,7 +517,7 @@ LOOP:
 						}
 					}
 				}
-				decoded, err := registry.Decode(dec, tok)
+				decoded, err := fieldRegistry.Decode(dec, tok)
 				if err == nil {
 					h.setNoLock(tok, decoded)
 					continue
@@ -1183,7 +1184,7 @@ LOOP:
 						}
 					}
 				}
-				decoded, err := registry.Decode(dec, tok)
+				decoded, err := fieldRegistry.Decode(dec, tok)
 				if err == nil {
 					h.setNoLock(tok, decoded)
 					continue
@@ -1344,4 +1345,11 @@ func init() {
 // OKPStandardFieldsFilter returns a KeyFilter that filters out standard OKP fields.
 func OKPStandardFieldsFilter() KeyFilter {
 	return okpStandardFields
+}
+
+func init() {
+	registry.Register(jwa.OKP().String(), registry.Constructor{
+		Public:  func() any { return newOKPPublicKey() },
+		Private: func() any { return newOKPPrivateKey() },
+	})
 }

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lestrrat-go/jwx/v3/internal/pool"
 	"github.com/lestrrat-go/jwx/v3/internal/tokens"
 	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk/internal/registry"
 )
 
 const (
@@ -519,7 +520,7 @@ LOOP:
 						}
 					}
 				}
-				decoded, err := registry.Decode(dec, tok)
+				decoded, err := fieldRegistry.Decode(dec, tok)
 				if err == nil {
 					h.setNoLock(tok, decoded)
 					continue
@@ -1344,7 +1345,7 @@ LOOP:
 						}
 					}
 				}
-				decoded, err := registry.Decode(dec, tok)
+				decoded, err := fieldRegistry.Decode(dec, tok)
 				if err == nil {
 					h.setNoLock(tok, decoded)
 					continue
@@ -1540,4 +1541,11 @@ func init() {
 // RSAStandardFieldsFilter returns a KeyFilter that filters out standard RSA fields.
 func RSAStandardFieldsFilter() KeyFilter {
 	return rsaStandardFields
+}
+
+func init() {
+	registry.Register(jwa.RSA().String(), registry.Constructor{
+		Public:  func() any { return newRSAPublicKey() },
+		Private: func() any { return newRSAPrivateKey() },
+	})
 }

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lestrrat-go/jwx/v3/internal/pool"
 	"github.com/lestrrat-go/jwx/v3/internal/tokens"
 	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk/internal/registry"
 )
 
 const (
@@ -476,7 +477,7 @@ LOOP:
 						}
 					}
 				}
-				decoded, err := registry.Decode(dec, tok)
+				decoded, err := fieldRegistry.Decode(dec, tok)
 				if err == nil {
 					h.setNoLock(tok, decoded)
 					continue
@@ -617,4 +618,10 @@ func init() {
 // SymmetricStandardFieldsFilter returns a KeyFilter that filters out standard Symmetric fields.
 func SymmetricStandardFieldsFilter() KeyFilter {
 	return symmetricStandardFields
+}
+
+func init() {
+	registry.Register(jwa.OctetSeq().String(), registry.Constructor{
+		Private: func() any { return newSymmetricKey() },
+	})
 }

--- a/jws/es256k.go
+++ b/jws/es256k.go
@@ -8,5 +8,5 @@ import (
 
 func init() {
 	// Register ES256K to EC algorithm family
-	addAlgorithmForKeyType(jwa.EC(), jwa.ES256K())
+	RegisterAlgorithmForKeyType(jwa.EC(), jwa.ES256K())
 }

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -539,6 +539,7 @@ func init() {
 	rawKeyToKeyType[reflect.TypeFor[*ecdsa.PublicKey]()] = jwa.EC()
 
 	addAlgorithmForKeyType(jwa.OKP(), jwa.EdDSA())
+	addAlgorithmForKeyType(jwa.OKP(), jwa.EdDSAEd25519())
 	for _, alg := range []jwa.SignatureAlgorithm{jwa.HS256(), jwa.HS384(), jwa.HS512()} {
 		addAlgorithmForKeyType(jwa.OctetSeq(), alg)
 	}

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -538,20 +538,23 @@ func init() {
 	rawKeyToKeyType[reflect.TypeFor[ecdsa.PublicKey]()] = jwa.EC()
 	rawKeyToKeyType[reflect.TypeFor[*ecdsa.PublicKey]()] = jwa.EC()
 
-	addAlgorithmForKeyType(jwa.OKP(), jwa.EdDSA())
-	addAlgorithmForKeyType(jwa.OKP(), jwa.EdDSAEd25519())
+	RegisterAlgorithmForKeyType(jwa.OKP(), jwa.EdDSA())
+	RegisterAlgorithmForKeyType(jwa.OKP(), jwa.EdDSAEd25519())
 	for _, alg := range []jwa.SignatureAlgorithm{jwa.HS256(), jwa.HS384(), jwa.HS512()} {
-		addAlgorithmForKeyType(jwa.OctetSeq(), alg)
+		RegisterAlgorithmForKeyType(jwa.OctetSeq(), alg)
 	}
 	for _, alg := range []jwa.SignatureAlgorithm{jwa.RS256(), jwa.RS384(), jwa.RS512(), jwa.PS256(), jwa.PS384(), jwa.PS512()} {
-		addAlgorithmForKeyType(jwa.RSA(), alg)
+		RegisterAlgorithmForKeyType(jwa.RSA(), alg)
 	}
 	for _, alg := range []jwa.SignatureAlgorithm{jwa.ES256(), jwa.ES384(), jwa.ES512()} {
-		addAlgorithmForKeyType(jwa.EC(), alg)
+		RegisterAlgorithmForKeyType(jwa.EC(), alg)
 	}
 }
 
-func addAlgorithmForKeyType(kty jwa.KeyType, alg jwa.SignatureAlgorithm) {
+// RegisterAlgorithmForKeyType registers an additional algorithm as valid for
+// the given key type. This is used internally by init() and can also be called
+// from external modules that provide support for additional algorithms (e.g. Ed448).
+func RegisterAlgorithmForKeyType(kty jwa.KeyType, alg jwa.SignatureAlgorithm) {
 	keyTypeToAlgorithms[kty] = append(keyTypeToAlgorithms[kty], alg)
 }
 

--- a/jws/jws_internal_test.go
+++ b/jws/jws_internal_test.go
@@ -32,6 +32,11 @@ func TestLegacySignatureSign(t *testing.T) {
 				// Skip alg=none
 				continue
 			}
+			if sig == jwa.EdDSAEd448() {
+				// Ed448 requires the jwx_ed448 build tag and uses
+				// circl, not the legacy signer path.
+				continue
+			}
 			signer, err := NewSigner(sig)
 			require.NoError(t, err, "NewSigner should succeed")
 			require.NotNil(t, signer, "NewSigner should return a valid signer")

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1361,6 +1361,7 @@ func TestAlgorithmsForKey(t *testing.T) {
 			}
 		}
 
+
 		sort.Slice(tc.Expected, func(i, j int) bool {
 			return tc.Expected[i].String() < tc.Expected[j].String()
 		})

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1361,7 +1361,6 @@ func TestAlgorithmsForKey(t *testing.T) {
 			}
 		}
 
-
 		sort.Slice(tc.Expected, func(i, j int) bool {
 			return tc.Expected[i].String() < tc.Expected[j].String()
 		})

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -392,12 +392,52 @@ func TestRoundtrip(t *testing.T) {
 			// "Verify(*ed25519.Public())": &pubkey,
 			"Verify(jwk.Key)": jwkKey,
 		}
-		for _, alg := range []jwa.SignatureAlgorithm{jwa.EdDSA()} {
+		for _, alg := range []jwa.SignatureAlgorithm{jwa.EdDSA(), jwa.EdDSAEd25519()} {
 			t.Run(alg.String(), func(t *testing.T) {
 				t.Parallel()
 				testRoundtrip(t, payload, alg, key, keys)
 			})
 		}
+	})
+}
+
+func TestRFC9864CrossAlgorithmVerify(t *testing.T) {
+	t.Parallel()
+
+	key, err := jwxtest.GenerateEd25519Key()
+	require.NoError(t, err, "ed25519 key generated")
+
+	payload := []byte("RFC 9864 cross-algorithm test")
+
+	t.Run("sign with EdDSAEd25519, verify with EdDSA", func(t *testing.T) {
+		t.Parallel()
+		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSAEd25519(), key))
+		require.NoError(t, err, "signing with EdDSAEd25519 should succeed")
+
+		// The alg header should be "Ed25519"
+		msg, err := jws.Parse(signed)
+		require.NoError(t, err, "parsing should succeed")
+		sigs := msg.Signatures()
+		require.Len(t, sigs, 1)
+		alg, ok := sigs[0].ProtectedHeaders().Algorithm()
+		require.True(t, ok, "algorithm should be present")
+		require.Equal(t, jwa.EdDSAEd25519(), alg)
+
+		// Verify with EdDSA should also work (same crypto)
+		verified, err := jws.Verify(signed, jws.WithKey(jwa.EdDSA(), key.Public()))
+		require.NoError(t, err, "verifying EdDSAEd25519-signed message with EdDSA should succeed")
+		require.Equal(t, payload, verified)
+	})
+
+	t.Run("sign with EdDSA, verify with EdDSAEd25519", func(t *testing.T) {
+		t.Parallel()
+		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSA(), key))
+		require.NoError(t, err, "signing with EdDSA should succeed")
+
+		// Verify with EdDSAEd25519 should also work (same crypto)
+		verified, err := jws.Verify(signed, jws.WithKey(jwa.EdDSAEd25519(), key.Public()))
+		require.NoError(t, err, "verifying EdDSA-signed message with EdDSAEd25519 should succeed")
+		require.Equal(t, payload, verified)
 	})
 }
 
@@ -1305,12 +1345,12 @@ func TestAlgorithmsForKey(t *testing.T) {
 		{
 			Name:     "ed25519.PublicKey",
 			Key:      ed25519.PublicKey(nil),
-			Expected: []jwa.SignatureAlgorithm{jwa.EdDSA()},
+			Expected: []jwa.SignatureAlgorithm{jwa.EdDSA(), jwa.EdDSAEd25519()},
 		},
 		{
 			Name:     "x25519.PublicKey",
 			Key:      &ecdh.PublicKey{},
-			Expected: []jwa.SignatureAlgorithm{jwa.EdDSA()},
+			Expected: []jwa.SignatureAlgorithm{jwa.EdDSA(), jwa.EdDSAEd25519()},
 		},
 	}
 

--- a/jws/jwsbb/jwsbb.go
+++ b/jws/jwsbb/jwsbb.go
@@ -44,6 +44,9 @@ const (
 
 	// EdDSA algorithm
 	edDSA = "EdDSA"
+
+	// Fully-specified EdDSA algorithms (RFC 9864)
+	edDSAEd25519 = "Ed25519"
 )
 
 // Signer is a generic interface that defines the method for signing payloads.
@@ -85,6 +88,9 @@ var jwsToDsigAlgorithm = map[string]string{
 
 	// EdDSA algorithm
 	edDSA: dsig.EdDSA,
+
+	// Fully-specified EdDSA algorithms (RFC 9864)
+	edDSAEd25519: dsig.EdDSA,
 }
 
 // getDsigAlgorithm returns the dsig algorithm name for a JWS algorithm

--- a/jws/jwsbb/jwsbb.go
+++ b/jws/jwsbb/jwsbb.go
@@ -17,6 +17,10 @@
 package jwsbb
 
 import (
+	"crypto"
+	"crypto/ed25519"
+	"fmt"
+
 	"github.com/lestrrat-go/dsig"
 )
 
@@ -97,4 +101,24 @@ var jwsToDsigAlgorithm = map[string]string{
 func getDsigAlgorithm(jwsAlg string) (string, bool) {
 	dsigAlg, ok := jwsToDsigAlgorithm[jwsAlg]
 	return dsigAlg, ok
+}
+
+// validateEdDSACurve enforces that fully-specified EdDSA algorithms (RFC 9864)
+// are only used with the correct key curve. The polymorphic "EdDSA" algorithm
+// accepts any EdDSA key without curve checks. The pub argument must be the
+// already-extracted public key (after jwk.Key unwrapping / keyconv).
+func validateEdDSACurve(jwsAlg string, pub crypto.PublicKey) error {
+	switch jwsAlg {
+	case edDSAEd25519:
+		if _, ok := pub.(ed25519.PublicKey); !ok {
+			return fmt.Errorf(`algorithm %q requires an Ed25519 key, got %T`, jwsAlg, pub)
+		}
+	case edDSA:
+		// Polymorphic EdDSA: no curve restriction
+	default:
+		// Unknown fully-specified EdDSA algorithm (e.g. Ed448): reject
+		// until the corresponding key type is supported
+		return fmt.Errorf(`unsupported fully-specified EdDSA algorithm %q`, jwsAlg)
+	}
+	return nil
 }

--- a/jws/jwsbb/jwsbb.go
+++ b/jws/jwsbb/jwsbb.go
@@ -103,6 +103,26 @@ func getDsigAlgorithm(jwsAlg string) (string, bool) {
 	return dsigAlg, ok
 }
 
+// Extension algorithm registries for algorithms not handled by dsig
+// (e.g. Ed448 from a separate module). Populated via RegisterEdDSAAlgorithm.
+var extSignFns = map[string]func(any, []byte) ([]byte, error){}
+var extVerifyFns = map[string]func(any, []byte, []byte) error{}
+var extValidateCurveFns = map[string]func(any) error{}
+
+// RegisterEdDSAAlgorithm registers sign, verify, and curve validation functions
+// for a fully-specified EdDSA algorithm (e.g. "Ed448"). This is intended to be
+// called from external modules that provide the crypto implementation.
+func RegisterEdDSAAlgorithm(
+	alg string,
+	signFn func(key any, payload []byte) ([]byte, error),
+	verifyFn func(key any, payload, signature []byte) error,
+	validateCurveFn func(pub any) error,
+) {
+	extSignFns[alg] = signFn
+	extVerifyFns[alg] = verifyFn
+	extValidateCurveFns[alg] = validateCurveFn
+}
+
 // validateEdDSACurve enforces that fully-specified EdDSA algorithms (RFC 9864)
 // are only used with the correct key curve. The polymorphic "EdDSA" algorithm
 // accepts any EdDSA key without curve checks. The pub argument must be the
@@ -116,8 +136,9 @@ func validateEdDSACurve(jwsAlg string, pub crypto.PublicKey) error {
 	case edDSA:
 		// Polymorphic EdDSA: no curve restriction
 	default:
-		// Unknown fully-specified EdDSA algorithm (e.g. Ed448): reject
-		// until the corresponding key type is supported
+		if fn, ok := extValidateCurveFns[jwsAlg]; ok {
+			return fn(pub)
+		}
 		return fmt.Errorf(`unsupported fully-specified EdDSA algorithm %q`, jwsAlg)
 	}
 	return nil

--- a/jws/jwsbb/sign.go
+++ b/jws/jwsbb/sign.go
@@ -23,6 +23,10 @@ import (
 func Sign(key any, alg string, payload []byte, rr io.Reader) ([]byte, error) {
 	dsigAlg, ok := getDsigAlgorithm(alg)
 	if !ok {
+		// Check extension algorithms (e.g. Ed448 from separate module)
+		if fn, ok := extSignFns[alg]; ok {
+			return fn(key, payload)
+		}
 		return nil, fmt.Errorf(`jwsbb.Sign: unsupported signature algorithm %q`, alg)
 	}
 
@@ -92,6 +96,8 @@ func dispatchECDSASign(key any, dsigAlg string, payload []byte, rr io.Reader) ([
 }
 
 func dispatchEdDSASign(key any, jwsAlg, dsigAlg string, payload []byte, rr io.Reader) ([]byte, error) {
+	// Note: Extension algorithms (e.g. Ed448) are handled in Sign() before this function is called.
+
 	// Try crypto.Signer first (dsig can handle it directly)
 	if signer, ok := key.(crypto.Signer); ok {
 		// Verify it's an EdDSA key

--- a/jws/jwsbb/sign.go
+++ b/jws/jwsbb/sign.go
@@ -40,7 +40,7 @@ func Sign(key any, alg string, payload []byte, rr io.Reader) ([]byte, error) {
 	case dsig.ECDSA:
 		return dispatchECDSASign(key, dsigAlg, payload, rr)
 	case dsig.EdDSAFamily:
-		return dispatchEdDSASign(key, dsigAlg, payload, rr)
+		return dispatchEdDSASign(key, alg, dsigAlg, payload, rr)
 	default:
 		return nil, fmt.Errorf(`jwsbb.Sign: unsupported dsig algorithm family %q`, dsigInfo.Family)
 	}
@@ -91,11 +91,14 @@ func dispatchECDSASign(key any, dsigAlg string, payload []byte, rr io.Reader) ([
 	return dsig.Sign(privkey, dsigAlg, payload, rr)
 }
 
-func dispatchEdDSASign(key any, dsigAlg string, payload []byte, rr io.Reader) ([]byte, error) {
+func dispatchEdDSASign(key any, jwsAlg, dsigAlg string, payload []byte, rr io.Reader) ([]byte, error) {
 	// Try crypto.Signer first (dsig can handle it directly)
 	if signer, ok := key.(crypto.Signer); ok {
 		// Verify it's an EdDSA key
-		if _, ok := signer.Public().(ed25519.PublicKey); ok {
+		if pub, ok := signer.Public().(ed25519.PublicKey); ok {
+			if err := validateEdDSACurve(jwsAlg, pub); err != nil {
+				return nil, fmt.Errorf(`jwsbb.Sign: %w`, err)
+			}
 			return dsig.Sign(signer, dsigAlg, payload, rr)
 		}
 	}
@@ -104,6 +107,10 @@ func dispatchEdDSASign(key any, dsigAlg string, payload []byte, rr io.Reader) ([
 	var privkey ed25519.PrivateKey
 	if err := keyconv.Ed25519PrivateKey(&privkey, key); err != nil {
 		return nil, fmt.Errorf(`jwsbb.Sign: invalid key type %T. ed25519.PrivateKey is required: %w`, key, err)
+	}
+
+	if err := validateEdDSACurve(jwsAlg, privkey.Public()); err != nil {
+		return nil, fmt.Errorf(`jwsbb.Sign: %w`, err)
 	}
 
 	return dsig.Sign(privkey, dsigAlg, payload, rr)

--- a/jws/jwsbb/verify.go
+++ b/jws/jwsbb/verify.go
@@ -18,6 +18,10 @@ import (
 func Verify(key any, alg string, payload, signature []byte) error {
 	dsigAlg, ok := getDsigAlgorithm(alg)
 	if !ok {
+		// Check extension algorithms (e.g. Ed448 from separate module)
+		if fn, ok := extVerifyFns[alg]; ok {
+			return fn(key, payload, signature)
+		}
 		return fmt.Errorf(`jwsbb.Verify: unsupported signature algorithm %q`, alg)
 	}
 
@@ -87,6 +91,8 @@ func dispatchECDSAVerify(key any, dsigAlg string, payload, signature []byte) err
 }
 
 func dispatchEdDSAVerify(key any, jwsAlg, dsigAlg string, payload, signature []byte) error {
+	// Note: Extension algorithms (e.g. Ed448) are handled in Verify() before this function is called.
+
 	// Try crypto.Signer first (dsig can handle it directly)
 	if signer, ok := key.(crypto.Signer); ok {
 		// Verify it's an EdDSA key

--- a/jws/jwsbb/verify.go
+++ b/jws/jwsbb/verify.go
@@ -35,7 +35,7 @@ func Verify(key any, alg string, payload, signature []byte) error {
 	case dsig.ECDSA:
 		return dispatchECDSAVerify(key, dsigAlg, payload, signature)
 	case dsig.EdDSAFamily:
-		return dispatchEdDSAVerify(key, dsigAlg, payload, signature)
+		return dispatchEdDSAVerify(key, alg, dsigAlg, payload, signature)
 	default:
 		return fmt.Errorf(`jwsbb.Verify: unsupported dsig algorithm family %q`, dsigInfo.Family)
 	}
@@ -86,11 +86,14 @@ func dispatchECDSAVerify(key any, dsigAlg string, payload, signature []byte) err
 	return dsig.Verify(pubkey, dsigAlg, payload, signature)
 }
 
-func dispatchEdDSAVerify(key any, dsigAlg string, payload, signature []byte) error {
+func dispatchEdDSAVerify(key any, jwsAlg, dsigAlg string, payload, signature []byte) error {
 	// Try crypto.Signer first (dsig can handle it directly)
 	if signer, ok := key.(crypto.Signer); ok {
 		// Verify it's an EdDSA key
-		if _, ok := signer.Public().(ed25519.PublicKey); ok {
+		if pub, ok := signer.Public().(ed25519.PublicKey); ok {
+			if err := validateEdDSACurve(jwsAlg, pub); err != nil {
+				return fmt.Errorf(`jwsbb.Verify: %w`, err)
+			}
 			return dsig.Verify(signer, dsigAlg, payload, signature)
 		}
 	}
@@ -99,6 +102,10 @@ func dispatchEdDSAVerify(key any, dsigAlg string, payload, signature []byte) err
 	var pubkey ed25519.PublicKey
 	if err := keyconv.Ed25519PublicKey(&pubkey, key); err != nil {
 		return fmt.Errorf(`jwsbb.Verify: invalid key type %T. ed25519.PublicKey is required: %w`, key, err)
+	}
+
+	if err := validateEdDSACurve(jwsAlg, pubkey); err != nil {
+		return fmt.Errorf(`jwsbb.Verify: %w`, err)
 	}
 
 	return dsig.Verify(pubkey, dsigAlg, payload, signature)

--- a/jws/legacy.go
+++ b/jws/legacy.go
@@ -61,7 +61,10 @@ func enableLegacySigners() {
 		}
 	}
 
-	for _, alg := range []jwa.SignatureAlgorithm{jwa.EdDSA(), jwa.EdDSAEd25519(), jwa.EdDSAEd448()} {
+	// Ed448 is intentionally excluded: the legacy EdDSA signer/verifier
+	// only supports ed25519. Ed448 is handled via the defaultSigner/defaultVerifier
+	// path which routes to jwsbb (and requires the jwx_ed448 build tag).
+	for _, alg := range []jwa.SignatureAlgorithm{jwa.EdDSA(), jwa.EdDSAEd25519()} {
 		if err := RegisterSigner(alg, SignerFactoryFn(func() (Signer, error) {
 			return legacy.NewEdDSASigner(), nil
 		})); err != nil {

--- a/jws/legacy.go
+++ b/jws/legacy.go
@@ -61,15 +61,17 @@ func enableLegacySigners() {
 		}
 	}
 
-	if err := RegisterSigner(jwa.EdDSA(), SignerFactoryFn(func() (Signer, error) {
-		return legacy.NewEdDSASigner(), nil
-	})); err != nil {
-		panic(fmt.Sprintf("RegisterSigner failed: %v", err))
-	}
-	if err := RegisterVerifier(jwa.EdDSA(), VerifierFactoryFn(func() (Verifier, error) {
-		return legacy.NewEdDSAVerifier(), nil
-	})); err != nil {
-		panic(fmt.Sprintf("RegisterVerifier failed: %v", err))
+	for _, alg := range []jwa.SignatureAlgorithm{jwa.EdDSA(), jwa.EdDSAEd25519(), jwa.EdDSAEd448()} {
+		if err := RegisterSigner(alg, SignerFactoryFn(func() (Signer, error) {
+			return legacy.NewEdDSASigner(), nil
+		})); err != nil {
+			panic(fmt.Sprintf("RegisterSigner failed: %v", err))
+		}
+		if err := RegisterVerifier(alg, VerifierFactoryFn(func() (Verifier, error) {
+			return legacy.NewEdDSAVerifier(), nil
+		})); err != nil {
+			panic(fmt.Sprintf("RegisterVerifier failed: %v", err))
+		}
 	}
 }
 

--- a/tools/cmd/genjwa/objects.yml
+++ b/tools/cmd/genjwa/objects.yml
@@ -141,7 +141,16 @@ algorithms:
         returnval_comment: ECDSA signature algorithm using secp256k1 curve and SHA-256
       - name: EdDSA
         value: EdDSA
-        returnval_comment: EdDSA signature algorithms
+        deprecated: true
+        returnval_comment: EdDSA signature algorithms (deprecated by RFC 9864, use EdDSAEd25519 or EdDSAEd448)
+      - name: EdDSAEd25519
+        value: Ed25519
+        returnval_comment: EdDSA signature algorithm using Ed25519 (RFC 9864)
+        comment: The function name is tentative and may change in future releases.
+      - name: EdDSAEd448
+        value: Ed448
+        returnval_comment: EdDSA signature algorithm using Ed448 (RFC 9864)
+        comment: The function name is tentative and may change in future releases.
       - name: PS256
         value: PS256
         returnval_comment: RSASSA-PSS signature algorithm using SHA-256 and MGF1-SHA256

--- a/tools/cmd/genjwk/main.go
+++ b/tools/cmd/genjwk/main.go
@@ -159,6 +159,34 @@ func generateKeyType(kt *KeyType, stdFields codegen.FieldList) error {
 		return fmt.Errorf(`failed to generate StandardFieldsFilter for %s: %w`, kt.Prefix, err)
 	}
 
+	// Generate init() to register key constructors in the internal registry.
+	// This allows jwk/jwkunsafe to create empty keys of any type.
+	o.LL("func init() {")
+	var publicIfName, privateIfName string
+	for _, obj := range kt.Objects {
+		ifName := kt.Prefix + obj.Name(true)
+		if v := obj.String(`interface`); v != "" {
+			ifName = v
+		}
+		switch obj.Name(false) {
+		case "publicKey":
+			publicIfName = ifName
+		case "privateKey":
+			privateIfName = ifName
+		case "symmetricKey":
+			privateIfName = ifName
+		}
+	}
+	o.L("registry.Register(%s.String(), registry.Constructor{", kt.KeyType)
+	if publicIfName != "" {
+		o.L("Public: func() any { return new%s() },", publicIfName)
+	}
+	if privateIfName != "" {
+		o.L("Private: func() any { return new%s() },", privateIfName)
+	}
+	o.L("})")
+	o.L("}")
+
 	if err := o.WriteFile(kt.Filename, codegen.WithFormatCode(true)); err != nil {
 		if cfe, ok := err.(codegen.CodeFormatError); ok {
 			fmt.Fprint(os.Stderr, cfe.Source())
@@ -596,7 +624,7 @@ func generateObject(o *codegen.Output, kt *KeyType, obj *codegen.Object) error {
 	o.L("}")
 	o.L("}")
 
-	o.L("decoded, err := registry.Decode(dec, tok)")
+	o.L("decoded, err := fieldRegistry.Decode(dec, tok)")
 	o.L("if err == nil {")
 	o.L("h.setNoLock(tok, decoded)")
 	o.L("continue")


### PR DESCRIPTION
Add Ed25519 and Ed448 as fully-specified SignatureAlgorithm values per RFC 9864, deprecate the polymorphic EdDSA. Go function names are EdDSAEd25519/EdDSAEd448 to avoid collision with the existing EllipticCurveAlgorithm Ed25519/Ed448 functions.