### PR TITLE
reject negative WithAcceptableSkew in jwt.Validate

### DIFF
--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -73,6 +73,9 @@ func Validate(t Token, options ...ValidateOption) error {
 			if err := o.Value(&skew); err != nil {
 				return fmt.Errorf(`jwt.Validate: value for WithAcceptableSkew() option must be time.Duration: %w`, err)
 			}
+			if skew < 0 {
+				return fmt.Errorf(`jwt.Validate: WithAcceptableSkew() must not be negative`)
+			}
 		case identTruncation{}:
 			if err := o.Value(&trunc); err != nil {
 				return fmt.Errorf(`jwt.Validate: value for WithTruncation() option must be time.Duration: %w`, err)


### PR DESCRIPTION
Rejects negative WithAcceptableSkew values in jwt.Validate(). A negative skew inverts the time window logic, making exp stricter while loosening iat/nbf checks.
