### PR TITLE
fix misleading Ed448 dispatch comments in jwsbb

### DIFF
--- a/jws/jwsbb/sign.go
+++ b/jws/jwsbb/sign.go
@@ -95,7 +95,8 @@ func dispatchECDSASign(key any, dsigAlg string, payload []byte, rr io.Reader) ([
 }
 
 func dispatchEdDSASign(key any, jwsAlg, dsigAlg string, payload []byte, rr io.Reader) ([]byte, error) {
-	// Note: Extension algorithms (e.g. Ed448) are handled in Sign() before this function is called.
+	// Note: Extension algorithms (e.g. Ed448) are registered as dsig.Custom family,
+	// so they take the dsig.Custom branch in Sign() and never reach this function.
 
 	// Try crypto.Signer first (dsig can handle it directly)
 	if signer, ok := key.(crypto.Signer); ok {

--- a/jws/jwsbb/verify.go
+++ b/jws/jwsbb/verify.go
@@ -90,7 +90,8 @@ func dispatchECDSAVerify(key any, dsigAlg string, payload, signature []byte) err
 }
 
 func dispatchEdDSAVerify(key any, jwsAlg, dsigAlg string, payload, signature []byte) error {
-	// Note: Extension algorithms (e.g. Ed448) are handled in Verify() before this function is called.
+	// Note: Extension algorithms (e.g. Ed448) are registered as dsig.Custom family,
+	// so they take the dsig.Custom branch in Verify() and never reach this function.
 
 	// Try crypto.Signer first (dsig can handle it directly)
 	if signer, ok := key.(crypto.Signer); ok {


### PR DESCRIPTION
Comments in dispatchEdDSASign/dispatchEdDSAVerify said Ed448 is handled before these functions — implies special pre-dispatch logic. Actually Ed448 registers as dsig.Custom family so it takes a different switch branch.