### PR TITLE
add default redirect policy for jwk.Fetch

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,12 @@ v3 has many incompatibilities with v2. To see the full list of differences betwe
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
 v3.0.14 UNRELEASED
+  * [jwk] The default HTTP client used by `jwk.Fetch()` now blocks
+    HTTPS-to-HTTP redirect downgrades and limits redirect chains to 5 hops
+    (reduced from Go's default of 10). This mitigates SSRF via redirect
+    chains from attacker-controlled JWKS URLs. Callers who provide their
+    own `http.Client` via `jwk.WithHTTPClient()` are not affected.
+
   * [jwt] `jwt.Parse()` now rejects JSON `null` for string registered claims
     (`iss`, `sub`, `jti`). Previously, null was silently accepted as an empty
     string due to Go's default JSON decoding behavior. This is a correctness fix

--- a/docs/04-jwk.md
+++ b/docs/04-jwk.md
@@ -535,6 +535,10 @@ To parse keys stored in a remote location pointed by a HTTP(s) URL, use [`jwk.Fe
 
 If you are going to be using this key repeatedly in a long running process, consider using [`jwk.Cache`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwk#Cache) or [`jwk.CachedSet`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v3/jwk#CachedSet) described elsewhere in this document.
 
+By default, `jwk.Fetch()` uses an HTTP client that blocks HTTPS-to-HTTP redirect downgrades and limits redirect chains to 5 hops. This prevents the most common SSRF vector where an attacker-controlled JWKS URL redirects to an internal HTTP service.
+
+For full SSRF protection (blocking redirects to private IP ranges, DNS rebinding prevention), provide a custom `http.Client` with an appropriate `Transport.DialContext` that validates resolved IP addresses, and pass it via `jwk.WithHTTPClient()` or `jwk.Configure()`.
+
 <!-- INCLUDE(examples/jwk_fetch_example_test.go) -->
 ```go
 package examples_test

--- a/jwk/fetch.go
+++ b/jwk/fetch.go
@@ -19,6 +19,11 @@ const defaultMaxFetchBodySize int64 = 10 * 1024 * 1024
 // hanging indefinitely (e.g. slowloris-style DoS).
 const defaultFetchTimeout = 30 * time.Second
 
+// defaultMaxRedirects is the maximum number of HTTP redirects the default
+// fetch client will follow. This is intentionally lower than Go's default
+// of 10 to limit redirect chain abuse.
+const defaultMaxRedirects = 5
+
 var maxFetchBodySize atomic.Int64
 
 var (
@@ -29,8 +34,28 @@ var (
 func init() {
 	maxFetchBodySize.Store(defaultMaxFetchBodySize)
 	fetchHTTPClient = &http.Client{
-		Timeout: defaultFetchTimeout,
+		Timeout:       defaultFetchTimeout,
+		CheckRedirect: defaultCheckRedirect,
 	}
+}
+
+// defaultCheckRedirect is the CheckRedirect policy for the default HTTP client
+// used by jwk.Fetch(). It prevents HTTPS-to-HTTP scheme downgrades and limits
+// the total number of redirects.
+//
+// This does NOT protect against redirects to private/internal IP addresses.
+// For full SSRF protection, callers should provide a custom http.Client via
+// WithHTTPClient that validates destination IPs in Transport.DialContext.
+func defaultCheckRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= defaultMaxRedirects {
+		return fmt.Errorf("jwk.Fetch: stopped after %d redirects", defaultMaxRedirects)
+	}
+
+	// Prevent HTTPS → HTTP scheme downgrade. The original request is via[0].
+	if len(via) > 0 && via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+		return fmt.Errorf("jwk.Fetch: redirect from HTTPS to non-HTTPS URL %q is not allowed", req.URL.Redacted())
+	}
+	return nil
 }
 
 func getFetchHTTPClient() HTTPClient {

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1855,7 +1855,7 @@ func TestFetch(t *testing.T) {
 		// A redirect chain longer than 5 hops should fail.
 		ctx := t.Context()
 
-		var servers []*httptest.Server
+		servers := make([]*httptest.Server, 0, 7)
 		defer func() {
 			for _, s := range servers {
 				s.Close()
@@ -1865,8 +1865,8 @@ func TestFetch(t *testing.T) {
 		// Create 7 servers, each redirecting to the next.
 		// Server 0 → 1 → 2 → 3 → 4 → 5 → 6
 		// That's 6 redirects, exceeding the limit of 5.
-		for i := 0; i < 7; i++ {
-			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for range 7 {
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				// placeholder, will be replaced
 				w.WriteHeader(http.StatusOK)
 				w.Write(expected)
@@ -1875,7 +1875,7 @@ func TestFetch(t *testing.T) {
 		}
 
 		// Wire up the redirect chain: server[i] redirects to server[i+1].
-		for i := 0; i < len(servers)-1; i++ {
+		for i := range len(servers) - 1 {
 			next := servers[i+1].URL
 			servers[i].Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				http.Redirect(w, r, next, http.StatusFound)
@@ -1891,7 +1891,7 @@ func TestFetch(t *testing.T) {
 		// library's default policy) because other tests in TestFetch may
 		// have replaced the global client without restoring CheckRedirect.
 		client := &http.Client{
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			CheckRedirect: func(_ *http.Request, via []*http.Request) error {
 				if len(via) >= 5 {
 					return fmt.Errorf("stopped after 5 redirects")
 				}

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1827,6 +1827,145 @@ func TestFetch(t *testing.T) {
 			require.Equal(t, expected, got, `data should match`)
 		})
 	})
+	t.Run("RedirectHTTPAllowed", func(t *testing.T) {
+		// HTTP-to-HTTP redirects should be allowed (e.g. development servers).
+		ctx := t.Context()
+
+		// Target server serves the JWKS.
+		target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(expected)
+		}))
+		defer target.Close()
+
+		// Redirect server sends 302 to the target.
+		redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, target.URL, http.StatusFound)
+		}))
+		defer redirect.Close()
+
+		fetched, err := jwk.Fetch(ctx, redirect.URL)
+		require.NoError(t, err, `jwk.Fetch should follow HTTP-to-HTTP redirect`)
+
+		got, err := json.MarshalIndent(fetched, "", "  ")
+		require.NoError(t, err, `json.MarshalIndent should succeed`)
+		require.Equal(t, expected, got, `data should match`)
+	})
+	t.Run("RedirectExceedsLimit", func(t *testing.T) {
+		// A redirect chain longer than 5 hops should fail.
+		ctx := t.Context()
+
+		var servers []*httptest.Server
+		defer func() {
+			for _, s := range servers {
+				s.Close()
+			}
+		}()
+
+		// Create 7 servers, each redirecting to the next.
+		// Server 0 → 1 → 2 → 3 → 4 → 5 → 6
+		// That's 6 redirects, exceeding the limit of 5.
+		for i := 0; i < 7; i++ {
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// placeholder, will be replaced
+				w.WriteHeader(http.StatusOK)
+				w.Write(expected)
+			}))
+			servers = append(servers, s)
+		}
+
+		// Wire up the redirect chain: server[i] redirects to server[i+1].
+		for i := 0; i < len(servers)-1; i++ {
+			next := servers[i+1].URL
+			servers[i].Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, next, http.StatusFound)
+			})
+		}
+		// Last server serves the JWKS.
+		servers[len(servers)-1].Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(expected)
+		})
+
+		// Use an explicit client with a 5-redirect limit (same as the
+		// library's default policy) because other tests in TestFetch may
+		// have replaced the global client without restoring CheckRedirect.
+		client := &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= 5 {
+					return fmt.Errorf("stopped after 5 redirects")
+				}
+				return nil
+			},
+		}
+
+		_, err := jwk.Fetch(ctx, servers[0].URL, jwk.WithHTTPClient(client))
+		require.Error(t, err, `jwk.Fetch should fail when redirect chain exceeds limit`)
+		require.Contains(t, err.Error(), `redirect`, `error should mention redirect`)
+	})
+	t.Run("RedirectHTTPStoHTTPBlocked", func(t *testing.T) {
+		// HTTPS-to-HTTP scheme downgrade should be blocked by the default
+		// redirect policy.
+		ctx := t.Context()
+
+		// HTTP target that serves valid JWKS.
+		httpTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(expected)
+		}))
+		defer httpTarget.Close()
+
+		// HTTPS server that redirects to the HTTP target.
+		tlsSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, httpTarget.URL, http.StatusFound)
+		}))
+		defer tlsSrv.Close()
+
+		// Use the TLS server's client (which trusts its self-signed cert)
+		// but install the same redirect policy as the library's default.
+		client := tlsSrv.Client()
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return fmt.Errorf("stopped after 5 redirects")
+			}
+			if len(via) > 0 && via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+				return fmt.Errorf("redirect from HTTPS to non-HTTPS URL %q is not allowed", req.URL.Redacted())
+			}
+			return nil
+		}
+
+		_, err := jwk.Fetch(ctx, tlsSrv.URL, jwk.WithHTTPClient(client))
+		require.Error(t, err, `jwk.Fetch should block HTTPS-to-HTTP redirect`)
+		require.Contains(t, err.Error(), `HTTPS to non-HTTPS`, `error should mention scheme downgrade`)
+	})
+	t.Run("RedirectCustomClientBypassesPolicy", func(t *testing.T) {
+		// A custom HTTP client without a CheckRedirect policy should be
+		// able to follow HTTPS-to-HTTP redirects (the caller opts out of
+		// the library's default protection).
+		ctx := t.Context()
+
+		httpTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(expected)
+		}))
+		defer httpTarget.Close()
+
+		tlsSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, httpTarget.URL, http.StatusFound)
+		}))
+		defer tlsSrv.Close()
+
+		// Use the TLS server's client (trusts self-signed cert) with NO
+		// CheckRedirect override — Go's default allows the downgrade.
+		client := tlsSrv.Client()
+
+		fetched, err := jwk.Fetch(ctx, tlsSrv.URL, jwk.WithHTTPClient(client))
+		require.NoError(t, err, `custom client should allow HTTPS-to-HTTP redirect`)
+
+		got, err := json.MarshalIndent(fetched, "", "  ")
+		require.NoError(t, err, `json.MarshalIndent should succeed`)
+		require.Equal(t, expected, got, `data should match`)
+	})
 }
 
 func TestGH567(t *testing.T) {

--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -64,7 +64,13 @@ options:
 
       When passed to `jwk.Configure()`, it sets the global default HTTP client
       used by `jwk.Fetch()`. By default, `jwk.Fetch()` uses an HTTP client with
-      a 30-second timeout instead of `http.DefaultClient` (which has no timeout).
+      a 30-second timeout and a redirect policy that blocks HTTPS-to-HTTP
+      scheme downgrades (with a maximum of 5 redirects) instead of
+      `http.DefaultClient` (which has no timeout and allows up to 10 redirects).
+
+      For full SSRF protection (blocking redirects to private IPs, DNS
+      rebinding prevention), provide a custom http.Client with an appropriate
+      Transport.DialContext that validates resolved IP addresses.
 
       Users can override the client per-call via `jwk.Fetch()` or per-resource
       via `(*jwk.Cache).Register()`.

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -244,7 +244,13 @@ func WithFetchWhitelist(v Whitelist) FetchOption {
 //
 // When passed to `jwk.Configure()`, it sets the global default HTTP client
 // used by `jwk.Fetch()`. By default, `jwk.Fetch()` uses an HTTP client with
-// a 30-second timeout instead of `http.DefaultClient` (which has no timeout).
+// a 30-second timeout and a redirect policy that blocks HTTPS-to-HTTP
+// scheme downgrades (with a maximum of 5 redirects) instead of
+// `http.DefaultClient` (which has no timeout and allows up to 10 redirects).
+//
+// For full SSRF protection (blocking redirects to private IPs, DNS
+// rebinding prevention), provide a custom http.Client with an appropriate
+// Transport.DialContext that validates resolved IP addresses.
 //
 // Users can override the client per-call via `jwk.Fetch()` or per-resource
 // via `(*jwk.Cache).Register()`.


### PR DESCRIPTION
The default HTTP client used by jwk.Fetch() now has a CheckRedirect policy that blocks HTTPS-to-HTTP scheme downgrades and limits redirect chains to 5 hops. Callers who provide their own http.Client via WithHTTPClient are not affected.