### PR TITLE
add jwk.DefaultHTTPClient

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -30,6 +30,7 @@ JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 
 - **Parse(src []byte, ...ParseOption) (Set, error)** / **ParseKey(data []byte, ...ParseOption) (Key, error)** — parse JWK/JWKS
 - **Fetch(ctx, url, ...FetchOption) (Set, error)** — HTTP fetch with optional whitelist, body size limit (default 10 MB via `WithMaxFetchBodySize`)
+- **DefaultHTTPClient() \*http.Client** — returns a new http.Client with library defaults (30s timeout, redirect policy)
 - **Import(raw any) (Key, error)** / **Export(key Key, dst any) error** — convert between Go crypto types and JWK
 - **PublicKeyOf(v any) (Key, error)** / **PublicSetOf(v Set) (Set, error)** — extract public keys
 - **NewCache(ctx, client) (*Cache, error)** — auto-refreshing JWKS cache

--- a/jwk/fetch.go
+++ b/jwk/fetch.go
@@ -33,7 +33,18 @@ var (
 
 func init() {
 	maxFetchBodySize.Store(defaultMaxFetchBodySize)
-	fetchHTTPClient = &http.Client{
+	fetchHTTPClient = DefaultHTTPClient()
+}
+
+// DefaultHTTPClient returns a new http.Client configured with the same
+// defaults used by jwk.Fetch(): a 30-second timeout, a redirect policy
+// that blocks HTTPS-to-HTTP scheme downgrades, and a maximum of 5 redirects.
+//
+// This is useful for callers who need the library's default protections
+// but want to wrap or augment the client (e.g. adding a custom Transport),
+// and for restoring defaults after calling jwk.Configure(jwk.WithHTTPClient(...)).
+func DefaultHTTPClient() *http.Client {
+	return &http.Client{
 		Timeout:       defaultFetchTimeout,
 		CheckRedirect: defaultCheckRedirect,
 	}

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1707,7 +1707,7 @@ func TestFetch(t *testing.T) {
 			Transport: &DummyRoundTripper{},
 		}
 		jwk.Configure(jwk.WithHTTPClient(teapotClient))
-		defer jwk.Configure(jwk.WithHTTPClient(&http.Client{Timeout: 30 * time.Second})) // restore
+		defer jwk.Configure(jwk.WithHTTPClient(jwk.DefaultHTTPClient())) // restore
 
 		ctx := t.Context()
 		_, err := jwk.Fetch(ctx, srv.URL)


### PR DESCRIPTION
Exports DefaultHTTPClient so callers (and tests) can obtain an http.Client with the library's default timeout and redirect policy. Fixes the ConfigureHTTPClient test that was restoring the global client without the redirect policy.