### PR TITLE
fix parse size limit race, validation, and jws coverage

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -53,6 +53,7 @@ JSON Web Signatures per RFC 7515. Sign, verify, parse.
 - **SplitCompact(src []byte) ([]byte, []byte, []byte, error)** — split compact JWS into parts
 - Key types: `Message`, `Signature`, `Headers`, `KeyProvider`, `KeySink`
 - Options: `WithKey()`, `WithKeySet()`, `WithVerifyAuto()`, `WithJSON()`, `WithDetachedPayload()`
+- Global/per-call settings: `WithMaxParseInputSize()` (usable in both `Settings()` and `ParseReader()`/`ReadFile()`)
 - Registration: `RegisterSigner()`, `RegisterVerifier()`, `AlgorithmsForKey()`, `RegisterAlgorithmForKeyType()`, `RegisterAlgorithmForCurve()`
 - Error sentinels: `SignError()`, `VerifyError()`, `VerificationError()`, `ParseError()`
 - Sub-package: `jws/jwsbb` — compact serialization, signing, verification building blocks

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 
 	"github.com/lestrrat-go/blackmagic"
 	"github.com/lestrrat-go/jwx/v3/internal/base64"
@@ -32,7 +33,11 @@ var muSettings sync.RWMutex
 var maxPBES2Count = 10000
 var minPBES2Count = 1000
 var maxDecompressBufferSize int64 = 10 * 1024 * 1024 // 10MB
-var maxParseInputSize int64 = 10 * 1024 * 1024       // 10MB
+var maxParseInputSize atomic.Int64
+
+func init() {
+	maxParseInputSize.Store(10 * 1024 * 1024) // 10MB
+}
 
 func Settings(options ...GlobalOption) {
 	muSettings.Lock()
@@ -58,9 +63,14 @@ func Settings(options ...GlobalOption) {
 			}
 			aescbc.SetMaxBufferSize(v)
 		case identMaxParseInputSize{}:
-			if err := option.Value(&maxParseInputSize); err != nil {
+			var v int64
+			if err := option.Value(&v); err != nil {
 				panic(fmt.Sprintf("jwe.Settings: value for option WithMaxParseInputSize must be an int64: %s", err))
 			}
+			if v <= 0 {
+				panic("jwe.Settings: WithMaxParseInputSize must be greater than zero")
+			}
+			maxParseInputSize.Store(v)
 		}
 	}
 }
@@ -969,8 +979,10 @@ func Decrypt(buf []byte, options ...DecryptOption) ([]byte, error) {
 // Parse parses the JWE message into a Message object. The JWE message
 // can be either compact or full JSON format.
 //
-// Parse() currently does not take any options, but the API accepts it
-// in anticipation of future addition.
+// Parse() currently does not process any options, but the API accepts
+// them so that callers like ParseReader can forward their option lists
+// without filtering. Options such as WithMaxParseInputSize are handled
+// by ParseReader before the data reaches this function.
 func Parse(buf []byte, _ ...ParseOption) (*Message, error) {
 	return parseJSONOrCompact(buf, false)
 }
@@ -1008,14 +1020,15 @@ func ParseString(s string, options ...ParseOption) (*Message, error) {
 
 // ParseReader is the same as Parse, but takes an io.Reader.
 func ParseReader(src io.Reader, options ...ParseOption) (*Message, error) {
-	muSettings.RLock()
-	maxSize := maxParseInputSize
-	muSettings.RUnlock()
+	maxSize := maxParseInputSize.Load()
 
 	for _, option := range options {
 		if option.Ident() == (identMaxParseInputSize{}) {
 			if err := option.Value(&maxSize); err != nil {
 				return nil, makeParseError(`jwe.ParseReader`, `invalid WithMaxParseInputSize: %w`, err)
+			}
+			if maxSize <= 0 {
+				return nil, makeParseError(`jwe.ParseReader`, `WithMaxParseInputSize must be greater than zero`)
 			}
 		}
 	}

--- a/jwk/fetch.go
+++ b/jwk/fetch.go
@@ -102,6 +102,9 @@ func Fetch(ctx context.Context, u string, options ...FetchOption) (Set, error) {
 			if err := option.Value(&maxBodySize); err != nil {
 				return nil, fmt.Errorf(`failed to retrieve MaxFetchBodySize option value: %w`, err)
 			}
+			if maxBodySize <= 0 {
+				return nil, fmt.Errorf(`jwk.Fetch: WithMaxFetchBodySize must be greater than zero`)
+			}
 		}
 	}
 

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -663,6 +663,9 @@ func Configure(options ...GlobalOption) {
 			if err := option.Value(&v); err != nil {
 				continue
 			}
+			if v <= 0 {
+				continue
+			}
 			maxFetchBodySizePtr = &v
 		}
 	}

--- a/jws/io.go
+++ b/jws/io.go
@@ -15,6 +15,12 @@ func (sysFS) Open(path string) (fs.File, error) {
 }
 
 func ReadFile(path string, options ...ReadFileOption) (*Message, error) {
+	var parseOptions []ParseOption
+	for _, option := range options {
+		if po, ok := option.(ParseOption); ok {
+			parseOptions = append(parseOptions, po)
+		}
+	}
 
 	var srcFS fs.FS = sysFS{}
 	for _, option := range options {
@@ -32,5 +38,5 @@ func ReadFile(path string, options ...ReadFileOption) (*Message, error) {
 	}
 
 	defer f.Close()
-	return ParseReader(f)
+	return ParseReader(f, parseOptions...)
 }

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -372,14 +372,6 @@ func ParseReader(src io.Reader, options ...ParseOption) (*Message, error) {
 	return Parse(buf, options...)
 }
 
-func parseJSONReader(src io.Reader) (result *Message, err error) {
-	var m Message
-	if err := json.NewDecoder(src).Decode(&m); err != nil {
-		return nil, fmt.Errorf(`failed to unmarshal jws message: %w`, err)
-	}
-	return &m, nil
-}
-
 func parseJSON(data []byte) (result *Message, err error) {
 	var m Message
 	if err := json.Unmarshal(data, &m); err != nil {
@@ -428,15 +420,6 @@ func SplitCompactReader(rdr io.Reader) ([]byte, []byte, []byte, error) {
 		return nil, nil, nil, makeParseError(`jws.Parse`, `%w`, err)
 	}
 	return hdr, payload, signature, nil
-}
-
-// parseCompactReader parses a JWS value serialized via compact serialization.
-func parseCompactReader(rdr io.Reader) (m *Message, err error) {
-	protected, payload, signature, err := SplitCompactReader(rdr)
-	if err != nil {
-		return nil, fmt.Errorf(`invalid compact serialization format: %w`, err)
-	}
-	return parse(protected, payload, signature)
 }
 
 func parseCompact(data []byte) (m *Message, err error) {

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -26,7 +26,6 @@
 package jws
 
 import (
-	"bufio"
 	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -36,6 +35,7 @@ import (
 	"io"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"unicode"
 	"unicode/utf8"
 
@@ -50,6 +50,12 @@ import (
 )
 
 var registry = json.NewRegistry()
+
+var maxParseInputSize atomic.Int64
+
+func init() {
+	maxParseInputSize.Store(10 * 1024 * 1024) // 10MB
+}
 
 var signers = make(map[jwa.SignatureAlgorithm]Signer)
 var muSigner = &sync.Mutex{}
@@ -328,46 +334,42 @@ func ParseString(src string) (*Message, error) {
 // struct. The input can be in either compact or full JSON serialization.
 //
 // On error, returns a jws.ParseError.
-func ParseReader(src io.Reader) (*Message, error) {
-	data, err := jwxio.ReadAllFromFiniteSource(src)
+func ParseReader(src io.Reader, options ...ParseOption) (*Message, error) {
+	maxSize := maxParseInputSize.Load()
+	for _, option := range options {
+		if option.Ident() == (identMaxParseInputSize{}) {
+			if err := option.Value(&maxSize); err != nil {
+				return nil, makeParseError(`jws.ParseReader`, `invalid WithMaxParseInputSize: %w`, err)
+			}
+			if maxSize <= 0 {
+				return nil, makeParseError(`jws.ParseReader`, `WithMaxParseInputSize must be greater than zero`)
+			}
+		}
+	}
+
+	limited := io.LimitReader(src, maxSize+1)
+	data, err := jwxio.ReadAllFromFiniteSource(limited)
 	if err == nil {
-		return Parse(data)
+		if int64(len(data)) > maxSize {
+			return nil, makeParseError(`jws.ParseReader`, `input exceeded max size of %d bytes`, maxSize)
+		}
+		return Parse(data, options...)
 	}
 
 	if !errors.Is(err, jwxio.NonFiniteSourceError()) {
 		return nil, makeParseError(`jws.ParseReader`, `failed to read from finite source: %w`, err)
 	}
 
-	rdr := bufio.NewReader(src)
-	var first rune
-	for {
-		r, _, err := rdr.ReadRune()
-		if err != nil {
-			return nil, makeParseError(`jws.ParseReader`, `failed to read rune: %w`, err)
-		}
-		if !unicode.IsSpace(r) {
-			first = r
-			if err := rdr.UnreadRune(); err != nil {
-				return nil, makeParseError(`jws.ParseReader`, `failed to unread rune: %w`, err)
-			}
-
-			break
-		}
-	}
-
-	var parser func(io.Reader) (*Message, error)
-	if first == tokens.OpenCurlyBracket {
-		parser = parseJSONReader
-	} else {
-		parser = parseCompactReader
-	}
-
-	m, err := parser(rdr)
+	// Non-finite source: read all with size limit
+	buf, err := io.ReadAll(io.LimitReader(src, maxSize+1))
 	if err != nil {
-		return nil, makeParseError(`jws.ParseReader`, `failed to parse reader: %w`, err)
+		return nil, makeParseError(`jws.ParseReader`, `failed to read from io.Reader: %w`, err)
+	}
+	if int64(len(buf)) > maxSize {
+		return nil, makeParseError(`jws.ParseReader`, `input exceeded max size of %d bytes`, maxSize)
 	}
 
-	return m, nil
+	return Parse(buf, options...)
 }
 
 func parseJSONReader(src io.Reader) (result *Message, err error) {
@@ -668,6 +670,15 @@ func Settings(options ...GlobalOption) {
 	for _, option := range options {
 		switch option.Ident() {
 		case identLegacySigners{}:
+		case identMaxParseInputSize{}:
+			var v int64
+			if err := option.Value(&v); err != nil {
+				panic(fmt.Sprintf("jws.Settings: value for WithMaxParseInputSize must be int64: %s", err))
+			}
+			if v <= 0 {
+				panic("jws.Settings: WithMaxParseInputSize must be greater than zero")
+			}
+			maxParseInputSize.Store(v)
 		}
 	}
 }

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1792,3 +1792,61 @@ func BenchmarkSplitCompatString(b *testing.B) {
 		}
 	}
 }
+
+func TestMaxParseInputSize(t *testing.T) {
+	t.Run("default rejects oversized input", func(t *testing.T) {
+		data := make([]byte, 10*1024*1024+1)
+		_, err := jws.ParseReader(bytes.NewReader(data))
+		require.Error(t, err, `jws.ParseReader should reject input exceeding default max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("per-call option overrides default", func(t *testing.T) {
+		data := make([]byte, 200)
+		_, err := jws.ParseReader(bytes.NewReader(data), jws.WithMaxParseInputSize(100))
+		require.Error(t, err, `jws.ParseReader should reject input exceeding per-call max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("input within limit is accepted", func(t *testing.T) {
+		data := []byte(`not-valid-jws-but-small`)
+		_, err := jws.ParseReader(bytes.NewReader(data), jws.WithMaxParseInputSize(1024))
+		// The error (if any) should NOT be about size
+		if err != nil {
+			require.NotContains(t, err.Error(), `exceeded max size`)
+		}
+	})
+	t.Run("global setting changes default", func(t *testing.T) {
+		jws.Settings(jws.WithMaxParseInputSize(50))
+		defer jws.Settings(jws.WithMaxParseInputSize(10 * 1024 * 1024)) // restore
+
+		data := make([]byte, 100)
+		_, err := jws.ParseReader(bytes.NewReader(data))
+		require.Error(t, err, `jws.ParseReader should reject input exceeding global max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("per-call option overrides global setting", func(t *testing.T) {
+		jws.Settings(jws.WithMaxParseInputSize(50))
+		defer jws.Settings(jws.WithMaxParseInputSize(10 * 1024 * 1024)) // restore
+
+		data := []byte(`not-valid-jws-but-small`)
+		_, err := jws.ParseReader(bytes.NewReader(data), jws.WithMaxParseInputSize(1024))
+		if err != nil {
+			require.NotContains(t, err.Error(), `exceeded max size`)
+		}
+	})
+	t.Run("negative value panics in Settings", func(t *testing.T) {
+		require.Panics(t, func() {
+			jws.Settings(jws.WithMaxParseInputSize(-1))
+		})
+	})
+	t.Run("zero value panics in Settings", func(t *testing.T) {
+		require.Panics(t, func() {
+			jws.Settings(jws.WithMaxParseInputSize(0))
+		})
+	})
+	t.Run("negative per-call value returns error", func(t *testing.T) {
+		data := []byte(`test`)
+		_, err := jws.ParseReader(bytes.NewReader(data), jws.WithMaxParseInputSize(-1))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `greater than zero`)
+	})
+}

--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -54,6 +54,14 @@ interfaces:
       - verifyOption
       - parseOption
       - readFileOption
+  - name: GlobalParseOption
+    methods:
+      - globalOption
+      - parseOption
+      - readFileOption
+    comment: |
+      GlobalParseOption describes an Option that can be passed to `jws.Settings()`,
+      `jws.Parse()`, and `jws.ReadFile()`.
   - name: GlobalOption
     comment: |
       GlobalOption can be passed to `jws.Settings()` to set global options for the JWS package.
@@ -228,3 +236,14 @@ options:
     constant_value: true
     comment: |
       WithLegacySigners is a no-op option that exists only for backwards compatibility.
+  - ident: MaxParseInputSize
+    interface: GlobalParseOption
+    argument_type: int64
+    comment: |
+      WithMaxParseInputSize specifies the maximum number of bytes read from an
+      io.Reader in `jws.ParseReader`. If the input exceeds this size,
+      `jws.ParseReader` will return an error. The default value is 10MB.
+
+      This option can be passed to `jws.Settings()` to change the default
+      globally, or to `jws.ParseReader()` / `jws.ReadFile()` for a per-call
+      override.

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -35,6 +35,25 @@ type globalOption struct {
 
 func (*globalOption) globalOption() {}
 
+// GlobalParseOption describes an Option that can be passed to `jws.Settings()`,
+// `jws.Parse()`, and `jws.ReadFile()`.
+type GlobalParseOption interface {
+	Option
+	globalOption()
+	parseOption()
+	readFileOption()
+}
+
+type globalParseOption struct {
+	Option
+}
+
+func (*globalParseOption) globalOption() {}
+
+func (*globalParseOption) parseOption() {}
+
+func (*globalParseOption) readFileOption() {}
+
 // ReadFileOption is a type of `Option` that can be passed to `jwe.Parse`
 type ParseOption interface {
 	Option
@@ -193,6 +212,7 @@ type identKey struct{}
 type identKeyProvider struct{}
 type identKeyUsed struct{}
 type identLegacySigners struct{}
+type identMaxParseInputSize struct{}
 type identMessage struct{}
 type identMultipleKeysPerKeyID struct{}
 type identPretty struct{}
@@ -241,6 +261,10 @@ func (identKeyUsed) String() string {
 
 func (identLegacySigners) String() string {
 	return "WithLegacySigners"
+}
+
+func (identMaxParseInputSize) String() string {
+	return "WithMaxParseInputSize"
 }
 
 func (identMessage) String() string {
@@ -359,6 +383,17 @@ func WithKeyUsed(v any) VerifyOption {
 // WithLegacySigners is a no-op option that exists only for backwards compatibility.
 func WithLegacySigners() GlobalOption {
 	return &globalOption{option.New(identLegacySigners{}, true)}
+}
+
+// WithMaxParseInputSize specifies the maximum number of bytes read from an
+// io.Reader in `jws.ParseReader`. If the input exceeds this size,
+// `jws.ParseReader` will return an error. The default value is 10MB.
+//
+// This option can be passed to `jws.Settings()` to change the default
+// globally, or to `jws.ParseReader()` / `jws.ReadFile()` for a per-call
+// override.
+func WithMaxParseInputSize(v int64) GlobalParseOption {
+	return &globalParseOption{option.New(identMaxParseInputSize{}, v)}
 }
 
 // WithMessage can be passed to Verify() to obtain the jws.Message upon

--- a/jws/options_gen_test.go
+++ b/jws/options_gen_test.go
@@ -19,6 +19,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithKeyProvider", identKeyProvider{}.String())
 	require.Equal(t, "WithKeyUsed", identKeyUsed{}.String())
 	require.Equal(t, "WithLegacySigners", identLegacySigners{}.String())
+	require.Equal(t, "WithMaxParseInputSize", identMaxParseInputSize{}.String())
 	require.Equal(t, "WithMessage", identMessage{}.String())
 	require.Equal(t, "WithMultipleKeysPerKeyID", identMultipleKeysPerKeyID{}.String())
 	require.Equal(t, "WithPretty", identPretty{}.String())

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -70,6 +70,9 @@ func Settings(options ...GlobalOption) {
 			if err := option.Value(&v); err != nil {
 				panic(fmt.Sprintf("jwt.Settings: value for WithMaxParseInputSize must be int64: %s", err))
 			}
+			if v <= 0 {
+				panic("jwt.Settings: WithMaxParseInputSize must be greater than zero")
+			}
 			maxParseInputSize.Store(v)
 		}
 	}
@@ -187,6 +190,9 @@ func ParseReader(src io.Reader, options ...ParseOption) (Token, error) {
 		if option.Ident() == (identMaxParseInputSize{}) {
 			if err := option.Value(&maxSize); err != nil {
 				return nil, jwterrs.ParseErrorf(`jwt.ParseReader`, `invalid WithMaxParseInputSize: %w`, err)
+			}
+			if maxSize <= 0 {
+				return nil, jwterrs.ParseErrorf(`jwt.ParseReader`, `WithMaxParseInputSize must be greater than zero`)
 			}
 		}
 	}

--- a/tools/cmd/genreadfile/main.go
+++ b/tools/cmd/genreadfile/main.go
@@ -31,9 +31,10 @@ func _main() error {
 			ParseOptions: true,
 		},
 		{
-			Package:    "jws",
-			ReturnType: "*Message",
-			Filename:   "jws/io.go",
+			Package:      "jws",
+			ReturnType:   "*Message",
+			Filename:     "jws/io.go",
+			ParseOptions: true,
 		},
 		{
 			Package:      "jwe",


### PR DESCRIPTION
Fix data race on jwe.maxParseInputSize (plain int64 read without lock), add <= 0 rejection for all MaxParseInputSize/MaxFetchBodySize setters, add MaxParseInputSize to jws.ParseReader matching jwt/jwe pattern.