### PR TITLE
zero private key fields on UnmarshalJSON error

### DIFF
--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -1154,7 +1154,7 @@ func (k *ecdsaPrivateKey) SetDecodeCtx(dc json.DecodeCtx) {
 	k.dc = dc
 }
 
-func (h *ecdsaPrivateKey) UnmarshalJSON(buf []byte) error {
+func (h *ecdsaPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.algorithm = nil
@@ -1169,6 +1169,16 @@ func (h *ecdsaPrivateKey) UnmarshalJSON(buf []byte) error {
 	h.x509CertThumbprintS256 = nil
 	h.x509URL = nil
 	h.y = nil
+	defer func() {
+		if retErr != nil {
+			clear(h.d)
+			h.d = nil
+			clear(h.x)
+			h.x = nil
+			clear(h.y)
+			h.y = nil
+		}
+	}()
 	dec := json.NewDecoder(bytes.NewReader(buf))
 LOOP:
 	for {

--- a/jwk/jwk_zero_on_error_test.go
+++ b/jwk/jwk_zero_on_error_test.go
@@ -1,0 +1,101 @@
+package jwk_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/lestrrat-go/jwx/v3/jwk/jwkunsafe"
+	"github.com/stretchr/testify/require"
+)
+
+// TestZeroPrivateKeyFieldsOnUnmarshalError verifies that when UnmarshalJSON
+// fails mid-parse, any already-decoded private key material is zeroed before
+// the error is returned. This prevents sensitive key bytes from lingering in
+// memory after a failed parse.
+func TestZeroPrivateKeyFieldsOnUnmarshalError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RSA", func(t *testing.T) {
+		t.Parallel()
+
+		// JSON with valid kty and d, but missing required fields n and e.
+		// The d field will be decoded, then the required-field check will fail.
+		src := `{"kty":"RSA","d":"AQAB"}`
+
+		key, err := jwkunsafe.NewKey(jwa.RSA())
+		require.NoError(t, err)
+
+		err = json.Unmarshal([]byte(src), key)
+		require.Error(t, err, "unmarshal should fail due to missing required fields")
+
+		rsaKey, ok := key.(jwk.RSAPrivateKey)
+		require.True(t, ok)
+
+		d, exists := rsaKey.D()
+		require.False(t, exists, "D() should report not-exists after failed unmarshal")
+		require.Nil(t, d, "D() value should be nil after failed unmarshal")
+	})
+
+	t.Run("ECDSA", func(t *testing.T) {
+		t.Parallel()
+
+		// Has kty, crv, and d, but missing required fields x and y.
+		src := `{"kty":"EC","crv":"P-256","d":"AQAB"}`
+
+		key, err := jwkunsafe.NewKey(jwa.EC())
+		require.NoError(t, err)
+
+		err = json.Unmarshal([]byte(src), key)
+		require.Error(t, err, "unmarshal should fail due to missing required fields")
+
+		ecKey, ok := key.(jwk.ECDSAPrivateKey)
+		require.True(t, ok)
+
+		d, exists := ecKey.D()
+		require.False(t, exists, "D() should report not-exists after failed unmarshal")
+		require.Nil(t, d, "D() value should be nil after failed unmarshal")
+	})
+
+	t.Run("OKP", func(t *testing.T) {
+		t.Parallel()
+
+		// Has kty and d, but missing required fields crv and x.
+		src := `{"kty":"OKP","d":"AQAB"}`
+
+		key, err := jwkunsafe.NewKey(jwa.OKP())
+		require.NoError(t, err)
+
+		err = json.Unmarshal([]byte(src), key)
+		require.Error(t, err, "unmarshal should fail due to missing required fields")
+
+		okpKey, ok := key.(jwk.OKPPrivateKey)
+		require.True(t, ok)
+
+		d, exists := okpKey.D()
+		require.False(t, exists, "D() should report not-exists after failed unmarshal")
+		require.Nil(t, d, "D() value should be nil after failed unmarshal")
+	})
+
+	t.Run("Symmetric", func(t *testing.T) {
+		t.Parallel()
+
+		// Has kty and k (octets), but includes an unrecognized field that
+		// will cause a decode error.
+		src := `{"kty":"oct","k":"AQAB","bogus":!!!}`
+
+		key, err := jwkunsafe.NewKey(jwa.OctetSeq())
+		require.NoError(t, err)
+
+		err = json.Unmarshal([]byte(src), key)
+		require.Error(t, err, "unmarshal should fail due to malformed JSON")
+
+		symKey, ok := key.(jwk.SymmetricKey)
+		require.True(t, ok)
+
+		octets, exists := symKey.Octets()
+		require.False(t, exists, "Octets() should report not-exists after failed unmarshal")
+		require.Nil(t, octets, "Octets() value should be nil after failed unmarshal")
+	})
+}

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -1084,7 +1084,7 @@ func (k *okpPrivateKey) SetDecodeCtx(dc json.DecodeCtx) {
 	k.dc = dc
 }
 
-func (h *okpPrivateKey) UnmarshalJSON(buf []byte) error {
+func (h *okpPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.algorithm = nil
@@ -1098,6 +1098,14 @@ func (h *okpPrivateKey) UnmarshalJSON(buf []byte) error {
 	h.x509CertThumbprint = nil
 	h.x509CertThumbprintS256 = nil
 	h.x509URL = nil
+	defer func() {
+		if retErr != nil {
+			clear(h.d)
+			h.d = nil
+			clear(h.x)
+			h.x = nil
+		}
+	}()
 	dec := json.NewDecoder(bytes.NewReader(buf))
 LOOP:
 	for {

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -1222,7 +1222,7 @@ func (k *rsaPrivateKey) SetDecodeCtx(dc json.DecodeCtx) {
 	k.dc = dc
 }
 
-func (h *rsaPrivateKey) UnmarshalJSON(buf []byte) error {
+func (h *rsaPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.algorithm = nil
@@ -1241,6 +1241,26 @@ func (h *rsaPrivateKey) UnmarshalJSON(buf []byte) error {
 	h.x509CertThumbprint = nil
 	h.x509CertThumbprintS256 = nil
 	h.x509URL = nil
+	defer func() {
+		if retErr != nil {
+			clear(h.d)
+			h.d = nil
+			clear(h.dp)
+			h.dp = nil
+			clear(h.dq)
+			h.dq = nil
+			clear(h.e)
+			h.e = nil
+			clear(h.n)
+			h.n = nil
+			clear(h.p)
+			h.p = nil
+			clear(h.q)
+			h.q = nil
+			clear(h.qi)
+			h.qi = nil
+		}
+	}()
 	dec := json.NewDecoder(bytes.NewReader(buf))
 LOOP:
 	for {

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -386,7 +386,7 @@ func (k *symmetricKey) SetDecodeCtx(dc json.DecodeCtx) {
 	k.dc = dc
 }
 
-func (h *symmetricKey) UnmarshalJSON(buf []byte) error {
+func (h *symmetricKey) UnmarshalJSON(buf []byte) (retErr error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.algorithm = nil
@@ -398,6 +398,12 @@ func (h *symmetricKey) UnmarshalJSON(buf []byte) error {
 	h.x509CertThumbprint = nil
 	h.x509CertThumbprintS256 = nil
 	h.x509URL = nil
+	defer func() {
+		if retErr != nil {
+			clear(h.octets)
+			h.octets = nil
+		}
+	}()
 	dec := json.NewDecoder(bytes.NewReader(buf))
 LOOP:
 	for {

--- a/tools/cmd/genjwk/main.go
+++ b/tools/cmd/genjwk/main.go
@@ -535,11 +535,29 @@ func generateObject(o *codegen.Output, kt *KeyType, obj *codegen.Object) error {
 	o.L("k.dc = dc")
 	o.L("}")
 
-	o.LL("func (h *%s) UnmarshalJSON(buf []byte) error {", structName)
+	hasSensitiveFields := obj.Name(true) == "PrivateKey" || obj.Name(true) == "SymmetricKey"
+	if hasSensitiveFields {
+		o.LL("func (h *%s) UnmarshalJSON(buf []byte) (retErr error) {", structName)
+	} else {
+		o.LL("func (h *%s) UnmarshalJSON(buf []byte) error {", structName)
+	}
 	o.L(`h.mu.Lock()`)
 	o.L(`defer h.mu.Unlock()`)
 	for _, f := range obj.Fields() {
 		o.L("h.%s = nil", f.Name(false))
+	}
+
+	if hasSensitiveFields {
+		o.L("defer func() {")
+		o.L("if retErr != nil {")
+		for _, f := range obj.Fields() {
+			if f.Type() == "[]byte" {
+				o.L("clear(h.%s)", f.Name(false))
+				o.L("h.%s = nil", f.Name(false))
+			}
+		}
+		o.L("}")
+		o.L("}()")
 	}
 
 	o.L("dec := json.NewDecoder(bytes.NewReader(buf))")


### PR DESCRIPTION
When UnmarshalJSON fails mid-parse on private/symmetric key types, already-decoded sensitive byte fields (d, p, q, dp, dq, qi, octets) now get zeroed and nilled via a defer cleanup before the error is returned.