### PR TITLE
check redirect scheme downgrade at every hop

### DIFF
--- a/jwk/fetch.go
+++ b/jwk/fetch.go
@@ -62,8 +62,9 @@ func defaultCheckRedirect(req *http.Request, via []*http.Request) error {
 		return fmt.Errorf("jwk.Fetch: stopped after %d redirects", defaultMaxRedirects)
 	}
 
-	// Prevent HTTPS → HTTP scheme downgrade. The original request is via[0].
-	if len(via) > 0 && via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+	// Prevent HTTPS → HTTP scheme downgrade at any hop.
+	// via[len(via)-1] is the immediately previous request in the chain.
+	if len(via) > 0 && via[len(via)-1].URL.Scheme == "https" && req.URL.Scheme != "https" {
 		return fmt.Errorf("jwk.Fetch: redirect from HTTPS to non-HTTPS URL %q is not allowed", req.URL.Redacted())
 	}
 	return nil

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1928,7 +1928,7 @@ func TestFetch(t *testing.T) {
 			if len(via) >= 5 {
 				return fmt.Errorf("stopped after 5 redirects")
 			}
-			if len(via) > 0 && via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+			if len(via) > 0 && via[len(via)-1].URL.Scheme == "https" && req.URL.Scheme != "https" {
 				return fmt.Errorf("redirect from HTTPS to non-HTTPS URL %q is not allowed", req.URL.Redacted())
 			}
 			return nil
@@ -1936,6 +1936,47 @@ func TestFetch(t *testing.T) {
 
 		_, err := jwk.Fetch(ctx, tlsSrv.URL, jwk.WithHTTPClient(client))
 		require.Error(t, err, `jwk.Fetch should block HTTPS-to-HTTP redirect`)
+		require.Contains(t, err.Error(), `HTTPS to non-HTTPS`, `error should mention scheme downgrade`)
+	})
+	t.Run("RedirectHTTPtoHTTPStoHTTPBlocked", func(t *testing.T) {
+		// An HTTP→HTTPS→HTTP chain should be blocked on the second redirect
+		// (HTTPS→HTTP downgrade), even though the original request was HTTP.
+		ctx := t.Context()
+
+		// HTTP target that serves valid JWKS.
+		httpTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(expected)
+		}))
+		defer httpTarget.Close()
+
+		// HTTPS intermediate that redirects to the HTTP target.
+		tlsIntermediate := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, httpTarget.URL, http.StatusFound)
+		}))
+		defer tlsIntermediate.Close()
+
+		// HTTP origin that redirects to the HTTPS intermediate.
+		httpOrigin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, tlsIntermediate.URL, http.StatusFound)
+		}))
+		defer httpOrigin.Close()
+
+		// Use the TLS intermediate's client (trusts its self-signed cert)
+		// with the same redirect policy as the library's default.
+		client := tlsIntermediate.Client()
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return fmt.Errorf("stopped after 5 redirects")
+			}
+			if len(via) > 0 && via[len(via)-1].URL.Scheme == "https" && req.URL.Scheme != "https" {
+				return fmt.Errorf("redirect from HTTPS to non-HTTPS URL %q is not allowed", req.URL.Redacted())
+			}
+			return nil
+		}
+
+		_, err := jwk.Fetch(ctx, httpOrigin.URL, jwk.WithHTTPClient(client))
+		require.Error(t, err, `jwk.Fetch should block HTTPS-to-HTTP downgrade even when chain starts with HTTP`)
 		require.Contains(t, err.Error(), `HTTPS to non-HTTPS`, `error should mention scheme downgrade`)
 	})
 	t.Run("RedirectCustomClientBypassesPolicy", func(t *testing.T) {

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1928,7 +1928,7 @@ func TestFetch(t *testing.T) {
 			if len(via) >= 5 {
 				return fmt.Errorf("stopped after 5 redirects")
 			}
-			if len(via) > 0 && via[len(via)-1].URL.Scheme == "https" && req.URL.Scheme != "https" {
+			if len(via) > 0 && via[len(via)-1].URL.Scheme == "https" && req.URL.Scheme != "https" { //nolint:goconst
 				return fmt.Errorf("redirect from HTTPS to non-HTTPS URL %q is not allowed", req.URL.Redacted())
 			}
 			return nil


### PR DESCRIPTION
Changes via[0] to via[len(via)-1] in defaultCheckRedirect so HTTPS→HTTP downgrades are caught at any hop in the chain, not just from the original request. Previously HTTP→HTTPS→HTTP was allowed because via[0] was HTTP.