### PR TITLE
remove minor entries from Changes

### DIFF
--- a/Changes
+++ b/Changes
@@ -71,13 +71,7 @@ v3.0.14 UNRELEASED
     empty "crit" array, standard JOSE header names in "crit", or "crit"-listed
     extensions not present in the protected header are now rejected.
 
-  * [jws] Fixed probe field name in panic message. (#1597)
-
-  * [jws] Use standard Go deprecation markers for deprecated functions. (#1596)
-
   * [jwk] Fixed inverted rlocker condition in RSA key export. (#1576)
-
-  * [jwe] Fixed typo in `jwe.Decrypt` error message. (#1577)
 
   * [jwe] Fixed X25519 ECDH-ES key agreement to include `apu` and `apv` parameters
     in the Concat KDF derivation, matching the ECDSA path. Previously these values


### PR DESCRIPTION
Remove cosmetic/housekeeping entries (panic message text, deprecation markers, error typo) from v3.0.14 changelog. Keep only entries end users care about.