### PR TITLE
pin jwx-circl-ed448 to latest commit

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/cloudflare/circl v1.6.3
 	github.com/emmansun/gmsm v0.41.1
 	github.com/lestrrat-go/httprc/v3 v3.0.5
-	github.com/lestrrat-go/jwx-circl-ed448 v0.0.0-20260402121447-cedb65399532
-	github.com/lestrrat-go/jwx/v3 v3.0.14-0.20260402121309-3637fea80189
+	github.com/lestrrat-go/jwx-circl-ed448 v0.0.0-20260402235158-570c11e70454
+	github.com/lestrrat-go/jwx/v3 v3.0.14-0.20260402234301-4ae43ddee427
 )
 
 require (

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -21,10 +21,10 @@ github.com/lestrrat-go/httpcc v1.0.1 h1:ydWCStUeJLkpYyjLDHihupbn2tYmZ7m22BGkcvZZ
 github.com/lestrrat-go/httpcc v1.0.1/go.mod h1:qiltp3Mt56+55GPVCbTdM9MlqhvzyuL6W/NMDA8vA5E=
 github.com/lestrrat-go/httprc/v3 v3.0.5 h1:S+Mb4L2I+bM6JGTibLmxExhyTOqnXjqx+zi9MoXw/TM=
 github.com/lestrrat-go/httprc/v3 v3.0.5/go.mod h1:mSMtkZW92Z98M5YoNNztbRGxbXHql7tSitCvaxvo9l0=
-github.com/lestrrat-go/jwx-circl-ed448 v0.0.0-20260402121447-cedb65399532 h1:z7fIDaRwlhuVLciHAYN6C3LiOXgiZ+3IlzPRRzeTGWY=
-github.com/lestrrat-go/jwx-circl-ed448 v0.0.0-20260402121447-cedb65399532/go.mod h1:1AvgYJsHI4+f5H3asHIAbPVm/VHijiBhtjyRfQWtcF0=
-github.com/lestrrat-go/jwx/v3 v3.0.14-0.20260402121309-3637fea80189 h1:hrnd7ScQM0AHPH9C6P8/82m7CaRxP8N2Tp4Pp3WNv0U=
-github.com/lestrrat-go/jwx/v3 v3.0.14-0.20260402121309-3637fea80189/go.mod h1:wSvwkMkRbW4gwHQW8XNIb7HXajRe38FKMmmWteBQpug=
+github.com/lestrrat-go/jwx-circl-ed448 v0.0.0-20260402235158-570c11e70454 h1:g2WJSjKLkxRDLHJm4WzYnCqNcQ5kEf/r9y1mAcbQS1c=
+github.com/lestrrat-go/jwx-circl-ed448 v0.0.0-20260402235158-570c11e70454/go.mod h1:PxA15ucVnJNcQTruX6wcMXy9ks+ka8lrjq7I2AqTkvQ=
+github.com/lestrrat-go/jwx/v3 v3.0.14-0.20260402234301-4ae43ddee427 h1:xEyNWus/E7KGMK5EiWv0Z9un8LxHyCgyma9FfL+8ePU=
+github.com/lestrrat-go/jwx/v3 v3.0.14-0.20260402234301-4ae43ddee427/go.mod h1:LaVeWOQEoDvlcJUSN0F2xrJDm6++CvncT3cw4w3hbDY=
 github.com/lestrrat-go/option/v2 v2.0.0 h1:XxrcaJESE1fokHy3FpaQ/cXW8ZsIdWcdFzzLOcID3Ss=
 github.com/lestrrat-go/option/v2 v2.0.0/go.mod h1:oSySsmzMoR0iRzCDCaUfsCzxQHUEuhOViQObyy7S6Vg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Update examples/go.mod to point at the latest jwx-circl-ed448 commit.