### PR TITLE
document WithStrictStringClaims scope to JWT only

### DIFF
--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -142,6 +142,9 @@ options:
       null is silently accepted as an empty string (matching Go's standard
       JSON decoding behavior). When set to true, null values are rejected
       per the RFC type definitions (e.g. StringOrURI).
+
+      This option only affects JWT claims. JWE and JWS header fields are
+      not subject to this check and will always accept null as an empty string.
   - ident: FormKey
     interface: ParseOption
     argument_type: string

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -477,6 +477,9 @@ func WithSignOption(v jws.SignOption) SignOption {
 // null is silently accepted as an empty string (matching Go's standard
 // JSON decoding behavior). When set to true, null values are rejected
 // per the RFC type definitions (e.g. StringOrURI).
+//
+// This option only affects JWT claims. JWE and JWS header fields are
+// not subject to this check and will always accept null as an empty string.
 func WithStrictStringClaims(v bool) ParseOption {
 	return &parseOption{option.New(identStrictStringClaims{}, v)}
 }


### PR DESCRIPTION
Clarify that WithStrictStringClaims only affects JWT claims — JWE and JWS header fields always accept null as empty string.