### PR TITLE
fix inconsistent mutex locking in data structures

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,14 @@ v3 has many incompatibilities with v2. To see the full list of differences betwe
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
 v3.0.14 UNRELEASED
+  * [jwt][jwe][jws][jwk] Fix inconsistent mutex locking across main data
+    structures. Named getters on JWK key types, MarshalJSON on JWK keys,
+    UnmarshalJSON on JWE headers, makePairs/MarshalJSON on JWT tokens,
+    rawBuffer on JWS headers, and Set/Keys on jwk.Set were missing proper
+    lock protection. Switch all mutex fields from *sync.RWMutex (pointer)
+    to sync.RWMutex (value) so go vet -copylocks catches accidental copies,
+    and convert affected value-receiver methods to pointer receivers.
+
   * [jwt][jwe][jws] Add `WithMaxParseInputSize(int64)` to limit bytes read from
     an `io.Reader` in `ParseReader` and `ReadFile`. Default is 10 MB. Can be set
     globally via `Settings()` or per-call. (#1630, #1632)

--- a/jwe/headers_gen.go
+++ b/jwe/headers_gen.go
@@ -108,12 +108,11 @@ type stdHeaders struct {
 	x509CertThumbprintS256 *string
 	x509URL                *string
 	privateParams          map[string]any
-	mu                     *sync.RWMutex
+	mu                     sync.RWMutex
 }
 
 func NewHeaders() Headers {
 	return &stdHeaders{
-		mu:            &sync.RWMutex{},
 		privateParams: map[string]any{},
 	}
 }
@@ -594,6 +593,8 @@ func (h *stdHeaders) Remove(key string) error {
 }
 
 func (h *stdHeaders) UnmarshalJSON(buf []byte) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	h.agreementPartyUInfo = nil
 	h.agreementPartyVInfo = nil
 	h.algorithm = nil
@@ -786,7 +787,7 @@ func (h *stdHeaders) Keys() []string {
 	return keys
 }
 
-func (h stdHeaders) MarshalJSON() ([]byte, error) {
+func (h *stdHeaders) MarshalJSON() ([]byte, error) {
 	data := make(map[string]any)
 	keys := make([]string, 0, 16+len(h.privateParams))
 	h.mu.RLock()

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -170,34 +170,64 @@ func ecdsaJWKToRaw(keyif Key, hint any) (any, error) {
 			}
 		}
 
-		locker, ok := k.(rlocker)
-		if ok {
+		// rlocker is unexported with unexported methods, so only our
+		// concrete types implement it. A successful assertion lets us
+		// type-assert to the concrete struct and read fields directly
+		// under a single batch lock. This avoids nested RLock (which
+		// deadlocks when a writer is pending) while preserving an
+		// atomic snapshot of all fields.
+		var crv jwa.EllipticCurveAlgorithm
+		var hasCrv bool
+		var od, ox, oy []byte
+		if locker, ok := k.(rlocker); ok {
 			locker.rlock()
-			defer locker.runlock()
+			concrete := k.(*ecdsaPrivateKey)
+			if concrete.crv != nil {
+				crv = *(concrete.crv)
+				hasCrv = true
+			}
+			od, ox, oy = concrete.d, concrete.x, concrete.y
+			locker.runlock()
+		} else {
+			// External implementation — use self-locking interface getters.
+			var ok bool
+			if crv, ok = k.Crv(); !ok {
+				return nil, fmt.Errorf(`missing "crv" field`)
+			}
+			hasCrv = true
+			if od, ok = k.D(); !ok {
+				return nil, fmt.Errorf(`missing "d" field`)
+			}
+			if ox, ok = k.X(); !ok {
+				return nil, fmt.Errorf(`missing "x" field`)
+			}
+			if oy, ok = k.Y(); !ok {
+				return nil, fmt.Errorf(`missing "y" field`)
+			}
 		}
 
-		crv, ok := k.Crv()
-		if !ok {
+		if !hasCrv {
 			return nil, fmt.Errorf(`missing "crv" field`)
 		}
 
 		if isECDH {
-			d, ok := k.D()
-			if !ok {
+			if od == nil {
 				return nil, fmt.Errorf(`missing "d" field`)
 			}
-			return buildECDHPrivateKey(crv, d)
+			return buildECDHPrivateKey(crv, od)
 		}
 
-		x, ok := k.X()
-		if !ok {
+		if ox == nil {
 			return nil, fmt.Errorf(`missing "x" field`)
 		}
-		y, ok := k.Y()
-		if !ok {
+		if oy == nil {
 			return nil, fmt.Errorf(`missing "y" field`)
 		}
-		pubk, err := buildECDSAPublicKey(crv, x, y)
+		if od == nil {
+			return nil, fmt.Errorf(`missing "d" field`)
+		}
+
+		pubk, err := buildECDSAPublicKey(crv, ox, oy)
 		if err != nil {
 			return nil, fmt.Errorf(`failed to build public key: %w`, err)
 		}
@@ -205,12 +235,7 @@ func ecdsaJWKToRaw(keyif Key, hint any) (any, error) {
 		var key ecdsa.PrivateKey
 		var d big.Int
 
-		origD, ok := k.D()
-		if !ok {
-			return nil, fmt.Errorf(`missing "d" field`)
-		}
-
-		d.SetBytes(origD)
+		d.SetBytes(od)
 		key.D = &d
 		key.PublicKey = *pubk
 
@@ -231,24 +256,40 @@ func ecdsaJWKToRaw(keyif Key, hint any) (any, error) {
 			}
 		}
 
-		locker, ok := k.(rlocker)
-		if ok {
+		// See ECDSAPrivateKey case above for explanation of the rlocker pattern.
+		var crv jwa.EllipticCurveAlgorithm
+		var hasCrv bool
+		var x, y []byte
+		if locker, ok := k.(rlocker); ok {
 			locker.rlock()
-			defer locker.runlock()
+			concrete := k.(*ecdsaPublicKey)
+			if concrete.crv != nil {
+				crv = *(concrete.crv)
+				hasCrv = true
+			}
+			x, y = concrete.x, concrete.y
+			locker.runlock()
+		} else {
+			var ok bool
+			if crv, ok = k.Crv(); !ok {
+				return nil, fmt.Errorf(`missing "crv" field`)
+			}
+			hasCrv = true
+			if x, ok = k.X(); !ok {
+				return nil, fmt.Errorf(`missing "x" field`)
+			}
+			if y, ok = k.Y(); !ok {
+				return nil, fmt.Errorf(`missing "y" field`)
+			}
 		}
 
-		crv, ok := k.Crv()
-		if !ok {
+		if !hasCrv {
 			return nil, fmt.Errorf(`missing "crv" field`)
 		}
-
-		x, ok := k.X()
-		if !ok {
+		if x == nil {
 			return nil, fmt.Errorf(`missing "x" field`)
 		}
-
-		y, ok := k.Y()
-		if !ok {
+		if y == nil {
 			return nil, fmt.Errorf(`missing "y" field`)
 		}
 		if isECDH {

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -181,7 +181,7 @@ func ecdsaJWKToRaw(keyif Key, hint any) (any, error) {
 		var od, ox, oy []byte
 		if locker, ok := k.(rlocker); ok {
 			locker.rlock()
-			concrete := k.(*ecdsaPrivateKey)
+			concrete := k.(*ecdsaPrivateKey) //nolint:forcetypeassert // rlocker is unexported; only our concrete types implement it
 			if concrete.crv != nil {
 				crv = *(concrete.crv)
 				hasCrv = true
@@ -262,7 +262,7 @@ func ecdsaJWKToRaw(keyif Key, hint any) (any, error) {
 		var x, y []byte
 		if locker, ok := k.(rlocker); ok {
 			locker.rlock()
-			concrete := k.(*ecdsaPublicKey)
+			concrete := k.(*ecdsaPublicKey) //nolint:forcetypeassert // rlocker is unexported; only our concrete types implement it
 			if concrete.crv != nil {
 				crv = *(concrete.crv)
 				hasCrv = true

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -346,12 +346,12 @@ func ecdsaThumbprint(hash crypto.Hash, crv, x, y string) []byte {
 
 // Thumbprint returns the JWK thumbprint using the indicated
 // hashing algorithm, according to RFC 7638
-func (k ecdsaPublicKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
+func (k *ecdsaPublicKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	k.mu.RLock()
 	defer k.mu.RUnlock()
 
 	var key ecdsa.PublicKey
-	if err := Export(&k, &key); err != nil {
+	if err := Export(k, &key); err != nil {
 		return nil, fmt.Errorf(`failed to export ecdsa.PublicKey for thumbprint generation: %w`, err)
 	}
 
@@ -370,12 +370,12 @@ func (k ecdsaPublicKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 
 // Thumbprint returns the JWK thumbprint using the indicated
 // hashing algorithm, according to RFC 7638
-func (k ecdsaPrivateKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
+func (k *ecdsaPrivateKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	k.mu.RLock()
 	defer k.mu.RUnlock()
 
 	var key ecdsa.PrivateKey
-	if err := Export(&k, &key); err != nil {
+	if err := Export(k, &key); err != nil {
 		return nil, fmt.Errorf(`failed to export ecdsa.PrivateKey for thumbprint generation: %w`, err)
 	}
 

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -45,7 +45,7 @@ type ecdsaPublicKey struct {
 	x509URL                *string     // https://tools.ietf.org/html/rfc7515#section-4.1.5
 	y                      []byte
 	privateParams          map[string]any
-	mu                     *sync.RWMutex
+	mu                     sync.RWMutex
 	dc                     json.DecodeCtx
 }
 
@@ -54,28 +54,29 @@ var _ Key = &ecdsaPublicKey{}
 
 func newECDSAPublicKey() *ecdsaPublicKey {
 	return &ecdsaPublicKey{
-		mu:            &sync.RWMutex{},
 		privateParams: make(map[string]any),
 	}
 }
 
-func (h ecdsaPublicKey) KeyType() jwa.KeyType {
+func (h *ecdsaPublicKey) KeyType() jwa.KeyType {
 	return jwa.EC()
 }
 
-func (h ecdsaPublicKey) rlock() {
+func (h *ecdsaPublicKey) rlock() {
 	h.mu.RLock()
 }
 
-func (h ecdsaPublicKey) runlock() {
+func (h *ecdsaPublicKey) runlock() {
 	h.mu.RUnlock()
 }
 
-func (h ecdsaPublicKey) IsPrivate() bool {
+func (h *ecdsaPublicKey) IsPrivate() bool {
 	return false
 }
 
 func (h *ecdsaPublicKey) Algorithm() (jwa.KeyAlgorithm, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		return *(h.algorithm), true
 	}
@@ -83,6 +84,8 @@ func (h *ecdsaPublicKey) Algorithm() (jwa.KeyAlgorithm, bool) {
 }
 
 func (h *ecdsaPublicKey) Crv() (jwa.EllipticCurveAlgorithm, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.crv != nil {
 		return *(h.crv), true
 	}
@@ -90,6 +93,8 @@ func (h *ecdsaPublicKey) Crv() (jwa.EllipticCurveAlgorithm, bool) {
 }
 
 func (h *ecdsaPublicKey) KeyID() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyID != nil {
 		return *(h.keyID), true
 	}
@@ -97,6 +102,8 @@ func (h *ecdsaPublicKey) KeyID() (string, bool) {
 }
 
 func (h *ecdsaPublicKey) KeyOps() (KeyOperationList, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyOps != nil {
 		return *(h.keyOps), true
 	}
@@ -104,6 +111,8 @@ func (h *ecdsaPublicKey) KeyOps() (KeyOperationList, bool) {
 }
 
 func (h *ecdsaPublicKey) KeyUsage() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyUsage != nil {
 		return *(h.keyUsage), true
 	}
@@ -111,6 +120,8 @@ func (h *ecdsaPublicKey) KeyUsage() (string, bool) {
 }
 
 func (h *ecdsaPublicKey) X() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x != nil {
 		return h.x, true
 	}
@@ -118,6 +129,8 @@ func (h *ecdsaPublicKey) X() ([]byte, bool) {
 }
 
 func (h *ecdsaPublicKey) X509CertChain() (*cert.Chain, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertChain != nil {
 		return h.x509CertChain, true
 	}
@@ -125,6 +138,8 @@ func (h *ecdsaPublicKey) X509CertChain() (*cert.Chain, bool) {
 }
 
 func (h *ecdsaPublicKey) X509CertThumbprint() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertThumbprint != nil {
 		return *(h.x509CertThumbprint), true
 	}
@@ -132,6 +147,8 @@ func (h *ecdsaPublicKey) X509CertThumbprint() (string, bool) {
 }
 
 func (h *ecdsaPublicKey) X509CertThumbprintS256() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertThumbprintS256 != nil {
 		return *(h.x509CertThumbprintS256), true
 	}
@@ -139,6 +156,8 @@ func (h *ecdsaPublicKey) X509CertThumbprintS256() (string, bool) {
 }
 
 func (h *ecdsaPublicKey) X509URL() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509URL != nil {
 		return *(h.x509URL), true
 	}
@@ -146,6 +165,8 @@ func (h *ecdsaPublicKey) X509URL() (string, bool) {
 }
 
 func (h *ecdsaPublicKey) Y() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.y != nil {
 		return h.y, true
 	}
@@ -586,11 +607,12 @@ LOOP:
 	return nil
 }
 
-func (h ecdsaPublicKey) MarshalJSON() ([]byte, error) {
+func (h *ecdsaPublicKey) MarshalJSON() ([]byte, error) {
 	data := make(map[string]any)
 	fields := make([]string, 0, 11)
 	data[KeyTypeKey] = jwa.EC()
 	fields = append(fields, KeyTypeKey)
+	h.mu.RLock()
 	if h.algorithm != nil {
 		data[AlgorithmKey] = *(h.algorithm)
 		fields = append(fields, AlgorithmKey)
@@ -639,6 +661,7 @@ func (h ecdsaPublicKey) MarshalJSON() ([]byte, error) {
 		data[k] = v
 		fields = append(fields, k)
 	}
+	h.mu.RUnlock()
 
 	sort.Strings(fields)
 	buf := pool.BytesBuffer().Get()
@@ -737,7 +760,7 @@ type ecdsaPrivateKey struct {
 	x509URL                *string     // https://tools.ietf.org/html/rfc7515#section-4.1.5
 	y                      []byte
 	privateParams          map[string]any
-	mu                     *sync.RWMutex
+	mu                     sync.RWMutex
 	dc                     json.DecodeCtx
 }
 
@@ -746,28 +769,29 @@ var _ Key = &ecdsaPrivateKey{}
 
 func newECDSAPrivateKey() *ecdsaPrivateKey {
 	return &ecdsaPrivateKey{
-		mu:            &sync.RWMutex{},
 		privateParams: make(map[string]any),
 	}
 }
 
-func (h ecdsaPrivateKey) KeyType() jwa.KeyType {
+func (h *ecdsaPrivateKey) KeyType() jwa.KeyType {
 	return jwa.EC()
 }
 
-func (h ecdsaPrivateKey) rlock() {
+func (h *ecdsaPrivateKey) rlock() {
 	h.mu.RLock()
 }
 
-func (h ecdsaPrivateKey) runlock() {
+func (h *ecdsaPrivateKey) runlock() {
 	h.mu.RUnlock()
 }
 
-func (h ecdsaPrivateKey) IsPrivate() bool {
+func (h *ecdsaPrivateKey) IsPrivate() bool {
 	return true
 }
 
 func (h *ecdsaPrivateKey) Algorithm() (jwa.KeyAlgorithm, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		return *(h.algorithm), true
 	}
@@ -775,6 +799,8 @@ func (h *ecdsaPrivateKey) Algorithm() (jwa.KeyAlgorithm, bool) {
 }
 
 func (h *ecdsaPrivateKey) Crv() (jwa.EllipticCurveAlgorithm, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.crv != nil {
 		return *(h.crv), true
 	}
@@ -782,6 +808,8 @@ func (h *ecdsaPrivateKey) Crv() (jwa.EllipticCurveAlgorithm, bool) {
 }
 
 func (h *ecdsaPrivateKey) D() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.d != nil {
 		return h.d, true
 	}
@@ -789,6 +817,8 @@ func (h *ecdsaPrivateKey) D() ([]byte, bool) {
 }
 
 func (h *ecdsaPrivateKey) KeyID() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyID != nil {
 		return *(h.keyID), true
 	}
@@ -796,6 +826,8 @@ func (h *ecdsaPrivateKey) KeyID() (string, bool) {
 }
 
 func (h *ecdsaPrivateKey) KeyOps() (KeyOperationList, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyOps != nil {
 		return *(h.keyOps), true
 	}
@@ -803,6 +835,8 @@ func (h *ecdsaPrivateKey) KeyOps() (KeyOperationList, bool) {
 }
 
 func (h *ecdsaPrivateKey) KeyUsage() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyUsage != nil {
 		return *(h.keyUsage), true
 	}
@@ -810,6 +844,8 @@ func (h *ecdsaPrivateKey) KeyUsage() (string, bool) {
 }
 
 func (h *ecdsaPrivateKey) X() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x != nil {
 		return h.x, true
 	}
@@ -817,6 +853,8 @@ func (h *ecdsaPrivateKey) X() ([]byte, bool) {
 }
 
 func (h *ecdsaPrivateKey) X509CertChain() (*cert.Chain, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertChain != nil {
 		return h.x509CertChain, true
 	}
@@ -824,6 +862,8 @@ func (h *ecdsaPrivateKey) X509CertChain() (*cert.Chain, bool) {
 }
 
 func (h *ecdsaPrivateKey) X509CertThumbprint() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertThumbprint != nil {
 		return *(h.x509CertThumbprint), true
 	}
@@ -831,6 +871,8 @@ func (h *ecdsaPrivateKey) X509CertThumbprint() (string, bool) {
 }
 
 func (h *ecdsaPrivateKey) X509CertThumbprintS256() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertThumbprintS256 != nil {
 		return *(h.x509CertThumbprintS256), true
 	}
@@ -838,6 +880,8 @@ func (h *ecdsaPrivateKey) X509CertThumbprintS256() (string, bool) {
 }
 
 func (h *ecdsaPrivateKey) X509URL() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509URL != nil {
 		return *(h.x509URL), true
 	}
@@ -845,6 +889,8 @@ func (h *ecdsaPrivateKey) X509URL() (string, bool) {
 }
 
 func (h *ecdsaPrivateKey) Y() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.y != nil {
 		return h.y, true
 	}
@@ -1326,11 +1372,12 @@ LOOP:
 	return nil
 }
 
-func (h ecdsaPrivateKey) MarshalJSON() ([]byte, error) {
+func (h *ecdsaPrivateKey) MarshalJSON() ([]byte, error) {
 	data := make(map[string]any)
 	fields := make([]string, 0, 12)
 	data[KeyTypeKey] = jwa.EC()
 	fields = append(fields, KeyTypeKey)
+	h.mu.RLock()
 	if h.algorithm != nil {
 		data[AlgorithmKey] = *(h.algorithm)
 		fields = append(fields, AlgorithmKey)
@@ -1383,6 +1430,7 @@ func (h ecdsaPrivateKey) MarshalJSON() ([]byte, error) {
 		data[k] = v
 		fields = append(fields, k)
 	}
+	h.mu.RUnlock()
 
 	sort.Strings(fields)
 	buf := pool.BytesBuffer().Get()

--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -313,7 +313,7 @@ func okpThumbprint(hash crypto.Hash, crv, x string) []byte {
 
 // Thumbprint returns the JWK thumbprint using the indicated
 // hashing algorithm, according to RFC 7638 / 8037
-func (k okpPublicKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
+func (k *okpPublicKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	k.mu.RLock()
 	defer k.mu.RUnlock()
 
@@ -330,7 +330,7 @@ func (k okpPublicKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 
 // Thumbprint returns the JWK thumbprint using the indicated
 // hashing algorithm, according to RFC 7638 / 8037
-func (k okpPrivateKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
+func (k *okpPrivateKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	k.mu.RLock()
 	defer k.mu.RUnlock()
 

--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -180,24 +180,46 @@ func okpJWKToRaw(key Key, _ any /* this is unused because this is half baked */)
 
 	switch key := extracted.(type) {
 	case OKPPrivateKey:
-		locker, ok := key.(rlocker)
-		if ok {
+		// rlocker is unexported with unexported methods, so only our
+		// concrete types implement it. A successful assertion lets us
+		// type-assert to the concrete struct and read fields directly
+		// under a single batch lock. This avoids nested RLock (which
+		// deadlocks when a writer is pending) while preserving an
+		// atomic snapshot of all fields.
+		var crv jwa.EllipticCurveAlgorithm
+		var hasCrv bool
+		var x, d []byte
+		if locker, ok := key.(rlocker); ok {
 			locker.rlock()
-			defer locker.runlock()
+			concrete := key.(*okpPrivateKey)
+			if concrete.crv != nil {
+				crv = *(concrete.crv)
+				hasCrv = true
+			}
+			x, d = concrete.x, concrete.d
+			locker.runlock()
+		} else {
+			// External implementation — use self-locking interface getters.
+			var ok bool
+			if crv, ok = key.Crv(); !ok {
+				return nil, fmt.Errorf(`missing "crv" field`)
+			}
+			hasCrv = true
+			if x, ok = key.X(); !ok {
+				return nil, fmt.Errorf(`missing "x" field`)
+			}
+			if d, ok = key.D(); !ok {
+				return nil, fmt.Errorf(`missing "d" field`)
+			}
 		}
 
-		crv, ok := key.Crv()
-		if !ok {
+		if !hasCrv {
 			return nil, fmt.Errorf(`missing "crv" field`)
 		}
-
-		x, ok := key.X()
-		if !ok {
+		if x == nil {
 			return nil, fmt.Errorf(`missing "x" field`)
 		}
-
-		d, ok := key.D()
-		if !ok {
+		if d == nil {
 			return nil, fmt.Errorf(`missing "d" field`)
 		}
 
@@ -207,21 +229,37 @@ func okpJWKToRaw(key Key, _ any /* this is unused because this is half baked */)
 		}
 		return privk, nil
 	case OKPPublicKey:
-		locker, ok := key.(rlocker)
-		if ok {
+		// See OKPPrivateKey case above for explanation of the rlocker pattern.
+		var crv jwa.EllipticCurveAlgorithm
+		var hasCrv bool
+		var x []byte
+		if locker, ok := key.(rlocker); ok {
 			locker.rlock()
-			defer locker.runlock()
+			concrete := key.(*okpPublicKey)
+			if concrete.crv != nil {
+				crv = *(concrete.crv)
+				hasCrv = true
+			}
+			x = concrete.x
+			locker.runlock()
+		} else {
+			var ok bool
+			if crv, ok = key.Crv(); !ok {
+				return nil, fmt.Errorf(`missing "crv" field`)
+			}
+			hasCrv = true
+			if x, ok = key.X(); !ok {
+				return nil, fmt.Errorf(`missing "x" field`)
+			}
 		}
 
-		crv, ok := key.Crv()
-		if !ok {
+		if !hasCrv {
 			return nil, fmt.Errorf(`missing "crv" field`)
 		}
-
-		x, ok := key.X()
-		if !ok {
+		if x == nil {
 			return nil, fmt.Errorf(`missing "x" field`)
 		}
+
 		pubk, err := buildOKPPublicKey(crv, x)
 		if err != nil {
 			return nil, fmt.Errorf(`jwk.OKPPublicKey: failed to build public key: %w`, err)

--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -191,7 +191,7 @@ func okpJWKToRaw(key Key, _ any /* this is unused because this is half baked */)
 		var x, d []byte
 		if locker, ok := key.(rlocker); ok {
 			locker.rlock()
-			concrete := key.(*okpPrivateKey)
+			concrete := key.(*okpPrivateKey) //nolint:forcetypeassert // rlocker is unexported; only our concrete types implement it
 			if concrete.crv != nil {
 				crv = *(concrete.crv)
 				hasCrv = true
@@ -235,7 +235,7 @@ func okpJWKToRaw(key Key, _ any /* this is unused because this is half baked */)
 		var x []byte
 		if locker, ok := key.(rlocker); ok {
 			locker.rlock()
-			concrete := key.(*okpPublicKey)
+			concrete := key.(*okpPublicKey) //nolint:forcetypeassert // rlocker is unexported; only our concrete types implement it
 			if concrete.crv != nil {
 				crv = *(concrete.crv)
 				hasCrv = true

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -42,7 +42,7 @@ type okpPublicKey struct {
 	x509CertThumbprintS256 *string     // https://tools.ietf.org/html/rfc7515#section-4.1.8
 	x509URL                *string     // https://tools.ietf.org/html/rfc7515#section-4.1.5
 	privateParams          map[string]any
-	mu                     *sync.RWMutex
+	mu                     sync.RWMutex
 	dc                     json.DecodeCtx
 }
 
@@ -51,28 +51,29 @@ var _ Key = &okpPublicKey{}
 
 func newOKPPublicKey() *okpPublicKey {
 	return &okpPublicKey{
-		mu:            &sync.RWMutex{},
 		privateParams: make(map[string]any),
 	}
 }
 
-func (h okpPublicKey) KeyType() jwa.KeyType {
+func (h *okpPublicKey) KeyType() jwa.KeyType {
 	return jwa.OKP()
 }
 
-func (h okpPublicKey) rlock() {
+func (h *okpPublicKey) rlock() {
 	h.mu.RLock()
 }
 
-func (h okpPublicKey) runlock() {
+func (h *okpPublicKey) runlock() {
 	h.mu.RUnlock()
 }
 
-func (h okpPublicKey) IsPrivate() bool {
+func (h *okpPublicKey) IsPrivate() bool {
 	return false
 }
 
 func (h *okpPublicKey) Algorithm() (jwa.KeyAlgorithm, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		return *(h.algorithm), true
 	}
@@ -80,6 +81,8 @@ func (h *okpPublicKey) Algorithm() (jwa.KeyAlgorithm, bool) {
 }
 
 func (h *okpPublicKey) Crv() (jwa.EllipticCurveAlgorithm, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.crv != nil {
 		return *(h.crv), true
 	}
@@ -87,6 +90,8 @@ func (h *okpPublicKey) Crv() (jwa.EllipticCurveAlgorithm, bool) {
 }
 
 func (h *okpPublicKey) KeyID() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyID != nil {
 		return *(h.keyID), true
 	}
@@ -94,6 +99,8 @@ func (h *okpPublicKey) KeyID() (string, bool) {
 }
 
 func (h *okpPublicKey) KeyOps() (KeyOperationList, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyOps != nil {
 		return *(h.keyOps), true
 	}
@@ -101,6 +108,8 @@ func (h *okpPublicKey) KeyOps() (KeyOperationList, bool) {
 }
 
 func (h *okpPublicKey) KeyUsage() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyUsage != nil {
 		return *(h.keyUsage), true
 	}
@@ -108,6 +117,8 @@ func (h *okpPublicKey) KeyUsage() (string, bool) {
 }
 
 func (h *okpPublicKey) X() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x != nil {
 		return h.x, true
 	}
@@ -115,6 +126,8 @@ func (h *okpPublicKey) X() ([]byte, bool) {
 }
 
 func (h *okpPublicKey) X509CertChain() (*cert.Chain, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertChain != nil {
 		return h.x509CertChain, true
 	}
@@ -122,6 +135,8 @@ func (h *okpPublicKey) X509CertChain() (*cert.Chain, bool) {
 }
 
 func (h *okpPublicKey) X509CertThumbprint() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertThumbprint != nil {
 		return *(h.x509CertThumbprint), true
 	}
@@ -129,6 +144,8 @@ func (h *okpPublicKey) X509CertThumbprint() (string, bool) {
 }
 
 func (h *okpPublicKey) X509CertThumbprintS256() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertThumbprintS256 != nil {
 		return *(h.x509CertThumbprintS256), true
 	}
@@ -136,6 +153,8 @@ func (h *okpPublicKey) X509CertThumbprintS256() (string, bool) {
 }
 
 func (h *okpPublicKey) X509URL() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509URL != nil {
 		return *(h.x509URL), true
 	}
@@ -545,11 +564,12 @@ LOOP:
 	return nil
 }
 
-func (h okpPublicKey) MarshalJSON() ([]byte, error) {
+func (h *okpPublicKey) MarshalJSON() ([]byte, error) {
 	data := make(map[string]any)
 	fields := make([]string, 0, 10)
 	data[KeyTypeKey] = jwa.OKP()
 	fields = append(fields, KeyTypeKey)
+	h.mu.RLock()
 	if h.algorithm != nil {
 		data[AlgorithmKey] = *(h.algorithm)
 		fields = append(fields, AlgorithmKey)
@@ -594,6 +614,7 @@ func (h okpPublicKey) MarshalJSON() ([]byte, error) {
 		data[k] = v
 		fields = append(fields, k)
 	}
+	h.mu.RUnlock()
 
 	sort.Strings(fields)
 	buf := pool.BytesBuffer().Get()
@@ -687,7 +708,7 @@ type okpPrivateKey struct {
 	x509CertThumbprintS256 *string     // https://tools.ietf.org/html/rfc7515#section-4.1.8
 	x509URL                *string     // https://tools.ietf.org/html/rfc7515#section-4.1.5
 	privateParams          map[string]any
-	mu                     *sync.RWMutex
+	mu                     sync.RWMutex
 	dc                     json.DecodeCtx
 }
 
@@ -696,28 +717,29 @@ var _ Key = &okpPrivateKey{}
 
 func newOKPPrivateKey() *okpPrivateKey {
 	return &okpPrivateKey{
-		mu:            &sync.RWMutex{},
 		privateParams: make(map[string]any),
 	}
 }
 
-func (h okpPrivateKey) KeyType() jwa.KeyType {
+func (h *okpPrivateKey) KeyType() jwa.KeyType {
 	return jwa.OKP()
 }
 
-func (h okpPrivateKey) rlock() {
+func (h *okpPrivateKey) rlock() {
 	h.mu.RLock()
 }
 
-func (h okpPrivateKey) runlock() {
+func (h *okpPrivateKey) runlock() {
 	h.mu.RUnlock()
 }
 
-func (h okpPrivateKey) IsPrivate() bool {
+func (h *okpPrivateKey) IsPrivate() bool {
 	return true
 }
 
 func (h *okpPrivateKey) Algorithm() (jwa.KeyAlgorithm, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		return *(h.algorithm), true
 	}
@@ -725,6 +747,8 @@ func (h *okpPrivateKey) Algorithm() (jwa.KeyAlgorithm, bool) {
 }
 
 func (h *okpPrivateKey) Crv() (jwa.EllipticCurveAlgorithm, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.crv != nil {
 		return *(h.crv), true
 	}
@@ -732,6 +756,8 @@ func (h *okpPrivateKey) Crv() (jwa.EllipticCurveAlgorithm, bool) {
 }
 
 func (h *okpPrivateKey) D() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.d != nil {
 		return h.d, true
 	}
@@ -739,6 +765,8 @@ func (h *okpPrivateKey) D() ([]byte, bool) {
 }
 
 func (h *okpPrivateKey) KeyID() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyID != nil {
 		return *(h.keyID), true
 	}
@@ -746,6 +774,8 @@ func (h *okpPrivateKey) KeyID() (string, bool) {
 }
 
 func (h *okpPrivateKey) KeyOps() (KeyOperationList, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyOps != nil {
 		return *(h.keyOps), true
 	}
@@ -753,6 +783,8 @@ func (h *okpPrivateKey) KeyOps() (KeyOperationList, bool) {
 }
 
 func (h *okpPrivateKey) KeyUsage() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyUsage != nil {
 		return *(h.keyUsage), true
 	}
@@ -760,6 +792,8 @@ func (h *okpPrivateKey) KeyUsage() (string, bool) {
 }
 
 func (h *okpPrivateKey) X() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x != nil {
 		return h.x, true
 	}
@@ -767,6 +801,8 @@ func (h *okpPrivateKey) X() ([]byte, bool) {
 }
 
 func (h *okpPrivateKey) X509CertChain() (*cert.Chain, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertChain != nil {
 		return h.x509CertChain, true
 	}
@@ -774,6 +810,8 @@ func (h *okpPrivateKey) X509CertChain() (*cert.Chain, bool) {
 }
 
 func (h *okpPrivateKey) X509CertThumbprint() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertThumbprint != nil {
 		return *(h.x509CertThumbprint), true
 	}
@@ -781,6 +819,8 @@ func (h *okpPrivateKey) X509CertThumbprint() (string, bool) {
 }
 
 func (h *okpPrivateKey) X509CertThumbprintS256() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertThumbprintS256 != nil {
 		return *(h.x509CertThumbprintS256), true
 	}
@@ -788,6 +828,8 @@ func (h *okpPrivateKey) X509CertThumbprintS256() (string, bool) {
 }
 
 func (h *okpPrivateKey) X509URL() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509URL != nil {
 		return *(h.x509URL), true
 	}
@@ -1236,11 +1278,12 @@ LOOP:
 	return nil
 }
 
-func (h okpPrivateKey) MarshalJSON() ([]byte, error) {
+func (h *okpPrivateKey) MarshalJSON() ([]byte, error) {
 	data := make(map[string]any)
 	fields := make([]string, 0, 11)
 	data[KeyTypeKey] = jwa.OKP()
 	fields = append(fields, KeyTypeKey)
+	h.mu.RLock()
 	if h.algorithm != nil {
 		data[AlgorithmKey] = *(h.algorithm)
 		fields = append(fields, AlgorithmKey)
@@ -1289,6 +1332,7 @@ func (h okpPrivateKey) MarshalJSON() ([]byte, error) {
 		data[k] = v
 		fields = append(fields, k)
 	}
+	h.mu.RUnlock()
 
 	sort.Strings(fields)
 	buf := pool.BytesBuffer().Get()

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -132,25 +132,66 @@ func rsaJWKToRaw(key Key, hint any) (any, error) {
 			return nil, fmt.Errorf(`invalid destination object type %T for private RSA JWK: %w`, hint, ContinueError())
 		}
 
-		locker, ok := key.(rlocker)
-		if ok {
+		// rlocker is unexported with unexported methods, so only our
+		// concrete types implement it. A successful assertion lets us
+		// type-assert to the concrete struct and read fields directly
+		// under a single batch lock. This avoids nested RLock (which
+		// deadlocks when a writer is pending) while preserving an
+		// atomic snapshot of all fields.
+		var od, oq, op, on, oe []byte
+		var odp, odq, oqi []byte
+		var hasDp, hasDq, hasQi bool
+		if locker, ok := key.(rlocker); ok {
 			locker.rlock()
-			defer locker.runlock()
+			concrete := key.(*rsaPrivateKey)
+			od, oq, op, on, oe = concrete.d, concrete.q, concrete.p, concrete.n, concrete.e
+			if concrete.dp != nil {
+				odp, hasDp = concrete.dp, true
+			}
+			if concrete.dq != nil {
+				odq, hasDq = concrete.dq, true
+			}
+			if concrete.qi != nil {
+				oqi, hasQi = concrete.qi, true
+			}
+			locker.runlock()
+		} else {
+			// External implementation — use self-locking interface getters.
+			var ok bool
+			if od, ok = key.D(); !ok {
+				return nil, fmt.Errorf(`missing "d" value`)
+			}
+			if oq, ok = key.Q(); !ok {
+				return nil, fmt.Errorf(`missing "q" value`)
+			}
+			if op, ok = key.P(); !ok {
+				return nil, fmt.Errorf(`missing "p" value`)
+			}
+			if on, ok = key.N(); !ok {
+				return nil, fmt.Errorf(`missing "n" value`)
+			}
+			if oe, ok = key.E(); !ok {
+				return nil, fmt.Errorf(`missing "e" value`)
+			}
+			odp, hasDp = key.DP()
+			odq, hasDq = key.DQ()
+			oqi, hasQi = key.QI()
 		}
 
-		od, ok := key.D()
-		if !ok {
+		if od == nil {
 			return nil, fmt.Errorf(`missing "d" value`)
 		}
-
-		oq, ok := key.Q()
-		if !ok {
+		if oq == nil {
 			return nil, fmt.Errorf(`missing "q" value`)
 		}
-
-		op, ok := key.P()
-		if !ok {
+		if op == nil {
 			return nil, fmt.Errorf(`missing "p" value`)
+		}
+		if on == nil {
+			return nil, fmt.Errorf(`missing "n" value`)
+		}
+		if oe == nil {
+			return nil, fmt.Errorf(`missing "e" value`)
 		}
 
 		var d, q, p big.Int // note: do not use from sync.Pool
@@ -159,36 +200,25 @@ func rsaJWKToRaw(key Key, hint any) (any, error) {
 		q.SetBytes(oq)
 		p.SetBytes(op)
 
-		// optional fields
 		var dp, dq, qi *big.Int
 
-		if odp, ok := key.DP(); ok {
+		if hasDp {
 			dp = &big.Int{} // note: do not use from sync.Pool
 			dp.SetBytes(odp)
 		}
 
-		if odq, ok := key.DQ(); ok {
+		if hasDq {
 			dq = &big.Int{} // note: do not use from sync.Pool
 			dq.SetBytes(odq)
 		}
 
-		if oqi, ok := key.QI(); ok {
+		if hasQi {
 			qi = &big.Int{} // note: do not use from sync.Pool
 			qi.SetBytes(oqi)
 		}
 
-		n, ok := key.N()
-		if !ok {
-			return nil, fmt.Errorf(`missing "n" value`)
-		}
-
-		e, ok := key.E()
-		if !ok {
-			return nil, fmt.Errorf(`missing "e" value`)
-		}
-
 		var privkey rsa.PrivateKey
-		buildRSAPublicKey(&privkey.PublicKey, n, e)
+		buildRSAPublicKey(&privkey.PublicKey, on, oe)
 		privkey.D = &d
 		privkey.Primes = []*big.Int{&p, &q}
 
@@ -212,19 +242,27 @@ func rsaJWKToRaw(key Key, hint any) (any, error) {
 			return nil, fmt.Errorf(`invalid destination object type %T for public RSA JWK: %w`, hint, ContinueError())
 		}
 
-		locker, ok := key.(rlocker)
-		if ok {
+		var n, e []byte
+		// See RSAPrivateKey case above for explanation of the rlocker pattern.
+		if locker, ok := key.(rlocker); ok {
 			locker.rlock()
-			defer locker.runlock()
+			concrete := key.(*rsaPublicKey)
+			n, e = concrete.n, concrete.e
+			locker.runlock()
+		} else {
+			var ok bool
+			if n, ok = key.N(); !ok {
+				return nil, fmt.Errorf(`missing "n" value`)
+			}
+			if e, ok = key.E(); !ok {
+				return nil, fmt.Errorf(`missing "e" value`)
+			}
 		}
 
-		n, ok := key.N()
-		if !ok {
+		if n == nil {
 			return nil, fmt.Errorf(`missing "n" value`)
 		}
-
-		e, ok := key.E()
-		if !ok {
+		if e == nil {
 			return nil, fmt.Errorf(`missing "e" value`)
 		}
 

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -143,7 +143,7 @@ func rsaJWKToRaw(key Key, hint any) (any, error) {
 		var hasDp, hasDq, hasQi bool
 		if locker, ok := key.(rlocker); ok {
 			locker.rlock()
-			concrete := key.(*rsaPrivateKey)
+			concrete := key.(*rsaPrivateKey) //nolint:forcetypeassert // rlocker is unexported; only our concrete types implement it
 			od, oq, op, on, oe = concrete.d, concrete.q, concrete.p, concrete.n, concrete.e
 			if concrete.dp != nil {
 				odp, hasDp = concrete.dp, true
@@ -246,7 +246,7 @@ func rsaJWKToRaw(key Key, hint any) (any, error) {
 		// See RSAPrivateKey case above for explanation of the rlocker pattern.
 		if locker, ok := key.(rlocker); ok {
 			locker.rlock()
-			concrete := key.(*rsaPublicKey)
+			concrete := key.(*rsaPublicKey) //nolint:forcetypeassert // rlocker is unexported; only our concrete types implement it
 			n, e = concrete.n, concrete.e
 			locker.runlock()
 		} else {

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -308,23 +308,23 @@ func (k *rsaPublicKey) PublicKey() (Key, error) {
 
 // Thumbprint returns the JWK thumbprint using the indicated
 // hashing algorithm, according to RFC 7638
-func (k rsaPrivateKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
+func (k *rsaPrivateKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	k.mu.RLock()
 	defer k.mu.RUnlock()
 
 	var key rsa.PrivateKey
-	if err := Export(&k, &key); err != nil {
+	if err := Export(k, &key); err != nil {
 		return nil, fmt.Errorf(`failed to export RSA private key: %w`, err)
 	}
 	return rsaThumbprint(hash, &key.PublicKey)
 }
 
-func (k rsaPublicKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
+func (k *rsaPublicKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	k.mu.RLock()
 	defer k.mu.RUnlock()
 
 	var key rsa.PublicKey
-	if err := Export(&k, &key); err != nil {
+	if err := Export(k, &key); err != nil {
 		return nil, fmt.Errorf(`failed to export RSA public key: %w`, err)
 	}
 	return rsaThumbprint(hash, &key)

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -47,7 +47,7 @@ type rsaPublicKey struct {
 	x509CertThumbprintS256 *string     // https://tools.ietf.org/html/rfc7515#section-4.1.8
 	x509URL                *string     // https://tools.ietf.org/html/rfc7515#section-4.1.5
 	privateParams          map[string]any
-	mu                     *sync.RWMutex
+	mu                     sync.RWMutex
 	dc                     json.DecodeCtx
 }
 
@@ -56,28 +56,29 @@ var _ Key = &rsaPublicKey{}
 
 func newRSAPublicKey() *rsaPublicKey {
 	return &rsaPublicKey{
-		mu:            &sync.RWMutex{},
 		privateParams: make(map[string]any),
 	}
 }
 
-func (h rsaPublicKey) KeyType() jwa.KeyType {
+func (h *rsaPublicKey) KeyType() jwa.KeyType {
 	return jwa.RSA()
 }
 
-func (h rsaPublicKey) rlock() {
+func (h *rsaPublicKey) rlock() {
 	h.mu.RLock()
 }
 
-func (h rsaPublicKey) runlock() {
+func (h *rsaPublicKey) runlock() {
 	h.mu.RUnlock()
 }
 
-func (h rsaPublicKey) IsPrivate() bool {
+func (h *rsaPublicKey) IsPrivate() bool {
 	return false
 }
 
 func (h *rsaPublicKey) Algorithm() (jwa.KeyAlgorithm, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		return *(h.algorithm), true
 	}
@@ -85,6 +86,8 @@ func (h *rsaPublicKey) Algorithm() (jwa.KeyAlgorithm, bool) {
 }
 
 func (h *rsaPublicKey) E() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.e != nil {
 		return h.e, true
 	}
@@ -92,6 +95,8 @@ func (h *rsaPublicKey) E() ([]byte, bool) {
 }
 
 func (h *rsaPublicKey) KeyID() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyID != nil {
 		return *(h.keyID), true
 	}
@@ -99,6 +104,8 @@ func (h *rsaPublicKey) KeyID() (string, bool) {
 }
 
 func (h *rsaPublicKey) KeyOps() (KeyOperationList, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyOps != nil {
 		return *(h.keyOps), true
 	}
@@ -106,6 +113,8 @@ func (h *rsaPublicKey) KeyOps() (KeyOperationList, bool) {
 }
 
 func (h *rsaPublicKey) KeyUsage() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyUsage != nil {
 		return *(h.keyUsage), true
 	}
@@ -113,6 +122,8 @@ func (h *rsaPublicKey) KeyUsage() (string, bool) {
 }
 
 func (h *rsaPublicKey) N() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.n != nil {
 		return h.n, true
 	}
@@ -120,6 +131,8 @@ func (h *rsaPublicKey) N() ([]byte, bool) {
 }
 
 func (h *rsaPublicKey) X509CertChain() (*cert.Chain, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertChain != nil {
 		return h.x509CertChain, true
 	}
@@ -127,6 +140,8 @@ func (h *rsaPublicKey) X509CertChain() (*cert.Chain, bool) {
 }
 
 func (h *rsaPublicKey) X509CertThumbprint() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertThumbprint != nil {
 		return *(h.x509CertThumbprint), true
 	}
@@ -134,6 +149,8 @@ func (h *rsaPublicKey) X509CertThumbprint() (string, bool) {
 }
 
 func (h *rsaPublicKey) X509CertThumbprintS256() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertThumbprintS256 != nil {
 		return *(h.x509CertThumbprintS256), true
 	}
@@ -141,6 +158,8 @@ func (h *rsaPublicKey) X509CertThumbprintS256() (string, bool) {
 }
 
 func (h *rsaPublicKey) X509URL() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509URL != nil {
 		return *(h.x509URL), true
 	}
@@ -553,11 +572,12 @@ LOOP:
 	return nil
 }
 
-func (h rsaPublicKey) MarshalJSON() ([]byte, error) {
+func (h *rsaPublicKey) MarshalJSON() ([]byte, error) {
 	data := make(map[string]any)
 	fields := make([]string, 0, 10)
 	data[KeyTypeKey] = jwa.RSA()
 	fields = append(fields, KeyTypeKey)
+	h.mu.RLock()
 	if h.algorithm != nil {
 		data[AlgorithmKey] = *(h.algorithm)
 		fields = append(fields, AlgorithmKey)
@@ -602,6 +622,7 @@ func (h rsaPublicKey) MarshalJSON() ([]byte, error) {
 		data[k] = v
 		fields = append(fields, k)
 	}
+	h.mu.RUnlock()
 
 	sort.Strings(fields)
 	buf := pool.BytesBuffer().Get()
@@ -705,7 +726,7 @@ type rsaPrivateKey struct {
 	x509CertThumbprintS256 *string     // https://tools.ietf.org/html/rfc7515#section-4.1.8
 	x509URL                *string     // https://tools.ietf.org/html/rfc7515#section-4.1.5
 	privateParams          map[string]any
-	mu                     *sync.RWMutex
+	mu                     sync.RWMutex
 	dc                     json.DecodeCtx
 }
 
@@ -714,28 +735,29 @@ var _ Key = &rsaPrivateKey{}
 
 func newRSAPrivateKey() *rsaPrivateKey {
 	return &rsaPrivateKey{
-		mu:            &sync.RWMutex{},
 		privateParams: make(map[string]any),
 	}
 }
 
-func (h rsaPrivateKey) KeyType() jwa.KeyType {
+func (h *rsaPrivateKey) KeyType() jwa.KeyType {
 	return jwa.RSA()
 }
 
-func (h rsaPrivateKey) rlock() {
+func (h *rsaPrivateKey) rlock() {
 	h.mu.RLock()
 }
 
-func (h rsaPrivateKey) runlock() {
+func (h *rsaPrivateKey) runlock() {
 	h.mu.RUnlock()
 }
 
-func (h rsaPrivateKey) IsPrivate() bool {
+func (h *rsaPrivateKey) IsPrivate() bool {
 	return true
 }
 
 func (h *rsaPrivateKey) Algorithm() (jwa.KeyAlgorithm, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		return *(h.algorithm), true
 	}
@@ -743,6 +765,8 @@ func (h *rsaPrivateKey) Algorithm() (jwa.KeyAlgorithm, bool) {
 }
 
 func (h *rsaPrivateKey) D() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.d != nil {
 		return h.d, true
 	}
@@ -750,6 +774,8 @@ func (h *rsaPrivateKey) D() ([]byte, bool) {
 }
 
 func (h *rsaPrivateKey) DP() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.dp != nil {
 		return h.dp, true
 	}
@@ -757,6 +783,8 @@ func (h *rsaPrivateKey) DP() ([]byte, bool) {
 }
 
 func (h *rsaPrivateKey) DQ() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.dq != nil {
 		return h.dq, true
 	}
@@ -764,6 +792,8 @@ func (h *rsaPrivateKey) DQ() ([]byte, bool) {
 }
 
 func (h *rsaPrivateKey) E() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.e != nil {
 		return h.e, true
 	}
@@ -771,6 +801,8 @@ func (h *rsaPrivateKey) E() ([]byte, bool) {
 }
 
 func (h *rsaPrivateKey) KeyID() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyID != nil {
 		return *(h.keyID), true
 	}
@@ -778,6 +810,8 @@ func (h *rsaPrivateKey) KeyID() (string, bool) {
 }
 
 func (h *rsaPrivateKey) KeyOps() (KeyOperationList, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyOps != nil {
 		return *(h.keyOps), true
 	}
@@ -785,6 +819,8 @@ func (h *rsaPrivateKey) KeyOps() (KeyOperationList, bool) {
 }
 
 func (h *rsaPrivateKey) KeyUsage() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyUsage != nil {
 		return *(h.keyUsage), true
 	}
@@ -792,6 +828,8 @@ func (h *rsaPrivateKey) KeyUsage() (string, bool) {
 }
 
 func (h *rsaPrivateKey) N() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.n != nil {
 		return h.n, true
 	}
@@ -799,6 +837,8 @@ func (h *rsaPrivateKey) N() ([]byte, bool) {
 }
 
 func (h *rsaPrivateKey) P() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.p != nil {
 		return h.p, true
 	}
@@ -806,6 +846,8 @@ func (h *rsaPrivateKey) P() ([]byte, bool) {
 }
 
 func (h *rsaPrivateKey) Q() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.q != nil {
 		return h.q, true
 	}
@@ -813,6 +855,8 @@ func (h *rsaPrivateKey) Q() ([]byte, bool) {
 }
 
 func (h *rsaPrivateKey) QI() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.qi != nil {
 		return h.qi, true
 	}
@@ -820,6 +864,8 @@ func (h *rsaPrivateKey) QI() ([]byte, bool) {
 }
 
 func (h *rsaPrivateKey) X509CertChain() (*cert.Chain, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertChain != nil {
 		return h.x509CertChain, true
 	}
@@ -827,6 +873,8 @@ func (h *rsaPrivateKey) X509CertChain() (*cert.Chain, bool) {
 }
 
 func (h *rsaPrivateKey) X509CertThumbprint() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertThumbprint != nil {
 		return *(h.x509CertThumbprint), true
 	}
@@ -834,6 +882,8 @@ func (h *rsaPrivateKey) X509CertThumbprint() (string, bool) {
 }
 
 func (h *rsaPrivateKey) X509CertThumbprintS256() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertThumbprintS256 != nil {
 		return *(h.x509CertThumbprintS256), true
 	}
@@ -841,6 +891,8 @@ func (h *rsaPrivateKey) X509CertThumbprintS256() (string, bool) {
 }
 
 func (h *rsaPrivateKey) X509URL() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509URL != nil {
 		return *(h.x509URL), true
 	}
@@ -1444,11 +1496,12 @@ LOOP:
 	return nil
 }
 
-func (h rsaPrivateKey) MarshalJSON() ([]byte, error) {
+func (h *rsaPrivateKey) MarshalJSON() ([]byte, error) {
 	data := make(map[string]any)
 	fields := make([]string, 0, 16)
 	data[KeyTypeKey] = jwa.RSA()
 	fields = append(fields, KeyTypeKey)
+	h.mu.RLock()
 	if h.algorithm != nil {
 		data[AlgorithmKey] = *(h.algorithm)
 		fields = append(fields, AlgorithmKey)
@@ -1517,6 +1570,7 @@ func (h rsaPrivateKey) MarshalJSON() ([]byte, error) {
 		data[k] = v
 		fields = append(fields, k)
 	}
+	h.mu.RUnlock()
 
 	sort.Strings(fields)
 	buf := pool.BytesBuffer().Get()

--- a/jwk/set.go
+++ b/jwk/set.go
@@ -27,8 +27,8 @@ func NewSet() Set {
 }
 
 func (s *set) Set(n string, v any) error {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if n == keysKey {
 		vl, ok := v.([]Key)
@@ -144,6 +144,8 @@ func (s *set) Clear() error {
 }
 
 func (s *set) Keys() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	ret := make([]string, len(s.privateParams))
 	var i int
 	for k := range s.privateParams {

--- a/jwk/symmetric.go
+++ b/jwk/symmetric.go
@@ -44,14 +44,27 @@ func octetSeqToRaw(key Key, hint any) (any, error) {
 			return nil, fmt.Errorf(`invalid destination object type %T for symmetric key: %w`, hint, ContinueError())
 		}
 
-		locker, ok := key.(rlocker)
-		if ok {
+		// rlocker is unexported with unexported methods, so only our
+		// concrete types implement it. A successful assertion lets us
+		// type-assert to the concrete struct and read fields directly
+		// under a single batch lock. This avoids nested RLock (which
+		// deadlocks when a writer is pending) while preserving an
+		// atomic snapshot of all fields.
+		var ooctets []byte
+		if locker, ok := key.(rlocker); ok {
 			locker.rlock()
-			defer locker.runlock()
+			concrete := key.(*symmetricKey)
+			ooctets = concrete.octets
+			locker.runlock()
+		} else {
+			// External implementation — use self-locking interface getters.
+			var ok bool
+			if ooctets, ok = key.Octets(); !ok {
+				return nil, fmt.Errorf(`jwk.SymmetricKey: missing "k" field`)
+			}
 		}
 
-		ooctets, ok := key.Octets()
-		if !ok {
+		if ooctets == nil {
 			return nil, fmt.Errorf(`jwk.SymmetricKey: missing "k" field`)
 		}
 

--- a/jwk/symmetric.go
+++ b/jwk/symmetric.go
@@ -53,7 +53,7 @@ func octetSeqToRaw(key Key, hint any) (any, error) {
 		var ooctets []byte
 		if locker, ok := key.(rlocker); ok {
 			locker.rlock()
-			concrete := key.(*symmetricKey)
+			concrete := key.(*symmetricKey) //nolint:forcetypeassert // rlocker is unexported; only our concrete types implement it
 			ooctets = concrete.octets
 			locker.runlock()
 		} else {

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -38,7 +38,7 @@ type symmetricKey struct {
 	x509CertThumbprintS256 *string     // https://tools.ietf.org/html/rfc7515#section-4.1.8
 	x509URL                *string     // https://tools.ietf.org/html/rfc7515#section-4.1.5
 	privateParams          map[string]any
-	mu                     *sync.RWMutex
+	mu                     sync.RWMutex
 	dc                     json.DecodeCtx
 }
 
@@ -47,24 +47,25 @@ var _ Key = &symmetricKey{}
 
 func newSymmetricKey() *symmetricKey {
 	return &symmetricKey{
-		mu:            &sync.RWMutex{},
 		privateParams: make(map[string]any),
 	}
 }
 
-func (h symmetricKey) KeyType() jwa.KeyType {
+func (h *symmetricKey) KeyType() jwa.KeyType {
 	return jwa.OctetSeq()
 }
 
-func (h symmetricKey) rlock() {
+func (h *symmetricKey) rlock() {
 	h.mu.RLock()
 }
 
-func (h symmetricKey) runlock() {
+func (h *symmetricKey) runlock() {
 	h.mu.RUnlock()
 }
 
 func (h *symmetricKey) Algorithm() (jwa.KeyAlgorithm, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		return *(h.algorithm), true
 	}
@@ -72,6 +73,8 @@ func (h *symmetricKey) Algorithm() (jwa.KeyAlgorithm, bool) {
 }
 
 func (h *symmetricKey) KeyID() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyID != nil {
 		return *(h.keyID), true
 	}
@@ -79,6 +82,8 @@ func (h *symmetricKey) KeyID() (string, bool) {
 }
 
 func (h *symmetricKey) KeyOps() (KeyOperationList, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyOps != nil {
 		return *(h.keyOps), true
 	}
@@ -86,6 +91,8 @@ func (h *symmetricKey) KeyOps() (KeyOperationList, bool) {
 }
 
 func (h *symmetricKey) KeyUsage() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.keyUsage != nil {
 		return *(h.keyUsage), true
 	}
@@ -93,6 +100,8 @@ func (h *symmetricKey) KeyUsage() (string, bool) {
 }
 
 func (h *symmetricKey) Octets() ([]byte, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.octets != nil {
 		return h.octets, true
 	}
@@ -100,6 +109,8 @@ func (h *symmetricKey) Octets() ([]byte, bool) {
 }
 
 func (h *symmetricKey) X509CertChain() (*cert.Chain, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertChain != nil {
 		return h.x509CertChain, true
 	}
@@ -107,6 +118,8 @@ func (h *symmetricKey) X509CertChain() (*cert.Chain, bool) {
 }
 
 func (h *symmetricKey) X509CertThumbprint() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertThumbprint != nil {
 		return *(h.x509CertThumbprint), true
 	}
@@ -114,6 +127,8 @@ func (h *symmetricKey) X509CertThumbprint() (string, bool) {
 }
 
 func (h *symmetricKey) X509CertThumbprintS256() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509CertThumbprintS256 != nil {
 		return *(h.x509CertThumbprintS256), true
 	}
@@ -121,6 +136,8 @@ func (h *symmetricKey) X509CertThumbprintS256() (string, bool) {
 }
 
 func (h *symmetricKey) X509URL() (string, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.x509URL != nil {
 		return *(h.x509URL), true
 	}
@@ -508,11 +525,12 @@ LOOP:
 	return nil
 }
 
-func (h symmetricKey) MarshalJSON() ([]byte, error) {
+func (h *symmetricKey) MarshalJSON() ([]byte, error) {
 	data := make(map[string]any)
 	fields := make([]string, 0, 9)
 	data[KeyTypeKey] = jwa.OctetSeq()
 	fields = append(fields, KeyTypeKey)
+	h.mu.RLock()
 	if h.algorithm != nil {
 		data[AlgorithmKey] = *(h.algorithm)
 		fields = append(fields, AlgorithmKey)
@@ -553,6 +571,7 @@ func (h symmetricKey) MarshalJSON() ([]byte, error) {
 		data[k] = v
 		fields = append(fields, k)
 	}
+	h.mu.RUnlock()
 
 	sort.Strings(fields)
 	buf := pool.BytesBuffer().Get()

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -87,15 +87,13 @@ type stdHeaders struct {
 	x509CertThumbprintS256 *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.8
 	x509URL                *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.5
 	privateParams          map[string]any
-	mu                     *sync.RWMutex
+	mu                     sync.RWMutex
 	dc                     DecodeCtx
 	raw                    []byte // stores the raw version of the header so it can be used later
 }
 
 func NewHeaders() Headers {
-	return &stdHeaders{
-		mu: &sync.RWMutex{},
-	}
+	return &stdHeaders{}
 }
 
 func (h *stdHeaders) Algorithm() (jwa.SignatureAlgorithm, bool) {
@@ -217,6 +215,8 @@ func (h *stdHeaders) SetDecodeCtx(dc DecodeCtx) {
 }
 
 func (h *stdHeaders) rawBuffer() []byte {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	return h.raw
 }
 
@@ -625,7 +625,7 @@ func (h *stdHeaders) Keys() []string {
 	return keys
 }
 
-func (h stdHeaders) MarshalJSON() ([]byte, error) {
+func (h *stdHeaders) MarshalJSON() ([]byte, error) {
 	h.mu.RLock()
 	data := make(map[string]any)
 	keys := make([]string, 0, 11+len(h.privateParams))

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -166,7 +166,7 @@ type Token interface {
 	Keys() []string
 }
 type stdToken struct {
-	mu                  *sync.RWMutex
+	mu                  sync.RWMutex
 	dc                  DecodeCtx          // per-object context for decoding
 	options             jwt.TokenOptionSet // per-object option
 	address             *AddressClaim
@@ -203,13 +203,14 @@ type stdToken struct {
 // Convenience accessors are provided for these standard claims
 func New() Token {
 	return &stdToken{
-		mu:            &sync.RWMutex{},
 		privateClaims: make(map[string]any),
 		options:       jwt.DefaultOptionSet(),
 	}
 }
 
 func (t *stdToken) Options() *jwt.TokenOptionSet {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
 	return &t.options
 }
 
@@ -1310,6 +1311,8 @@ func putClaimPairList(list []claimPair) {
 
 func (t *stdToken) makePairs() ([]claimPair, error) {
 	pairs := getClaimPairList()
+	t.mu.RLock()
+	defer t.mu.RUnlock()
 	if t.address != nil {
 		buf, err := json.Marshal(*(t.address))
 		if err != nil {
@@ -1507,7 +1510,7 @@ func (t *stdToken) makePairs() ([]claimPair, error) {
 	return pairs, nil
 }
 
-func (t stdToken) MarshalJSON() ([]byte, error) {
+func (t *stdToken) MarshalJSON() ([]byte, error) {
 	buf := pool.BytesBuffer().Get()
 	defer pool.BytesBuffer().Put(buf)
 	pairs, err := t.makePairs()

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -101,7 +101,7 @@ type Token interface {
 	Keys() []string
 }
 type stdToken struct {
-	mu            *sync.RWMutex
+	mu            sync.RWMutex
 	dc            DecodeCtx          // per-object context for decoding
 	options       TokenOptionSet     // per-object option
 	audience      types.StringList   // https://tools.ietf.org/html/rfc7519#section-4.1.3
@@ -119,13 +119,14 @@ type stdToken struct {
 // Convenience accessors are provided for these standard claims
 func New() Token {
 	return &stdToken{
-		mu:            &sync.RWMutex{},
 		privateClaims: make(map[string]any),
 		options:       DefaultOptionSet(),
 	}
 }
 
 func (t *stdToken) Options() *TokenOptionSet {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
 	return &t.options
 }
 
@@ -548,6 +549,8 @@ func putClaimPairList(list []claimPair) {
 
 func (t *stdToken) makePairs() ([]claimPair, error) {
 	pairs := getClaimPairList()
+	t.mu.RLock()
+	defer t.mu.RUnlock()
 	if t.audience != nil {
 		buf, err := json.MarshalAudience(t.audience, t.options.IsEnabled(FlattenAudience))
 		if err != nil {
@@ -612,7 +615,7 @@ func (t *stdToken) makePairs() ([]claimPair, error) {
 	return pairs, nil
 }
 
-func (t stdToken) MarshalJSON() ([]byte, error) {
+func (t *stdToken) MarshalJSON() ([]byte, error) {
 	buf := pool.BytesBuffer().Get()
 	defer pool.BytesBuffer().Put(buf)
 	pairs, err := t.makePairs()

--- a/tools/cmd/genjwe/main.go
+++ b/tools/cmd/genjwe/main.go
@@ -160,12 +160,11 @@ func generateHeaders(obj *codegen.Object) error {
 		}
 	}
 	o.L("privateParams map[string]any")
-	o.L("mu *sync.RWMutex")
+	o.L("mu sync.RWMutex")
 	o.L("}") // end type StandardHeaders
 
 	o.LL("func NewHeaders() Headers {")
 	o.L("return &stdHeaders{")
-	o.L("mu: &sync.RWMutex{},")
 	o.L("privateParams: map[string]any{},")
 	o.L("}")
 	o.L("}")
@@ -304,6 +303,8 @@ func generateHeaders(obj *codegen.Object) error {
 	o.L("}")
 
 	o.LL("func (h *stdHeaders) UnmarshalJSON(buf []byte) error {")
+	o.L("h.mu.Lock()")
+	o.L("defer h.mu.Unlock()")
 	for _, f := range obj.Fields() {
 		o.L("h.%s = nil", f.Name(false))
 	}
@@ -400,7 +401,7 @@ func generateHeaders(obj *codegen.Object) error {
 	o.L("return keys")
 	o.L("}")
 
-	o.LL("func (h stdHeaders) MarshalJSON() ([]byte, error) {")
+	o.LL("func (h *stdHeaders) MarshalJSON() ([]byte, error) {")
 	o.L("data := make(map[string]any)")
 	o.L("keys := make([]string, 0, %d+len(h.privateParams))", len(obj.Fields()))
 	o.L("h.mu.RLock()")

--- a/tools/cmd/genjwk/main.go
+++ b/tools/cmd/genjwk/main.go
@@ -281,7 +281,7 @@ func generateObject(o *codegen.Output, kt *KeyType, obj *codegen.Object) error {
 		}
 	}
 	o.L("privateParams map[string]any")
-	o.L("mu *sync.RWMutex")
+	o.L("mu sync.RWMutex")
 	o.L("dc json.DecodeCtx")
 	o.L("}")
 
@@ -290,25 +290,24 @@ func generateObject(o *codegen.Output, kt *KeyType, obj *codegen.Object) error {
 
 	o.LL("func new%s() *%s {", ifName, structName)
 	o.L("return &%s{", structName)
-	o.L("mu: &sync.RWMutex{},")
 	o.L("privateParams: make(map[string]any),")
 	o.L("}")
 	o.L("}")
 
-	o.LL("func (h %s) KeyType() jwa.KeyType {", structName)
+	o.LL("func (h *%s) KeyType() jwa.KeyType {", structName)
 	o.L("return %s", kt.KeyType)
 	o.L("}")
 
-	o.LL("func (h %s) rlock() {", structName)
+	o.LL("func (h *%s) rlock() {", structName)
 	o.L("h.mu.RLock()")
 	o.L("}")
 
-	o.LL("func (h %s) runlock() {", structName)
+	o.LL("func (h *%s) runlock() {", structName)
 	o.L("h.mu.RUnlock()")
 	o.L("}")
 
 	if objName == "PublicKey" || objName == "PrivateKey" {
-		o.LL("func (h %s) IsPrivate() bool {", structName)
+		o.LL("func (h *%s) IsPrivate() bool {", structName)
 		o.L("return %s", fmt.Sprint(objName == "PrivateKey"))
 		o.L("}")
 	}
@@ -323,6 +322,8 @@ func generateObject(o *codegen.Output, kt *KeyType, obj *codegen.Object) error {
 			o.R("%s", PointerElem(f))
 		}
 		o.R(", bool) {")
+		o.L("h.mu.RLock()")
+		o.L("defer h.mu.RUnlock()")
 
 		if f.Bool(`hasGet`) {
 			o.L("if h.%s != nil {", f.Name(false))
@@ -675,11 +676,12 @@ func generateObject(o *codegen.Output, kt *KeyType, obj *codegen.Object) error {
 	o.L("return nil")
 	o.L("}")
 
-	o.LL("func (h %s) MarshalJSON() ([]byte, error) {", structName)
+	o.LL("func (h *%s) MarshalJSON() ([]byte, error) {", structName)
 	o.L("data := make(map[string]any)")
 	o.L("fields := make([]string, 0, %d)", len(obj.Fields()))
 	o.L("data[KeyTypeKey] = %s", kt.KeyType)
 	o.L("fields = append(fields, KeyTypeKey)")
+	o.L("h.mu.RLock()")
 	for _, f := range obj.Fields() {
 		var keyName string
 		if f.Bool(`is_std`) {
@@ -700,6 +702,7 @@ func generateObject(o *codegen.Output, kt *KeyType, obj *codegen.Object) error {
 	o.L("data[k] = v")
 	o.L("fields = append(fields, k)")
 	o.L("}")
+	o.L("h.mu.RUnlock()")
 
 	o.LL("sort.Strings(fields)")
 	o.L("buf := pool.BytesBuffer().Get()")

--- a/tools/cmd/genjws/main.go
+++ b/tools/cmd/genjws/main.go
@@ -146,15 +146,13 @@ func generateHeaders(obj *codegen.Object) error {
 	}
 
 	o.L("privateParams map[string]any")
-	o.L("mu *sync.RWMutex")
+	o.L("mu sync.RWMutex")
 	o.L("dc DecodeCtx")
 	o.L("raw []byte // stores the raw version of the header so it can be used later")
 	o.L("}") // end type StandardHeaders
 
 	o.LL("func NewHeaders() Headers {")
-	o.L("return &stdHeaders{")
-	o.L("mu: &sync.RWMutex{},")
-	o.L("}")
+	o.L("return &stdHeaders{}")
 	o.L("}")
 
 	for _, f := range obj.Fields() {
@@ -191,8 +189,9 @@ func generateHeaders(obj *codegen.Object) error {
 	o.L("h.dc = dc")
 	o.L("}")
 
-	// This has no lock because nothing can assign to it
 	o.LL("func (h *stdHeaders) rawBuffer() []byte {")
+	o.L("h.mu.RLock()")
+	o.L("defer h.mu.RUnlock()")
 	o.L("return h.raw")
 	o.L("}")
 
@@ -416,7 +415,7 @@ func generateHeaders(obj *codegen.Object) error {
 	o.L("return keys")
 	o.L("}")
 
-	o.LL("func (h stdHeaders) MarshalJSON() ([]byte, error) {")
+	o.LL("func (h *stdHeaders) MarshalJSON() ([]byte, error) {")
 	o.L("h.mu.RLock()")
 	o.L("data := make(map[string]any)")
 	o.L("keys := make([]string, 0, %d+len(h.privateParams))", len(obj.Fields()))

--- a/tools/cmd/genjwt/main.go
+++ b/tools/cmd/genjwt/main.go
@@ -200,7 +200,7 @@ func generateToken(obj *codegen.Object) error {
 	o.L("}")
 
 	o.L("type %s struct {", obj.Name(false))
-	o.L("mu *sync.RWMutex")
+	o.L("mu sync.RWMutex")
 	o.L("dc DecodeCtx // per-object context for decoding")
 	o.L("options %sTokenOptionSet // per-object option", pkgPrefix)
 	for _, f := range fields {
@@ -228,13 +228,14 @@ func generateToken(obj *codegen.Object) error {
 	o.R(".\n// Convenience accessors are provided for these standard claims")
 	o.L("func New() %s {", obj.String(`interface`))
 	o.L("return &%s{", obj.Name(false))
-	o.L("mu: &sync.RWMutex{},")
 	o.L("privateClaims: make(map[string]any),")
 	o.L("options: %sDefaultOptionSet(),", pkgPrefix)
 	o.L("}")
 	o.L("}")
 
 	o.LL("func (t *%s) Options() *%sTokenOptionSet {", obj.Name(false), pkgPrefix)
+	o.L("t.mu.RLock()")
+	o.L("defer t.mu.RUnlock()")
 	o.L("return &t.options")
 	o.L("}")
 
@@ -555,6 +556,8 @@ func generateToken(obj *codegen.Object) error {
 	o.L("// allocated slice back to the pool.")
 	o.LL("func (t *%s) makePairs() ([]claimPair, error) {", obj.Name(false))
 	o.L("pairs := getClaimPairList()")
+	o.L("t.mu.RLock()")
+	o.L("defer t.mu.RUnlock()")
 	for _, f := range fields {
 		o.L("if t.%s != nil {", f.Name(false))
 		if f.Name(false) == `audience` {
@@ -595,7 +598,7 @@ func generateToken(obj *codegen.Object) error {
 	o.LL("return pairs, nil")
 	o.L("}")
 
-	o.LL("func (t %s) MarshalJSON() ([]byte, error) {", obj.Name(false))
+	o.LL("func (t *%s) MarshalJSON() ([]byte, error) {", obj.Name(false))
 	o.L("buf := pool.BytesBuffer().Get()")
 	o.L("defer pool.BytesBuffer().Put(buf)")
 	o.L("pairs, err := t.makePairs()")


### PR DESCRIPTION
Fix missing or incorrect lock protection across jwt, jwe, jws, and jwk data structures. Switch mutex fields from pointer to value type, add RLock to JWK named getters and JWK MarshalJSON, add Lock to JWE UnmarshalJSON, add RLock to JWT makePairs/Options and JWS rawBuffer, fix jwk.Set using RLock for writes. Refactor rlocker call sites to access concrete struct fields directly under the batch lock to avoid nested RLock deadlock.