### PR TITLE
add jwk.WrapHTTPClientDefaults

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,11 @@ v3.0.14 UNRELEASED
     chains from attacker-controlled JWKS URLs. Callers who provide their
     own `http.Client` via `jwk.WithHTTPClient()` are not affected.
 
+  * [jwk] Add `jwk.WrapHTTPClientDefaults()` to apply the library's default
+    safety behaviors (timeout, redirect policy) to a caller-provided
+    `*http.Client`. Existing client settings (Transport, Jar, etc.) are
+    preserved; CheckRedirect is wrapped rather than overwritten.
+
   * [jwt] Add `jwt.WithStrictStringClaims(true)` global option to reject
     JSON `null` for string registered claims (`iss`, `sub`, `jti`). By default,
     null is silently accepted as an empty string (matching Go's standard JSON

--- a/jwk/fetch.go
+++ b/jwk/fetch.go
@@ -44,10 +44,37 @@ func init() {
 // but want to wrap or augment the client (e.g. adding a custom Transport),
 // and for restoring defaults after calling jwk.Configure(jwk.WithHTTPClient(...)).
 func DefaultHTTPClient() *http.Client {
-	return &http.Client{
-		Timeout:       defaultFetchTimeout,
-		CheckRedirect: defaultCheckRedirect,
+	return WrapHTTPClientDefaults(&http.Client{})
+}
+
+// WrapHTTPClientDefaults returns a shallow copy of the given http.Client with the
+// library's default safety behaviors applied. Existing client settings
+// (Transport, Jar, etc.) are preserved.
+//
+//   - Timeout: applied only when the client has no timeout set (zero value).
+//   - CheckRedirect: if the client already has one, the library's redirect
+//     policy runs first; if it passes, the original CheckRedirect is called.
+//     If the client has no CheckRedirect, the library's policy is used directly.
+//
+// This is useful when you need to bring your own http.Client (e.g. for custom
+// TLS configuration) but still want the library's redirect hardening.
+func WrapHTTPClientDefaults(client *http.Client) *http.Client {
+	cloned := *client
+	if cloned.Timeout == 0 {
+		cloned.Timeout = defaultFetchTimeout
 	}
+	orig := cloned.CheckRedirect
+	if orig == nil {
+		cloned.CheckRedirect = defaultCheckRedirect
+	} else {
+		cloned.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			if err := defaultCheckRedirect(req, via); err != nil {
+				return err
+			}
+			return orig(req, via)
+		}
+	}
+	return &cloned
 }
 
 // defaultCheckRedirect is the CheckRedirect policy for the default HTTP client

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1922,17 +1922,8 @@ func TestFetch(t *testing.T) {
 		defer tlsSrv.Close()
 
 		// Use the TLS server's client (which trusts its self-signed cert)
-		// but install the same redirect policy as the library's default.
-		client := tlsSrv.Client()
-		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 5 {
-				return fmt.Errorf("stopped after 5 redirects")
-			}
-			if len(via) > 0 && via[len(via)-1].URL.Scheme == "https" && req.URL.Scheme != "https" { //nolint:goconst
-				return fmt.Errorf("redirect from HTTPS to non-HTTPS URL %q is not allowed", req.URL.Redacted())
-			}
-			return nil
-		}
+		// hardened with the library's actual redirect policy.
+		client := jwk.WrapHTTPClientDefaults(tlsSrv.Client())
 
 		_, err := jwk.Fetch(ctx, tlsSrv.URL, jwk.WithHTTPClient(client))
 		require.Error(t, err, `jwk.Fetch should block HTTPS-to-HTTP redirect`)
@@ -1963,17 +1954,8 @@ func TestFetch(t *testing.T) {
 		defer httpOrigin.Close()
 
 		// Use the TLS intermediate's client (trusts its self-signed cert)
-		// with the same redirect policy as the library's default.
-		client := tlsIntermediate.Client()
-		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 5 {
-				return fmt.Errorf("stopped after 5 redirects")
-			}
-			if len(via) > 0 && via[len(via)-1].URL.Scheme == "https" && req.URL.Scheme != "https" {
-				return fmt.Errorf("redirect from HTTPS to non-HTTPS URL %q is not allowed", req.URL.Redacted())
-			}
-			return nil
-		}
+		// hardened with the library's actual redirect policy.
+		client := jwk.WrapHTTPClientDefaults(tlsIntermediate.Client())
 
 		_, err := jwk.Fetch(ctx, httpOrigin.URL, jwk.WithHTTPClient(client))
 		require.Error(t, err, `jwk.Fetch should block HTTPS-to-HTTP downgrade even when chain starts with HTTP`)


### PR DESCRIPTION
Apply the library's default HTTP client behaviors (timeout, redirect policy) to a caller-provided *http.Client. Wraps existing CheckRedirect rather than overwriting it. Redirect tests now exercise the real policy instead of hand-rolled copies.