### PR TITLE
pin jwx-circl-ed448 to ce28e4bb in examples

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/cloudflare/circl v1.6.3
 	github.com/emmansun/gmsm v0.41.1
 	github.com/lestrrat-go/httprc/v3 v3.0.5
-	github.com/lestrrat-go/jwx-circl-ed448 v0.0.0-20260402235158-570c11e70454
-	github.com/lestrrat-go/jwx/v3 v3.0.14-0.20260402234301-4ae43ddee427
+	github.com/lestrrat-go/jwx-circl-ed448 v0.0.0-20260403052429-ce28e4bb9ad6
+	github.com/lestrrat-go/jwx/v3 v3.0.14-0.20260403051613-136a2d956850
 )
 
 require (

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -21,10 +21,10 @@ github.com/lestrrat-go/httpcc v1.0.1 h1:ydWCStUeJLkpYyjLDHihupbn2tYmZ7m22BGkcvZZ
 github.com/lestrrat-go/httpcc v1.0.1/go.mod h1:qiltp3Mt56+55GPVCbTdM9MlqhvzyuL6W/NMDA8vA5E=
 github.com/lestrrat-go/httprc/v3 v3.0.5 h1:S+Mb4L2I+bM6JGTibLmxExhyTOqnXjqx+zi9MoXw/TM=
 github.com/lestrrat-go/httprc/v3 v3.0.5/go.mod h1:mSMtkZW92Z98M5YoNNztbRGxbXHql7tSitCvaxvo9l0=
-github.com/lestrrat-go/jwx-circl-ed448 v0.0.0-20260402235158-570c11e70454 h1:g2WJSjKLkxRDLHJm4WzYnCqNcQ5kEf/r9y1mAcbQS1c=
-github.com/lestrrat-go/jwx-circl-ed448 v0.0.0-20260402235158-570c11e70454/go.mod h1:PxA15ucVnJNcQTruX6wcMXy9ks+ka8lrjq7I2AqTkvQ=
-github.com/lestrrat-go/jwx/v3 v3.0.14-0.20260402234301-4ae43ddee427 h1:xEyNWus/E7KGMK5EiWv0Z9un8LxHyCgyma9FfL+8ePU=
-github.com/lestrrat-go/jwx/v3 v3.0.14-0.20260402234301-4ae43ddee427/go.mod h1:LaVeWOQEoDvlcJUSN0F2xrJDm6++CvncT3cw4w3hbDY=
+github.com/lestrrat-go/jwx-circl-ed448 v0.0.0-20260403052429-ce28e4bb9ad6 h1:y4wVbETXEBlFZJ08oH7YbR/NlTYekFC/xoV2pjU2nFM=
+github.com/lestrrat-go/jwx-circl-ed448 v0.0.0-20260403052429-ce28e4bb9ad6/go.mod h1:GQWmQK+H4/axpI+mMiY4OB9h4b5sMICxpYugOvCdrWM=
+github.com/lestrrat-go/jwx/v3 v3.0.14-0.20260403051613-136a2d956850 h1:SXYbvHjZ7CEwIE6KlDO1ixazE1t/nB1hNOC8Wjhp9Kg=
+github.com/lestrrat-go/jwx/v3 v3.0.14-0.20260403051613-136a2d956850/go.mod h1:LaVeWOQEoDvlcJUSN0F2xrJDm6++CvncT3cw4w3hbDY=
 github.com/lestrrat-go/option/v2 v2.0.0 h1:XxrcaJESE1fokHy3FpaQ/cXW8ZsIdWcdFzzLOcID3Ss=
 github.com/lestrrat-go/option/v2 v2.0.0/go.mod h1:oSySsmzMoR0iRzCDCaUfsCzxQHUEuhOViQObyy7S6Vg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Update examples/go.mod to use latest jwx-circl-ed448 commit (ce28e4bb9ad6) which includes RegisterAlgorithmForCurve support.