### PR TITLE
add default HTTP timeout for jwk.Fetch

### DIFF
--- a/jwk/fetch.go
+++ b/jwk/fetch.go
@@ -108,7 +108,7 @@ func Fetch(ctx context.Context, u string, options ...FetchOption) (Set, error) {
 	var parseOptions []ParseOption
 	//nolint:revive // I want to keep the type of `wl` as `Whitelist` instead of `InsecureWhitelist`
 	var wl Whitelist = InsecureWhitelist{}
-	var client HTTPClient = getFetchHTTPClient()
+	var client = getFetchHTTPClient()
 	var maxBodySize = maxFetchBodySize.Load()
 	for _, option := range options {
 		if parseOpt, ok := option.(ParseOption); ok {

--- a/jwk/fetch.go
+++ b/jwk/fetch.go
@@ -5,17 +5,44 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // defaultMaxFetchBodySize is the initial default maximum number of bytes read
 // from an HTTP response body when fetching a JWKS (10 MB).
 const defaultMaxFetchBodySize int64 = 10 * 1024 * 1024
 
+// defaultFetchTimeout is the default timeout for HTTP requests made by
+// jwk.Fetch(). This prevents malicious or unresponsive JWKS endpoints from
+// hanging indefinitely (e.g. slowloris-style DoS).
+const defaultFetchTimeout = 30 * time.Second
+
 var maxFetchBodySize atomic.Int64
+
+var (
+	fetchHTTPClientMu sync.RWMutex
+	fetchHTTPClient   HTTPClient
+)
 
 func init() {
 	maxFetchBodySize.Store(defaultMaxFetchBodySize)
+	fetchHTTPClient = &http.Client{
+		Timeout: defaultFetchTimeout,
+	}
+}
+
+func getFetchHTTPClient() HTTPClient {
+	fetchHTTPClientMu.RLock()
+	defer fetchHTTPClientMu.RUnlock()
+	return fetchHTTPClient
+}
+
+func setFetchHTTPClient(c HTTPClient) {
+	fetchHTTPClientMu.Lock()
+	defer fetchHTTPClientMu.Unlock()
+	fetchHTTPClient = c
 }
 
 // Fetcher is an interface that represents an object that fetches a JWKS.
@@ -81,7 +108,7 @@ func Fetch(ctx context.Context, u string, options ...FetchOption) (Set, error) {
 	var parseOptions []ParseOption
 	//nolint:revive // I want to keep the type of `wl` as `Whitelist` instead of `InsecureWhitelist`
 	var wl Whitelist = InsecureWhitelist{}
-	var client HTTPClient = http.DefaultClient
+	var client HTTPClient = getFetchHTTPClient()
 	var maxBodySize = maxFetchBodySize.Load()
 	for _, option := range options {
 		if parseOpt, ok := option.(ParseOption); ok {

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -650,6 +650,7 @@ func IsKeyValidationError(err error) bool {
 func Configure(options ...GlobalOption) {
 	var strictKeyUsagePtr *bool
 	var maxFetchBodySizePtr *int64
+	var httpClientPtr *HTTPClient
 	for _, option := range options {
 		switch option.Ident() {
 		case identStrictKeyUsage{}:
@@ -667,6 +668,12 @@ func Configure(options ...GlobalOption) {
 				continue
 			}
 			maxFetchBodySizePtr = &v
+		case identHTTPClient{}:
+			var v HTTPClient
+			if err := option.Value(&v); err != nil {
+				continue
+			}
+			httpClientPtr = &v
 		}
 	}
 
@@ -676,6 +683,10 @@ func Configure(options ...GlobalOption) {
 
 	if maxFetchBodySizePtr != nil {
 		maxFetchBodySize.Store(*maxFetchBodySizePtr)
+	}
+
+	if httpClientPtr != nil {
+		setFetchHTTPClient(*httpClientPtr)
 	}
 }
 

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1682,6 +1682,46 @@ func TestFetch(t *testing.T) {
 		require.Error(t, err, `jwk.Fetch should fail`)
 		require.Contains(t, err.Error(), `418`, `error should contain 418`)
 	})
+	t.Run("DefaultTimeout", func(t *testing.T) {
+		// Create a server that delays longer than the context deadline.
+		// The default HTTP client has a 30s timeout, but we use a short
+		// context deadline to test that the fetch respects context cancellation.
+		slowSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case <-time.After(5 * time.Second):
+				w.WriteHeader(http.StatusOK)
+			case <-r.Context().Done():
+			}
+		}))
+		defer slowSrv.Close()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
+
+		_, err := jwk.Fetch(ctx, slowSrv.URL)
+		require.Error(t, err, `jwk.Fetch should fail with timeout`)
+	})
+	t.Run("ConfigureHTTPClient", func(t *testing.T) {
+		// Configure a global HTTP client that returns 418 (teapot).
+		teapotClient := &http.Client{
+			Transport: &DummyRoundTripper{},
+		}
+		jwk.Configure(jwk.WithHTTPClient(teapotClient))
+		defer jwk.Configure(jwk.WithHTTPClient(&http.Client{Timeout: 30 * time.Second})) // restore
+
+		ctx := t.Context()
+		_, err := jwk.Fetch(ctx, srv.URL)
+		require.Error(t, err, `jwk.Fetch should fail with globally configured client`)
+		require.Contains(t, err.Error(), `418`, `error should contain 418 from global client`)
+
+		// Per-call override should take precedence
+		fetched, err := jwk.Fetch(ctx, srv.URL, jwk.WithHTTPClient(http.DefaultClient))
+		require.NoError(t, err, `per-call WithHTTPClient should override global`)
+
+		got, err := json.MarshalIndent(fetched, "", "  ")
+		require.NoError(t, err, `json.MarshalIndent should succeed`)
+		require.Equal(t, expected, got, `data should match`)
+	})
 	t.Run("Whitelist", func(t *testing.T) {
 		testcases := []struct {
 			Name      string

--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -56,11 +56,18 @@ interfaces:
       `jwk.Fetch()`, and `(*jwk.Cache).Register()`.
 options:
   - ident: HTTPClient
-    interface: RegisterFetchOption
+    interface: GlobalFetchOption
     argument_type: HTTPClient
     comment: |
       WithHTTPClient allows users to specify the "net/http".Client object that
       is used when fetching jwk.Set objects.
+
+      When passed to `jwk.Configure()`, it sets the global default HTTP client
+      used by `jwk.Fetch()`. By default, `jwk.Fetch()` uses an HTTP client with
+      a 30-second timeout instead of `http.DefaultClient` (which has no timeout).
+
+      Users can override the client per-call via `jwk.Fetch()` or per-resource
+      via `(*jwk.Cache).Register()`.
   - ident: MaxFetchBodySize
     interface: GlobalFetchOption
     argument_type: int64

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -241,8 +241,15 @@ func WithFetchWhitelist(v Whitelist) FetchOption {
 
 // WithHTTPClient allows users to specify the "net/http".Client object that
 // is used when fetching jwk.Set objects.
-func WithHTTPClient(v HTTPClient) RegisterFetchOption {
-	return &registerFetchOption{option.New(identHTTPClient{}, v)}
+//
+// When passed to `jwk.Configure()`, it sets the global default HTTP client
+// used by `jwk.Fetch()`. By default, `jwk.Fetch()` uses an HTTP client with
+// a 30-second timeout instead of `http.DefaultClient` (which has no timeout).
+//
+// Users can override the client per-call via `jwk.Fetch()` or per-resource
+// via `(*jwk.Cache).Register()`.
+func WithHTTPClient(v HTTPClient) GlobalFetchOption {
+	return &globalFetchOption{option.New(identHTTPClient{}, v)}
 }
 
 // WithIgnoreParseError is only applicable when used with `jwk.Parse()`


### PR DESCRIPTION
jwk.Fetch() now uses an HTTP client with a 30-second timeout instead of http.DefaultClient (no timeout). Prevents slowloris-style DoS from malicious JWKS endpoints. WithHTTPClient promoted to GlobalFetchOption so the default client is configurable via jwk.Configure().