### PR TITLE
accept ParseOption in jws.ParseString, clean up Changes

### DIFF
--- a/Changes
+++ b/Changes
@@ -71,13 +71,7 @@ v3.0.14 UNRELEASED
     empty "crit" array, standard JOSE header names in "crit", or "crit"-listed
     extensions not present in the protected header are now rejected.
 
-  * [jws] Fixed probe field name in panic message. (#1597)
-
-  * [jws] Use standard Go deprecation markers for deprecated functions. (#1596)
-
   * [jwk] Fixed inverted rlocker condition in RSA key export. (#1576)
-
-  * [jwe] Fixed typo in `jwe.Decrypt` error message. (#1577)
 
   * [jwe] Fixed X25519 ECDH-ES key agreement to include `apu` and `apv` parameters
     in the Concat KDF derivation, matching the ECDSA path. Previously these values

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -337,8 +337,8 @@ func Parse(src []byte, options ...ParseOption) (*Message, error) {
 // struct. The input can be in either compact or full JSON serialization.
 //
 // On error, returns a jws.ParseError.
-func ParseString(src string) (*Message, error) {
-	msg, err := Parse([]byte(src))
+func ParseString(src string, options ...ParseOption) (*Message, error) {
+	msg, err := Parse([]byte(src), options...)
 	if err != nil {
 		return nil, makeParseError(`jws.ParseString`, `failed to parse string: %w`, err)
 	}


### PR DESCRIPTION
jws.ParseString now accepts ParseOption (matching Parse). Removed minor/cosmetic entries from Changes.