### PR TITLE
add max input size limit to jwt/jwe ParseReader

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -68,7 +68,7 @@ JSON Web Encryption per RFC 7516. Encrypt, decrypt, parse.
 - **Parse(buf []byte, ...ParseOption) (*Message, error)** — parse without decryption
 - Key types: `Message`, `Recipient`, `Headers`, `KeyProvider`, `KeyEncrypter`, `KeyDecrypter`
 - Options: `WithKey()`, `WithKeySet()`, `WithContentEncryption()`, `WithCompress()`, `WithJSON()`, `WithProtectedHeaders()`
-- Global/per-call settings: `WithMaxPBES2Count()`, `WithMinPBES2Count()`, `WithMaxDecompressBufferSize()` (usable in both `Settings()` and `Decrypt()`); `WithCBCBufferSize()` (global only)
+- Global/per-call settings: `WithMaxPBES2Count()`, `WithMinPBES2Count()`, `WithMaxDecompressBufferSize()` (usable in both `Settings()` and `Decrypt()`); `WithMaxParseInputSize()` (usable in both `Settings()` and `ParseReader()`/`ReadFile()`); `WithCBCBufferSize()` (global only)
 - Error sentinels: `EncryptError()`, `DecryptError()`, `RecipientError()`, `ParseError()`
 - Internal subpackages: `jwe/internal/{aescbc,cipher,concatkdf,content_crypt,keygen}`, `jwe/jwebb`
 - Files: `jwe.go`, `message.go`, `interface.go`, `headers.go`, `errors.go`, `options.go`, `key_provider.go`, `compress.go`, `filter.go`
@@ -87,6 +87,7 @@ JSON Web Tokens per RFC 7519. Parse, sign, validate.
 - Validator factories: `IsExpirationValid()`, `IsIssuedAtValid()`, `IsNbfValid()`, `IsRequired()`, `ClaimValueIs()`, `ClaimContainsString()`
 - Key types: `Token` (interface), `Validator`, `ValidatorFunc`, `Clock`, `ClockFunc`, `Serializer`, `TokenFilter`
 - Token options: `FlattenAudience` per-token option
+- Global/per-call settings: `WithMaxParseInputSize()` (usable in both `Settings()` and `ParseReader()`/`ReadFile()`)
 - Error sentinels: `TokenExpiredError()`, `TokenNotYetValidError()`, `InvalidIssuerError()`, `InvalidAudienceError()`, `ValidateError()`, `ParseError()`
 - Files: `jwt.go`, `validate.go`, `serialize.go`, `http.go`, `filter.go`, `errors.go`, `options.go`, `fastpath.go`, `token_options.go`
 - Imports: jwa, jws, jwe, jwk, transform, internal/json

--- a/jwe/io.go
+++ b/jwe/io.go
@@ -15,6 +15,12 @@ func (sysFS) Open(path string) (fs.File, error) {
 }
 
 func ReadFile(path string, options ...ReadFileOption) (*Message, error) {
+	var parseOptions []ParseOption
+	for _, option := range options {
+		if po, ok := option.(ParseOption); ok {
+			parseOptions = append(parseOptions, po)
+		}
+	}
 
 	var srcFS fs.FS = sysFS{}
 	for _, option := range options {
@@ -32,5 +38,5 @@ func ReadFile(path string, options ...ReadFileOption) (*Message, error) {
 	}
 
 	defer f.Close()
-	return ParseReader(f)
+	return ParseReader(f, parseOptions...)
 }

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -32,6 +32,7 @@ var muSettings sync.RWMutex
 var maxPBES2Count = 10000
 var minPBES2Count = 1000
 var maxDecompressBufferSize int64 = 10 * 1024 * 1024 // 10MB
+var maxParseInputSize int64 = 10 * 1024 * 1024       // 10MB
 
 func Settings(options ...GlobalOption) {
 	muSettings.Lock()
@@ -56,6 +57,10 @@ func Settings(options ...GlobalOption) {
 				panic(fmt.Sprintf("jwe.Settings: value for option WithCBCBufferSize must be an int64: %s", err))
 			}
 			aescbc.SetMaxBufferSize(v)
+		case identMaxParseInputSize{}:
+			if err := option.Value(&maxParseInputSize); err != nil {
+				panic(fmt.Sprintf("jwe.Settings: value for option WithMaxParseInputSize must be an int64: %s", err))
+			}
 		}
 	}
 }
@@ -993,8 +998,8 @@ func parseJSONOrCompact(buf []byte, storeProtectedHeaders bool) (*Message, error
 }
 
 // ParseString is the same as Parse, but takes a string.
-func ParseString(s string) (*Message, error) {
-	msg, err := Parse([]byte(s))
+func ParseString(s string, options ...ParseOption) (*Message, error) {
+	msg, err := Parse([]byte(s), options...)
 	if err != nil {
 		return nil, makeParseError(`jwe.ParseString`, `%w`, err)
 	}
@@ -1002,12 +1007,27 @@ func ParseString(s string) (*Message, error) {
 }
 
 // ParseReader is the same as Parse, but takes an io.Reader.
-func ParseReader(src io.Reader) (*Message, error) {
-	buf, err := io.ReadAll(src)
+func ParseReader(src io.Reader, options ...ParseOption) (*Message, error) {
+	muSettings.RLock()
+	maxSize := maxParseInputSize
+	muSettings.RUnlock()
+
+	for _, option := range options {
+		if option.Ident() == (identMaxParseInputSize{}) {
+			if err := option.Value(&maxSize); err != nil {
+				return nil, makeParseError(`jwe.ParseReader`, `invalid WithMaxParseInputSize: %w`, err)
+			}
+		}
+	}
+
+	buf, err := io.ReadAll(io.LimitReader(src, maxSize+1))
 	if err != nil {
 		return nil, makeParseError(`jwe.ParseReader`, `failed to read from io.Reader: %w`, err)
 	}
-	msg, err := Parse(buf)
+	if int64(len(buf)) > maxSize {
+		return nil, makeParseError(`jwe.ParseReader`, `input exceeded max size of %d bytes`, maxSize)
+	}
+	msg, err := Parse(buf, options...)
 	if err != nil {
 		return nil, makeParseError(`jwe.ParseReader`, `%w`, err)
 	}

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1240,3 +1240,53 @@ func TestGH1470(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestMaxParseInputSize(t *testing.T) {
+	t.Run("default rejects oversized input", func(t *testing.T) {
+		data := make([]byte, 10*1024*1024+1)
+		_, err := jwe.ParseReader(bytes.NewReader(data))
+		require.Error(t, err, `jwe.ParseReader should reject input exceeding default max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("per-call option overrides default", func(t *testing.T) {
+		data := make([]byte, 200)
+		_, err := jwe.ParseReader(bytes.NewReader(data), jwe.WithMaxParseInputSize(100))
+		require.Error(t, err, `jwe.ParseReader should reject input exceeding per-call max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("input within limit is accepted", func(t *testing.T) {
+		data := []byte(`not-valid-jwe-but-small`)
+		_, err := jwe.ParseReader(bytes.NewReader(data), jwe.WithMaxParseInputSize(1024))
+		// The error (if any) should NOT be about size
+		if err != nil {
+			require.NotContains(t, err.Error(), `exceeded max size`)
+		}
+	})
+	t.Run("global setting changes default", func(t *testing.T) {
+		jwe.Settings(jwe.WithMaxParseInputSize(50))
+		defer jwe.Settings(jwe.WithMaxParseInputSize(10 * 1024 * 1024)) // restore
+
+		data := make([]byte, 100)
+		_, err := jwe.ParseReader(bytes.NewReader(data))
+		require.Error(t, err, `jwe.ParseReader should reject input exceeding global max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("per-call option overrides global setting", func(t *testing.T) {
+		jwe.Settings(jwe.WithMaxParseInputSize(50))
+		defer jwe.Settings(jwe.WithMaxParseInputSize(10 * 1024 * 1024)) // restore
+
+		data := []byte(`not-valid-jwe-but-small`)
+		_, err := jwe.ParseReader(bytes.NewReader(data), jwe.WithMaxParseInputSize(1024))
+		if err != nil {
+			require.NotContains(t, err.Error(), `exceeded max size`)
+		}
+	})
+	t.Run("ParseReader with no options still works", func(t *testing.T) {
+		// Verify backwards compatibility: calling ParseReader without options compiles and runs
+		data := []byte(`not-valid-jwe`)
+		_, err := jwe.ParseReader(bytes.NewReader(data))
+		// Should fail with a parse error, not a compilation or size error
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), `exceeded max size`)
+	})
+}

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -37,6 +37,13 @@ interfaces:
       - readFileOption
     comment: |
       ReadFileOption is a type of `Option` that can be passed to `jwe.Parse`
+  - name: GlobalParseOption
+    methods:
+      - globalOption
+      - readFileOption
+    comment: |
+      GlobalParseOption describes an Option that can be passed to `jwe.Settings()`
+      and `jwe.ReadFile()`.
   - name: ReadFileOption
     comment: |
       ReadFileOption is a type of `Option` that can be passed to `jwe.ReadFile`
@@ -183,6 +190,16 @@ options:
       In v2, this option was called MaxBufferSize.
 
       This option has a global effect.
+  - ident: MaxParseInputSize
+    interface: GlobalParseOption
+    argument_type: int64
+    comment: |
+      WithMaxParseInputSize specifies the maximum number of bytes read from an
+      io.Reader in `jwe.ParseReader`. If the input exceeds this size,
+      `jwe.ParseReader` will return an error. The default value is 10MB.
+
+      This option can be passed to `jwe.Settings()` to change the default
+      globally, or to `jwe.ReadFile()` for a per-call override.
   - ident: LegacyHeaderMerging
     interface: EncryptOption
     argument_type: bool

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -90,6 +90,22 @@ type globalOption struct {
 
 func (*globalOption) globalOption() {}
 
+// GlobalParseOption describes an Option that can be passed to `jwe.Settings()`
+// and `jwe.ReadFile()`.
+type GlobalParseOption interface {
+	Option
+	globalOption()
+	readFileOption()
+}
+
+type globalParseOption struct {
+	Option
+}
+
+func (*globalParseOption) globalOption() {}
+
+func (*globalParseOption) readFileOption() {}
+
 // ReadFileOption is a type of `Option` that can be passed to `jwe.Parse`
 type ParseOption interface {
 	Option
@@ -150,6 +166,7 @@ type identKeyUsed struct{}
 type identLegacyHeaderMerging struct{}
 type identMaxDecompressBufferSize struct{}
 type identMaxPBES2Count struct{}
+type identMaxParseInputSize struct{}
 type identMergeProtectedHeaders struct{}
 type identMessage struct{}
 type identMinPBES2Count struct{}
@@ -205,6 +222,10 @@ func (identMaxDecompressBufferSize) String() string {
 
 func (identMaxPBES2Count) String() string {
 	return "WithMaxPBES2Count"
+}
+
+func (identMaxParseInputSize) String() string {
+	return "WithMaxParseInputSize"
 }
 
 func (identMergeProtectedHeaders) String() string {
@@ -360,6 +381,16 @@ func WithMaxDecompressBufferSize(v int64) GlobalDecryptOption {
 // specific call.
 func WithMaxPBES2Count(v int) GlobalDecryptOption {
 	return &globalDecryptOption{option.New(identMaxPBES2Count{}, v)}
+}
+
+// WithMaxParseInputSize specifies the maximum number of bytes read from an
+// io.Reader in `jwe.ParseReader`. If the input exceeds this size,
+// `jwe.ParseReader` will return an error. The default value is 10MB.
+//
+// This option can be passed to `jwe.Settings()` to change the default
+// globally, or to `jwe.ReadFile()` for a per-call override.
+func WithMaxParseInputSize(v int64) GlobalParseOption {
+	return &globalParseOption{option.New(identMaxParseInputSize{}, v)}
 }
 
 // WithMergeProtectedHeaders specify that when given multiple headers

--- a/jwe/options_gen_test.go
+++ b/jwe/options_gen_test.go
@@ -21,6 +21,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithLegacyHeaderMerging", identLegacyHeaderMerging{}.String())
 	require.Equal(t, "WithMaxDecompressBufferSize", identMaxDecompressBufferSize{}.String())
 	require.Equal(t, "WithMaxPBES2Count", identMaxPBES2Count{}.String())
+	require.Equal(t, "WithMaxParseInputSize", identMaxParseInputSize{}.String())
 	require.Equal(t, "WithMergeProtectedHeaders", identMergeProtectedHeaders{}.String())
 	require.Equal(t, "WithMessage", identMessage{}.String())
 	require.Equal(t, "WithMinPBES2Count", identMinPBES2Count{}.String())

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -20,6 +20,11 @@ import (
 )
 
 var defaultTruncation atomic.Int64
+var maxParseInputSize atomic.Int64
+
+func init() {
+	maxParseInputSize.Store(10 * 1024 * 1024) // 10MB
+}
 
 // Settings controls global settings that are specific to JWTs.
 func Settings(options ...GlobalOption) {
@@ -60,6 +65,12 @@ func Settings(options ...GlobalOption) {
 			if v >= 0 && v <= int(types.MaxPrecision) {
 				formatPrecision = uint32(v)
 			}
+		case identMaxParseInputSize{}:
+			var v int64
+			if err := option.Value(&v); err != nil {
+				panic(fmt.Sprintf("jwt.Settings: value for WithMaxParseInputSize must be int64: %s", err))
+			}
+			maxParseInputSize.Store(v)
 		}
 	}
 
@@ -171,10 +182,21 @@ func ParseInsecure(s []byte, options ...ParseOption) (Token, error) {
 
 // ParseReader calls Parse against an io.Reader
 func ParseReader(src io.Reader, options ...ParseOption) (Token, error) {
-	// We're going to need the raw bytes regardless. Read it.
-	data, err := io.ReadAll(src)
+	maxSize := maxParseInputSize.Load()
+	for _, option := range options {
+		if option.Ident() == (identMaxParseInputSize{}) {
+			if err := option.Value(&maxSize); err != nil {
+				return nil, jwterrs.ParseErrorf(`jwt.ParseReader`, `invalid WithMaxParseInputSize: %w`, err)
+			}
+		}
+	}
+
+	data, err := io.ReadAll(io.LimitReader(src, maxSize+1))
 	if err != nil {
 		return nil, jwterrs.ParseErrorf(`jwt.ParseReader`, `failed to read from token data source: %w`, err)
+	}
+	if int64(len(data)) > maxSize {
+		return nil, jwterrs.ParseErrorf(`jwt.ParseReader`, `input exceeded max size of %d bytes`, maxSize)
 	}
 	tok, err := parseBytes(data, options...)
 	if err != nil {

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1671,3 +1671,50 @@ func TestGH1484(t *testing.T) {
 		})
 	}
 }
+
+func TestMaxParseInputSize(t *testing.T) {
+	t.Run("default rejects oversized input", func(t *testing.T) {
+		// Create a reader that exceeds 10MB
+		data := make([]byte, 10*1024*1024+1)
+		_, err := jwt.ParseReader(bytes.NewReader(data), jwt.WithVerify(false), jwt.WithValidate(false))
+		require.Error(t, err, `jwt.ParseReader should reject input exceeding default max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("per-call option overrides default", func(t *testing.T) {
+		// Use a very small limit
+		data := make([]byte, 200)
+		_, err := jwt.ParseReader(bytes.NewReader(data), jwt.WithMaxParseInputSize(100), jwt.WithVerify(false), jwt.WithValidate(false))
+		require.Error(t, err, `jwt.ParseReader should reject input exceeding per-call max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("input within limit is accepted", func(t *testing.T) {
+		// A small valid-ish payload should not trigger the size limit.
+		// We just test that the size check passes; parsing may still fail for other reasons.
+		data := []byte(`{"foo":"bar"}`)
+		_, err := jwt.ParseReader(bytes.NewReader(data), jwt.WithMaxParseInputSize(1024), jwt.WithVerify(false), jwt.WithValidate(false))
+		// The error (if any) should NOT be about size
+		if err != nil {
+			require.NotContains(t, err.Error(), `exceeded max size`)
+		}
+	})
+	t.Run("global setting changes default", func(t *testing.T) {
+		jwt.Settings(jwt.WithMaxParseInputSize(50))
+		defer jwt.Settings(jwt.WithMaxParseInputSize(10 * 1024 * 1024)) // restore
+
+		data := make([]byte, 100)
+		_, err := jwt.ParseReader(bytes.NewReader(data), jwt.WithVerify(false), jwt.WithValidate(false))
+		require.Error(t, err, `jwt.ParseReader should reject input exceeding global max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("per-call option overrides global setting", func(t *testing.T) {
+		jwt.Settings(jwt.WithMaxParseInputSize(50))
+		defer jwt.Settings(jwt.WithMaxParseInputSize(10 * 1024 * 1024)) // restore
+
+		// Per-call with a larger limit should allow the input
+		data := []byte(`{"foo":"bar"}`)
+		_, err := jwt.ParseReader(bytes.NewReader(data), jwt.WithMaxParseInputSize(1024), jwt.WithVerify(false), jwt.WithValidate(false))
+		if err != nil {
+			require.NotContains(t, err.Error(), `exceeded max size`)
+		}
+	})
+}

--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -48,6 +48,14 @@ interfaces:
   - name: ReadFileOption
     comment: |
       ReadFileOption is a type of `Option` that can be passed to `jws.ReadFile`
+  - name: GlobalParseOption
+    methods:
+      - globalOption
+      - parseOption
+      - readFileOption
+    comment: |
+      GlobalParseOption describes an Option that can be passed to `jwt.Settings()`,
+      `jwt.Parse()`, and `jwt.ReadFile()`.
   - name: GlobalValidateOption
     methods:
       - globalOption
@@ -272,3 +280,14 @@ options:
     comment: |
       WithBase64Encoder specifies the base64 encoder to use for signing
       tokens and verifying JWS signatures.
+  - ident: MaxParseInputSize
+    interface: GlobalParseOption
+    argument_type: int64
+    comment: |
+      WithMaxParseInputSize specifies the maximum number of bytes read from an
+      io.Reader in `jwt.ParseReader`. If the input exceeds this size,
+      `jwt.ParseReader` will return an error. The default value is 10MB.
+
+      This option can be passed to `jwt.Settings()` to change the default
+      globally, or to `jwt.ParseReader()` / `jwt.ReadFile()` for a per-call
+      override.

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -39,6 +39,25 @@ type globalOption struct {
 
 func (*globalOption) globalOption() {}
 
+// GlobalParseOption describes an Option that can be passed to `jwt.Settings()`,
+// `jwt.Parse()`, and `jwt.ReadFile()`.
+type GlobalParseOption interface {
+	Option
+	globalOption()
+	parseOption()
+	readFileOption()
+}
+
+type globalParseOption struct {
+	Option
+}
+
+func (*globalParseOption) globalOption() {}
+
+func (*globalParseOption) parseOption() {}
+
+func (*globalParseOption) readFileOption() {}
+
 // GlobalValidateOption describes an Option that can be passed to `jwt.Settings()` and `jwt.Validate()`
 type GlobalValidateOption interface {
 	Option
@@ -175,6 +194,7 @@ type identFlattenAudience struct{}
 type identFormKey struct{}
 type identHeaderKey struct{}
 type identKeyProvider struct{}
+type identMaxParseInputSize struct{}
 type identNumericDateFormatPrecision struct{}
 type identNumericDateParsePedantic struct{}
 type identNumericDateParsePrecision struct{}
@@ -233,6 +253,10 @@ func (identHeaderKey) String() string {
 
 func (identKeyProvider) String() string {
 	return "WithKeyProvider"
+}
+
+func (identMaxParseInputSize) String() string {
+	return "WithMaxParseInputSize"
 }
 
 func (identNumericDateFormatPrecision) String() string {
@@ -368,6 +392,17 @@ func WithHeaderKey(v string) ParseOption {
 // for `jws.KeyProvider` in the `jws` package for details on how this works.
 func WithKeyProvider(v jws.KeyProvider) ParseOption {
 	return &parseOption{option.New(identKeyProvider{}, v)}
+}
+
+// WithMaxParseInputSize specifies the maximum number of bytes read from an
+// io.Reader in `jwt.ParseReader`. If the input exceeds this size,
+// `jwt.ParseReader` will return an error. The default value is 10MB.
+//
+// This option can be passed to `jwt.Settings()` to change the default
+// globally, or to `jwt.ParseReader()` / `jwt.ReadFile()` for a per-call
+// override.
+func WithMaxParseInputSize(v int64) GlobalParseOption {
+	return &globalParseOption{option.New(identMaxParseInputSize{}, v)}
 }
 
 // WithNumericDateFormatPrecision sets the precision up to which the

--- a/jwt/options_gen_test.go
+++ b/jwt/options_gen_test.go
@@ -21,6 +21,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithFormKey", identFormKey{}.String())
 	require.Equal(t, "WithHeaderKey", identHeaderKey{}.String())
 	require.Equal(t, "WithKeyProvider", identKeyProvider{}.String())
+	require.Equal(t, "WithMaxParseInputSize", identMaxParseInputSize{}.String())
 	require.Equal(t, "WithNumericDateFormatPrecision", identNumericDateFormatPrecision{}.String())
 	require.Equal(t, "WithNumericDateParsePedantic", identNumericDateParsePedantic{}.String())
 	require.Equal(t, "WithNumericDateParsePrecision", identNumericDateParsePrecision{}.String())

--- a/tools/cmd/genreadfile/main.go
+++ b/tools/cmd/genreadfile/main.go
@@ -36,9 +36,10 @@ func _main() error {
 			Filename:   "jws/io.go",
 		},
 		{
-			Package:    "jwe",
-			ReturnType: "*Message",
-			Filename:   "jwe/io.go",
+			Package:      "jwe",
+			ReturnType:   "*Message",
+			Filename:     "jwe/io.go",
+			ParseOptions: true,
 		},
 		{
 			Package:      "jwt",


### PR DESCRIPTION
jwt.ParseReader and jwe.ParseReader called io.ReadAll with no size cap. Add WithMaxParseInputSize option (default 10MB) configurable both globally via Settings() and per-call. Matches existing patterns from jwk.WithMaxFetchBodySize and jwe.WithMaxDecompressBufferSize.