### PR TITLE
add jwkunsafe package docs and tests

### DIFF
--- a/jwk/jwkunsafe/jwkunsafe.go
+++ b/jwk/jwkunsafe/jwkunsafe.go
@@ -1,9 +1,18 @@
 // Package jwkunsafe provides low-level JWK key construction functions.
 //
-// These functions create empty, unpopulated key objects. In most cases you
-// should use [jwk.Import] or [jwk.ParseKey] instead. This package exists
-// for extension module authors who need to register custom [jwk.KeyImporter]
-// implementations for new key types (e.g. Ed448).
+// This package exposes APIs that are not intended for general use, but are
+// necessary for advanced use cases such as external modules that add new key
+// types (e.g. Ed448  via github.com/lestrrat-go/jwx-circl-ed448).
+//
+// Function in this package return objects in incomplete state that end-users
+// should not be expected to use directly. For example, the keys returned by
+// [NewKey] and [NewPublicKey] have no fields set, and must be fully populated
+// by the caller before they can be used. Normally, end-users only receive
+// fully-populated keys via [jwk.Parse] and related functions, and never
+// need to worry about the objects keys being unusable, which is something
+// this module works very hard to ensure.
+//
+// Unless you know exactly what you are doing, you should not use this package directly.
 package jwkunsafe
 
 import (

--- a/jwk/jwkunsafe/jwkunsafe_test.go
+++ b/jwk/jwkunsafe/jwkunsafe_test.go
@@ -1,0 +1,74 @@
+package jwkunsafe_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk/jwkunsafe"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewKey(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		Name string
+		Kty  jwa.KeyType
+	}{
+		{"EC", jwa.EC()},
+		{"OKP", jwa.OKP()},
+		{"RSA", jwa.RSA()},
+		{"OctetSeq", jwa.OctetSeq()},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			key, err := jwkunsafe.NewKey(tc.Kty)
+			require.NoError(t, err, "NewKey(%s) should succeed", tc.Kty)
+			require.NotNil(t, key)
+			require.Equal(t, tc.Kty, key.KeyType(), "KeyType should match")
+		})
+	}
+
+	t.Run("UnknownKeyType", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwkunsafe.NewKey(jwa.InvalidKeyType())
+		require.Error(t, err, "NewKey with unknown key type should fail")
+	})
+}
+
+func TestNewPublicKey(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		Name string
+		Kty  jwa.KeyType
+	}{
+		{"EC", jwa.EC()},
+		{"OKP", jwa.OKP()},
+		{"RSA", jwa.RSA()},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			key, err := jwkunsafe.NewPublicKey(tc.Kty)
+			require.NoError(t, err, "NewPublicKey(%s) should succeed", tc.Kty)
+			require.NotNil(t, key)
+			require.Equal(t, tc.Kty, key.KeyType(), "KeyType should match")
+		})
+	}
+
+	t.Run("OctetSeqHasNoPublicKey", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwkunsafe.NewPublicKey(jwa.OctetSeq())
+		require.Error(t, err, "NewPublicKey(OctetSeq) should fail — symmetric keys have no public variant")
+	})
+
+	t.Run("UnknownKeyType", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwkunsafe.NewPublicKey(jwa.InvalidKeyType())
+		require.Error(t, err, "NewPublicKey with unknown key type should fail")
+	})
+}


### PR DESCRIPTION
- expand package doc comment explaining purpose and caveats
- add table-driven tests for NewKey and NewPublicKey covering all registered key types and error paths