### PR TITLE
add WithMaxFetchBodySize to limit Fetch response body

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -29,7 +29,7 @@ Algorithm identifiers per RFC 7518. Registry pattern with thread-safe lookup.
 JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 
 - **Parse(src []byte, ...ParseOption) (Set, error)** / **ParseKey(data []byte, ...ParseOption) (Key, error)** — parse JWK/JWKS
-- **Fetch(ctx, url, ...FetchOption) (Set, error)** — HTTP fetch with optional whitelist
+- **Fetch(ctx, url, ...FetchOption) (Set, error)** — HTTP fetch with optional whitelist, body size limit (default 10 MB via `WithMaxFetchBodySize`)
 - **Import(raw any) (Key, error)** / **Export(key Key, dst any) error** — convert between Go crypto types and JWK
 - **PublicKeyOf(v any) (Key, error)** / **PublicSetOf(v Set) (Set, error)** — extract public keys
 - **NewCache(ctx, client) (*Cache, error)** — auto-refreshing JWKS cache

--- a/jwk/cache.go
+++ b/jwk/cache.go
@@ -81,13 +81,22 @@ type Cache struct {
 // conjection with `httprc.NewResource` to create a `httprc.Resource` object
 // to auto-update `jwk.Set` objects.
 type Transformer struct {
-	parseOptions []ParseOption
+	parseOptions     []ParseOption
+	maxFetchBodySize int64
 }
 
 func (t Transformer) Transform(_ context.Context, res *http.Response) (Set, error) {
-	buf, err := io.ReadAll(res.Body)
+	maxBodySize := t.maxFetchBodySize
+	if maxBodySize <= 0 {
+		maxBodySize = defaultMaxFetchBodySize
+	}
+
+	buf, err := io.ReadAll(io.LimitReader(res.Body, maxBodySize+1))
 	if err != nil {
 		return nil, fmt.Errorf(`failed to read response body status: %w`, err)
+	}
+	if int64(len(buf)) > maxBodySize {
+		return nil, fmt.Errorf(`response body at %q exceeded max size of %d bytes`, res.Request.URL.String(), maxBodySize)
 	}
 
 	set, err := Parse(buf, t.parseOptions...)
@@ -125,6 +134,7 @@ func NewCache(ctx context.Context, client *httprc.Client) (*Cache, error) {
 func (c *Cache) Register(ctx context.Context, u string, options ...RegisterOption) error {
 	var parseOptions []ParseOption
 	var resourceOptions []httprc.NewResourceOption
+	var maxFetchBodySize int64
 	waitReady := true
 	for _, option := range options {
 		switch option := option.(type) {
@@ -148,12 +158,17 @@ func (c *Cache) Register(ctx context.Context, u string, options ...RegisterOptio
 				if err := option.Value(&waitReady); err != nil {
 					return fmt.Errorf(`failed to retrieve WaitReady option value: %w`, err)
 				}
+			case identMaxFetchBodySize{}:
+				if err := option.Value(&maxFetchBodySize); err != nil {
+					return fmt.Errorf(`failed to retrieve MaxFetchBodySize option value: %w`, err)
+				}
 			}
 		}
 	}
 
 	r, err := httprc.NewResource[Set](u, &Transformer{
-		parseOptions: parseOptions,
+		parseOptions:     parseOptions,
+		maxFetchBodySize: maxFetchBodySize,
 	}, resourceOptions...)
 	if err != nil {
 		return fmt.Errorf(`failed to create httprc.Resource: %w`, err)

--- a/jwk/fetch.go
+++ b/jwk/fetch.go
@@ -7,6 +7,10 @@ import (
 	"net/http"
 )
 
+// defaultMaxFetchBodySize is the default maximum number of bytes read
+// from an HTTP response body when fetching a JWKS (10 MB).
+const defaultMaxFetchBodySize int64 = 10 * 1024 * 1024
+
 // Fetcher is an interface that represents an object that fetches a JWKS.
 // Currently this is only used in the `jws.WithVerifyAuto` option.
 //
@@ -71,6 +75,7 @@ func Fetch(ctx context.Context, u string, options ...FetchOption) (Set, error) {
 	//nolint:revive // I want to keep the type of `wl` as `Whitelist` instead of `InsecureWhitelist`
 	var wl Whitelist = InsecureWhitelist{}
 	var client HTTPClient = http.DefaultClient
+	var maxBodySize int64 = defaultMaxFetchBodySize
 	for _, option := range options {
 		if parseOpt, ok := option.(ParseOption); ok {
 			parseOptions = append(parseOptions, parseOpt)
@@ -85,6 +90,10 @@ func Fetch(ctx context.Context, u string, options ...FetchOption) (Set, error) {
 		case identFetchWhitelist{}:
 			if err := option.Value(&wl); err != nil {
 				return nil, fmt.Errorf(`failed to retrieve fetch whitelist option value: %w`, err)
+			}
+		case identMaxFetchBodySize{}:
+			if err := option.Value(&maxBodySize); err != nil {
+				return nil, fmt.Errorf(`failed to retrieve MaxFetchBodySize option value: %w`, err)
 			}
 		}
 	}
@@ -108,9 +117,12 @@ func Fetch(ctx context.Context, u string, options ...FetchOption) (Set, error) {
 		return nil, fmt.Errorf(`jwk.Fetch: request returned status %d, expected 200`, res.StatusCode)
 	}
 
-	buf, err := io.ReadAll(res.Body)
+	buf, err := io.ReadAll(io.LimitReader(res.Body, maxBodySize+1))
 	if err != nil {
 		return nil, fmt.Errorf(`jwk.Fetch: failed to read response body for %q: %w`, u, err)
+	}
+	if int64(len(buf)) > maxBodySize {
+		return nil, fmt.Errorf(`jwk.Fetch: response body for %q exceeded max size of %d bytes`, u, maxBodySize)
 	}
 
 	return Parse(buf, parseOptions...)

--- a/jwk/fetch.go
+++ b/jwk/fetch.go
@@ -75,7 +75,7 @@ func Fetch(ctx context.Context, u string, options ...FetchOption) (Set, error) {
 	//nolint:revive // I want to keep the type of `wl` as `Whitelist` instead of `InsecureWhitelist`
 	var wl Whitelist = InsecureWhitelist{}
 	var client HTTPClient = http.DefaultClient
-	var maxBodySize int64 = defaultMaxFetchBodySize
+	var maxBodySize = defaultMaxFetchBodySize
 	for _, option := range options {
 		if parseOpt, ok := option.(ParseOption); ok {
 			parseOptions = append(parseOptions, parseOpt)

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1743,6 +1743,26 @@ func TestFetch(t *testing.T) {
 			})
 		}
 	})
+	t.Run("MaxFetchBodySize", func(t *testing.T) {
+		t.Run("ExceedsLimit", func(t *testing.T) {
+			ctx := t.Context()
+			// The test server serves `expected` which is the JSON-encoded JWKS.
+			// Set a limit smaller than the response body size.
+			_, err := jwk.Fetch(ctx, srv.URL, jwk.WithMaxFetchBodySize(10))
+			require.Error(t, err, `jwk.Fetch should fail when response exceeds max body size`)
+			require.Contains(t, err.Error(), `exceeded max size`, `error should mention exceeded max size`)
+		})
+		t.Run("WithinLimit", func(t *testing.T) {
+			ctx := t.Context()
+			// Set a limit larger than the response body size.
+			fetched, err := jwk.Fetch(ctx, srv.URL, jwk.WithMaxFetchBodySize(1<<20))
+			require.NoError(t, err, `jwk.Fetch should succeed when response is within max body size`)
+
+			got, err := json.MarshalIndent(fetched, "", "  ")
+			require.NoError(t, err, `json.MarshalIndent should succeed`)
+			require.Equal(t, expected, got, `data should match`)
+		})
+	})
 }
 
 func TestGH567(t *testing.T) {

--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -52,6 +52,15 @@ options:
     comment: |
       WithHTTPClient allows users to specify the "net/http".Client object that
       is used when fetching jwk.Set objects.
+  - ident: MaxFetchBodySize
+    interface: RegisterFetchOption
+    argument_type: int64
+    comment: |
+      WithMaxFetchBodySize specifies the maximum number of bytes to read from
+      an HTTP response body when fetching a JWKS. If the response body exceeds
+      this size, the fetch returns an error. The default value is 10MB (10485760).
+
+      This option can be passed to `jwk.Fetch()` or `(*jwk.Cache).Register()`.
   - ident: ThumbprintHash
     interface: AssignKeyIDOption
     argument_type: crypto.Hash

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -149,6 +149,7 @@ type identFetchWhitelist struct{}
 type identHTTPClient struct{}
 type identIgnoreParseError struct{}
 type identLocalRegistry struct{}
+type identMaxFetchBodySize struct{}
 type identPEM struct{}
 type identPEMDecoder struct{}
 type identStrictKeyUsage struct{}
@@ -174,6 +175,10 @@ func (identIgnoreParseError) String() string {
 
 func (identLocalRegistry) String() string {
 	return "withLocalRegistry"
+}
+
+func (identMaxFetchBodySize) String() string {
+	return "WithMaxFetchBodySize"
 }
 
 func (identPEM) String() string {
@@ -244,6 +249,15 @@ func WithIgnoreParseError(v bool) ParseOption {
 // This option is only available for internal code. Users don't get to play with it
 func withLocalRegistry(v *json.Registry) ParseOption {
 	return &parseOption{option.New(identLocalRegistry{}, v)}
+}
+
+// WithMaxFetchBodySize specifies the maximum number of bytes to read from
+// an HTTP response body when fetching a JWKS. If the response body exceeds
+// this size, the fetch returns an error. The default value is 10MB (10485760).
+//
+// This option can be passed to `jwk.Fetch()` or `(*jwk.Cache).Register()`.
+func WithMaxFetchBodySize(v int64) RegisterFetchOption {
+	return &registerFetchOption{option.New(identMaxFetchBodySize{}, v)}
 }
 
 // WithPEM specifies that the input to `Parse()` is a PEM encoded key.

--- a/jwk/options_gen_test.go
+++ b/jwk/options_gen_test.go
@@ -14,6 +14,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithHTTPClient", identHTTPClient{}.String())
 	require.Equal(t, "WithIgnoreParseError", identIgnoreParseError{}.String())
 	require.Equal(t, "withLocalRegistry", identLocalRegistry{}.String())
+	require.Equal(t, "WithMaxFetchBodySize", identMaxFetchBodySize{}.String())
 	require.Equal(t, "WithPEM", identPEM{}.String())
 	require.Equal(t, "WithPEMDecoder", identPEMDecoder{}.String())
 	require.Equal(t, "WithStrictKeyUsage", identStrictKeyUsage{}.String())


### PR DESCRIPTION
Adds WithMaxFetchBodySize(int64) option to cap HTTP response body reads in jwk.Fetch() and Cache Transformer. Default 10 MB. Prevents OOM from malicious/oversized JWKS endpoints. Uses io.LimitReader with +1 byte to detect oversized responses without reading them fully.
