### PR TITLE
reuse shared HTTP client in Cache.Register

### DIFF
--- a/jwk/cache.go
+++ b/jwk/cache.go
@@ -172,7 +172,7 @@ func (c *Cache) Register(ctx context.Context, u string, options ...RegisterOptio
 	// client which includes timeout and redirect protections. Without this,
 	// httprc would fall back to http.DefaultClient which has no such protections.
 	if !hasHTTPClient {
-		resourceOptions = append(resourceOptions, httprc.WithHTTPClient(DefaultHTTPClient()))
+		resourceOptions = append(resourceOptions, httprc.WithHTTPClient(getFetchHTTPClient()))
 	}
 
 	r, err := httprc.NewResource[Set](u, &Transformer{


### PR DESCRIPTION
Cache.Register now calls getFetchHTTPClient() instead of DefaultHTTPClient(), reusing the shared client rather than allocating a new one per call.