### PR TITLE
make null string claim rejection opt-in

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,11 +11,11 @@ v3.0.14 UNRELEASED
     chains from attacker-controlled JWKS URLs. Callers who provide their
     own `http.Client` via `jwk.WithHTTPClient()` are not affected.
 
-  * [jwt] `jwt.Parse()` now rejects JSON `null` for string registered claims
-    (`iss`, `sub`, `jti`). Previously, null was silently accepted as an empty
-    string due to Go's default JSON decoding behavior. This is a correctness fix
-    per the RFC type definitions (StringOrURI) rather than a security fix —
-    legitimate token issuers do not emit null for these claims. (#1484)
+  * [jwt] Add `jwt.WithStrictStringClaims(true)` global option to reject
+    JSON `null` for string registered claims (`iss`, `sub`, `jti`). By default,
+    null is silently accepted as an empty string (matching Go's standard JSON
+    decoding behavior). When enabled via `jwt.Settings(jwt.WithStrictStringClaims(true))`,
+    null values are rejected per the RFC type definitions (StringOrURI). (#1484)
 
   * [jwa] Add fully-specified EdDSA signature algorithms `Ed25519` and `Ed448` per
     RFC 9864. The polymorphic `EdDSA` algorithm is now marked as deprecated.

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -11,6 +11,12 @@ import (
 
 var useNumber uint32 // TODO: at some point, change to atomic.Bool
 
+// RejectNullStrings controls whether ReadNextStringToken rejects JSON null
+// values. When false (the default), null is silently accepted as "".
+// When true, null causes an error. This can be enabled via
+// jwt.Settings(jwt.WithStrictStringClaims(true)).
+var RejectNullStrings uint32
+
 func UseNumber() bool {
 	return atomic.LoadUint32(&useNumber) == 1
 }
@@ -46,24 +52,30 @@ func AssignNextBytesToken(dst *[]byte, dec *Decoder) error {
 }
 
 // ReadNextStringToken reads the next JSON token from the decoder and
-// returns it as a string. JSON null is explicitly rejected: while Go's
-// json.Decoder silently converts null to "", the JSON spec treats null
-// as a distinct type from string. In practice this is low-risk — legitimate
-// issuers rarely emit null for string claims — but rejecting null is the
-// correct behavior per the RFC type definitions (e.g. StringOrURI).
+// returns it as a string. By default, JSON null is silently accepted as "".
+// When RejectNullStrings is enabled (via jwt.Settings(jwt.WithStrictStringClaims(true))),
+// null is rejected per the RFC type definitions (e.g. StringOrURI).
 func ReadNextStringToken(dec *Decoder) (string, error) {
-	var val any
+	if atomic.LoadUint32(&RejectNullStrings) == 1 {
+		var val any
+		if err := dec.Decode(&val); err != nil {
+			return "", fmt.Errorf(`error reading next value: %w`, err)
+		}
+		if val == nil {
+			return "", fmt.Errorf(`error reading next value: expected string, got null`)
+		}
+		s, ok := val.(string)
+		if !ok {
+			return "", fmt.Errorf(`error reading next value: expected string, got %T`, val)
+		}
+		return s, nil
+	}
+
+	var val string
 	if err := dec.Decode(&val); err != nil {
 		return "", fmt.Errorf(`error reading next value: %w`, err)
 	}
-	if val == nil {
-		return "", fmt.Errorf(`error reading next value: expected string, got null`)
-	}
-	s, ok := val.(string)
-	if !ok {
-		return "", fmt.Errorf(`error reading next value: expected string, got %T`, val)
-	}
-	return s, nil
+	return val, nil
 }
 
 func AssignNextStringToken(dst **string, dec *Decoder) error {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -74,6 +74,16 @@ func Settings(options ...GlobalOption) {
 				panic("jwt.Settings: WithMaxParseInputSize must be greater than zero")
 			}
 			maxParseInputSize.Store(v)
+		case identStrictStringClaims{}:
+			var v bool
+			if err := option.Value(&v); err != nil {
+				panic(fmt.Sprintf("jwt.Settings: value for WithStrictStringClaims must be bool: %s", err))
+			}
+			var newVal uint32
+			if v {
+				newVal = 1
+			}
+			atomic.StoreUint32(&json.RejectNullStrings, newVal)
 		}
 	}
 

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1641,14 +1641,11 @@ func TestGH1482(t *testing.T) {
 }
 
 // TestGH1484 tests that jwt.Parse rejects JSON null for string registered
-// claims (iss, sub, jti). Go's json.Decoder silently converts null to ""
-// for string targets, so the library must explicitly check for this.
-// Low real-world risk — legitimate issuers don't emit null — but correct
-// per the RFC StringOrURI type definitions.
+// claims (iss, sub, jti) when WithStrictStringClaims is enabled.
+// By default, null is silently accepted as "" (Go's standard behavior).
+// When strict mode is enabled, null causes an error per the RFC
+// StringOrURI type definitions.
 func TestGH1484(t *testing.T) {
-	// Tokens signed with HS256 key "abracadabra".
-	// null_sub generated from issue report; null_iss and null_jti
-	// constructed by signing matching payloads with the same key.
 	testcases := []struct {
 		Name    string
 		Payload string
@@ -1661,15 +1658,32 @@ func TestGH1484(t *testing.T) {
 	key, err := jwk.Import([]byte("abracadabra"))
 	require.NoError(t, err, `jwk.Import should succeed`)
 
-	for _, tc := range testcases {
-		t.Run(tc.Name, func(t *testing.T) {
-			signed, err := jws.Sign([]byte(tc.Payload), jws.WithKey(jwa.HS256(), key))
-			require.NoError(t, err, `jws.Sign should succeed`)
+	t.Run("default accepts null", func(t *testing.T) {
+		for _, tc := range testcases {
+			t.Run(tc.Name, func(t *testing.T) {
+				signed, err := jws.Sign([]byte(tc.Payload), jws.WithKey(jwa.HS256(), key))
+				require.NoError(t, err, `jws.Sign should succeed`)
 
-			_, err = jwt.Parse(signed, jwt.WithKey(jwa.HS256(), key))
-			require.Error(t, err, `jwt.Parse should reject null claim`)
-		})
-	}
+				_, err = jwt.Parse(signed, jwt.WithKey(jwa.HS256(), key))
+				require.NoError(t, err, `jwt.Parse should accept null claim by default`)
+			})
+		}
+	})
+
+	t.Run("strict rejects null", func(t *testing.T) {
+		jwt.Settings(jwt.WithStrictStringClaims(true))
+		defer jwt.Settings(jwt.WithStrictStringClaims(false))
+
+		for _, tc := range testcases {
+			t.Run(tc.Name, func(t *testing.T) {
+				signed, err := jws.Sign([]byte(tc.Payload), jws.WithKey(jwa.HS256(), key))
+				require.NoError(t, err, `jws.Sign should succeed`)
+
+				_, err = jwt.Parse(signed, jwt.WithKey(jwa.HS256(), key))
+				require.Error(t, err, `jwt.Parse should reject null claim when strict`)
+			})
+		}
+	})
 }
 
 func TestMaxParseInputSize(t *testing.T) {

--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -133,6 +133,17 @@ options:
 
       See the documentation for `jwt.TokenOptionSet`, `(jwt.Token).Options`, and
       `jwt.FlattenAudience` for more details
+  - ident: StrictStringClaims
+    interface: GlobalOption
+    argument_type: bool
+    comment: |
+      WithStrictStringClaims controls whether JSON null values for string
+      claims (such as "iss", "sub", "jti") cause a parse error. By default,
+      null is silently accepted as an empty string (matching Go's standard
+      JSON decoding behavior). When set to true, null values are rejected
+      per the RFC type definitions (e.g. StringOrURI).
+
+      This option can only be set globally via `jwt.Settings()`.
   - ident: FormKey
     interface: ParseOption
     argument_type: string

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -201,6 +201,7 @@ type identNumericDateParsePrecision struct{}
 type identPedantic struct{}
 type identResetValidators struct{}
 type identSignOption struct{}
+type identStrictStringClaims struct{}
 type identToken struct{}
 type identTruncation struct{}
 type identValidate struct{}
@@ -281,6 +282,10 @@ func (identResetValidators) String() string {
 
 func (identSignOption) String() string {
 	return "WithSignOption"
+}
+
+func (identStrictStringClaims) String() string {
+	return "WithStrictStringClaims"
 }
 
 func (identToken) String() string {
@@ -465,6 +470,17 @@ func WithResetValidators(v bool) ValidateOption {
 // need to use this.
 func WithSignOption(v jws.SignOption) SignOption {
 	return &signOption{option.New(identSignOption{}, v)}
+}
+
+// WithStrictStringClaims controls whether JSON null values for string
+// claims (such as "iss", "sub", "jti") cause a parse error. By default,
+// null is silently accepted as an empty string (matching Go's standard
+// JSON decoding behavior). When set to true, null values are rejected
+// per the RFC type definitions (e.g. StringOrURI).
+//
+// This option can only be set globally via `jwt.Settings()`.
+func WithStrictStringClaims(v bool) GlobalOption {
+	return &globalOption{option.New(identStrictStringClaims{}, v)}
 }
 
 // WithToken specifies the token instance in which the resulting JWT is stored

--- a/jwt/options_gen_test.go
+++ b/jwt/options_gen_test.go
@@ -28,6 +28,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithPedantic", identPedantic{}.String())
 	require.Equal(t, "WithResetValidators", identResetValidators{}.String())
 	require.Equal(t, "WithSignOption", identSignOption{}.String())
+	require.Equal(t, "WithStrictStringClaims", identStrictStringClaims{}.String())
 	require.Equal(t, "WithToken", identToken{}.String())
 	require.Equal(t, "WithTruncation", identTruncation{}.String())
 	require.Equal(t, "WithValidate", identValidate{}.String())


### PR DESCRIPTION
PR #1605 changed ReadNextStringToken to reject JSON null for string claims by default. This makes that behavior opt-in via jwt.Settings(jwt.WithStrictStringClaims(true)), preserving the previous default of accepting null as empty string.