### PR TITLE
add per-call PBES2 count overrides to jwe.Decrypt

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -68,7 +68,7 @@ JSON Web Encryption per RFC 7516. Encrypt, decrypt, parse.
 - **Parse(buf []byte, ...ParseOption) (*Message, error)** — parse without decryption
 - Key types: `Message`, `Recipient`, `Headers`, `KeyProvider`, `KeyEncrypter`, `KeyDecrypter`
 - Options: `WithKey()`, `WithKeySet()`, `WithContentEncryption()`, `WithCompress()`, `WithJSON()`, `WithProtectedHeaders()`
-- Global settings: `WithMaxPBES2Count()`, `WithMaxDecompressBufferSize()`, `WithCBCBufferSize()`
+- Global/per-call settings: `WithMaxPBES2Count()`, `WithMinPBES2Count()`, `WithMaxDecompressBufferSize()` (usable in both `Settings()` and `Decrypt()`); `WithCBCBufferSize()` (global only)
 - Error sentinels: `EncryptError()`, `DecryptError()`, `RecipientError()`, `ParseError()`
 - Internal subpackages: `jwe/internal/{aescbc,cipher,concatkdf,content_crypt,keygen}`, `jwe/jwebb`
 - Files: `jwe.go`, `message.go`, `interface.go`, `headers.go`, `errors.go`, `options.go`, `key_provider.go`, `compress.go`, `filter.go`

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -232,6 +232,8 @@ type decryptContext struct {
 	cek                     *[]byte
 	dst                     *Message
 	maxDecompressBufferSize int64
+	maxPBES2Count           int
+	minPBES2Count           int
 	//nolint:containedctx
 	ctx context.Context
 }
@@ -250,14 +252,17 @@ func freeDecryptContext(dc *decryptContext) *decryptContext {
 	dc.cek = nil
 	dc.dst = nil
 	dc.maxDecompressBufferSize = 0
+	dc.maxPBES2Count = 0
+	dc.minPBES2Count = 0
 	dc.ctx = context.Background()
 	return dc
 }
 
 func (dc *decryptContext) ProcessOptions(options []DecryptOption) error {
-	// Set default max decompress buffer size
 	muSettings.RLock()
 	dc.maxDecompressBufferSize = maxDecompressBufferSize
+	dc.maxPBES2Count = maxPBES2Count
+	dc.minPBES2Count = minPBES2Count
 	muSettings.RUnlock()
 
 	for _, option := range options {
@@ -293,6 +298,14 @@ func (dc *decryptContext) ProcessOptions(options []DecryptOption) error {
 		case identMaxDecompressBufferSize{}:
 			if err := option.Value(&dc.maxDecompressBufferSize); err != nil {
 				return fmt.Errorf("jwe.decrypt: WithMaxDecompressBufferSize must be int64: %w", err)
+			}
+		case identMaxPBES2Count{}:
+			if err := option.Value(&dc.maxPBES2Count); err != nil {
+				return fmt.Errorf("jwe.decrypt: WithMaxPBES2Count must be int: %w", err)
+			}
+		case identMinPBES2Count{}:
+			if err := option.Value(&dc.minPBES2Count); err != nil {
+				return fmt.Errorf("jwe.decrypt: WithMinPBES2Count must be int: %w", err)
 			}
 		case identContext{}:
 			if err := option.Value(&dc.ctx); err != nil {
@@ -528,10 +541,8 @@ func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgo
 			countFlt = count
 		}
 
-		muSettings.RLock()
-		maxCount := maxPBES2Count
-		minCount := minPBES2Count
-		muSettings.RUnlock()
+		maxCount := dc.maxPBES2Count
+		minCount := dc.minPBES2Count
 		if countFlt > float64(maxCount) {
 			return nil, fmt.Errorf("invalid 'p2c' value")
 		}

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -894,6 +894,46 @@ func TestMinPBES2Count(t *testing.T) {
 	})
 }
 
+func TestPBES2CountPerCall(t *testing.T) {
+	password := []byte(`supersecret`)
+	key, err := jwk.Import(password)
+	require.NoError(t, err, `jwk.Import should succeed`)
+
+	payload := []byte(`hello world`)
+	encrypted, err := jwe.Encrypt(payload, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+	require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+	t.Run("per-call max rejects high p2c", func(t *testing.T) {
+		// Default p2c is 10000. Set per-call max to 100 — should fail.
+		_, err := jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.PBES2_HS256_A128KW(), key),
+			jwe.WithMaxPBES2Count(100),
+		)
+		require.Error(t, err, `jwe.Decrypt should fail when p2c exceeds per-call max`)
+	})
+	t.Run("per-call min rejects low p2c", func(t *testing.T) {
+		// Default p2c is 10000. Set per-call min to 20000 — should fail.
+		_, err := jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.PBES2_HS256_A128KW(), key),
+			jwe.WithMinPBES2Count(20000),
+		)
+		require.Error(t, err, `jwe.Decrypt should fail when p2c is below per-call min`)
+	})
+	t.Run("per-call override does not affect global", func(t *testing.T) {
+		// Use restrictive per-call setting, then verify default still works.
+		_, err := jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.PBES2_HS256_A128KW(), key),
+			jwe.WithMaxPBES2Count(100),
+		)
+		require.Error(t, err, `jwe.Decrypt should fail with restrictive per-call max`)
+
+		// Without per-call override, should succeed with global defaults.
+		decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+		require.NoError(t, err, `jwe.Decrypt should succeed with global defaults`)
+		require.Equal(t, payload, decrypted, `decrypted payload should match`)
+	})
+}
+
 func TestCBCBufferSize(t *testing.T) {
 	// NOTE: This has GLOBAL EFFECT
 	jwe.Settings(jwe.WithCBCBufferSize(1))

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -140,23 +140,27 @@ options:
       This option is currently considered EXPERIMENTAL, and is subject to
       future changes across minor/micro versions.
   - ident: MaxPBES2Count
-    interface: GlobalOption
+    interface: GlobalDecryptOption
     argument_type: int
     comment: |
       WithMaxPBES2Count specifies the maximum number of PBES2 iterations
       to use when decrypting a message. If not specified, the default
       value of 10,000 is used.
 
-      This option has a global effect.
+      This option can be used for `jwe.Settings()`, which changes the behavior
+      globally, or for `jwe.Decrypt()`, which changes the behavior for that
+      specific call.
   - ident: MinPBES2Count
-    interface: GlobalOption
+    interface: GlobalDecryptOption
     argument_type: int
     comment: |
       WithMinPBES2Count specifies the minimum number of PBES2 iterations
       to accept when decrypting a message. If not specified, the default
       value of 1,000 is used. Set to 0 to disable the minimum check.
 
-      This option has a global effect.
+      This option can be used for `jwe.Settings()`, which changes the behavior
+      globally, or for `jwe.Decrypt()`, which changes the behavior for that
+      specific call.
   - ident: MaxDecompressBufferSize
     interface: GlobalDecryptOption
     argument_type: int64

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -355,9 +355,11 @@ func WithMaxDecompressBufferSize(v int64) GlobalDecryptOption {
 // to use when decrypting a message. If not specified, the default
 // value of 10,000 is used.
 //
-// This option has a global effect.
-func WithMaxPBES2Count(v int) GlobalOption {
-	return &globalOption{option.New(identMaxPBES2Count{}, v)}
+// This option can be used for `jwe.Settings()`, which changes the behavior
+// globally, or for `jwe.Decrypt()`, which changes the behavior for that
+// specific call.
+func WithMaxPBES2Count(v int) GlobalDecryptOption {
+	return &globalDecryptOption{option.New(identMaxPBES2Count{}, v)}
 }
 
 // WithMergeProtectedHeaders specify that when given multiple headers
@@ -378,9 +380,11 @@ func WithMessage(v *Message) DecryptOption {
 // to accept when decrypting a message. If not specified, the default
 // value of 1,000 is used. Set to 0 to disable the minimum check.
 //
-// This option has a global effect.
-func WithMinPBES2Count(v int) GlobalOption {
-	return &globalOption{option.New(identMinPBES2Count{}, v)}
+// This option can be used for `jwe.Settings()`, which changes the behavior
+// globally, or for `jwe.Decrypt()`, which changes the behavior for that
+// specific call.
+func WithMinPBES2Count(v int) GlobalDecryptOption {
+	return &globalDecryptOption{option.New(identMinPBES2Count{}, v)}
 }
 
 // WithPretty specifies whether the JSON output should be formatted and


### PR DESCRIPTION
Changes WithMaxPBES2Count and WithMinPBES2Count from GlobalOption to GlobalDecryptOption, allowing per-call overrides via jwe.Decrypt() alongside the existing jwe.Settings() global path. Follows the same pattern as WithMaxDecompressBufferSize.
