### PR TITLE
add per-call opt-out for crit header validation

### DIFF
--- a/Changes
+++ b/Changes
@@ -69,7 +69,9 @@ v3.0.14 UNRELEASED
   * [jws] `jws.Verify()` and `jws.VerifyCompactFast()` now validate the "crit"
     (Critical) header parameter per RFC 7515 Section 4.1.11. Signatures with an
     empty "crit" array, standard JOSE header names in "crit", or "crit"-listed
-    extensions not present in the protected header are now rejected.
+    extensions not present in the protected header are now rejected. To disable
+    this validation on a per-call basis, pass
+    `jws.WithStrictCriticalHeaders(false)` to `jws.Verify()`.
 
   * [jws] Fixed probe field name in panic message. (#1597)
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -31,4 +31,4 @@ require (
 
 replace github.com/cloudflare/circl v1.0.0 => github.com/cloudflare/circl v1.0.1-0.20210104183656-96a0695de3c3
 
-replace github.com/lestrrat-go/jwx/v3 v3.0.0 => ../
+replace github.com/lestrrat-go/jwx/v3 => ../

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -23,8 +23,6 @@ github.com/lestrrat-go/httprc/v3 v3.0.5 h1:S+Mb4L2I+bM6JGTibLmxExhyTOqnXjqx+zi9M
 github.com/lestrrat-go/httprc/v3 v3.0.5/go.mod h1:mSMtkZW92Z98M5YoNNztbRGxbXHql7tSitCvaxvo9l0=
 github.com/lestrrat-go/jwx-circl-ed448 v0.0.0-20260403052429-ce28e4bb9ad6 h1:y4wVbETXEBlFZJ08oH7YbR/NlTYekFC/xoV2pjU2nFM=
 github.com/lestrrat-go/jwx-circl-ed448 v0.0.0-20260403052429-ce28e4bb9ad6/go.mod h1:GQWmQK+H4/axpI+mMiY4OB9h4b5sMICxpYugOvCdrWM=
-github.com/lestrrat-go/jwx/v3 v3.0.14-0.20260403051613-136a2d956850 h1:SXYbvHjZ7CEwIE6KlDO1ixazE1t/nB1hNOC8Wjhp9Kg=
-github.com/lestrrat-go/jwx/v3 v3.0.14-0.20260403051613-136a2d956850/go.mod h1:LaVeWOQEoDvlcJUSN0F2xrJDm6++CvncT3cw4w3hbDY=
 github.com/lestrrat-go/option/v2 v2.0.0 h1:XxrcaJESE1fokHy3FpaQ/cXW8ZsIdWcdFzzLOcID3Ss=
 github.com/lestrrat-go/option/v2 v2.0.0/go.mod h1:oSySsmzMoR0iRzCDCaUfsCzxQHUEuhOViQObyy7S6Vg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/examples/jws_verify_with_crit_opt_out_example_test.go
+++ b/examples/jws_verify_with_crit_opt_out_example_test.go
@@ -1,0 +1,41 @@
+package examples_test
+
+import (
+	"fmt"
+
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/lestrrat-go/jwx/v3/jws"
+)
+
+func Example_jws_verify_with_crit_opt_out() {
+	// This JWS has a "crit" header listing "x-custom", but the "x-custom"
+	// header is not present in the protected header. Per RFC 7515 Section
+	// 4.1.11, this should be rejected.
+	const src = `eyJhbGciOiJIUzI1NiIsImNyaXQiOlsieC1jdXN0b20iXX0.TG9yZW0gaXBzdW0.nqgPb01MwodtcEhQ-Hm0zWTrpa5whLjI9D-xZj-PrDo`
+
+	key, err := jwk.Import([]byte(`abracadabra`))
+	if err != nil {
+		fmt.Printf("failed to create key: %s\n", err)
+		return
+	}
+
+	// By default, jws.Verify validates the "crit" header and rejects
+	// this message because "x-custom" is not present.
+	_, err = jws.Verify([]byte(src), jws.WithKey(jwa.HS256(), key))
+	if err != nil {
+		fmt.Printf("strict crit (default): %s\n", err)
+	}
+
+	// WithStrictCriticalHeaders(false) skips "crit" validation,
+	// restoring the pre-v3.0.14 behavior.
+	payload, err := jws.Verify([]byte(src), jws.WithKey(jwa.HS256(), key), jws.WithStrictCriticalHeaders(false))
+	if err != nil {
+		fmt.Printf("failed to verify payload: %s\n", err)
+		return
+	}
+	fmt.Printf("relaxed crit: %s\n", payload)
+	// OUTPUT:
+	// strict crit (default): jws.Verify: could not verify message using any of the signatures or keys: jws.Verify: signature #1 has invalid "crit" header: jws.Verify: "crit" header references extension "x-custom", but it is not present in the protected header
+	// relaxed crit: Lorem ipsum
+}

--- a/examples/jws_verify_with_crit_opt_out_example_test.go
+++ b/examples/jws_verify_with_crit_opt_out_example_test.go
@@ -9,10 +9,13 @@ import (
 )
 
 func Example_jws_verify_with_crit_opt_out() {
-	// This JWS has a "crit" header listing "x-custom", but the "x-custom"
-	// header is not present in the protected header. Per RFC 7515 Section
-	// 4.1.11, this should be rejected.
-	const src = `eyJhbGciOiJIUzI1NiIsImNyaXQiOlsieC1jdXN0b20iXX0.TG9yZW0gaXBzdW0.nqgPb01MwodtcEhQ-Hm0zWTrpa5whLjI9D-xZj-PrDo`
+	// This JWS has crit: ["x-custom"] with the "x-custom" header present
+	// in the protected header. This is valid per RFC 7515 Section 4.1.11.
+	const validCrit = `eyJhbGciOiJIUzI1NiIsImNyaXQiOlsieC1jdXN0b20iXSwieC1jdXN0b20iOiJ2YWx1ZSJ9.TG9yZW0gaXBzdW0.JGhCiLa5O8-dJqGHwzjFW_KYRAgMA85v2dlsDs2B2fc`
+
+	// This JWS has crit: ["x-custom"] but the "x-custom" header is NOT
+	// present. Per RFC 7515 Section 4.1.11, this should be rejected.
+	const invalidCrit = `eyJhbGciOiJIUzI1NiIsImNyaXQiOlsieC1jdXN0b20iXX0.TG9yZW0gaXBzdW0.nqgPb01MwodtcEhQ-Hm0zWTrpa5whLjI9D-xZj-PrDo`
 
 	key, err := jwk.Import([]byte(`abracadabra`))
 	if err != nil {
@@ -20,22 +23,29 @@ func Example_jws_verify_with_crit_opt_out() {
 		return
 	}
 
-	// By default, jws.Verify validates the "crit" header and rejects
-	// this message because "x-custom" is not present.
-	_, err = jws.Verify([]byte(src), jws.WithKey(jwa.HS256(), key))
+	// By default, jws.Verify validates the "crit" header per RFC 7515.
+	// A valid crit header succeeds:
+	payload, err := jws.Verify([]byte(validCrit), jws.WithKey(jwa.HS256(), key))
 	if err != nil {
-		fmt.Printf("strict crit (default): %s\n", err)
+		fmt.Printf("failed to verify: %s\n", err)
+		return
 	}
+	fmt.Printf("strict, valid crit: %s\n", payload)
+
+	// An invalid crit header is rejected:
+	_, err = jws.Verify([]byte(invalidCrit), jws.WithKey(jwa.HS256(), key))
+	fmt.Printf("strict, invalid crit: verification error = %t\n", err != nil)
 
 	// WithStrictCriticalHeaders(false) skips "crit" validation,
 	// restoring the pre-v3.0.14 behavior.
-	payload, err := jws.Verify([]byte(src), jws.WithKey(jwa.HS256(), key), jws.WithStrictCriticalHeaders(false))
+	payload, err = jws.Verify([]byte(invalidCrit), jws.WithKey(jwa.HS256(), key), jws.WithStrictCriticalHeaders(false))
 	if err != nil {
-		fmt.Printf("failed to verify payload: %s\n", err)
+		fmt.Printf("failed to verify: %s\n", err)
 		return
 	}
-	fmt.Printf("relaxed crit: %s\n", payload)
+	fmt.Printf("relaxed, invalid crit: %s\n", payload)
 	// OUTPUT:
-	// strict crit (default): jws.Verify: could not verify message using any of the signatures or keys: jws.Verify: signature #1 has invalid "crit" header: jws.Verify: "crit" header references extension "x-custom", but it is not present in the protected header
-	// relaxed crit: Lorem ipsum
+	// strict, valid crit: Lorem ipsum
+	// strict, invalid crit: verification error = true
+	// relaxed, invalid crit: Lorem ipsum
 }

--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -187,3 +187,62 @@ func TestCriticalHeaderValidationFastPath(t *testing.T) {
 		require.ErrorContains(t, err, `x-absent`)
 	})
 }
+
+func TestWithStrictCriticalHeaders(t *testing.T) {
+	payload := []byte(`hello world`)
+
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+
+	sign := func(t *testing.T, hdrs jws.Headers) []byte {
+		t.Helper()
+		signed, err := jws.Sign(payload, jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)))
+		require.NoError(t, err, `jws.Sign should succeed`)
+		return signed
+	}
+
+	t.Run("empty crit rejected by default", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
+		require.Error(t, err, `jws.Verify should fail with strict crit by default`)
+	})
+
+	t.Run("empty crit accepted when strict disabled", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key), jws.WithStrictCriticalHeaders(false))
+		require.NoError(t, err, `jws.Verify should succeed when strict crit is disabled`)
+	})
+
+	t.Run("missing crit extension accepted when strict disabled", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-missing"}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key), jws.WithStrictCriticalHeaders(false))
+		require.NoError(t, err, `jws.Verify should succeed when strict crit is disabled`)
+	})
+
+	t.Run("standard header in crit accepted when strict disabled", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"alg"}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key), jws.WithStrictCriticalHeaders(false))
+		require.NoError(t, err, `jws.Verify should succeed when strict crit is disabled`)
+	})
+
+	t.Run("explicit true still validates", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{}))
+		signed := sign(t, hdrs)
+
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key), jws.WithStrictCriticalHeaders(true))
+		require.Error(t, err, `jws.Verify should fail with explicit strict crit`)
+	})
+}

--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -259,3 +259,13 @@ options:
       This option can be passed to `jws.Settings()` to change the default
       globally, or to `jws.Parse()` / `jws.ReadFile()` for a per-call
       override.
+  - ident: StrictCriticalHeaders
+    interface: VerifyOption
+    argument_type: bool
+    comment: |
+      WithStrictCriticalHeaders specifies whether the "crit" (Critical)
+      header parameter should be validated per RFC 7515 Section 4.1.11
+      during verification. The default is true.
+
+      When set to false, the "crit" header is silently ignored during
+      jws.Verify(), matching the behavior of v3.0.13 and earlier.

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -221,6 +221,7 @@ type identProtectedHeaders struct{}
 type identPublicHeaders struct{}
 type identRequireKid struct{}
 type identSerialization struct{}
+type identStrictCriticalHeaders struct{}
 type identUseDefault struct{}
 type identValidateKey struct{}
 
@@ -298,6 +299,10 @@ func (identRequireKid) String() string {
 
 func (identSerialization) String() string {
 	return "WithSerialization"
+}
+
+func (identStrictCriticalHeaders) String() string {
+	return "WithStrictCriticalHeaders"
 }
 
 func (identUseDefault) String() string {
@@ -467,6 +472,16 @@ func WithRequireKid(v bool) WithKeySetSuboption {
 // do not need to specify this option other than to be explicit about it
 func WithCompact() SignVerifyParseOption {
 	return &signVerifyParseOption{option.New(identSerialization{}, fmtCompact)}
+}
+
+// WithStrictCriticalHeaders specifies whether the "crit" (Critical)
+// header parameter should be validated per RFC 7515 Section 4.1.11
+// during verification. The default is true.
+//
+// When set to false, the "crit" header is silently ignored during
+// jws.Verify(), matching the behavior of v3.0.13 and earlier.
+func WithStrictCriticalHeaders(v bool) VerifyOption {
+	return &verifyOption{option.New(identStrictCriticalHeaders{}, v)}
 }
 
 // WithUseDefault specifies that if and only if a jwk.Key contains

--- a/jws/options_gen_test.go
+++ b/jws/options_gen_test.go
@@ -28,6 +28,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithPublicHeaders", identPublicHeaders{}.String())
 	require.Equal(t, "WithRequireKid", identRequireKid{}.String())
 	require.Equal(t, "WithSerialization", identSerialization{}.String())
+	require.Equal(t, "WithStrictCriticalHeaders", identStrictCriticalHeaders{}.String())
 	require.Equal(t, "WithUseDefault", identUseDefault{}.String())
 	require.Equal(t, "WithValidateKey", identValidateKey{}.String())
 }

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -23,6 +23,7 @@ type verifyContext struct {
 	keyProviders    []KeyProvider
 	keyUsed         any
 	validateKey     bool
+	strictCritical  bool
 	encoder         Base64Encoder
 	//nolint:containedctx
 	ctx context.Context
@@ -32,8 +33,9 @@ var verifyContextPool = pool.New[*verifyContext](allocVerifyContext, freeVerifyC
 
 func allocVerifyContext() *verifyContext {
 	return &verifyContext{
-		encoder: base64.DefaultEncoder(),
-		ctx:     context.Background(),
+		strictCritical: true,
+		encoder:        base64.DefaultEncoder(),
+		ctx:            context.Background(),
 	}
 }
 
@@ -44,6 +46,7 @@ func freeVerifyContext(vc *verifyContext) *verifyContext {
 	vc.keyProviders = vc.keyProviders[:0]
 	vc.keyUsed = nil
 	vc.validateKey = false
+	vc.strictCritical = true
 	vc.encoder = base64.DefaultEncoder()
 	vc.ctx = context.Background()
 	return vc
@@ -87,6 +90,10 @@ func (vc *verifyContext) ProcessOptions(options []VerifyOption) error {
 		case identValidateKey{}:
 			if err := option.Value(&vc.validateKey); err != nil {
 				return makeVerifyError(`failed to retrieve validate-key option value: %w`, err)
+			}
+		case identStrictCriticalHeaders{}:
+			if err := option.Value(&vc.strictCritical); err != nil {
+				return makeVerifyError(`failed to retrieve strict-critical-headers option value: %w`, err)
 			}
 		case identSerialization{}:
 			vc.parseOptions = append(vc.parseOptions, option.(ParseOption))
@@ -152,11 +159,11 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 			rawHeaders = protected
 		}
 
-		// Validate the "crit" header per RFC 7515 Section 4.1.11 before
-		// attempting signature verification with any keys.
-		if err := validateCritical(sig.protected); err != nil {
-			errs = append(errs, makeVerifyError(`signature #%d has invalid "crit" header: %w`, idx+1, err))
-			continue
+		if vc.strictCritical {
+			if err := validateCritical(sig.protected); err != nil {
+				errs = append(errs, makeVerifyError(`signature #%d has invalid "crit" header: %w`, idx+1, err))
+				continue
+			}
 		}
 
 		verifyBuf = verifyBuf[:0]


### PR DESCRIPTION
WithStrictCriticalHeaders(false) on jws.Verify() skips RFC 7515 crit header validation, restoring pre-v3.0.14 behavior on a per-call basis.