### PR TITLE
validate algorithm-key compatibility in WithKey

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -26,6 +26,7 @@
 package jws
 
 import (
+	"crypto"
 	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -610,6 +611,20 @@ func AlgorithmsForKey(key any) ([]jwa.SignatureAlgorithm, error) {
 	case []byte:
 		kty = jwa.OctetSeq()
 	default:
+		// For crypto.Signer from external packages (e.g. KMS-backed signers),
+		// extract the underlying public key type via .Public().
+		// Standard library types (*rsa.PrivateKey, etc.) are already handled
+		// by the concrete cases above.
+		if signer, ok := key.(crypto.Signer); ok {
+			pub := signer.Public()
+			// Guard: only recurse if the public key is not itself a crypto.Signer,
+			// to prevent infinite recursion from pathological implementations.
+			if _, isSigner := pub.(crypto.Signer); !isSigner {
+				if algs, err := AlgorithmsForKey(pub); err == nil {
+					return algs, nil
+				}
+			}
+		}
 		imported, err := jwk.Import(key)
 		if err != nil {
 			return nil, fmt.Errorf(`unknown key type %T`, key)
@@ -669,6 +684,21 @@ func isRegisteredUnderAnyCurve(alg jwa.SignatureAlgorithm) bool {
 	return false
 }
 
+// validateAlgorithmForKey checks that alg is compatible with key.
+// If the key type is not recognized (e.g. an opaque crypto.Signer whose
+// .Public() also returns an unrecognized type), validation is skipped
+// and the crypto layer will catch any real incompatibility.
+func validateAlgorithmForKey(alg jwa.SignatureAlgorithm, key any) error {
+	algs, err := AlgorithmsForKey(key)
+	if err != nil {
+		return nil //nolint:nilerr // intentional: unrecognized key types skip validation
+	}
+	if !slices.Contains(algs, alg) {
+		return fmt.Errorf(`algorithm %q is not compatible with key type %T`, alg, key)
+	}
+	return nil
+}
+
 // Settings allows you to set global settings for this JWS operations.
 //
 // Currently, the only setting available is `jws.WithLegacySigners()`,
@@ -721,6 +751,10 @@ func Settings(options ...GlobalOption) {
 // Since this function avoids doing many checks that jws.Verify would perform,
 // you must ensure to perform the necessary checks including ensuring that algorithm is safe to use for your payload yourself.
 func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]byte, error) {
+	if err := validateAlgorithmForKey(alg, key); err != nil {
+		return nil, makeVerifyError(`%w`, err)
+	}
+
 	algstr := alg.String()
 
 	// Split the serialized JWT into its components

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1942,3 +1942,109 @@ func TestMaxSignatures(t *testing.T) {
 		require.Error(t, err, `jws.Verify should fail when signatures exceed limit`)
 	})
 }
+
+func TestAlgorithmKeyMismatch(t *testing.T) {
+	rsaKey, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err)
+
+	ecKey, err := jwxtest.GenerateEcdsaKey(jwa.P256())
+	require.NoError(t, err)
+
+	edKey, err := jwxtest.GenerateEd25519Key()
+	require.NoError(t, err)
+
+	hmacKey := jwxtest.GenerateSymmetricKey()
+
+	// Sign a valid HMAC message to use in Verify/VerifyCompactFast tests
+	validCompact, err := jws.Sign([]byte("test"), jws.WithKey(jwa.HS256(), hmacKey))
+	require.NoError(t, err)
+
+	testcases := []struct {
+		Name string
+		Alg  jwa.SignatureAlgorithm
+		Key  any
+	}{
+		{"RS256 with ECDSA key", jwa.RS256(), ecKey},
+		{"RS256 with Ed25519 key", jwa.RS256(), edKey},
+		{"RS256 with HMAC key", jwa.RS256(), hmacKey},
+		{"ES256 with RSA key", jwa.ES256(), rsaKey},
+		{"ES256 with Ed25519 key", jwa.ES256(), edKey},
+		{"ES256 with HMAC key", jwa.ES256(), hmacKey},
+		{"EdDSA with RSA key", jwa.EdDSA(), rsaKey},
+		{"EdDSA with ECDSA key", jwa.EdDSA(), ecKey},
+		{"EdDSA with HMAC key", jwa.EdDSA(), hmacKey},
+		{"HS256 with RSA key", jwa.HS256(), rsaKey},
+		{"HS256 with ECDSA key", jwa.HS256(), ecKey},
+		{"HS256 with Ed25519 key", jwa.HS256(), edKey},
+	}
+
+	for _, tc := range testcases {
+		t.Run("Sign/"+tc.Name, func(t *testing.T) {
+			_, err := jws.Sign([]byte("payload"), jws.WithKey(tc.Alg, tc.Key))
+			require.Error(t, err)
+			require.True(t, errors.Is(err, jws.SignError()), `error should be SignError`)
+			require.Contains(t, err.Error(), "not compatible")
+		})
+		t.Run("Verify/"+tc.Name, func(t *testing.T) {
+			_, err := jws.Verify(validCompact, jws.WithKey(tc.Alg, tc.Key))
+			require.Error(t, err)
+			require.True(t, errors.Is(err, jws.VerifyError()), `error should be VerifyError`)
+			require.Contains(t, err.Error(), "not compatible")
+		})
+		t.Run("VerifyCompactFast/"+tc.Name, func(t *testing.T) {
+			_, err := jws.VerifyCompactFast(tc.Key, validCompact, tc.Alg)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, jws.VerifyError()), `error should be VerifyError`)
+			require.Contains(t, err.Error(), "not compatible")
+		})
+	}
+}
+
+// testCryptoSigner wraps a crypto.Signer so that AlgorithmsForKey
+// doesn't match it as a concrete standard library type.
+type testCryptoSigner struct {
+	crypto.Signer
+}
+
+func TestAlgorithmsForKeyCryptoSigner(t *testing.T) {
+	rsaKey, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err)
+
+	signer := testCryptoSigner{rsaKey}
+
+	t.Run("AlgorithmsForKey resolves via Public()", func(t *testing.T) {
+		algs, err := jws.AlgorithmsForKey(signer)
+		require.NoError(t, err, `AlgorithmsForKey should succeed for crypto.Signer wrapping RSA`)
+
+		require.Contains(t, algs, jwa.RS256())
+		require.Contains(t, algs, jwa.PS256())
+	})
+
+	t.Run("matching algorithm passes validation", func(t *testing.T) {
+		signed, err := jws.Sign([]byte("payload"), jws.WithKey(jwa.RS256(), signer))
+		require.NoError(t, err, `Sign with matching crypto.Signer should succeed`)
+
+		_, err = jws.Verify(signed, jws.WithKey(jwa.RS256(), &rsaKey.PublicKey))
+		require.NoError(t, err, `Verify should succeed`)
+	})
+
+	t.Run("mismatching algorithm is rejected early", func(t *testing.T) {
+		_, err := jws.Sign([]byte("payload"), jws.WithKey(jwa.ES256(), signer))
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jws.SignError()))
+		require.Contains(t, err.Error(), "not compatible")
+	})
+}
+
+func TestVerifyWithNonSignatureAlgorithm(t *testing.T) {
+	hmacKey := jwxtest.GenerateSymmetricKey()
+	signed, err := jws.Sign([]byte("test"), jws.WithKey(jwa.HS256(), hmacKey))
+	require.NoError(t, err)
+
+	// jwa.A128KW is a KeyEncryptionAlgorithm, not a SignatureAlgorithm.
+	// Previously the unchecked type assertion in verify_context would panic.
+	_, err = jws.Verify(signed, jws.WithKey(jwa.A128KW(), hmacKey))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, jws.VerifyError()))
+	require.Contains(t, err.Error(), "SignatureAlgorithm")
+}

--- a/jws/sign_context.go
+++ b/jws/sign_context.go
@@ -77,6 +77,10 @@ func (sc *signContext) ProcessOptions(options []SignOption) error {
 				return makeSignError(`"none" (jwa.NoSignature) cannot be used with jws.WithKey`)
 			}
 
+			if err := validateAlgorithmForKey(alg, data.key); err != nil {
+				return makeSignError(`%w`, err)
+			}
+
 			sb := signatureBuilderPool.Get()
 			sb.alg = alg
 			sb.protected = data.protected

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -69,8 +69,18 @@ func (vc *verifyContext) ProcessOptions(options []VerifyOption) error {
 			if err := option.Value(&pair); err != nil {
 				return makeVerifyError(`invalid value for option WithKey: %w`, err)
 			}
+
+			alg, ok := pair.alg.(jwa.SignatureAlgorithm)
+			if !ok {
+				return makeVerifyError(`expected algorithm to be of type jwa.SignatureAlgorithm but got (%[1]q, %[1]T)`, pair.alg)
+			}
+
+			if err := validateAlgorithmForKey(alg, pair.key); err != nil {
+				return makeVerifyError(`%w`, err)
+			}
+
 			vc.keyProviders = append(vc.keyProviders, &staticKeyProvider{
-				alg: pair.alg.(jwa.SignatureAlgorithm),
+				alg: alg,
 				key: pair.key,
 			})
 		case identKeyProvider{}:


### PR DESCRIPTION
Add early algorithm-key compatibility check in jws.Sign, jws.Verify, and jws.VerifyCompactFast using existing AlgorithmsForKey. Enhance AlgorithmsForKey to resolve crypto.Signer via .Public() for external signer implementations. Fix unchecked type assertion in verify_context that could panic when passing a non-SignatureAlgorithm to WithKey.