### PR TITLE
add global default for MaxFetchBodySize

### DIFF
--- a/jwk/cache.go
+++ b/jwk/cache.go
@@ -88,7 +88,7 @@ type Transformer struct {
 func (t Transformer) Transform(_ context.Context, res *http.Response) (Set, error) {
 	maxBodySize := t.maxFetchBodySize
 	if maxBodySize <= 0 {
-		maxBodySize = defaultMaxFetchBodySize
+		maxBodySize = maxFetchBodySize.Load()
 	}
 
 	buf, err := io.ReadAll(io.LimitReader(res.Body, maxBodySize+1))

--- a/jwk/fetch.go
+++ b/jwk/fetch.go
@@ -5,11 +5,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync/atomic"
 )
 
-// defaultMaxFetchBodySize is the default maximum number of bytes read
+// defaultMaxFetchBodySize is the initial default maximum number of bytes read
 // from an HTTP response body when fetching a JWKS (10 MB).
 const defaultMaxFetchBodySize int64 = 10 * 1024 * 1024
+
+var maxFetchBodySize atomic.Int64
+
+func init() {
+	maxFetchBodySize.Store(defaultMaxFetchBodySize)
+}
 
 // Fetcher is an interface that represents an object that fetches a JWKS.
 // Currently this is only used in the `jws.WithVerifyAuto` option.
@@ -75,7 +82,7 @@ func Fetch(ctx context.Context, u string, options ...FetchOption) (Set, error) {
 	//nolint:revive // I want to keep the type of `wl` as `Whitelist` instead of `InsecureWhitelist`
 	var wl Whitelist = InsecureWhitelist{}
 	var client HTTPClient = http.DefaultClient
-	var maxBodySize = defaultMaxFetchBodySize
+	var maxBodySize = maxFetchBodySize.Load()
 	for _, option := range options {
 		if parseOpt, ok := option.(ParseOption); ok {
 			parseOptions = append(parseOptions, parseOpt)

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -649,6 +649,7 @@ func IsKeyValidationError(err error) bool {
 // Configure is used to configure global behavior of the jwk package.
 func Configure(options ...GlobalOption) {
 	var strictKeyUsagePtr *bool
+	var maxFetchBodySizePtr *int64
 	for _, option := range options {
 		switch option.Ident() {
 		case identStrictKeyUsage{}:
@@ -657,11 +658,21 @@ func Configure(options ...GlobalOption) {
 				continue
 			}
 			strictKeyUsagePtr = &v
+		case identMaxFetchBodySize{}:
+			var v int64
+			if err := option.Value(&v); err != nil {
+				continue
+			}
+			maxFetchBodySizePtr = &v
 		}
 	}
 
 	if strictKeyUsagePtr != nil {
 		strictKeyUsage.Store(*strictKeyUsagePtr)
+	}
+
+	if maxFetchBodySizePtr != nil {
+		maxFetchBodySize.Store(*maxFetchBodySizePtr)
 	}
 }
 

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1762,6 +1762,30 @@ func TestFetch(t *testing.T) {
 			require.NoError(t, err, `json.MarshalIndent should succeed`)
 			require.Equal(t, expected, got, `data should match`)
 		})
+		t.Run("GlobalDefault", func(t *testing.T) {
+			ctx := t.Context()
+			// Set a global limit smaller than the response body size.
+			jwk.Configure(jwk.WithMaxFetchBodySize(10))
+			defer jwk.Configure(jwk.WithMaxFetchBodySize(10 * 1024 * 1024)) // restore
+
+			_, err := jwk.Fetch(ctx, srv.URL)
+			require.Error(t, err, `jwk.Fetch should fail when response exceeds global max body size`)
+			require.Contains(t, err.Error(), `exceeded max size`)
+		})
+		t.Run("PerCallOverridesGlobal", func(t *testing.T) {
+			ctx := t.Context()
+			// Set a global limit smaller than the response body size.
+			jwk.Configure(jwk.WithMaxFetchBodySize(10))
+			defer jwk.Configure(jwk.WithMaxFetchBodySize(10 * 1024 * 1024)) // restore
+
+			// Per-call with a larger limit should allow the fetch
+			fetched, err := jwk.Fetch(ctx, srv.URL, jwk.WithMaxFetchBodySize(1<<20))
+			require.NoError(t, err, `per-call option should override global`)
+
+			got, err := json.MarshalIndent(fetched, "", "  ")
+			require.NoError(t, err, `json.MarshalIndent should succeed`)
+			require.Equal(t, expected, got, `data should match`)
+		})
 	})
 }
 

--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -45,6 +45,15 @@ interfaces:
     comment: |
       GlobalOption is a type of Option that can be passed to the `jwk.Configure()` to
       change the global configuration of the jwk package.
+  - name: GlobalFetchOption
+    methods:
+      - globalOption
+      - fetchOption
+      - registerOption
+      - parseOption
+    comment: |
+      GlobalFetchOption describes an Option that can be passed to `jwk.Configure()`,
+      `jwk.Fetch()`, and `(*jwk.Cache).Register()`.
 options:
   - ident: HTTPClient
     interface: RegisterFetchOption
@@ -53,14 +62,16 @@ options:
       WithHTTPClient allows users to specify the "net/http".Client object that
       is used when fetching jwk.Set objects.
   - ident: MaxFetchBodySize
-    interface: RegisterFetchOption
+    interface: GlobalFetchOption
     argument_type: int64
     comment: |
       WithMaxFetchBodySize specifies the maximum number of bytes to read from
       an HTTP response body when fetching a JWKS. If the response body exceeds
       this size, the fetch returns an error. The default value is 10MB (10485760).
 
-      This option can be passed to `jwk.Fetch()` or `(*jwk.Cache).Register()`.
+      This option can be passed to `jwk.Configure()` to change the default
+      globally, or to `jwk.Fetch()` / `(*jwk.Cache).Register()` for a per-call
+      override.
   - ident: ThumbprintHash
     interface: AssignKeyIDOption
     argument_type: crypto.Hash

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -56,6 +56,28 @@ func (*fetchOption) parseOption() {}
 
 func (*fetchOption) registerOption() {}
 
+// GlobalFetchOption describes an Option that can be passed to `jwk.Configure()`,
+// `jwk.Fetch()`, and `(*jwk.Cache).Register()`.
+type GlobalFetchOption interface {
+	Option
+	globalOption()
+	fetchOption()
+	registerOption()
+	parseOption()
+}
+
+type globalFetchOption struct {
+	Option
+}
+
+func (*globalFetchOption) globalOption() {}
+
+func (*globalFetchOption) fetchOption() {}
+
+func (*globalFetchOption) registerOption() {}
+
+func (*globalFetchOption) parseOption() {}
+
 // GlobalOption is a type of Option that can be passed to the `jwk.Configure()` to
 // change the global configuration of the jwk package.
 type GlobalOption interface {
@@ -255,9 +277,11 @@ func withLocalRegistry(v *json.Registry) ParseOption {
 // an HTTP response body when fetching a JWKS. If the response body exceeds
 // this size, the fetch returns an error. The default value is 10MB (10485760).
 //
-// This option can be passed to `jwk.Fetch()` or `(*jwk.Cache).Register()`.
-func WithMaxFetchBodySize(v int64) RegisterFetchOption {
-	return &registerFetchOption{option.New(identMaxFetchBodySize{}, v)}
+// This option can be passed to `jwk.Configure()` to change the default
+// globally, or to `jwk.Fetch()` / `(*jwk.Cache).Register()` for a per-call
+// override.
+func WithMaxFetchBodySize(v int64) GlobalFetchOption {
+	return &globalFetchOption{option.New(identMaxFetchBodySize{}, v)}
 }
 
 // WithPEM specifies that the input to `Parse()` is a PEM encoded key.


### PR DESCRIPTION
WithMaxFetchBodySize was already per-call for jwk.Fetch() and Cache.Register(), but had no global default via jwk.Configure(). This adds it, matching the pattern from jwt/jwe WithMaxParseInputSize which supports both global and per-call configuration.