### PR TITLE
accept year 0000 in OIDC birthdate per spec

### DIFF
--- a/jwt/openid/birthdate.go
+++ b/jwt/openid/birthdate.go
@@ -114,10 +114,13 @@ func (b *BirthdateClaim) Accept(v any) error {
 		// strconv.ParseInt (and strconv.ParseUint that it uses internally)
 		// only returns range errors, so we should be safe.
 		year := parseBirthdayInt(v[indices[2]:indices[3]])
-		if year <= 0 {
+		if year < 0 {
 			return fmt.Errorf(`failed to parse birthdate year`)
 		}
-		tmp.year = &year
+		if year > 0 {
+			tmp.year = &year
+		}
+		// year == 0 (i.e. "0000") means omitted per OIDC spec; leave tmp.year as nil
 
 		month := parseBirthdayInt(v[indices[4]:indices[5]])
 		if month <= 0 {

--- a/jwt/openid/openid_test.go
+++ b/jwt/openid/openid_test.go
@@ -561,7 +561,9 @@ func TestBirthdateClaim(t *testing.T) {
 			},
 			{
 				Source: `"0000-01-01"`,
-				Error:  true,
+				Year:   0, // year 0000 means omitted per OIDC spec
+				Month:  1,
+				Day:    1,
 			},
 			{
 				Source: `"0001-00-01"`,


### PR DESCRIPTION
The OIDC spec says birthdate year MAY be 0000 to indicate the year is omitted. Previously rejected with year <= 0 check. Now treats 0000 as omitted (year pointer left nil, Year() returns 0).
