### PR TITLE
fix X509CertChain() to return false when chain is nil

### DIFF
--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -118,7 +118,10 @@ func (h *ecdsaPublicKey) X() ([]byte, bool) {
 }
 
 func (h *ecdsaPublicKey) X509CertChain() (*cert.Chain, bool) {
-	return h.x509CertChain, true
+	if h.x509CertChain != nil {
+		return h.x509CertChain, true
+	}
+	return nil, false
 }
 
 func (h *ecdsaPublicKey) X509CertThumbprint() (string, bool) {
@@ -804,7 +807,10 @@ func (h *ecdsaPrivateKey) X() ([]byte, bool) {
 }
 
 func (h *ecdsaPrivateKey) X509CertChain() (*cert.Chain, bool) {
-	return h.x509CertChain, true
+	if h.x509CertChain != nil {
+		return h.x509CertChain, true
+	}
+	return nil, false
 }
 
 func (h *ecdsaPrivateKey) X509CertThumbprint() (string, bool) {

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -115,7 +115,10 @@ func (h *okpPublicKey) X() ([]byte, bool) {
 }
 
 func (h *okpPublicKey) X509CertChain() (*cert.Chain, bool) {
-	return h.x509CertChain, true
+	if h.x509CertChain != nil {
+		return h.x509CertChain, true
+	}
+	return nil, false
 }
 
 func (h *okpPublicKey) X509CertThumbprint() (string, bool) {
@@ -759,7 +762,10 @@ func (h *okpPrivateKey) X() ([]byte, bool) {
 }
 
 func (h *okpPrivateKey) X509CertChain() (*cert.Chain, bool) {
-	return h.x509CertChain, true
+	if h.x509CertChain != nil {
+		return h.x509CertChain, true
+	}
+	return nil, false
 }
 
 func (h *okpPrivateKey) X509CertThumbprint() (string, bool) {

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -120,7 +120,10 @@ func (h *rsaPublicKey) N() ([]byte, bool) {
 }
 
 func (h *rsaPublicKey) X509CertChain() (*cert.Chain, bool) {
-	return h.x509CertChain, true
+	if h.x509CertChain != nil {
+		return h.x509CertChain, true
+	}
+	return nil, false
 }
 
 func (h *rsaPublicKey) X509CertThumbprint() (string, bool) {
@@ -807,7 +810,10 @@ func (h *rsaPrivateKey) QI() ([]byte, bool) {
 }
 
 func (h *rsaPrivateKey) X509CertChain() (*cert.Chain, bool) {
-	return h.x509CertChain, true
+	if h.x509CertChain != nil {
+		return h.x509CertChain, true
+	}
+	return nil, false
 }
 
 func (h *rsaPrivateKey) X509CertThumbprint() (string, bool) {

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -100,7 +100,10 @@ func (h *symmetricKey) Octets() ([]byte, bool) {
 }
 
 func (h *symmetricKey) X509CertChain() (*cert.Chain, bool) {
-	return h.x509CertChain, true
+	if h.x509CertChain != nil {
+		return h.x509CertChain, true
+	}
+	return nil, false
 }
 
 func (h *symmetricKey) X509CertThumbprint() (string, bool) {

--- a/tools/cmd/genjwk/main.go
+++ b/tools/cmd/genjwk/main.go
@@ -344,7 +344,10 @@ func generateObject(o *codegen.Output, kt *KeyType, obj *codegen.Object) error {
 				o.L("return h.%s, true", f.Name(false))
 			}
 		} else {
-			o.L(`return h.%s, true`, f.Name(false))
+			o.L("if h.%s != nil {", f.Name(false))
+			o.L("return h.%s, true", f.Name(false))
+			o.L("}")
+			o.L("return nil, false")
 		}
 		o.L("}") // func (h *stdHeaders) %s() %s
 	}


### PR DESCRIPTION
Fixes genjwk generator to nil-check pointer-type fields in getter methods. Previously X509CertChain() unconditionally returned true as the second value even when the chain was nil, breaking callers using the (value, ok) idiom.
