### PR TITLE
add max recipients limit for JWE messages

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -69,7 +69,7 @@ JSON Web Encryption per RFC 7516. Encrypt, decrypt, parse.
 - **Parse(buf []byte, ...ParseOption) (*Message, error)** — parse without decryption
 - Key types: `Message`, `Recipient`, `Headers`, `KeyProvider`, `KeyEncrypter`, `KeyDecrypter`
 - Options: `WithKey()`, `WithKeySet()`, `WithContentEncryption()`, `WithCompress()`, `WithJSON()`, `WithProtectedHeaders()`
-- Global/per-call settings: `WithMaxPBES2Count()`, `WithMinPBES2Count()`, `WithMaxDecompressBufferSize()` (usable in both `Settings()` and `Decrypt()`); `WithMaxParseInputSize()` (usable in both `Settings()` and `ParseReader()`/`ReadFile()`); `WithCBCBufferSize()` (global only)
+- Global/per-call settings: `WithMaxPBES2Count()`, `WithMinPBES2Count()`, `WithMaxDecompressBufferSize()`, `WithMaxRecipients()` (usable in both `Settings()` and `Decrypt()`); `WithMaxParseInputSize()` (usable in both `Settings()` and `ParseReader()`/`ReadFile()`); `WithCBCBufferSize()` (global only)
 - Error sentinels: `EncryptError()`, `DecryptError()`, `RecipientError()`, `ParseError()`
 - Internal subpackages: `jwe/internal/{aescbc,cipher,concatkdf,content_crypt,keygen}`, `jwe/jwebb`
 - Files: `jwe.go`, `message.go`, `interface.go`, `headers.go`, `errors.go`, `options.go`, `key_provider.go`, `compress.go`, `filter.go`

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -32,6 +32,7 @@ import (
 var muSettings sync.RWMutex
 var maxPBES2Count = 10000
 var minPBES2Count = 1000
+var maxRecipients = 100
 var maxDecompressBufferSize int64 = 10 * 1024 * 1024 // 10MB
 var maxParseInputSize atomic.Int64
 
@@ -51,6 +52,10 @@ func Settings(options ...GlobalOption) {
 		case identMinPBES2Count{}:
 			if err := option.Value(&minPBES2Count); err != nil {
 				panic(fmt.Sprintf("jwe.Settings: value for option WithMinPBES2Count must be an int: %s", err))
+			}
+		case identMaxRecipients{}:
+			if err := option.Value(&maxRecipients); err != nil {
+				panic(fmt.Sprintf("jwe.Settings: value for option WithMaxRecipients must be an int: %s", err))
 			}
 		case identMaxDecompressBufferSize{}:
 			if err := option.Value(&maxDecompressBufferSize); err != nil {
@@ -246,6 +251,7 @@ type decryptContext struct {
 	keyUsed                 any
 	cek                     *[]byte
 	dst                     *Message
+	maxRecipients           int
 	maxDecompressBufferSize int64
 	maxPBES2Count           int
 	minPBES2Count           int
@@ -266,6 +272,7 @@ func freeDecryptContext(dc *decryptContext) *decryptContext {
 	dc.keyUsed = nil
 	dc.cek = nil
 	dc.dst = nil
+	dc.maxRecipients = 0
 	dc.maxDecompressBufferSize = 0
 	dc.maxPBES2Count = 0
 	dc.minPBES2Count = 0
@@ -275,6 +282,7 @@ func freeDecryptContext(dc *decryptContext) *decryptContext {
 
 func (dc *decryptContext) ProcessOptions(options []DecryptOption) error {
 	muSettings.RLock()
+	dc.maxRecipients = maxRecipients
 	dc.maxDecompressBufferSize = maxDecompressBufferSize
 	dc.maxPBES2Count = maxPBES2Count
 	dc.minPBES2Count = minPBES2Count
@@ -310,6 +318,10 @@ func (dc *decryptContext) ProcessOptions(options []DecryptOption) error {
 			if err := option.Value(&dc.cek); err != nil {
 				return fmt.Errorf("jwe.decrypt: WithCEK must be a *[]byte: %w", err)
 			}
+		case identMaxRecipients{}:
+			if err := option.Value(&dc.maxRecipients); err != nil {
+				return fmt.Errorf("jwe.decrypt: WithMaxRecipients must be int: %w", err)
+			}
 		case identMaxDecompressBufferSize{}:
 			if err := option.Value(&dc.maxDecompressBufferSize); err != nil {
 				return fmt.Errorf("jwe.decrypt: WithMaxDecompressBufferSize must be int64: %w", err)
@@ -337,7 +349,7 @@ func (dc *decryptContext) ProcessOptions(options []DecryptOption) error {
 }
 
 func (dc *decryptContext) DecryptMessage(buf []byte) ([]byte, error) {
-	msg, err := parseJSONOrCompact(buf, true)
+	msg, err := parseJSONOrCompact(buf, true, dc.maxRecipients)
 	if err != nil {
 		return nil, fmt.Errorf(`failed to parse buffer for Decrypt: %w`, err)
 	}
@@ -984,12 +996,15 @@ func Decrypt(buf []byte, options ...DecryptOption) ([]byte, error) {
 // without filtering. Options such as WithMaxParseInputSize are handled
 // by ParseReader before the data reaches this function.
 func Parse(buf []byte, _ ...ParseOption) (*Message, error) {
-	return parseJSONOrCompact(buf, false)
+	muSettings.RLock()
+	maxR := maxRecipients
+	muSettings.RUnlock()
+	return parseJSONOrCompact(buf, false, maxR)
 }
 
 // errors are wrapped within this function, because we call it directly
 // from Decrypt as well.
-func parseJSONOrCompact(buf []byte, storeProtectedHeaders bool) (*Message, error) {
+func parseJSONOrCompact(buf []byte, storeProtectedHeaders bool, maxR int) (*Message, error) {
 	buf = bytes.TrimSpace(buf)
 	if len(buf) == 0 {
 		return nil, makeParseError(`jwe.Parse`, `empty buffer`)
@@ -1006,6 +1021,11 @@ func parseJSONOrCompact(buf []byte, storeProtectedHeaders bool) (*Message, error
 	if err != nil {
 		return nil, makeParseError(`jwe.Parse`, `%w`, err)
 	}
+
+	if maxR > 0 && len(msg.recipients) > maxR {
+		return nil, makeParseError(`jwe.Parse`, `too many recipients in JWE message (%d > %d)`, len(msg.recipients), maxR)
+	}
+
 	return msg, nil
 }
 

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1290,3 +1290,96 @@ func TestMaxParseInputSize(t *testing.T) {
 		require.NotContains(t, err.Error(), `exceeded max size`)
 	})
 }
+
+func TestMaxRecipients(t *testing.T) {
+	privkey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, `rsa.GenerateKey should succeed`)
+
+	pubkey := &privkey.PublicKey
+
+	// Build a valid JWE with a single recipient, then modify the JSON
+	// to duplicate recipients for testing limits.
+	encrypted, err := jwe.Encrypt(
+		[]byte("hello"),
+		jwe.WithKey(jwa.RSA_OAEP(), pubkey),
+		jwe.WithContentEncryption(jwa.A128CBC_HS256()),
+		jwe.WithJSON(),
+	)
+	require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+	// Parse the JSON to extract a recipient, then build a message with many recipients.
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(encrypted, &parsed))
+
+	// The single-recipient JSON format uses "header" and "encrypted_key" at the top level.
+	// Build a recipients array from this.
+	singleRecipient := map[string]interface{}{
+		"encrypted_key": parsed["encrypted_key"],
+	}
+	if h, ok := parsed["header"]; ok {
+		singleRecipient["header"] = h
+	}
+
+	makeMessage := func(n int) []byte {
+		recipients := make([]interface{}, n)
+		for i := range recipients {
+			recipients[i] = singleRecipient
+		}
+
+		msg := map[string]interface{}{
+			"protected":  parsed["protected"],
+			"iv":         parsed["iv"],
+			"ciphertext": parsed["ciphertext"],
+			"tag":        parsed["tag"],
+			"recipients": recipients,
+		}
+
+		buf, err := json.Marshal(msg)
+		require.NoError(t, err)
+		return buf
+	}
+
+	t.Run("parse rejects over global limit", func(t *testing.T) {
+		// Default limit is 100
+		msg := makeMessage(101)
+		_, err := jwe.Parse(msg)
+		require.Error(t, err, `jwe.Parse should fail with too many recipients`)
+		require.Contains(t, err.Error(), `too many recipients`)
+	})
+
+	t.Run("parse accepts within global limit", func(t *testing.T) {
+		msg := makeMessage(100)
+		_, err := jwe.Parse(msg)
+		require.NoError(t, err, `jwe.Parse should succeed within limit`)
+	})
+
+	t.Run("global settings override", func(t *testing.T) {
+		jwe.Settings(jwe.WithMaxRecipients(5))
+		defer jwe.Settings(jwe.WithMaxRecipients(100))
+
+		msg := makeMessage(6)
+		_, err := jwe.Parse(msg)
+		require.Error(t, err, `jwe.Parse should fail with lowered limit`)
+		require.Contains(t, err.Error(), `too many recipients`)
+
+		msg = makeMessage(5)
+		_, err = jwe.Parse(msg)
+		require.NoError(t, err, `jwe.Parse should succeed at exactly the limit`)
+	})
+
+	t.Run("per-call decrypt override", func(t *testing.T) {
+		// Set global limit low
+		jwe.Settings(jwe.WithMaxRecipients(5))
+		defer jwe.Settings(jwe.WithMaxRecipients(100))
+
+		msg := makeMessage(10)
+
+		// Should fail with global limit
+		_, err := jwe.Decrypt(msg, jwe.WithKey(jwa.RSA_OAEP(), privkey))
+		require.Error(t, err, `jwe.Decrypt should fail with global limit of 5`)
+
+		// Should succeed with per-call override
+		_, err = jwe.Decrypt(msg, jwe.WithKey(jwa.RSA_OAEP(), privkey), jwe.WithMaxRecipients(10))
+		require.NoError(t, err, `jwe.Decrypt should succeed with per-call limit of 10`)
+	})
+}

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1308,12 +1308,12 @@ func TestMaxRecipients(t *testing.T) {
 	require.NoError(t, err, `jwe.Encrypt should succeed`)
 
 	// Parse the JSON to extract a recipient, then build a message with many recipients.
-	var parsed map[string]interface{}
+	var parsed map[string]any
 	require.NoError(t, json.Unmarshal(encrypted, &parsed))
 
 	// The single-recipient JSON format uses "header" and "encrypted_key" at the top level.
 	// Build a recipients array from this.
-	singleRecipient := map[string]interface{}{
+	singleRecipient := map[string]any{
 		"encrypted_key": parsed["encrypted_key"],
 	}
 	if h, ok := parsed["header"]; ok {
@@ -1321,12 +1321,12 @@ func TestMaxRecipients(t *testing.T) {
 	}
 
 	makeMessage := func(n int) []byte {
-		recipients := make([]interface{}, n)
+		recipients := make([]any, n)
 		for i := range recipients {
 			recipients[i] = singleRecipient
 		}
 
-		msg := map[string]interface{}{
+		msg := map[string]any{
 			"protected":  parsed["protected"],
 			"iv":         parsed["iv"],
 			"ciphertext": parsed["ciphertext"],

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -168,6 +168,18 @@ options:
       This option can be used for `jwe.Settings()`, which changes the behavior
       globally, or for `jwe.Decrypt()`, which changes the behavior for that
       specific call.
+  - ident: MaxRecipients
+    interface: GlobalDecryptOption
+    argument_type: int
+    comment: |
+      WithMaxRecipients specifies the maximum number of recipients allowed
+      in a JWE message. If a JWE message contains more recipients than this
+      value, parsing or decryption will return an error. The default value
+      is 100.
+
+      This option can be used for `jwe.Settings()`, which changes the behavior
+      globally, or for `jwe.Decrypt()`, which changes the behavior for that
+      specific call.
   - ident: MaxDecompressBufferSize
     interface: GlobalDecryptOption
     argument_type: int64

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -167,6 +167,7 @@ type identLegacyHeaderMerging struct{}
 type identMaxDecompressBufferSize struct{}
 type identMaxPBES2Count struct{}
 type identMaxParseInputSize struct{}
+type identMaxRecipients struct{}
 type identMergeProtectedHeaders struct{}
 type identMessage struct{}
 type identMinPBES2Count struct{}
@@ -226,6 +227,10 @@ func (identMaxPBES2Count) String() string {
 
 func (identMaxParseInputSize) String() string {
 	return "WithMaxParseInputSize"
+}
+
+func (identMaxRecipients) String() string {
+	return "WithMaxRecipients"
 }
 
 func (identMergeProtectedHeaders) String() string {
@@ -391,6 +396,18 @@ func WithMaxPBES2Count(v int) GlobalDecryptOption {
 // globally, or to `jwe.ReadFile()` for a per-call override.
 func WithMaxParseInputSize(v int64) GlobalParseOption {
 	return &globalParseOption{option.New(identMaxParseInputSize{}, v)}
+}
+
+// WithMaxRecipients specifies the maximum number of recipients allowed
+// in a JWE message. If a JWE message contains more recipients than this
+// value, parsing or decryption will return an error. The default value
+// is 100.
+//
+// This option can be used for `jwe.Settings()`, which changes the behavior
+// globally, or for `jwe.Decrypt()`, which changes the behavior for that
+// specific call.
+func WithMaxRecipients(v int) GlobalDecryptOption {
+	return &globalDecryptOption{option.New(identMaxRecipients{}, v)}
 }
 
 // WithMergeProtectedHeaders specify that when given multiple headers

--- a/jwe/options_gen_test.go
+++ b/jwe/options_gen_test.go
@@ -22,6 +22,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithMaxDecompressBufferSize", identMaxDecompressBufferSize{}.String())
 	require.Equal(t, "WithMaxPBES2Count", identMaxPBES2Count{}.String())
 	require.Equal(t, "WithMaxParseInputSize", identMaxParseInputSize{}.String())
+	require.Equal(t, "WithMaxRecipients", identMaxRecipients{}.String())
 	require.Equal(t, "WithMergeProtectedHeaders", identMergeProtectedHeaders{}.String())
 	require.Equal(t, "WithMessage", identMessage{}.String())
 	require.Equal(t, "WithMinPBES2Count", identMinPBES2Count{}.String())


### PR DESCRIPTION
Adds WithMaxRecipients (default 100) to cap the number of recipients in JSON-serialized JWE messages. Prevents DoS via crafted messages with thousands of recipients triggering O(n) decryption attempts.

Configurable globally via jwe.Settings() and per-call via jwe.Decrypt().