### PR TITLE
protect global settings with mutex

### DIFF
--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -7,6 +7,7 @@ import (
 	"crypto/ed25519"
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/lestrrat-go/jwx/v3/internal/base64"
 	"github.com/lestrrat-go/jwx/v3/jwa"
@@ -57,6 +58,8 @@ func (k *okpPublicKey) Import(rawKeyIf any) error {
 		crv = jwa.X25519()
 		k.crv = &crv
 	default:
+		muOKPRawKeyImporters.RLock()
+		defer muOKPRawKeyImporters.RUnlock()
 		for _, fn := range okpRawKeyImporters {
 			c, x, _, ok := fn(rawKeyIf)
 			if ok {
@@ -90,6 +93,8 @@ func (k *okpPrivateKey) Import(rawKeyIf any) error {
 		crv = jwa.X25519()
 		k.crv = &crv
 	default:
+		muOKPRawKeyImporters.RLock()
+		defer muOKPRawKeyImporters.RUnlock()
 		for _, fn := range okpRawKeyImporters {
 			c, x, d, ok := fn(rawKeyIf)
 			if ok {
@@ -110,10 +115,13 @@ func (k *okpPrivateKey) Import(rawKeyIf any) error {
 // Returns the curve, x, d (nil for public), and true if handled.
 type OKPRawKeyImporter func(key any) (crv jwa.EllipticCurveAlgorithm, x, d []byte, ok bool)
 
+var muOKPRawKeyImporters sync.RWMutex
 var okpRawKeyImporters []OKPRawKeyImporter
 
 // RegisterOKPRawKeyImporter registers a function that can import raw keys as OKP keys.
 func RegisterOKPRawKeyImporter(fn OKPRawKeyImporter) {
+	muOKPRawKeyImporters.Lock()
+	defer muOKPRawKeyImporters.Unlock()
 	okpRawKeyImporters = append(okpRawKeyImporters, fn)
 }
 

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -528,6 +528,7 @@ func RegisterCustomField(name string, object any) {
 }
 
 // Helpers for signature verification
+var muAlgorithmMaps sync.RWMutex
 var keyTypeToAlgorithms = make(map[jwa.KeyType][]jwa.SignatureAlgorithm)
 var curveToAlgorithms = make(map[jwa.EllipticCurveAlgorithm][]jwa.SignatureAlgorithm)
 
@@ -549,6 +550,8 @@ func init() {
 // the given key type. This is used internally by init() and can also be called
 // from external modules that provide support for additional algorithms (e.g. Ed448).
 func RegisterAlgorithmForKeyType(kty jwa.KeyType, alg jwa.SignatureAlgorithm) {
+	muAlgorithmMaps.Lock()
+	defer muAlgorithmMaps.Unlock()
 	keyTypeToAlgorithms[kty] = append(keyTypeToAlgorithms[kty], alg)
 }
 
@@ -560,6 +563,8 @@ func RegisterAlgorithmForKeyType(kty jwa.KeyType, alg jwa.SignatureAlgorithm) {
 // This function is append-only and deduplicates entries, so builtin
 // registrations cannot be overwritten by external modules.
 func RegisterAlgorithmForCurve(crv jwa.EllipticCurveAlgorithm, alg jwa.SignatureAlgorithm) {
+	muAlgorithmMaps.Lock()
+	defer muAlgorithmMaps.Unlock()
 	if slices.Contains(curveToAlgorithms[crv], alg) {
 		return
 	}
@@ -617,6 +622,9 @@ func AlgorithmsForKey(key any) ([]jwa.SignatureAlgorithm, error) {
 			crv, hasCrv = ck.Crv()
 		}
 	}
+
+	muAlgorithmMaps.RLock()
+	defer muAlgorithmMaps.RUnlock()
 
 	ktyAlgs, ok := keyTypeToAlgorithms[kty]
 	if !ok {

--- a/jwt/internal/types/date.go
+++ b/jwt/internal/types/date.go
@@ -58,8 +58,7 @@ func parseNumericString(x string) (time.Time, error) {
 
 	// Only check for the escape hatch if it's the pedantic
 	// flag is off
-	pedantic := Pedantic.Load()
-	if pedantic != 1 {
+	if Pedantic.Load() != 1 {
 		// This is an escape hatch for non-conformant providers
 		// that gives us RFC3339 instead of epoch time
 		for _, r := range x {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/lestrrat-go/jwx/v3/jwt/internal/types"
 )
 
+var muSettings sync.Mutex
 var defaultTruncation atomic.Int64
 var maxParseInputSize atomic.Int64
 
@@ -28,6 +30,9 @@ func init() {
 
 // Settings controls global settings that are specific to JWTs.
 func Settings(options ...GlobalOption) {
+	muSettings.Lock()
+	defer muSettings.Unlock()
+
 	var flattenAudience bool
 	var parsePedantic bool
 	var parsePrecision = types.MaxPrecision + 1  // illegal value, so we can detect nothing was set
@@ -78,28 +83,19 @@ func Settings(options ...GlobalOption) {
 	}
 
 	if parsePrecision <= types.MaxPrecision { // remember we set default to max + 1
-		v := types.ParsePrecision.Load()
-		if v != parsePrecision {
-			types.ParsePrecision.CompareAndSwap(v, parsePrecision)
-		}
+		types.ParsePrecision.Store(parsePrecision)
 	}
 
 	if formatPrecision <= types.MaxPrecision { // remember we set default to max + 1
-		v := types.FormatPrecision.Load()
-		if v != formatPrecision {
-			types.FormatPrecision.CompareAndSwap(v, formatPrecision)
-		}
+		types.FormatPrecision.Store(formatPrecision)
 	}
 
 	{
-		v := types.Pedantic.Load()
-		if (v == 1) != parsePedantic {
-			var newVal uint32
-			if parsePedantic {
-				newVal = 1
-			}
-			types.Pedantic.CompareAndSwap(v, newVal)
+		var newVal uint32
+		if parsePedantic {
+			newVal = 1
 		}
+		types.Pedantic.Store(newVal)
 	}
 
 	{


### PR DESCRIPTION
Add mutex protection to unprotected global variables: okpRawKeyImporters in jwk, keyTypeToAlgorithms/curveToAlgorithms in jws, Settings() serialization in jwt, and atomic reads in jwt/internal/types.