### PR TITLE
document WithStrictStringClaims scope includes JWK

### DIFF
--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -143,7 +143,7 @@ options:
       JSON decoding behavior). When set to true, null values are rejected
       per the RFC type definitions (e.g. StringOrURI).
 
-      This option only affects JWT claims. JWE and JWS header fields are
+      This option only affects JWT claims. JWK, JWE, and JWS fields are
       not subject to this check and will always accept null as an empty string.
   - ident: FormKey
     interface: ParseOption

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -478,7 +478,7 @@ func WithSignOption(v jws.SignOption) SignOption {
 // JSON decoding behavior). When set to true, null values are rejected
 // per the RFC type definitions (e.g. StringOrURI).
 //
-// This option only affects JWT claims. JWE and JWS header fields are
+// This option only affects JWT claims. JWK, JWE, and JWS fields are
 // not subject to this check and will always accept null as an empty string.
 func WithStrictStringClaims(v bool) ParseOption {
 	return &parseOption{option.New(identStrictStringClaims{}, v)}


### PR DESCRIPTION
Add JWK to the list of unaffected field types in the WithStrictStringClaims doc comment. The original text only mentioned JWE and JWS, but JWK also uses ReadNextStringToken and is equally unaffected by this option.