### PR TITLE
fix OKP key export dispatch for Ed448

### DIFF
--- a/jwk/doc.go
+++ b/jwk/doc.go
@@ -22,7 +22,7 @@
 //
 //	jwkKey, _ := jwk.Import(rsaPrivateKey)
 //	var rawKey *rsa.PRrivateKey
-//	jwkKey.Raw(&rawKey)
+//	jwk.Export(jwkKey, &rawKey)
 //
 // You can use them to sign/verify/encrypt/decrypt:
 //

--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/lestrrat-go/blackmagic"
 	"github.com/lestrrat-go/jwx/v3/internal/base64"
 	"github.com/lestrrat-go/jwx/v3/jwa"
 )
@@ -131,27 +130,6 @@ func buildOKPPublicKey(alg jwa.EllipticCurveAlgorithm, xbuf []byte) (any, error)
 	default:
 		return nil, fmt.Errorf(`invalid curve algorithm %s`, alg)
 	}
-}
-
-// Raw returns the EC-DSA public key represented by this JWK
-func (k *okpPublicKey) Raw(v any) error {
-	k.mu.RLock()
-	defer k.mu.RUnlock()
-
-	crv, ok := k.Crv()
-	if !ok {
-		return fmt.Errorf(`missing "crv" field`)
-	}
-
-	pubk, err := buildOKPPublicKey(crv, k.x)
-	if err != nil {
-		return fmt.Errorf(`jwk.OKPPublicKey: failed to build public key: %w`, err)
-	}
-
-	if err := blackmagic.AssignIfCompatible(v, pubk); err != nil {
-		return fmt.Errorf(`jwk.OKPPublicKey: failed to assign to destination variable: %w`, err)
-	}
-	return nil
 }
 
 func buildOKPPrivateKey(alg jwa.EllipticCurveAlgorithm, xbuf []byte, dbuf []byte) (any, error) {

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -34,7 +34,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"reflect"
 	"sync"
 	"unicode"
 	"unicode/utf8"
@@ -527,17 +526,9 @@ func RegisterCustomField(name string, object any) {
 }
 
 // Helpers for signature verification
-var rawKeyToKeyType = make(map[reflect.Type]jwa.KeyType)
 var keyTypeToAlgorithms = make(map[jwa.KeyType][]jwa.SignatureAlgorithm)
 
 func init() {
-	rawKeyToKeyType[reflect.TypeFor[[]byte]()] = jwa.OctetSeq()
-	rawKeyToKeyType[reflect.TypeFor[ed25519.PublicKey]()] = jwa.OKP()
-	rawKeyToKeyType[reflect.TypeFor[rsa.PublicKey]()] = jwa.RSA()
-	rawKeyToKeyType[reflect.TypeFor[*rsa.PublicKey]()] = jwa.RSA()
-	rawKeyToKeyType[reflect.TypeFor[ecdsa.PublicKey]()] = jwa.EC()
-	rawKeyToKeyType[reflect.TypeFor[*ecdsa.PublicKey]()] = jwa.EC()
-
 	RegisterAlgorithmForKeyType(jwa.OKP(), jwa.EdDSA())
 	RegisterAlgorithmForKeyType(jwa.OKP(), jwa.EdDSAEd25519())
 	for _, alg := range []jwa.SignatureAlgorithm{jwa.HS256(), jwa.HS384(), jwa.HS512()} {
@@ -576,7 +567,11 @@ func AlgorithmsForKey(key any) ([]jwa.SignatureAlgorithm, error) {
 	case []byte:
 		kty = jwa.OctetSeq()
 	default:
-		return nil, fmt.Errorf(`unknown key type %T`, key)
+		imported, err := jwk.Import(key)
+		if err != nil {
+			return nil, fmt.Errorf(`unknown key type %T`, key)
+		}
+		kty = imported.KeyType()
 	}
 
 	algs, ok := keyTypeToAlgorithms[kty]


### PR DESCRIPTION
Remove vestigial okpPublicKey.Raw() that bypassed Export() dispatch (failing for Ed448). Use jwk.Import fallback in AlgorithmsForKey for extensible key type support.