### PR TITLE
use atomic wrappers for global settings

### DIFF
--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -9,16 +9,16 @@ import (
 	"github.com/lestrrat-go/jwx/v3/internal/base64"
 )
 
-var useNumber uint32 // TODO: at some point, change to atomic.Bool
+var useNumber atomic.Uint32
 
 // RejectNullStrings controls whether ReadNextStringToken rejects JSON null
 // values. When false (the default), null is silently accepted as "".
 // When true, null causes an error. This can be enabled via
 // jwt.Settings(jwt.WithStrictStringClaims(true)).
-var RejectNullStrings uint32
+var RejectNullStrings atomic.Uint32
 
 func UseNumber() bool {
-	return atomic.LoadUint32(&useNumber) == 1
+	return useNumber.Load() == 1
 }
 
 // Sets the global configuration for json decoding
@@ -27,7 +27,7 @@ func DecoderSettings(inUseNumber bool) {
 	if inUseNumber {
 		val = 1
 	}
-	atomic.StoreUint32(&useNumber, val)
+	useNumber.Store(val)
 }
 
 // Unmarshal respects the values specified in DecoderSettings,
@@ -56,7 +56,7 @@ func AssignNextBytesToken(dst *[]byte, dec *Decoder) error {
 // When RejectNullStrings is enabled (via jwt.Settings(jwt.WithStrictStringClaims(true))),
 // null is rejected per the RFC type definitions (e.g. StringOrURI).
 func ReadNextStringToken(dec *Decoder) (string, error) {
-	if atomic.LoadUint32(&RejectNullStrings) == 1 {
+	if RejectNullStrings.Load() == 1 {
 		var val any
 		if err := dec.Decode(&val); err != nil {
 			return "", fmt.Errorf(`error reading next value: %w`, err)

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sync"
 	"sync/atomic"
 
 	"github.com/lestrrat-go/blackmagic"
@@ -29,38 +28,47 @@ import (
 
 // #region globals
 
-var muSettings sync.RWMutex
-var maxPBES2Count = 10000
-var minPBES2Count = 1000
-var maxRecipients = 100
-var maxDecompressBufferSize int64 = 10 * 1024 * 1024 // 10MB
+var maxPBES2Count atomic.Int64
+var minPBES2Count atomic.Int64
+var maxRecipients atomic.Int64
+var maxDecompressBufferSize atomic.Int64
 var maxParseInputSize atomic.Int64
 
 func init() {
-	maxParseInputSize.Store(10 * 1024 * 1024) // 10MB
+	maxPBES2Count.Store(10000)
+	minPBES2Count.Store(1000)
+	maxRecipients.Store(100)
+	maxDecompressBufferSize.Store(10 * 1024 * 1024) // 10MB
+	maxParseInputSize.Store(10 * 1024 * 1024)       // 10MB
 }
 
 func Settings(options ...GlobalOption) {
-	muSettings.Lock()
-	defer muSettings.Unlock()
 	for _, option := range options {
 		switch option.Ident() {
 		case identMaxPBES2Count{}:
-			if err := option.Value(&maxPBES2Count); err != nil {
+			var v int
+			if err := option.Value(&v); err != nil {
 				panic(fmt.Sprintf("jwe.Settings: value for option WithMaxPBES2Count must be an int: %s", err))
 			}
+			maxPBES2Count.Store(int64(v))
 		case identMinPBES2Count{}:
-			if err := option.Value(&minPBES2Count); err != nil {
+			var v int
+			if err := option.Value(&v); err != nil {
 				panic(fmt.Sprintf("jwe.Settings: value for option WithMinPBES2Count must be an int: %s", err))
 			}
+			minPBES2Count.Store(int64(v))
 		case identMaxRecipients{}:
-			if err := option.Value(&maxRecipients); err != nil {
+			var v int
+			if err := option.Value(&v); err != nil {
 				panic(fmt.Sprintf("jwe.Settings: value for option WithMaxRecipients must be an int: %s", err))
 			}
+			maxRecipients.Store(int64(v))
 		case identMaxDecompressBufferSize{}:
-			if err := option.Value(&maxDecompressBufferSize); err != nil {
+			var v int64
+			if err := option.Value(&v); err != nil {
 				panic(fmt.Sprintf("jwe.Settings: value for option WithMaxDecompressBufferSize must be an int64: %s", err))
 			}
+			maxDecompressBufferSize.Store(v)
 		case identCBCBufferSize{}:
 			var v int64
 			if err := option.Value(&v); err != nil {
@@ -281,12 +289,10 @@ func freeDecryptContext(dc *decryptContext) *decryptContext {
 }
 
 func (dc *decryptContext) ProcessOptions(options []DecryptOption) error {
-	muSettings.RLock()
-	dc.maxRecipients = maxRecipients
-	dc.maxDecompressBufferSize = maxDecompressBufferSize
-	dc.maxPBES2Count = maxPBES2Count
-	dc.minPBES2Count = minPBES2Count
-	muSettings.RUnlock()
+	dc.maxRecipients = int(maxRecipients.Load())
+	dc.maxDecompressBufferSize = maxDecompressBufferSize.Load()
+	dc.maxPBES2Count = int(maxPBES2Count.Load())
+	dc.minPBES2Count = int(minPBES2Count.Load())
 
 	for _, option := range options {
 		switch option.Ident() {
@@ -996,10 +1002,7 @@ func Decrypt(buf []byte, options ...DecryptOption) ([]byte, error) {
 // without filtering. Options such as WithMaxParseInputSize are handled
 // by ParseReader before the data reaches this function.
 func Parse(buf []byte, _ ...ParseOption) (*Message, error) {
-	muSettings.RLock()
-	maxR := maxRecipients
-	muSettings.RUnlock()
-	return parseJSONOrCompact(buf, false, maxR)
+	return parseJSONOrCompact(buf, false, int(maxRecipients.Load()))
 }
 
 // errors are wrapped within this function, because we call it directly

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -51,11 +51,11 @@ import (
 
 var registry = json.NewRegistry()
 
-var muSettings sync.RWMutex
-var maxSignatures = 100
+var maxSignatures atomic.Int64
 var maxParseInputSize atomic.Int64
 
 func init() {
+	maxSignatures.Store(100)
 	maxParseInputSize.Store(10 * 1024 * 1024) // 10MB
 }
 
@@ -267,9 +267,7 @@ func getB64Value(hdr Headers) bool {
 //
 // On error, returns a jws.ParseError.
 func Parse(src []byte, options ...ParseOption) (*Message, error) {
-	muSettings.RLock()
-	maxSigs := maxSignatures
-	muSettings.RUnlock()
+	maxSigs := int(maxSignatures.Load())
 
 	var formats int
 	for _, option := range options {
@@ -665,8 +663,6 @@ func isRegisteredUnderAnyCurve(alg jwa.SignatureAlgorithm) bool {
 // Currently, the only setting available is `jws.WithLegacySigners()`,
 // which for various reason is now a no-op.
 func Settings(options ...GlobalOption) {
-	muSettings.Lock()
-	defer muSettings.Unlock()
 	for _, option := range options {
 		switch option.Ident() {
 		case identLegacySigners{}:
@@ -680,9 +676,11 @@ func Settings(options ...GlobalOption) {
 			}
 			maxParseInputSize.Store(v)
 		case identMaxSignatures{}:
-			if err := option.Value(&maxSignatures); err != nil {
+			var v int
+			if err := option.Value(&v); err != nil {
 				panic(fmt.Sprintf("jws.Settings: value for WithMaxSignatures must be an int: %s", err))
 			}
+			maxSignatures.Store(int64(v))
 		}
 	}
 }

--- a/jwt/internal/types/date.go
+++ b/jwt/internal/types/date.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v3/internal/json"
@@ -15,9 +16,9 @@ const (
 	MaxPrecision     uint32 = 9 // nanosecond level
 )
 
-var Pedantic uint32
-var ParsePrecision = DefaultPrecision
-var FormatPrecision = DefaultPrecision
+var Pedantic atomic.Uint32
+var ParsePrecision atomic.Uint32
+var FormatPrecision atomic.Uint32
 
 // NumericDate represents the date format used in the 'nbf' claim
 type NumericDate struct {
@@ -57,7 +58,8 @@ func parseNumericString(x string) (time.Time, error) {
 
 	// Only check for the escape hatch if it's the pedantic
 	// flag is off
-	if Pedantic != 1 {
+	pedantic := Pedantic.Load()
+	if pedantic != 1 {
 		// This is an escape hatch for non-conformant providers
 		// that gives us RFC3339 instead of epoch time
 		for _, r := range x {
@@ -77,12 +79,13 @@ func parseNumericString(x string) (time.Time, error) {
 
 	var fractional string
 	whole := x
+	parsePrecision := ParsePrecision.Load()
 	if i := strings.IndexRune(x, tokens.Period); i > 0 {
-		if ParsePrecision > 0 && len(x) > i+1 {
+		if parsePrecision > 0 && len(x) > i+1 {
 			fractional = x[i+1:] // everything after the tokens.Period
-			if int(ParsePrecision) < len(fractional) {
+			if int(parsePrecision) < len(fractional) {
 				// Remove insignificant digits
-				fractional = fractional[:int(ParsePrecision)]
+				fractional = fractional[:int(parsePrecision)]
 			}
 			// Replace missing fractional diits with zeros
 			for len(fractional) < int(MaxPrecision) {
@@ -146,7 +149,8 @@ func (n *NumericDate) Accept(v any) error {
 }
 
 func (n NumericDate) String() string {
-	if FormatPrecision == 0 {
+	formatPrecision := FormatPrecision.Load()
+	if formatPrecision == 0 {
 		return strconv.FormatInt(n.Unix(), 10)
 	}
 
@@ -159,7 +163,7 @@ func (n NumericDate) String() string {
 	}
 
 	slwhole := len(s) - int(MaxPrecision)
-	s = s[:slwhole] + "." + s[slwhole:slwhole+int(FormatPrecision)]
+	s = s[:slwhole] + "." + s[slwhole:slwhole+int(formatPrecision)]
 	if s[0] == tokens.Period {
 		s = "0" + s
 	}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -83,43 +83,43 @@ func Settings(options ...GlobalOption) {
 			if v {
 				newVal = 1
 			}
-			atomic.StoreUint32(&json.RejectNullStrings, newVal)
+			json.RejectNullStrings.Store(newVal)
 		}
 	}
 
 	if parsePrecision <= types.MaxPrecision { // remember we set default to max + 1
-		v := atomic.LoadUint32(&types.ParsePrecision)
+		v := types.ParsePrecision.Load()
 		if v != parsePrecision {
-			atomic.CompareAndSwapUint32(&types.ParsePrecision, v, parsePrecision)
+			types.ParsePrecision.CompareAndSwap(v, parsePrecision)
 		}
 	}
 
 	if formatPrecision <= types.MaxPrecision { // remember we set default to max + 1
-		v := atomic.LoadUint32(&types.FormatPrecision)
+		v := types.FormatPrecision.Load()
 		if v != formatPrecision {
-			atomic.CompareAndSwapUint32(&types.FormatPrecision, v, formatPrecision)
+			types.FormatPrecision.CompareAndSwap(v, formatPrecision)
 		}
 	}
 
 	{
-		v := atomic.LoadUint32(&types.Pedantic)
+		v := types.Pedantic.Load()
 		if (v == 1) != parsePedantic {
 			var newVal uint32
 			if parsePedantic {
 				newVal = 1
 			}
-			atomic.CompareAndSwapUint32(&types.Pedantic, v, newVal)
+			types.Pedantic.CompareAndSwap(v, newVal)
 		}
 	}
 
 	{
-		defaultOptionsMu.Lock()
+		opts := TokenOptionSet(defaultOptions.Load())
 		if flattenAudience {
-			defaultOptions.Enable(FlattenAudience)
+			opts.Enable(FlattenAudience)
 		} else {
-			defaultOptions.Disable(FlattenAudience)
+			opts.Disable(FlattenAudience)
 		}
-		defaultOptionsMu.Unlock()
+		defaultOptions.Store(opts.Value())
 	}
 
 	if truncation >= 0 {

--- a/jwt/token_options.go
+++ b/jwt/token_options.go
@@ -1,12 +1,11 @@
 package jwt
 
-import "sync"
+import "sync/atomic"
 
 // TokenOptionSet is a bit flag containing per-token options.
 type TokenOptionSet uint64
 
-var defaultOptions TokenOptionSet
-var defaultOptionsMu sync.RWMutex
+var defaultOptions atomic.Uint64
 
 // TokenOption describes a single token option that can be set on
 // the per-token option set (TokenOptionSet)
@@ -45,7 +44,7 @@ func (o TokenOptionSet) Value() uint64 {
 // option set. This may differ depending on if/when functions that
 // change the global state has been called, such as `jwt.Settings`
 func DefaultOptionSet() TokenOptionSet {
-	return TokenOptionSet(defaultOptions.Value())
+	return TokenOptionSet(defaultOptions.Load())
 }
 
 // Clear sets all bits to zero, effectively disabling all options


### PR DESCRIPTION
- Convert plain int/uint32/int64 global settings to atomic.Int64/Uint32/Uint64 wrappers
- Remove muSettings mutexes from jwe and jws packages
- Fix race in jwt.DefaultOptionSet() (read without lock)
- Fix non-atomic reads in jwt/internal/types/date.go
