### PR TITLE
add max signatures limit for JWS messages

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -53,7 +53,7 @@ JSON Web Signatures per RFC 7515. Sign, verify, parse.
 - **SplitCompact(src []byte) ([]byte, []byte, []byte, error)** — split compact JWS into parts
 - Key types: `Message`, `Signature`, `Headers`, `KeyProvider`, `KeySink`
 - Options: `WithKey()`, `WithKeySet()`, `WithVerifyAuto()`, `WithJSON()`, `WithDetachedPayload()`
-- Global/per-call settings: `WithMaxParseInputSize()` (usable in both `Settings()` and `ParseReader()`/`ReadFile()`)
+- Global/per-call settings: `WithMaxParseInputSize()` (usable in both `Settings()` and `ParseReader()`/`ReadFile()`); `WithMaxSignatures()` (usable in both `Settings()` and `Parse()`/`ReadFile()`)
 - Registration: `RegisterSigner()`, `RegisterVerifier()`, `AlgorithmsForKey()`, `RegisterAlgorithmForKeyType()`, `RegisterAlgorithmForCurve()`
 - Error sentinels: `SignError()`, `VerifyError()`, `VerificationError()`, `ParseError()`
 - Sub-package: `jws/jwsbb` — compact serialization, signing, verification building blocks

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -51,6 +51,8 @@ import (
 
 var registry = json.NewRegistry()
 
+var muSettings sync.RWMutex
+var maxSignatures = 100
 var maxParseInputSize atomic.Int64
 
 func init() {
@@ -265,6 +267,10 @@ func getB64Value(hdr Headers) bool {
 //
 // On error, returns a jws.ParseError.
 func Parse(src []byte, options ...ParseOption) (*Message, error) {
+	muSettings.RLock()
+	maxSigs := maxSignatures
+	muSettings.RUnlock()
+
 	var formats int
 	for _, option := range options {
 		switch option.Ident() {
@@ -278,6 +284,10 @@ func Parse(src []byte, options ...ParseOption) (*Message, error) {
 				formats |= fmtJSON
 			case fmtCompact:
 				formats |= fmtCompact
+			}
+		case identMaxSignatures{}:
+			if err := option.Value(&maxSigs); err != nil {
+				return nil, makeParseError(`jws.Parse`, `failed to retrieve max signatures option value: %w`, err)
 			}
 		}
 	}
@@ -312,6 +322,11 @@ func Parse(src []byte, options ...ParseOption) (*Message, error) {
 		if err != nil {
 			return nil, makeParseError(`jws.Parse`, `failed to parse JSON format: %w`, err)
 		}
+
+		if maxSigs > 0 && len(msg.signatures) > maxSigs {
+			return nil, makeParseError(`jws.Parse`, `too many signatures in JWS message (%d > %d)`, len(msg.signatures), maxSigs)
+		}
+
 		return msg, nil
 	}
 
@@ -650,6 +665,8 @@ func isRegisteredUnderAnyCurve(alg jwa.SignatureAlgorithm) bool {
 // Currently, the only setting available is `jws.WithLegacySigners()`,
 // which for various reason is now a no-op.
 func Settings(options ...GlobalOption) {
+	muSettings.Lock()
+	defer muSettings.Unlock()
 	for _, option := range options {
 		switch option.Ident() {
 		case identLegacySigners{}:
@@ -662,6 +679,10 @@ func Settings(options ...GlobalOption) {
 				panic("jws.Settings: WithMaxParseInputSize must be greater than zero")
 			}
 			maxParseInputSize.Store(v)
+		case identMaxSignatures{}:
+			if err := option.Value(&maxSignatures); err != nil {
+				panic(fmt.Sprintf("jws.Settings: value for WithMaxSignatures must be an int: %s", err))
+			}
 		}
 	}
 }

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1850,3 +1850,95 @@ func TestMaxParseInputSize(t *testing.T) {
 		require.Contains(t, err.Error(), `greater than zero`)
 	})
 }
+
+func TestMaxSignatures(t *testing.T) {
+	key1, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err, `GenerateRsaKey should succeed`)
+	key2, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err, `GenerateRsaKey should succeed`)
+
+	// Build a valid JWS with JSON serialization (two signatures to get array format).
+	signed, err := jws.Sign(
+		[]byte("hello"),
+		jws.WithJSON(),
+		jws.WithKey(jwa.RS256(), key1),
+		jws.WithKey(jwa.RS256(), key2),
+	)
+	require.NoError(t, err, `jws.Sign should succeed`)
+
+	// Parse the JSON and extract a signature entry so we can duplicate it.
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(signed, &parsed))
+
+	sigs, ok := parsed["signatures"].([]any)
+	require.True(t, ok, `signatures field must be an array`)
+	require.True(t, len(sigs) > 0)
+
+	singleSig := sigs[0]
+
+	makeMessage := func(n int) []byte {
+		signatures := make([]any, n)
+		for i := range signatures {
+			signatures[i] = singleSig
+		}
+		msg := map[string]any{
+			"payload":    parsed["payload"],
+			"signatures": signatures,
+		}
+		buf, err := json.Marshal(msg)
+		require.NoError(t, err)
+		return buf
+	}
+
+	t.Run("parse rejects over global limit", func(t *testing.T) {
+		msg := makeMessage(101)
+		_, err := jws.Parse(msg)
+		require.Error(t, err, `jws.Parse should fail with too many signatures`)
+		require.Contains(t, err.Error(), `too many signatures`)
+	})
+
+	t.Run("parse accepts within global limit", func(t *testing.T) {
+		msg := makeMessage(100)
+		_, err := jws.Parse(msg)
+		require.NoError(t, err, `jws.Parse should succeed within limit`)
+	})
+
+	t.Run("global settings override", func(t *testing.T) {
+		jws.Settings(jws.WithMaxSignatures(5))
+		defer jws.Settings(jws.WithMaxSignatures(100))
+
+		msg := makeMessage(6)
+		_, err := jws.Parse(msg)
+		require.Error(t, err, `jws.Parse should fail with lowered limit`)
+		require.Contains(t, err.Error(), `too many signatures`)
+
+		msg = makeMessage(5)
+		_, err = jws.Parse(msg)
+		require.NoError(t, err, `jws.Parse should succeed at exactly the limit`)
+	})
+
+	t.Run("per-call parse override", func(t *testing.T) {
+		jws.Settings(jws.WithMaxSignatures(5))
+		defer jws.Settings(jws.WithMaxSignatures(100))
+
+		msg := makeMessage(10)
+
+		// Should fail with global limit
+		_, err := jws.Parse(msg)
+		require.Error(t, err, `jws.Parse should fail with global limit of 5`)
+
+		// Should succeed with per-call override
+		_, err = jws.Parse(msg, jws.WithMaxSignatures(10))
+		require.NoError(t, err, `jws.Parse should succeed with per-call limit of 10`)
+	})
+
+	t.Run("verify inherits limit", func(t *testing.T) {
+		jws.Settings(jws.WithMaxSignatures(5))
+		defer jws.Settings(jws.WithMaxSignatures(100))
+
+		msg := makeMessage(6)
+
+		_, err := jws.Verify(msg, jws.WithKey(jwa.RS256(), &key1.PublicKey))
+		require.Error(t, err, `jws.Verify should fail when signatures exceed limit`)
+	})
+}

--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -247,3 +247,15 @@ options:
       This option can be passed to `jws.Settings()` to change the default
       globally, or to `jws.ParseReader()` / `jws.ReadFile()` for a per-call
       override.
+  - ident: MaxSignatures
+    interface: GlobalParseOption
+    argument_type: int
+    comment: |
+      WithMaxSignatures specifies the maximum number of signatures allowed
+      in a JWS message using JSON serialization. If a JWS message contains
+      more signatures than this value, parsing will return an error.
+      The default value is 100.
+
+      This option can be passed to `jws.Settings()` to change the default
+      globally, or to `jws.Parse()` / `jws.ReadFile()` for a per-call
+      override.

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -213,6 +213,7 @@ type identKeyProvider struct{}
 type identKeyUsed struct{}
 type identLegacySigners struct{}
 type identMaxParseInputSize struct{}
+type identMaxSignatures struct{}
 type identMessage struct{}
 type identMultipleKeysPerKeyID struct{}
 type identPretty struct{}
@@ -265,6 +266,10 @@ func (identLegacySigners) String() string {
 
 func (identMaxParseInputSize) String() string {
 	return "WithMaxParseInputSize"
+}
+
+func (identMaxSignatures) String() string {
+	return "WithMaxSignatures"
 }
 
 func (identMessage) String() string {
@@ -394,6 +399,18 @@ func WithLegacySigners() GlobalOption {
 // override.
 func WithMaxParseInputSize(v int64) GlobalParseOption {
 	return &globalParseOption{option.New(identMaxParseInputSize{}, v)}
+}
+
+// WithMaxSignatures specifies the maximum number of signatures allowed
+// in a JWS message using JSON serialization. If a JWS message contains
+// more signatures than this value, parsing will return an error.
+// The default value is 100.
+//
+// This option can be passed to `jws.Settings()` to change the default
+// globally, or to `jws.Parse()` / `jws.ReadFile()` for a per-call
+// override.
+func WithMaxSignatures(v int) GlobalParseOption {
+	return &globalParseOption{option.New(identMaxSignatures{}, v)}
 }
 
 // WithMessage can be passed to Verify() to obtain the jws.Message upon

--- a/jws/options_gen_test.go
+++ b/jws/options_gen_test.go
@@ -20,6 +20,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithKeyUsed", identKeyUsed{}.String())
 	require.Equal(t, "WithLegacySigners", identLegacySigners{}.String())
 	require.Equal(t, "WithMaxParseInputSize", identMaxParseInputSize{}.String())
+	require.Equal(t, "WithMaxSignatures", identMaxSignatures{}.String())
 	require.Equal(t, "WithMessage", identMessage{}.String())
 	require.Equal(t, "WithMultipleKeysPerKeyID", identMultipleKeysPerKeyID{}.String())
 	require.Equal(t, "WithPretty", identPretty{}.String())


### PR DESCRIPTION
Adds WithMaxSignatures() option (default 100) to limit the number of signatures in JSON-serialized JWS messages. Prevents CPU exhaustion from crafted messages with thousands of signatures. Configurable globally via jws.Settings() and per-call via jws.Parse(). Mirrors the JWE WithMaxRecipients pattern from #1633.