### PR TITLE
fix data race in x509 decoder registry iteration

### DIFF
--- a/jwk/x509.go
+++ b/jwk/x509.go
@@ -154,7 +154,7 @@ func (f X509DecodeFunc) DecodeX509(dst any, block *pem.Block) error {
 	return f(dst, block)
 }
 
-var muX509Decoders sync.Mutex
+var muX509Decoders sync.RWMutex
 var x509Decoders = map[any]int{}
 var x509DecoderList = []X509Decoder{}
 
@@ -222,8 +222,12 @@ func decodeX509(dst any, src []byte) error {
 		return fmt.Errorf(`failed to decode PEM data`)
 	}
 
+	muX509Decoders.RLock()
+	decoders := x509DecoderList
+	muX509Decoders.RUnlock()
+
 	var errs []error
-	for _, d := range x509DecoderList {
+	for _, d := range decoders {
 		if err := d.DecodeX509(dst, block); err != nil {
 			errs = append(errs, err)
 			continue


### PR DESCRIPTION
Changes muX509Decoders from sync.Mutex to sync.RWMutex and snapshots x509DecoderList under RLock in decodeX509(). Previously the iteration was unprotected while Register/Unregister modified the slice under lock.
