### PR TITLE
make WithStrictStringClaims per-call only

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,10 +36,10 @@ v3.0.14 UNRELEASED
     `*http.Client`. Existing client settings (Transport, Jar, etc.) are
     preserved; CheckRedirect is wrapped rather than overwritten.
 
-  * [jwt] `jwt.WithStrictStringClaims(true)` is now a per-call `ParseOption`
-    instead of a global `jwt.Settings()` option. Pass it to `jwt.Parse()` or
+  * [jwt] Add `jwt.WithStrictStringClaims(true)` option for `jwt.Parse()` and
     `jwt.ReadFile()` to reject JSON `null` for string registered claims
-    (`iss`, `sub`, `jti`). (#1484)
+    (`iss`, `sub`, `jti`). By default, null is silently accepted as an empty
+    string. (#1484)
 
   * [jwa] Add fully-specified EdDSA signature algorithms `Ed25519` and `Ed448` per
     RFC 9864. The polymorphic `EdDSA` algorithm is now marked as deprecated.

--- a/Changes
+++ b/Changes
@@ -36,11 +36,10 @@ v3.0.14 UNRELEASED
     `*http.Client`. Existing client settings (Transport, Jar, etc.) are
     preserved; CheckRedirect is wrapped rather than overwritten.
 
-  * [jwt] Add `jwt.WithStrictStringClaims(true)` global option to reject
-    JSON `null` for string registered claims (`iss`, `sub`, `jti`). By default,
-    null is silently accepted as an empty string (matching Go's standard JSON
-    decoding behavior). When enabled via `jwt.Settings(jwt.WithStrictStringClaims(true))`,
-    null values are rejected per the RFC type definitions (StringOrURI). (#1484)
+  * [jwt] `jwt.WithStrictStringClaims(true)` is now a per-call `ParseOption`
+    instead of a global `jwt.Settings()` option. Pass it to `jwt.Parse()` or
+    `jwt.ReadFile()` to reject JSON `null` for string registered claims
+    (`iss`, `sub`, `jti`). (#1484)
 
   * [jwa] Add fully-specified EdDSA signature algorithms `Ed25519` and `Ed448` per
     RFC 9864. The polymorphic `EdDSA` algorithm is now marked as deprecated.

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -11,12 +11,6 @@ import (
 
 var useNumber atomic.Uint32
 
-// RejectNullStrings controls whether ReadNextStringToken rejects JSON null
-// values. When false (the default), null is silently accepted as "".
-// When true, null causes an error. This can be enabled via
-// jwt.Settings(jwt.WithStrictStringClaims(true)).
-var RejectNullStrings atomic.Uint32
-
 func UseNumber() bool {
 	return useNumber.Load() == 1
 }
@@ -51,12 +45,21 @@ func AssignNextBytesToken(dst *[]byte, dec *Decoder) error {
 	return nil
 }
 
+func shouldRejectNullStrings(dc DecodeCtx) bool {
+	if dc != nil {
+		if sdc, ok := dc.(StrictStringDecodeCtx); ok {
+			return sdc.StrictStrings()
+		}
+	}
+	return false
+}
+
 // ReadNextStringToken reads the next JSON token from the decoder and
 // returns it as a string. By default, JSON null is silently accepted as "".
-// When RejectNullStrings is enabled (via jwt.Settings(jwt.WithStrictStringClaims(true))),
-// null is rejected per the RFC type definitions (e.g. StringOrURI).
-func ReadNextStringToken(dec *Decoder) (string, error) {
-	if RejectNullStrings.Load() == 1 {
+// When the given DecodeCtx implements StrictStringDecodeCtx and StrictStrings()
+// returns true, null values are rejected.
+func ReadNextStringToken(dec *Decoder, dc DecodeCtx) (string, error) {
+	if shouldRejectNullStrings(dc) {
 		var val any
 		if err := dec.Decode(&val); err != nil {
 			return "", fmt.Errorf(`error reading next value: %w`, err)
@@ -78,8 +81,8 @@ func ReadNextStringToken(dec *Decoder) (string, error) {
 	return val, nil
 }
 
-func AssignNextStringToken(dst **string, dec *Decoder) error {
-	val, err := ReadNextStringToken(dec)
+func AssignNextStringToken(dst **string, dec *Decoder, dc DecodeCtx) error {
+	val, err := ReadNextStringToken(dec, dc)
 	if err != nil {
 		return err
 	}
@@ -131,17 +134,35 @@ type DecodeCtxContainer interface {
 	SetDecodeCtx(DecodeCtx)
 }
 
-// stock decodeCtx. should cover 80% of the cases
-type decodeCtx struct {
-	registry *Registry
+// StrictStringDecodeCtx is an optional interface that DecodeCtx implementations
+// can satisfy to control per-call null string rejection.
+type StrictStringDecodeCtx interface {
+	StrictStrings() bool
 }
 
+// stock decodeCtx. should cover 80% of the cases
+type decodeCtx struct {
+	registry      *Registry
+	strictStrings bool
+}
+
+// NewDecodeCtx creates a new DecodeCtx with the given registry.
 func NewDecodeCtx(r *Registry) DecodeCtx {
 	return &decodeCtx{registry: r}
 }
 
+// NewDecodeCtxStrictStrings creates a new DecodeCtx with the given registry
+// and strict string rejection flag.
+func NewDecodeCtxStrictStrings(r *Registry, strict bool) DecodeCtx {
+	return &decodeCtx{registry: r, strictStrings: strict}
+}
+
 func (dc *decodeCtx) Registry() *Registry {
 	return dc.registry
+}
+
+func (dc *decodeCtx) StrictStrings() bool {
+	return dc.strictStrings
 }
 
 func Dump(v any) {

--- a/jwe/headers_gen.go
+++ b/jwe/headers_gen.go
@@ -640,7 +640,7 @@ LOOP:
 				}
 				h.contentEncryption = &decoded
 			case ContentTypeKey:
-				if err := json.AssignNextStringToken(&h.contentType, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.contentType, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, ContentTypeKey, err)
 				}
 			case CriticalKey:
@@ -670,15 +670,15 @@ LOOP:
 				}
 				h.jwk = key
 			case JWKSetURLKey:
-				if err := json.AssignNextStringToken(&h.jwkSetURL, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.jwkSetURL, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, JWKSetURLKey, err)
 				}
 			case KeyIDKey:
-				if err := json.AssignNextStringToken(&h.keyID, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyID, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyIDKey, err)
 				}
 			case TypeKey:
-				if err := json.AssignNextStringToken(&h.typ, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.typ, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, TypeKey, err)
 				}
 			case X509CertChainKey:
@@ -688,15 +688,15 @@ LOOP:
 				}
 				h.x509CertChain = &decoded
 			case X509CertThumbprintKey:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintKey, err)
 				}
 			case X509CertThumbprintS256Key:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintS256Key, err)
 				}
 			case X509URLKey:
-				if err := json.AssignNextStringToken(&h.x509URL, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509URL, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509URLKey, err)
 				}
 			default:

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -480,7 +480,7 @@ LOOP:
 		case string: // Objects can only have string keys
 			switch tok {
 			case KeyTypeKey:
-				val, err := json.ReadNextStringToken(dec)
+				val, err := json.ReadNextStringToken(dec, h.dc)
 				if err != nil {
 					return fmt.Errorf(`error reading token: %w`, err)
 				}
@@ -504,7 +504,7 @@ LOOP:
 				}
 				h.crv = &decoded
 			case KeyIDKey:
-				if err := json.AssignNextStringToken(&h.keyID, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyID, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyIDKey, err)
 				}
 			case KeyOpsKey:
@@ -514,7 +514,7 @@ LOOP:
 				}
 				h.keyOps = &decoded
 			case KeyUsageKey:
-				if err := json.AssignNextStringToken(&h.keyUsage, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 				}
 			case ECDSAXKey:
@@ -528,15 +528,15 @@ LOOP:
 				}
 				h.x509CertChain = &decoded
 			case X509CertThumbprintKey:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintKey, err)
 				}
 			case X509CertThumbprintS256Key:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintS256Key, err)
 				}
 			case X509URLKey:
-				if err := json.AssignNextStringToken(&h.x509URL, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509URL, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509URLKey, err)
 				}
 			case ECDSAYKey:
@@ -1188,7 +1188,7 @@ LOOP:
 		case string: // Objects can only have string keys
 			switch tok {
 			case KeyTypeKey:
-				val, err := json.ReadNextStringToken(dec)
+				val, err := json.ReadNextStringToken(dec, h.dc)
 				if err != nil {
 					return fmt.Errorf(`error reading token: %w`, err)
 				}
@@ -1216,7 +1216,7 @@ LOOP:
 					return fmt.Errorf(`failed to decode value for key %s: %w`, ECDSADKey, err)
 				}
 			case KeyIDKey:
-				if err := json.AssignNextStringToken(&h.keyID, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyID, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyIDKey, err)
 				}
 			case KeyOpsKey:
@@ -1226,7 +1226,7 @@ LOOP:
 				}
 				h.keyOps = &decoded
 			case KeyUsageKey:
-				if err := json.AssignNextStringToken(&h.keyUsage, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 				}
 			case ECDSAXKey:
@@ -1240,15 +1240,15 @@ LOOP:
 				}
 				h.x509CertChain = &decoded
 			case X509CertThumbprintKey:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintKey, err)
 				}
 			case X509CertThumbprintS256Key:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintS256Key, err)
 				}
 			case X509URLKey:
-				if err := json.AssignNextStringToken(&h.x509URL, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509URL, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509URLKey, err)
 				}
 			case ECDSAYKey:

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -451,7 +451,7 @@ LOOP:
 		case string: // Objects can only have string keys
 			switch tok {
 			case KeyTypeKey:
-				val, err := json.ReadNextStringToken(dec)
+				val, err := json.ReadNextStringToken(dec, h.dc)
 				if err != nil {
 					return fmt.Errorf(`error reading token: %w`, err)
 				}
@@ -475,7 +475,7 @@ LOOP:
 				}
 				h.crv = &decoded
 			case KeyIDKey:
-				if err := json.AssignNextStringToken(&h.keyID, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyID, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyIDKey, err)
 				}
 			case KeyOpsKey:
@@ -485,7 +485,7 @@ LOOP:
 				}
 				h.keyOps = &decoded
 			case KeyUsageKey:
-				if err := json.AssignNextStringToken(&h.keyUsage, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 				}
 			case OKPXKey:
@@ -499,15 +499,15 @@ LOOP:
 				}
 				h.x509CertChain = &decoded
 			case X509CertThumbprintKey:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintKey, err)
 				}
 			case X509CertThumbprintS256Key:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintS256Key, err)
 				}
 			case X509URLKey:
-				if err := json.AssignNextStringToken(&h.x509URL, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509URL, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509URLKey, err)
 				}
 			default:
@@ -1117,7 +1117,7 @@ LOOP:
 		case string: // Objects can only have string keys
 			switch tok {
 			case KeyTypeKey:
-				val, err := json.ReadNextStringToken(dec)
+				val, err := json.ReadNextStringToken(dec, h.dc)
 				if err != nil {
 					return fmt.Errorf(`error reading token: %w`, err)
 				}
@@ -1145,7 +1145,7 @@ LOOP:
 					return fmt.Errorf(`failed to decode value for key %s: %w`, OKPDKey, err)
 				}
 			case KeyIDKey:
-				if err := json.AssignNextStringToken(&h.keyID, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyID, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyIDKey, err)
 				}
 			case KeyOpsKey:
@@ -1155,7 +1155,7 @@ LOOP:
 				}
 				h.keyOps = &decoded
 			case KeyUsageKey:
-				if err := json.AssignNextStringToken(&h.keyUsage, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 				}
 			case OKPXKey:
@@ -1169,15 +1169,15 @@ LOOP:
 				}
 				h.x509CertChain = &decoded
 			case X509CertThumbprintKey:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintKey, err)
 				}
 			case X509CertThumbprintS256Key:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintS256Key, err)
 				}
 			case X509URLKey:
-				if err := json.AssignNextStringToken(&h.x509URL, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509URL, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509URLKey, err)
 				}
 			default:

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -456,7 +456,7 @@ LOOP:
 		case string: // Objects can only have string keys
 			switch tok {
 			case KeyTypeKey:
-				val, err := json.ReadNextStringToken(dec)
+				val, err := json.ReadNextStringToken(dec, h.dc)
 				if err != nil {
 					return fmt.Errorf(`error reading token: %w`, err)
 				}
@@ -478,7 +478,7 @@ LOOP:
 					return fmt.Errorf(`failed to decode value for key %s: %w`, RSAEKey, err)
 				}
 			case KeyIDKey:
-				if err := json.AssignNextStringToken(&h.keyID, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyID, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyIDKey, err)
 				}
 			case KeyOpsKey:
@@ -488,7 +488,7 @@ LOOP:
 				}
 				h.keyOps = &decoded
 			case KeyUsageKey:
-				if err := json.AssignNextStringToken(&h.keyUsage, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 				}
 			case RSANKey:
@@ -502,15 +502,15 @@ LOOP:
 				}
 				h.x509CertChain = &decoded
 			case X509CertThumbprintKey:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintKey, err)
 				}
 			case X509CertThumbprintS256Key:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintS256Key, err)
 				}
 			case X509URLKey:
-				if err := json.AssignNextStringToken(&h.x509URL, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509URL, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509URLKey, err)
 				}
 			default:
@@ -1260,7 +1260,7 @@ LOOP:
 		case string: // Objects can only have string keys
 			switch tok {
 			case KeyTypeKey:
-				val, err := json.ReadNextStringToken(dec)
+				val, err := json.ReadNextStringToken(dec, h.dc)
 				if err != nil {
 					return fmt.Errorf(`error reading token: %w`, err)
 				}
@@ -1294,7 +1294,7 @@ LOOP:
 					return fmt.Errorf(`failed to decode value for key %s: %w`, RSAEKey, err)
 				}
 			case KeyIDKey:
-				if err := json.AssignNextStringToken(&h.keyID, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyID, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyIDKey, err)
 				}
 			case KeyOpsKey:
@@ -1304,7 +1304,7 @@ LOOP:
 				}
 				h.keyOps = &decoded
 			case KeyUsageKey:
-				if err := json.AssignNextStringToken(&h.keyUsage, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 				}
 			case RSANKey:
@@ -1330,15 +1330,15 @@ LOOP:
 				}
 				h.x509CertChain = &decoded
 			case X509CertThumbprintKey:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintKey, err)
 				}
 			case X509CertThumbprintS256Key:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintS256Key, err)
 				}
 			case X509URLKey:
-				if err := json.AssignNextStringToken(&h.x509URL, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509URL, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509URLKey, err)
 				}
 			default:

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -417,7 +417,7 @@ LOOP:
 		case string: // Objects can only have string keys
 			switch tok {
 			case KeyTypeKey:
-				val, err := json.ReadNextStringToken(dec)
+				val, err := json.ReadNextStringToken(dec, h.dc)
 				if err != nil {
 					return fmt.Errorf(`error reading token: %w`, err)
 				}
@@ -435,7 +435,7 @@ LOOP:
 				}
 				h.algorithm = &alg
 			case KeyIDKey:
-				if err := json.AssignNextStringToken(&h.keyID, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyID, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyIDKey, err)
 				}
 			case KeyOpsKey:
@@ -445,7 +445,7 @@ LOOP:
 				}
 				h.keyOps = &decoded
 			case KeyUsageKey:
-				if err := json.AssignNextStringToken(&h.keyUsage, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 				}
 			case SymmetricOctetsKey:
@@ -459,15 +459,15 @@ LOOP:
 				}
 				h.x509CertChain = &decoded
 			case X509CertThumbprintKey:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintKey, err)
 				}
 			case X509CertThumbprintS256Key:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintS256Key, err)
 				}
 			case X509URLKey:
-				if err := json.AssignNextStringToken(&h.x509URL, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509URL, dec, h.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509URLKey, err)
 				}
 			default:

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -513,7 +513,7 @@ LOOP:
 				}
 				h.algorithm = &decoded
 			case ContentTypeKey:
-				if err := json.AssignNextStringToken(&h.contentType, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.contentType, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, ContentTypeKey, err)
 				}
 			case CriticalKey:
@@ -533,15 +533,15 @@ LOOP:
 				}
 				h.jwk = key
 			case JWKSetURLKey:
-				if err := json.AssignNextStringToken(&h.jwkSetURL, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.jwkSetURL, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, JWKSetURLKey, err)
 				}
 			case KeyIDKey:
-				if err := json.AssignNextStringToken(&h.keyID, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.keyID, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, KeyIDKey, err)
 				}
 			case TypeKey:
-				if err := json.AssignNextStringToken(&h.typ, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.typ, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, TypeKey, err)
 				}
 			case X509CertChainKey:
@@ -551,15 +551,15 @@ LOOP:
 				}
 				h.x509CertChain = &decoded
 			case X509CertThumbprintKey:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprint, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintKey, err)
 				}
 			case X509CertThumbprintS256Key:
-				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509CertThumbprintS256, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509CertThumbprintS256Key, err)
 				}
 			case X509URLKey:
-				if err := json.AssignNextStringToken(&h.x509URL, dec); err != nil {
+				if err := json.AssignNextStringToken(&h.x509URL, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, X509URLKey, err)
 				}
 			default:

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -74,16 +74,6 @@ func Settings(options ...GlobalOption) {
 				panic("jwt.Settings: WithMaxParseInputSize must be greater than zero")
 			}
 			maxParseInputSize.Store(v)
-		case identStrictStringClaims{}:
-			var v bool
-			if err := option.Value(&v); err != nil {
-				panic(fmt.Sprintf("jwt.Settings: value for WithStrictStringClaims must be bool: %s", err))
-			}
-			var newVal uint32
-			if v {
-				newVal = 1
-			}
-			json.RejectNullStrings.Store(newVal)
 		}
 	}
 
@@ -222,15 +212,16 @@ func ParseReader(src io.Reader, options ...ParseOption) (Token, error) {
 }
 
 type parseCtx struct {
-	token            Token
-	validateOpts     []ValidateOption
-	verifyOpts       []jws.VerifyOption
-	localReg         *json.Registry
-	pedantic         bool
-	skipVerification bool
-	validate         bool
-	withKeyCount     int
-	withKey          *withKey // this is used to detect if we have a WithKey option
+	token              Token
+	validateOpts       []ValidateOption
+	verifyOpts         []jws.VerifyOption
+	localReg           *json.Registry
+	strictStringClaims *bool // per-call override; nil = use global
+	pedantic           bool
+	skipVerification   bool
+	validate           bool
+	withKeyCount       int
+	withKey            *withKey // this is used to detect if we have a WithKey option
 }
 
 func parseBytes(data []byte, options ...ParseOption) (Token, error) {
@@ -300,6 +291,12 @@ func parseBytes(data []byte, options ...ParseOption) (Token, error) {
 				ctx.localReg = json.NewRegistry()
 			}
 			ctx.localReg.Register(pair.Name, pair.Value)
+		case identStrictStringClaims{}:
+			var v bool
+			if err := o.Value(&v); err != nil {
+				return nil, fmt.Errorf("jwt.parseBytes: value for WithStrictStringClaims must be bool: %w", err)
+			}
+			ctx.strictStringClaims = &v
 		}
 	}
 
@@ -453,12 +450,18 @@ OUTER:
 		ctx.token = New()
 	}
 
-	if ctx.localReg != nil {
+	if ctx.localReg != nil || ctx.strictStringClaims != nil {
 		dcToken, ok := ctx.token.(TokenWithDecodeCtx)
 		if !ok {
-			return nil, fmt.Errorf(`typed claim was requested, but the token (%T) does not support DecodeCtx`, ctx.token)
+			return nil, fmt.Errorf(`typed claim or strict string claims was requested, but the token (%T) does not support DecodeCtx`, ctx.token)
 		}
-		dc := json.NewDecodeCtx(ctx.localReg)
+
+		var strict bool
+		if ctx.strictStringClaims != nil {
+			strict = *ctx.strictStringClaims
+		}
+
+		dc := json.NewDecodeCtxStrictStrings(ctx.localReg, strict)
 		dcToken.SetDecodeCtx(dc)
 		defer func() { dcToken.SetDecodeCtx(nil) }()
 	}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1671,15 +1671,12 @@ func TestGH1484(t *testing.T) {
 	})
 
 	t.Run("strict rejects null", func(t *testing.T) {
-		jwt.Settings(jwt.WithStrictStringClaims(true))
-		defer jwt.Settings(jwt.WithStrictStringClaims(false))
-
 		for _, tc := range testcases {
 			t.Run(tc.Name, func(t *testing.T) {
 				signed, err := jws.Sign([]byte(tc.Payload), jws.WithKey(jwa.HS256(), key))
 				require.NoError(t, err, `jws.Sign should succeed`)
 
-				_, err = jwt.Parse(signed, jwt.WithKey(jwa.HS256(), key))
+				_, err = jwt.Parse(signed, jwt.WithKey(jwa.HS256(), key), jwt.WithStrictStringClaims(true))
 				require.Error(t, err, `jwt.Parse should reject null claim when strict`)
 			})
 		}

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -1059,7 +1059,7 @@ LOOP:
 				}
 				t.birthdate = &decoded
 			case EmailKey:
-				if err := json.AssignNextStringToken(&t.email, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.email, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, EmailKey, err)
 				}
 			case EmailVerifiedKey:
@@ -1075,15 +1075,15 @@ LOOP:
 				}
 				t.expiration = &decoded
 			case FamilyNameKey:
-				if err := json.AssignNextStringToken(&t.familyName, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.familyName, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, FamilyNameKey, err)
 				}
 			case GenderKey:
-				if err := json.AssignNextStringToken(&t.gender, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.gender, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, GenderKey, err)
 				}
 			case GivenNameKey:
-				if err := json.AssignNextStringToken(&t.givenName, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.givenName, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, GivenNameKey, err)
 				}
 			case IssuedAtKey:
@@ -1093,27 +1093,27 @@ LOOP:
 				}
 				t.issuedAt = &decoded
 			case IssuerKey:
-				if err := json.AssignNextStringToken(&t.issuer, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.issuer, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, IssuerKey, err)
 				}
 			case JwtIDKey:
-				if err := json.AssignNextStringToken(&t.jwtID, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.jwtID, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, JwtIDKey, err)
 				}
 			case LocaleKey:
-				if err := json.AssignNextStringToken(&t.locale, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.locale, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, LocaleKey, err)
 				}
 			case MiddleNameKey:
-				if err := json.AssignNextStringToken(&t.middleName, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.middleName, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, MiddleNameKey, err)
 				}
 			case NameKey:
-				if err := json.AssignNextStringToken(&t.name, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.name, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, NameKey, err)
 				}
 			case NicknameKey:
-				if err := json.AssignNextStringToken(&t.nickname, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.nickname, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, NicknameKey, err)
 				}
 			case NotBeforeKey:
@@ -1123,7 +1123,7 @@ LOOP:
 				}
 				t.notBefore = &decoded
 			case PhoneNumberKey:
-				if err := json.AssignNextStringToken(&t.phoneNumber, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.phoneNumber, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, PhoneNumberKey, err)
 				}
 			case PhoneNumberVerifiedKey:
@@ -1133,19 +1133,19 @@ LOOP:
 				}
 				t.phoneNumberVerified = &decoded
 			case PictureKey:
-				if err := json.AssignNextStringToken(&t.picture, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.picture, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, PictureKey, err)
 				}
 			case PreferredUsernameKey:
-				if err := json.AssignNextStringToken(&t.preferredUsername, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.preferredUsername, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, PreferredUsernameKey, err)
 				}
 			case ProfileKey:
-				if err := json.AssignNextStringToken(&t.profile, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.profile, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, ProfileKey, err)
 				}
 			case SubjectKey:
-				if err := json.AssignNextStringToken(&t.subject, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.subject, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, SubjectKey, err)
 				}
 			case UpdatedAtKey:
@@ -1155,11 +1155,11 @@ LOOP:
 				}
 				t.updatedAt = &decoded
 			case WebsiteKey:
-				if err := json.AssignNextStringToken(&t.website, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.website, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, WebsiteKey, err)
 				}
 			case ZoneinfoKey:
-				if err := json.AssignNextStringToken(&t.zoneinfo, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.zoneinfo, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, ZoneinfoKey, err)
 				}
 			default:

--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -134,7 +134,7 @@ options:
       See the documentation for `jwt.TokenOptionSet`, `(jwt.Token).Options`, and
       `jwt.FlattenAudience` for more details
   - ident: StrictStringClaims
-    interface: GlobalOption
+    interface: ParseOption
     argument_type: bool
     comment: |
       WithStrictStringClaims controls whether JSON null values for string
@@ -142,8 +142,6 @@ options:
       null is silently accepted as an empty string (matching Go's standard
       JSON decoding behavior). When set to true, null values are rejected
       per the RFC type definitions (e.g. StringOrURI).
-
-      This option can only be set globally via `jwt.Settings()`.
   - ident: FormKey
     interface: ParseOption
     argument_type: string

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -477,10 +477,8 @@ func WithSignOption(v jws.SignOption) SignOption {
 // null is silently accepted as an empty string (matching Go's standard
 // JSON decoding behavior). When set to true, null values are rejected
 // per the RFC type definitions (e.g. StringOrURI).
-//
-// This option can only be set globally via `jwt.Settings()`.
-func WithStrictStringClaims(v bool) GlobalOption {
-	return &globalOption{option.New(identStrictStringClaims{}, v)}
+func WithStrictStringClaims(v bool) ParseOption {
+	return &parseOption{option.New(identStrictStringClaims{}, v)}
 }
 
 // WithToken specifies the token instance in which the resulting JWT is stored

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -440,11 +440,11 @@ LOOP:
 				}
 				t.issuedAt = &decoded
 			case IssuerKey:
-				if err := json.AssignNextStringToken(&t.issuer, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.issuer, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, IssuerKey, err)
 				}
 			case JwtIDKey:
-				if err := json.AssignNextStringToken(&t.jwtID, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.jwtID, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, JwtIDKey, err)
 				}
 			case NotBeforeKey:
@@ -454,7 +454,7 @@ LOOP:
 				}
 				t.notBefore = &decoded
 			case SubjectKey:
-				if err := json.AssignNextStringToken(&t.subject, dec); err != nil {
+				if err := json.AssignNextStringToken(&t.subject, dec, t.dc); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, SubjectKey, err)
 				}
 			default:

--- a/tools/cmd/genjwe/main.go
+++ b/tools/cmd/genjwe/main.go
@@ -323,7 +323,7 @@ func generateHeaders(obj *codegen.Object) error {
 	for _, f := range obj.Fields() {
 		if f.Type() == "string" {
 			o.L("case %sKey:", f.Name(true))
-			o.L("if err := json.AssignNextStringToken(&h.%s, dec); err != nil {", f.Name(false))
+			o.L("if err := json.AssignNextStringToken(&h.%s, dec, nil); err != nil {", f.Name(false))
 			o.L("return fmt.Errorf(`failed to decode value for key %%s: %%w`, %sKey, err)", f.Name(true))
 			o.L("}")
 		} else if f.Type() == "[]byte" {

--- a/tools/cmd/genjwk/main.go
+++ b/tools/cmd/genjwk/main.go
@@ -562,7 +562,7 @@ func generateObject(o *codegen.Output, kt *KeyType, obj *codegen.Object) error {
 	o.L("switch tok {")
 	// kty is special. Hardcode it.
 	o.L("case KeyTypeKey:")
-	o.L("val, err := json.ReadNextStringToken(dec)")
+	o.L("val, err := json.ReadNextStringToken(dec, h.dc)")
 	o.L("if err != nil {")
 	o.L("return fmt.Errorf(`error reading token: %%w`, err)")
 	o.L("}")
@@ -573,7 +573,7 @@ func generateObject(o *codegen.Output, kt *KeyType, obj *codegen.Object) error {
 	for _, f := range obj.Fields() {
 		if f.Type() == "string" {
 			o.L("case %sKey:", f.Name(true))
-			o.L("if err := json.AssignNextStringToken(&h.%s, dec); err != nil {", f.Name(false))
+			o.L("if err := json.AssignNextStringToken(&h.%s, dec, h.dc); err != nil {", f.Name(false))
 			o.L("return fmt.Errorf(`failed to decode value for key %%s: %%w`, %sKey, err)", f.Name(true))
 			o.L("}")
 		} else if f.Type() == "jwa.KeyAlgorithm" {

--- a/tools/cmd/genjws/main.go
+++ b/tools/cmd/genjws/main.go
@@ -336,7 +336,7 @@ func generateHeaders(obj *codegen.Object) error {
 	for _, f := range obj.Fields() {
 		if f.Type() == "string" {
 			o.L("case %sKey:", f.Name(true))
-			o.L("if err := json.AssignNextStringToken(&h.%s, dec); err != nil {", f.Name(false))
+			o.L("if err := json.AssignNextStringToken(&h.%s, dec, nil); err != nil {", f.Name(false))
 			o.L("return fmt.Errorf(`failed to decode value for key %%s: %%w`, %sKey, err)", f.Name(true))
 			o.L("}")
 		} else if f.Type() == "[]byte" {

--- a/tools/cmd/genjwt/main.go
+++ b/tools/cmd/genjwt/main.go
@@ -448,7 +448,7 @@ func generateToken(obj *codegen.Object) error {
 	for _, f := range fields {
 		if f.Type() == "string" {
 			o.L("case %sKey:", f.Name(true))
-			o.L("if err := json.AssignNextStringToken(&t.%s, dec); err != nil {", f.Name(false))
+			o.L("if err := json.AssignNextStringToken(&t.%s, dec, t.dc); err != nil {", f.Name(false))
 			o.L("return fmt.Errorf(`failed to decode value for key %%s: %%w`, %sKey, err)", f.Name(true))
 			o.L("}")
 		} else if f.Type() == byteSliceType {


### PR DESCRIPTION
Remove global json.RejectNullStrings atomic. WithStrictStringClaims is now a per-call ParseOption on jwt.Parse/ReadFile instead of a global jwt.Settings option. Strict flag flows through DecodeCtx so it only affects JWT claim deserialization, not JWS/JWE/JWK header parsing.