### PR TITLE
deep-copy slice fields in generated Set methods

### DIFF
--- a/jwe/headers_gen.go
+++ b/jwe/headers_gen.go
@@ -430,13 +430,23 @@ func (h *stdHeaders) setNoLock(name string, value any) error {
 	switch name {
 	case AgreementPartyUInfoKey:
 		if v, ok := value.([]byte); ok {
-			h.agreementPartyUInfo = v
+			if v == nil {
+				h.agreementPartyUInfo = nil
+			} else {
+				h.agreementPartyUInfo = make([]byte, len(v))
+				copy(h.agreementPartyUInfo, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, AgreementPartyUInfoKey, value)
 	case AgreementPartyVInfoKey:
 		if v, ok := value.([]byte); ok {
-			h.agreementPartyVInfo = v
+			if v == nil {
+				h.agreementPartyVInfo = nil
+			} else {
+				h.agreementPartyVInfo = make([]byte, len(v))
+				copy(h.agreementPartyVInfo, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, AgreementPartyVInfoKey, value)
@@ -469,7 +479,12 @@ func (h *stdHeaders) setNoLock(name string, value any) error {
 		return fmt.Errorf(`invalid value for %s key: %T`, ContentTypeKey, value)
 	case CriticalKey:
 		if v, ok := value.([]string); ok {
-			h.critical = v
+			if v == nil {
+				h.critical = nil
+			} else {
+				h.critical = make([]string, len(v))
+				copy(h.critical, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, CriticalKey, value)

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -352,7 +352,12 @@ func (h *ecdsaPublicKey) setNoLock(name string, value any) error {
 		}
 	case ECDSAXKey:
 		if v, ok := value.([]byte); ok {
-			h.x = v
+			if v == nil {
+				h.x = nil
+			} else {
+				h.x = make([]byte, len(v))
+				copy(h.x, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, ECDSAXKey, value)
@@ -382,7 +387,12 @@ func (h *ecdsaPublicKey) setNoLock(name string, value any) error {
 		return fmt.Errorf(`invalid value for %s key: %T`, X509URLKey, value)
 	case ECDSAYKey:
 		if v, ok := value.([]byte); ok {
-			h.y = v
+			if v == nil {
+				h.y = nil
+			} else {
+				h.y = make([]byte, len(v))
+				copy(h.y, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, ECDSAYKey, value)
@@ -1023,7 +1033,12 @@ func (h *ecdsaPrivateKey) setNoLock(name string, value any) error {
 		return fmt.Errorf(`invalid value for %s key: %T`, ECDSACrvKey, value)
 	case ECDSADKey:
 		if v, ok := value.([]byte); ok {
-			h.d = v
+			if v == nil {
+				h.d = nil
+			} else {
+				h.d = make([]byte, len(v))
+				copy(h.d, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, ECDSADKey, value)
@@ -1057,7 +1072,12 @@ func (h *ecdsaPrivateKey) setNoLock(name string, value any) error {
 		}
 	case ECDSAXKey:
 		if v, ok := value.([]byte); ok {
-			h.x = v
+			if v == nil {
+				h.x = nil
+			} else {
+				h.x = make([]byte, len(v))
+				copy(h.x, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, ECDSAXKey, value)
@@ -1087,7 +1107,12 @@ func (h *ecdsaPrivateKey) setNoLock(name string, value any) error {
 		return fmt.Errorf(`invalid value for %s key: %T`, X509URLKey, value)
 	case ECDSAYKey:
 		if v, ok := value.([]byte); ok {
-			h.y = v
+			if v == nil {
+				h.y = nil
+			} else {
+				h.y = make([]byte, len(v))
+				copy(h.y, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, ECDSAYKey, value)

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -332,7 +332,12 @@ func (h *okpPublicKey) setNoLock(name string, value any) error {
 		}
 	case OKPXKey:
 		if v, ok := value.([]byte); ok {
-			h.x = v
+			if v == nil {
+				h.x = nil
+			} else {
+				h.x = make([]byte, len(v))
+				copy(h.x, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, OKPXKey, value)
@@ -961,7 +966,12 @@ func (h *okpPrivateKey) setNoLock(name string, value any) error {
 		return fmt.Errorf(`invalid value for %s key: %T`, OKPCrvKey, value)
 	case OKPDKey:
 		if v, ok := value.([]byte); ok {
-			h.d = v
+			if v == nil {
+				h.d = nil
+			} else {
+				h.d = make([]byte, len(v))
+				copy(h.d, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, OKPDKey, value)
@@ -995,7 +1005,12 @@ func (h *okpPrivateKey) setNoLock(name string, value any) error {
 		}
 	case OKPXKey:
 		if v, ok := value.([]byte); ok {
-			h.x = v
+			if v == nil {
+				h.x = nil
+			} else {
+				h.x = make([]byte, len(v))
+				copy(h.x, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, OKPXKey, value)

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -303,7 +303,12 @@ func (h *rsaPublicKey) setNoLock(name string, value any) error {
 		return nil
 	case RSAEKey:
 		if v, ok := value.([]byte); ok {
-			h.e = v
+			if v == nil {
+				h.e = nil
+			} else {
+				h.e = make([]byte, len(v))
+				copy(h.e, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, RSAEKey, value)
@@ -337,7 +342,12 @@ func (h *rsaPublicKey) setNoLock(name string, value any) error {
 		}
 	case RSANKey:
 		if v, ok := value.([]byte); ok {
-			h.n = v
+			if v == nil {
+				h.n = nil
+			} else {
+				h.n = make([]byte, len(v))
+				copy(h.n, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, RSANKey, value)
@@ -1053,25 +1063,45 @@ func (h *rsaPrivateKey) setNoLock(name string, value any) error {
 		return nil
 	case RSADKey:
 		if v, ok := value.([]byte); ok {
-			h.d = v
+			if v == nil {
+				h.d = nil
+			} else {
+				h.d = make([]byte, len(v))
+				copy(h.d, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, RSADKey, value)
 	case RSADPKey:
 		if v, ok := value.([]byte); ok {
-			h.dp = v
+			if v == nil {
+				h.dp = nil
+			} else {
+				h.dp = make([]byte, len(v))
+				copy(h.dp, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, RSADPKey, value)
 	case RSADQKey:
 		if v, ok := value.([]byte); ok {
-			h.dq = v
+			if v == nil {
+				h.dq = nil
+			} else {
+				h.dq = make([]byte, len(v))
+				copy(h.dq, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, RSADQKey, value)
 	case RSAEKey:
 		if v, ok := value.([]byte); ok {
-			h.e = v
+			if v == nil {
+				h.e = nil
+			} else {
+				h.e = make([]byte, len(v))
+				copy(h.e, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, RSAEKey, value)
@@ -1105,25 +1135,45 @@ func (h *rsaPrivateKey) setNoLock(name string, value any) error {
 		}
 	case RSANKey:
 		if v, ok := value.([]byte); ok {
-			h.n = v
+			if v == nil {
+				h.n = nil
+			} else {
+				h.n = make([]byte, len(v))
+				copy(h.n, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, RSANKey, value)
 	case RSAPKey:
 		if v, ok := value.([]byte); ok {
-			h.p = v
+			if v == nil {
+				h.p = nil
+			} else {
+				h.p = make([]byte, len(v))
+				copy(h.p, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, RSAPKey, value)
 	case RSAQKey:
 		if v, ok := value.([]byte); ok {
-			h.q = v
+			if v == nil {
+				h.q = nil
+			} else {
+				h.q = make([]byte, len(v))
+				copy(h.q, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, RSAQKey, value)
 	case RSAQIKey:
 		if v, ok := value.([]byte); ok {
-			h.qi = v
+			if v == nil {
+				h.qi = nil
+			} else {
+				h.qi = make([]byte, len(v))
+				copy(h.qi, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, RSAQIKey, value)

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -301,7 +301,12 @@ func (h *symmetricKey) setNoLock(name string, value any) error {
 		}
 	case SymmetricOctetsKey:
 		if v, ok := value.([]byte); ok {
-			h.octets = v
+			if v == nil {
+				h.octets = nil
+			} else {
+				h.octets = make([]byte, len(v))
+				copy(h.octets, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, SymmetricOctetsKey, value)

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -391,7 +391,12 @@ func (h *stdHeaders) setNoLock(name string, value any) error {
 		return fmt.Errorf(`invalid value for %s key: %T`, ContentTypeKey, value)
 	case CriticalKey:
 		if v, ok := value.([]string); ok {
-			h.critical = v
+			if v == nil {
+				h.critical = nil
+			} else {
+				h.critical = make([]string, len(v))
+				copy(h.critical, v)
+			}
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, CriticalKey, value)

--- a/tools/cmd/genjwe/main.go
+++ b/tools/cmd/genjwe/main.go
@@ -265,6 +265,13 @@ func generateHeaders(obj *codegen.Object) error {
 
 			if fieldStorageTypeIsIndirect(f.Type()) {
 				o.L("h.%s = &v", f.Name(false))
+			} else if strings.HasPrefix(f.Type(), "[]") {
+				o.L("if v == nil {")
+				o.L("h.%s = nil", f.Name(false))
+				o.L("} else {")
+				o.L("h.%s = make(%s, len(v))", f.Name(false), f.Type())
+				o.L("copy(h.%s, v)", f.Name(false))
+				o.L("}")
 			} else {
 				o.L("h.%s = v", f.Name(false))
 			}

--- a/tools/cmd/genjwk/main.go
+++ b/tools/cmd/genjwk/main.go
@@ -478,6 +478,13 @@ func generateObject(o *codegen.Output, kt *KeyType, obj *codegen.Object) error {
 			o.L("if v, ok := value.(%s); ok {", f.Type())
 			if fieldStorageTypeIsIndirect(f.Type()) {
 				o.L("h.%s = &v", f.Name(false))
+			} else if strings.HasPrefix(f.Type(), "[]") {
+				o.L("if v == nil {")
+				o.L("h.%s = nil", f.Name(false))
+				o.L("} else {")
+				o.L("h.%s = make(%s, len(v))", f.Name(false), f.Type())
+				o.L("copy(h.%s, v)", f.Name(false))
+				o.L("}")
 			} else {
 				o.L("h.%s = v", f.Name(false))
 			}

--- a/tools/cmd/genjws/main.go
+++ b/tools/cmd/genjws/main.go
@@ -279,6 +279,13 @@ func generateHeaders(obj *codegen.Object) error {
 			o.L("if v, ok := value.(%s); ok {", f.Type())
 			if fieldStorageTypeIsIndirect(f.Type()) {
 				o.L("h.%s = &v", f.Name(false))
+			} else if strings.HasPrefix(f.Type(), "[]") {
+				o.L("if v == nil {")
+				o.L("h.%s = nil", f.Name(false))
+				o.L("} else {")
+				o.L("h.%s = make(%s, len(v))", f.Name(false), f.Type())
+				o.L("copy(h.%s, v)", f.Name(false))
+				o.L("}")
 			} else {
 				o.L("h.%s = v", f.Name(false))
 			}


### PR DESCRIPTION
Generated Set() methods for slice-typed fields ([]string, []byte) assigned the caller's slice directly, so Copy()/Clone() produced headers sharing the same backing array. Now uses make+copy, preserving nil vs empty semantics.