### PR TITLE
add ECDH-ES extension point for external modules

### DIFF
--- a/jwe/decrypt.go
+++ b/jwe/decrypt.go
@@ -164,15 +164,12 @@ func decryptKeyECDHES(recipientKey []byte, alg string, ctalg jwa.ContentEncrypti
 		apv = v
 	}
 
-	// Try custom ECDH-ES key deriver (e.g., X448 from external modules)
-	if deriver, ok := key.(jwebb.ECDHESKeyDeriver); ok {
-		return jwebb.KeyDecryptECDHESCustom(recipientKey, derivedAlg, apu, apv, deriver, pubkey, keysize, keywrap)
+	deriver, err := jwebb.NewECDHESKeyDeriver(key)
+	if err != nil {
+		return nil, fmt.Errorf(`jwe: decrypt key: %w`, err)
 	}
 
-	if !keywrap {
-		return jwebb.KeyDecryptECDHES(recipientKey, nil, derivedAlg, apu, apv, key, pubkey, keysize)
-	}
-	return jwebb.KeyDecryptECDHESKeyWrap(recipientKey, recipientKey, alg, apu, apv, key, pubkey, keysize)
+	return jwebb.KeyDecryptECDHESCustom(recipientKey, derivedAlg, apu, apv, deriver, pubkey, keysize, keywrap)
 }
 
 func decryptKeyHPKE(recipientKey []byte, alg string, ctalg jwa.ContentEncryptionAlgorithm, key any, headers Headers) ([]byte, error) {

--- a/jwe/decrypt.go
+++ b/jwe/decrypt.go
@@ -164,6 +164,11 @@ func decryptKeyECDHES(recipientKey []byte, alg string, ctalg jwa.ContentEncrypti
 		apv = v
 	}
 
+	// Try custom ECDH-ES key deriver (e.g., X448 from external modules)
+	if deriver, ok := key.(jwebb.ECDHESKeyDeriver); ok {
+		return jwebb.KeyDecryptECDHESCustom(recipientKey, derivedAlg, apu, apv, deriver, pubkey, keysize, keywrap)
+	}
+
 	if !keywrap {
 		return jwebb.KeyDecryptECDHES(recipientKey, nil, derivedAlg, apu, apv, key, pubkey, keysize)
 	}

--- a/jwe/encrypt.go
+++ b/jwe/encrypt.go
@@ -161,6 +161,10 @@ func (e *encrypter) encryptKeyECDHES(cek []byte, alg, ctalg string) (keygen.Byte
 		}
 		return jwebb.KeyEncryptECDHESKeyWrapECDSA(cek, alg, e.apu, e.apv, key, keysize, ctalg)
 	default:
+		// Try custom ECDH-ES key generator (e.g., X448 from external modules)
+		if gen, ok := keyToUse.(jwebb.ECDHESKeyGenerator); ok {
+			return jwebb.KeyEncryptECDHESCustom(cek, alg, e.apu, e.apv, gen, keysize, ctalg, keywrap)
+		}
 		return nil, fmt.Errorf(`jwe: encrypt key: unsupported key type for ECDH-ES: %T`, keyToUse)
 	}
 }

--- a/jwe/encrypt.go
+++ b/jwe/encrypt.go
@@ -1,8 +1,6 @@
 package jwe
 
 import (
-	"crypto/ecdh"
-	"crypto/ecdsa"
 	"crypto/rsa"
 	"fmt"
 
@@ -115,58 +113,12 @@ func (e *encrypter) encryptKeyECDHES(cek []byte, alg, ctalg string) (keygen.Byte
 		return nil, fmt.Errorf(`jwe: encrypt key: failed to determine ECDH-ES key size: %w`, err)
 	}
 
-	keyToUse := e.key
-
-	// Normalize key to public key pointer form
-	switch key := keyToUse.(type) {
-	case *ecdsa.PublicKey:
-		// already correct
-	case ecdsa.PublicKey:
-		keyToUse = &key
-	case *ecdsa.PrivateKey:
-		keyToUse = &key.PublicKey
-	case ecdsa.PrivateKey:
-		keyToUse = &key.PublicKey
-	case *ecdh.PublicKey:
-		// already correct
-	case ecdh.PublicKey:
-		keyToUse = &key
-	case ecdh.PrivateKey:
-		keyToUse = key.PublicKey()
-	case *ecdh.PrivateKey:
-		keyToUse = key.PublicKey()
+	gen, err := jwebb.NewECDHESKeyGenerator(e.key)
+	if err != nil {
+		return nil, fmt.Errorf(`jwe: encrypt key: %w`, err)
 	}
 
-	// Handle ecdh.PublicKey (X25519 or convert to ECDSA)
-	switch key := keyToUse.(type) {
-	case *ecdh.PublicKey:
-		if key.Curve() == ecdh.X25519() {
-			if !keywrap {
-				return jwebb.KeyEncryptECDHESX25519(cek, alg, e.apu, e.apv, key, keysize, ctalg)
-			}
-			return jwebb.KeyEncryptECDHESKeyWrapX25519(cek, alg, e.apu, e.apv, key, keysize, ctalg)
-		}
-
-		ecdsaKeyV, err := keyconv.ECDHToECDSA(key)
-		if err != nil {
-			return nil, fmt.Errorf(`jwe: encrypt key: failed to convert ECDH public key to ECDSA: %w`, err)
-		}
-		keyToUse = ecdsaKeyV
-	}
-
-	switch key := keyToUse.(type) {
-	case *ecdsa.PublicKey:
-		if !keywrap {
-			return jwebb.KeyEncryptECDHESECDSA(cek, alg, e.apu, e.apv, key, keysize, ctalg)
-		}
-		return jwebb.KeyEncryptECDHESKeyWrapECDSA(cek, alg, e.apu, e.apv, key, keysize, ctalg)
-	default:
-		// Try custom ECDH-ES key generator (e.g., X448 from external modules)
-		if gen, ok := keyToUse.(jwebb.ECDHESKeyGenerator); ok {
-			return jwebb.KeyEncryptECDHESCustom(cek, alg, e.apu, e.apv, gen, keysize, ctalg, keywrap)
-		}
-		return nil, fmt.Errorf(`jwe: encrypt key: unsupported key type for ECDH-ES: %T`, keyToUse)
-	}
+	return jwebb.KeyEncryptECDHESCustom(cek, alg, e.apu, e.apv, gen, keysize, ctalg, keywrap)
 }
 
 func (e *encrypter) encryptKeyHPKE(cek []byte, alg, ctalg string) (keygen.ByteSource, error) {

--- a/jwe/internal/keygen/keygen.go
+++ b/jwe/internal/keygen/keygen.go
@@ -1,17 +1,10 @@
 package keygen
 
 import (
-	"crypto"
-	"crypto/ecdh"
-	"crypto/ecdsa"
 	"crypto/rand"
-	"encoding/binary"
 	"fmt"
 	"io"
 
-	"github.com/lestrrat-go/jwx/v4/internal/ecutil"
-	"github.com/lestrrat-go/jwx/v4/internal/tokens"
-	"github.com/lestrrat-go/jwx/v4/jwe/internal/concatkdf"
 	"github.com/lestrrat-go/jwx/v4/jwk"
 )
 
@@ -26,74 +19,6 @@ func Random(n int) (ByteSource, error) {
 		return nil, fmt.Errorf(`failed to read from rand.Reader: %w`, err)
 	}
 	return ByteKey(buf), nil
-}
-
-// Ecdhes generates a new key using ECDH-ES
-func Ecdhes(alg string, enc string, keysize int, pubkey *ecdsa.PublicKey, apu, apv []byte) (ByteSource, error) {
-	priv, err := ecdsa.GenerateKey(pubkey.Curve, rand.Reader)
-	if err != nil {
-		return nil, fmt.Errorf(`failed to generate key for ECDH-ES: %w`, err)
-	}
-
-	var algorithm string
-	if alg == tokens.ECDH_ES {
-		algorithm = enc
-	} else {
-		algorithm = alg
-	}
-
-	pubinfo := make([]byte, 4)
-	binary.BigEndian.PutUint32(pubinfo, uint32(keysize)*8)
-
-	if !priv.PublicKey.Curve.IsOnCurve(pubkey.X, pubkey.Y) {
-		return nil, fmt.Errorf(`public key used does not contain a point (X,Y) on the curve`)
-	}
-	z, _ := priv.PublicKey.Curve.ScalarMult(pubkey.X, pubkey.Y, priv.D.Bytes())
-	zBytes := ecutil.AllocECPointBuffer(z, priv.PublicKey.Curve)
-	defer ecutil.ReleaseECPointBuffer(zBytes)
-	kdf := concatkdf.New(crypto.SHA256, []byte(algorithm), zBytes, apu, apv, pubinfo, []byte{})
-	kek := make([]byte, keysize)
-	if _, err := kdf.Read(kek); err != nil {
-		return nil, fmt.Errorf(`failed to read kdf: %w`, err)
-	}
-
-	return ByteWithECPublicKey{
-		PublicKey: &priv.PublicKey,
-		ByteKey:   ByteKey(kek),
-	}, nil
-}
-
-// X25519 generates a new key using ECDH-ES with X25519
-func X25519(alg string, enc string, keysize int, pubkey *ecdh.PublicKey, apu, apv []byte) (ByteSource, error) {
-	priv, err := ecdh.X25519().GenerateKey(rand.Reader)
-	if err != nil {
-		return nil, fmt.Errorf(`failed to generate key for X25519: %w`, err)
-	}
-
-	var algorithm string
-	if alg == tokens.ECDH_ES {
-		algorithm = enc
-	} else {
-		algorithm = alg
-	}
-
-	pubinfo := make([]byte, 4)
-	binary.BigEndian.PutUint32(pubinfo, uint32(keysize)*8)
-
-	zBytes, err := priv.ECDH(pubkey)
-	if err != nil {
-		return nil, fmt.Errorf(`failed to compute Z: %w`, err)
-	}
-	kdf := concatkdf.New(crypto.SHA256, []byte(algorithm), zBytes, apu, apv, pubinfo, []byte{})
-	kek := make([]byte, keysize)
-	if _, err := kdf.Read(kek); err != nil {
-		return nil, fmt.Errorf(`failed to read kdf: %w`, err)
-	}
-
-	return ByteWithECPublicKey{
-		PublicKey: priv.PublicKey(),
-		ByteKey:   ByteKey(kek),
-	}, nil
 }
 
 // HeaderPopulate populates the header with the required EC-DSA public key

--- a/jwe/jwebb/BUILD.bazel
+++ b/jwe/jwebb/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "jwebb",
     srcs = [
         "content_cipher.go",
+        "ecdh_es_ext.go",
         "hpke_params.go",
         "jwebb.go",
         "key_decrypt_asymmetric.go",

--- a/jwe/jwebb/BUILD.bazel
+++ b/jwe/jwebb/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     importpath = "github.com/lestrrat-go/jwx/v4/jwe/jwebb",
     visibility = ["//jwe:__subpackages__"],
     deps = [
+        "//internal/ecutil",
         "//internal/keyconv",
         "//internal/pool",
         "//internal/tokens",
@@ -37,6 +38,7 @@ go_test(
     name = "jwebb_test",
     srcs = [
         "decrypt_test.go",
+        "ecdh_es_ext_test.go",
         "jwebb_test.go",
         "keywrap_test.go",
     ],

--- a/jwe/jwebb/decrypt_test.go
+++ b/jwe/jwebb/decrypt_test.go
@@ -108,73 +108,31 @@ func TestKeyDecryptRSAOAEP(t *testing.T) {
 	require.Equal(t, cek, decrypted)
 }
 
-func TestKeyDecryptECDHES(t *testing.T) {
-	// Generate ECDSA key pairs for Alice and Bob
-	alicePriv, err := jwxtest.GenerateEcdsaKey(jwa.P256())
-	require.NoError(t, err)
-	bobPriv, err := jwxtest.GenerateEcdsaKey(jwa.P256())
-	require.NoError(t, err)
-
-	apu := testAPU
-	apv := testAPV
-
-	// Test ECDH-ES direct key agreement (no key wrapping)
-	decrypted, err := jwebb.KeyDecryptECDHES(nil, nil, tokens.ECDH_ES, apu, apv, alicePriv, &bobPriv.PublicKey, 16)
-	require.NoError(t, err)
-	require.NotNil(t, decrypted)
-	require.Len(t, decrypted, 16)
-}
-
-func TestKeyDecryptECDHESKeyWrap(t *testing.T) {
+func TestKeyDecryptECDHESCustom(t *testing.T) {
 	cek := testCEK
 
-	// Generate ECDSA key pairs - use the same key for both sides to ensure compatibility
+	// Generate ECDSA key pair
 	privkey, err := jwxtest.GenerateEcdsaKey(jwa.P256())
 	require.NoError(t, err)
-	pubkey := &privkey.PublicKey
 
 	apu := testAPU
 	apv := testAPV
 
-	// First encrypt using ECDH-ES+A128KW
-	encrypted, err := jwebb.KeyEncryptECDHESKeyWrapECDSA(cek, tokens.ECDH_ES_A128KW, apu, apv, pubkey, 16, tokens.A128GCM)
+	// Encrypt using the unified path
+	gen, err := jwebb.NewECDHESKeyGenerator(&privkey.PublicKey)
 	require.NoError(t, err)
 
-	// Extract the public key from the encrypted result
-	// ECDH-ES encryption returns a ByteWithECPublicKey
+	encrypted, err := jwebb.KeyEncryptECDHESCustom(cek, tokens.ECDH_ES_A128KW, apu, apv, gen, 16, tokens.A128GCM, true)
+	require.NoError(t, err)
+
 	encryptedWithPubKey, ok := encrypted.(keygen.ByteWithECPublicKey)
 	require.True(t, ok, "encrypted result should have public key")
 
-	// Now decrypt using the corresponding private key and the ephemeral public key
-	decrypted, err := jwebb.KeyDecryptECDHESKeyWrap(encryptedWithPubKey.Bytes(), encryptedWithPubKey.Bytes(), tokens.ECDH_ES_A128KW, apu, apv, privkey, encryptedWithPubKey.PublicKey, 16)
+	// Decrypt using the unified path
+	deriver, err := jwebb.NewECDHESKeyDeriver(privkey)
+	require.NoError(t, err)
+
+	decrypted, err := jwebb.KeyDecryptECDHESCustom(encryptedWithPubKey.Bytes(), tokens.ECDH_ES_A128KW, apu, apv, deriver, encryptedWithPubKey.PublicKey, 16, true)
 	require.NoError(t, err)
 	require.Equal(t, cek, decrypted)
-}
-
-func TestDeriveECDHES(t *testing.T) {
-	// Generate ECDSA key pairs
-	alicePriv, err := jwxtest.GenerateEcdsaKey(jwa.P256())
-	require.NoError(t, err)
-	bobPriv, err := jwxtest.GenerateEcdsaKey(jwa.P256())
-	require.NoError(t, err)
-
-	apu := testAPU
-	apv := testAPV
-
-	// Test key derivation
-	key1, err := jwebb.DeriveECDHES(tokens.A128GCM, apu, apv, alicePriv, &bobPriv.PublicKey, 16)
-	require.NoError(t, err)
-	require.Len(t, key1, 16)
-
-	// Test that the same inputs produce the same key
-	key2, err := jwebb.DeriveECDHES(tokens.A128GCM, apu, apv, alicePriv, &bobPriv.PublicKey, 16)
-	require.NoError(t, err)
-	require.Equal(t, key1, key2)
-
-	// Test that different private keys produce different results
-	charliePriv, err := jwxtest.GenerateEcdsaKey(jwa.P256())
-	require.NoError(t, err)
-	key3, err := jwebb.DeriveECDHES(tokens.A128GCM, apu, apv, charliePriv, &bobPriv.PublicKey, 16)
-	require.NoError(t, err)
-	require.NotEqual(t, key1, key3)
 }

--- a/jwe/jwebb/ecdh_es_ext.go
+++ b/jwe/jwebb/ecdh_es_ext.go
@@ -1,0 +1,122 @@
+package jwebb
+
+import (
+	"crypto"
+	"crypto/aes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/lestrrat-go/jwx/v4/internal/tokens"
+	"github.com/lestrrat-go/jwx/v4/jwe/internal/concatkdf"
+	"github.com/lestrrat-go/jwx/v4/jwe/internal/keygen"
+)
+
+// ECDHESKeyGenerator is implemented by raw public key types that can
+// perform ECDH-ES key generation for JWE encryption. This allows
+// external modules to provide ECDH-ES support for key types not in
+// Go's standard library (e.g., X448 from cloudflare/circl).
+//
+// When jwe.Encrypt encounters a raw key implementing this interface
+// in the ECDH-ES path, it delegates key generation to the key itself.
+type ECDHESKeyGenerator interface {
+	// GenerateECDHES generates an ephemeral key pair, performs the ECDH
+	// operation with this public key, and derives the key encryption key
+	// via Concat KDF.
+	//
+	// alg is the derived algorithm label used in the KDF (the content
+	// encryption algorithm for bare ECDH-ES, or the key wrapping
+	// algorithm for ECDH-ES+AxxxKW).
+	//
+	// Returns the derived key bytes and the ephemeral public key. The
+	// ephemeral public key must be importable by jwk.Import so it can
+	// be stored as the 'epk' JWE header.
+	GenerateECDHES(alg string, keysize int, apu, apv []byte) (derivedKey []byte, ephemeralPubKey any, err error)
+}
+
+// ECDHESKeyDeriver is implemented by raw private key types that can
+// perform ECDH-ES key derivation for JWE decryption. This allows
+// external modules to provide ECDH-ES support for key types not in
+// Go's standard library (e.g., X448 from cloudflare/circl).
+//
+// When jwe.Decrypt encounters a raw key implementing this interface
+// in the ECDH-ES path, it delegates key derivation to the key itself.
+type ECDHESKeyDeriver interface {
+	// DeriveECDHES performs the ECDH operation using this private key and
+	// the given ephemeral public key, then derives the key via Concat KDF.
+	//
+	// The ephemeralPubKey is the raw key exported from the 'epk' JWE header.
+	DeriveECDHES(alg string, keysize int, ephemeralPubKey any, apu, apv []byte) ([]byte, error)
+}
+
+// DeriveECDHESRaw performs the Concat KDF key derivation used in ECDH-ES,
+// given a pre-computed ECDH shared secret (Z). This is a low-level helper
+// for ECDHESKeyGenerator/ECDHESKeyDeriver implementations that handle the
+// ECDH computation themselves.
+func DeriveECDHESRaw(alg string, zBytes, apu, apv []byte, keysize int) ([]byte, error) {
+	pubinfo := make([]byte, 4)
+	binary.BigEndian.PutUint32(pubinfo, uint32(keysize)*tokens.BitsPerByte)
+	kdf := concatkdf.New(crypto.SHA256, []byte(alg), zBytes, apu, apv, pubinfo, []byte{})
+	key := make([]byte, keysize)
+	if _, err := kdf.Read(key); err != nil {
+		return nil, fmt.Errorf(`jwebb.DeriveECDHESRaw: failed to read kdf: %w`, err)
+	}
+	return key, nil
+}
+
+// KeyEncryptECDHESCustom encrypts using ECDH-ES with a custom key type
+// that implements ECDHESKeyGenerator.
+func KeyEncryptECDHESCustom(cek []byte, alg string, apu, apv []byte, gen ECDHESKeyGenerator, keysize uint32, ctalg string, keywrap bool) (keygen.ByteSource, error) {
+	var derivedAlg string
+	if alg == tokens.ECDH_ES {
+		derivedAlg = ctalg
+	} else {
+		derivedAlg = alg
+	}
+
+	derivedKey, epk, err := gen.GenerateECDHES(derivedAlg, int(keysize), apu, apv)
+	if err != nil {
+		return nil, fmt.Errorf(`failed to generate ECDH-ES key: %w`, err)
+	}
+
+	bwpk := keygen.ByteWithECPublicKey{
+		PublicKey: epk,
+		ByteKey:   keygen.ByteKey(derivedKey),
+	}
+
+	if !keywrap {
+		return bwpk, nil
+	}
+
+	block, err := aes.NewCipher(bwpk.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf(`failed to generate cipher from generated key: %w`, err)
+	}
+
+	jek, err := Wrap(block, cek)
+	if err != nil {
+		return nil, fmt.Errorf(`failed to wrap data: %w`, err)
+	}
+
+	bwpk.ByteKey = keygen.ByteKey(jek)
+	return bwpk, nil
+}
+
+// KeyDecryptECDHESCustom decrypts using ECDH-ES with a custom key type
+// that implements ECDHESKeyDeriver.
+func KeyDecryptECDHESCustom(recipientKey []byte, alg string, apu, apv []byte, deriver ECDHESKeyDeriver, pubkey any, keysize uint32, keywrap bool) ([]byte, error) {
+	derivedKey, err := deriver.DeriveECDHES(alg, int(keysize), pubkey, apu, apv)
+	if err != nil {
+		return nil, fmt.Errorf(`failed to derive ECDH-ES key: %w`, err)
+	}
+
+	if !keywrap {
+		return derivedKey, nil
+	}
+
+	block, err := aes.NewCipher(derivedKey)
+	if err != nil {
+		return nil, fmt.Errorf(`failed to create cipher for ECDH-ES key unwrap: %w`, err)
+	}
+
+	return Unwrap(block, recipientKey)
+}

--- a/jwe/jwebb/ecdh_es_ext.go
+++ b/jwe/jwebb/ecdh_es_ext.go
@@ -3,9 +3,14 @@ package jwebb
 import (
 	"crypto"
 	"crypto/aes"
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 
+	"github.com/lestrrat-go/jwx/v4/internal/ecutil"
+	"github.com/lestrrat-go/jwx/v4/internal/keyconv"
 	"github.com/lestrrat-go/jwx/v4/internal/tokens"
 	"github.com/lestrrat-go/jwx/v4/jwe/internal/concatkdf"
 	"github.com/lestrrat-go/jwx/v4/jwe/internal/keygen"
@@ -119,4 +124,147 @@ func KeyDecryptECDHESCustom(recipientKey []byte, alg string, apu, apv []byte, de
 	}
 
 	return Unwrap(block, recipientKey)
+}
+
+// NewECDHESKeyGenerator normalizes a raw key into an ECDHESKeyGenerator.
+// If the key already implements ECDHESKeyGenerator, it is returned as-is.
+// Otherwise, stdlib key types (*ecdh.PublicKey, *ecdsa.PublicKey, and their
+// private key counterparts) are wrapped in an adapter.
+func NewECDHESKeyGenerator(key any) (ECDHESKeyGenerator, error) {
+	if gen, ok := key.(ECDHESKeyGenerator); ok {
+		return gen, nil
+	}
+
+	switch k := key.(type) {
+	case *ecdh.PublicKey:
+		return &ecdhGenerator{key: k}, nil
+	case *ecdh.PrivateKey:
+		return &ecdhGenerator{key: k.PublicKey()}, nil
+	case ecdh.PrivateKey:
+		return &ecdhGenerator{key: k.PublicKey()}, nil
+	case *ecdsa.PublicKey:
+		return &ecdsaGenerator{key: k}, nil
+	case ecdsa.PublicKey:
+		return &ecdsaGenerator{key: &k}, nil
+	case *ecdsa.PrivateKey:
+		return &ecdsaGenerator{key: &k.PublicKey}, nil
+	case ecdsa.PrivateKey:
+		return &ecdsaGenerator{key: &k.PublicKey}, nil
+	default:
+		return nil, fmt.Errorf(`unsupported key type for ECDH-ES key generation: %T`, key)
+	}
+}
+
+// NewECDHESKeyDeriver normalizes a raw key into an ECDHESKeyDeriver.
+// If the key already implements ECDHESKeyDeriver, it is returned as-is.
+// Otherwise, stdlib private key types (*ecdh.PrivateKey, *ecdsa.PrivateKey)
+// are wrapped in an adapter.
+func NewECDHESKeyDeriver(key any) (ECDHESKeyDeriver, error) {
+	if d, ok := key.(ECDHESKeyDeriver); ok {
+		return d, nil
+	}
+
+	switch k := key.(type) {
+	case *ecdh.PrivateKey:
+		return &ecdhDeriver{key: k}, nil
+	case *ecdsa.PrivateKey:
+		return &ecdsaDeriver{key: k}, nil
+	default:
+		return nil, fmt.Errorf(`unsupported key type for ECDH-ES key derivation: %T`, key)
+	}
+}
+
+// ecdhGenerator wraps *ecdh.PublicKey to implement ECDHESKeyGenerator.
+// Handles both NIST curves (P-256, P-384, P-521) and X25519.
+type ecdhGenerator struct {
+	key *ecdh.PublicKey
+}
+
+func (g *ecdhGenerator) GenerateECDHES(alg string, keysize int, apu, apv []byte) ([]byte, any, error) {
+	priv, err := g.key.Curve().GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf(`failed to generate ephemeral key: %w`, err)
+	}
+
+	z, err := priv.ECDH(g.key)
+	if err != nil {
+		return nil, nil, fmt.Errorf(`failed to compute ECDH: %w`, err)
+	}
+
+	derived, err := DeriveECDHESRaw(alg, z, apu, apv, keysize)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return derived, priv.PublicKey(), nil
+}
+
+// ecdsaGenerator wraps *ecdsa.PublicKey to implement ECDHESKeyGenerator.
+type ecdsaGenerator struct {
+	key *ecdsa.PublicKey
+}
+
+func (g *ecdsaGenerator) GenerateECDHES(alg string, keysize int, apu, apv []byte) ([]byte, any, error) {
+	priv, err := ecdsa.GenerateKey(g.key.Curve, rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf(`failed to generate ephemeral key: %w`, err)
+	}
+
+	if !priv.PublicKey.Curve.IsOnCurve(g.key.X, g.key.Y) {
+		return nil, nil, fmt.Errorf(`public key used does not contain a point (X,Y) on the curve`)
+	}
+
+	z, _ := priv.PublicKey.Curve.ScalarMult(g.key.X, g.key.Y, priv.D.Bytes())
+	zBytes := ecutil.AllocECPointBuffer(z, priv.PublicKey.Curve)
+	defer ecutil.ReleaseECPointBuffer(zBytes)
+
+	derived, err := DeriveECDHESRaw(alg, zBytes, apu, apv, keysize)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return derived, &priv.PublicKey, nil
+}
+
+// ecdhDeriver wraps *ecdh.PrivateKey to implement ECDHESKeyDeriver.
+type ecdhDeriver struct {
+	key *ecdh.PrivateKey
+}
+
+func (d *ecdhDeriver) DeriveECDHES(alg string, keysize int, ephemeralPubKey any, apu, apv []byte) ([]byte, error) {
+	pub, err := keyconv.ECDHPublicKey(ephemeralPubKey)
+	if err != nil {
+		return nil, fmt.Errorf(`failed to convert ephemeral public key: %w`, err)
+	}
+
+	z, err := d.key.ECDH(pub)
+	if err != nil {
+		return nil, fmt.Errorf(`failed to compute ECDH: %w`, err)
+	}
+
+	return DeriveECDHESRaw(alg, z, apu, apv, keysize)
+}
+
+// ecdsaDeriver wraps *ecdsa.PrivateKey to implement ECDHESKeyDeriver.
+type ecdsaDeriver struct {
+	key *ecdsa.PrivateKey
+}
+
+func (d *ecdsaDeriver) DeriveECDHES(alg string, keysize int, ephemeralPubKey any, apu, apv []byte) ([]byte, error) {
+	ecdhPriv, err := d.key.ECDH()
+	if err != nil {
+		return nil, fmt.Errorf(`failed to convert ECDSA to ECDH private key: %w`, err)
+	}
+
+	pub, err := keyconv.ECDHPublicKey(ephemeralPubKey)
+	if err != nil {
+		return nil, fmt.Errorf(`failed to convert ephemeral public key: %w`, err)
+	}
+
+	z, err := ecdhPriv.ECDH(pub)
+	if err != nil {
+		return nil, fmt.Errorf(`failed to compute ECDH: %w`, err)
+	}
+
+	return DeriveECDHESRaw(alg, z, apu, apv, keysize)
 }

--- a/jwe/jwebb/ecdh_es_ext_test.go
+++ b/jwe/jwebb/ecdh_es_ext_test.go
@@ -1,0 +1,210 @@
+package jwebb_test
+
+import (
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwe/jwebb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewECDHESKeyGenerator(t *testing.T) {
+	t.Run("ecdh P-256", func(t *testing.T) {
+		priv, err := ecdh.P256().GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		gen, err := jwebb.NewECDHESKeyGenerator(priv.PublicKey())
+		require.NoError(t, err)
+		require.NotNil(t, gen)
+
+		derived, epk, err := gen.GenerateECDHES("A128GCM", 16, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, derived, 16)
+		require.NotNil(t, epk)
+	})
+
+	t.Run("ecdh P-384", func(t *testing.T) {
+		priv, err := ecdh.P384().GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		gen, err := jwebb.NewECDHESKeyGenerator(priv.PublicKey())
+		require.NoError(t, err)
+
+		derived, epk, err := gen.GenerateECDHES("A256GCM", 32, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, derived, 32)
+		require.NotNil(t, epk)
+	})
+
+	t.Run("ecdh P-521", func(t *testing.T) {
+		priv, err := ecdh.P521().GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		gen, err := jwebb.NewECDHESKeyGenerator(priv.PublicKey())
+		require.NoError(t, err)
+
+		derived, epk, err := gen.GenerateECDHES("A256GCM", 32, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, derived, 32)
+		require.NotNil(t, epk)
+	})
+
+	t.Run("ecdh X25519", func(t *testing.T) {
+		priv, err := ecdh.X25519().GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		gen, err := jwebb.NewECDHESKeyGenerator(priv.PublicKey())
+		require.NoError(t, err)
+
+		derived, epk, err := gen.GenerateECDHES("A128GCM", 16, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, derived, 16)
+		require.NotNil(t, epk)
+	})
+
+	t.Run("ecdsa P-256", func(t *testing.T) {
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+
+		gen, err := jwebb.NewECDHESKeyGenerator(&priv.PublicKey)
+		require.NoError(t, err)
+
+		derived, epk, err := gen.GenerateECDHES("A128GCM", 16, nil, nil)
+		require.NoError(t, err)
+		require.Len(t, derived, 16)
+		require.NotNil(t, epk)
+	})
+
+	t.Run("ecdh private key extracts public", func(t *testing.T) {
+		priv, err := ecdh.P256().GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		gen, err := jwebb.NewECDHESKeyGenerator(priv)
+		require.NoError(t, err)
+		require.NotNil(t, gen)
+	})
+
+	t.Run("ecdsa private key extracts public", func(t *testing.T) {
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+
+		gen, err := jwebb.NewECDHESKeyGenerator(priv)
+		require.NoError(t, err)
+		require.NotNil(t, gen)
+	})
+
+	t.Run("unsupported key type", func(t *testing.T) {
+		_, err := jwebb.NewECDHESKeyGenerator([]byte("not a key"))
+		require.Error(t, err)
+	})
+}
+
+func TestNewECDHESKeyDeriver(t *testing.T) {
+	t.Run("ecdh P-256", func(t *testing.T) {
+		priv, err := ecdh.P256().GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		deriver, err := jwebb.NewECDHESKeyDeriver(priv)
+		require.NoError(t, err)
+		require.NotNil(t, deriver)
+	})
+
+	t.Run("ecdh X25519", func(t *testing.T) {
+		priv, err := ecdh.X25519().GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		deriver, err := jwebb.NewECDHESKeyDeriver(priv)
+		require.NoError(t, err)
+		require.NotNil(t, deriver)
+	})
+
+	t.Run("ecdsa P-256", func(t *testing.T) {
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+
+		deriver, err := jwebb.NewECDHESKeyDeriver(priv)
+		require.NoError(t, err)
+		require.NotNil(t, deriver)
+	})
+
+	t.Run("already implements ECDHESKeyDeriver", func(t *testing.T) {
+		priv, err := ecdh.P256().GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		// First wrap it, then pass the wrapper — should return as-is
+		deriver, err := jwebb.NewECDHESKeyDeriver(priv)
+		require.NoError(t, err)
+
+		deriver2, err := jwebb.NewECDHESKeyDeriver(deriver)
+		require.NoError(t, err)
+		require.NotNil(t, deriver2)
+	})
+
+	t.Run("unsupported key type", func(t *testing.T) {
+		_, err := jwebb.NewECDHESKeyDeriver([]byte("not a key"))
+		require.Error(t, err)
+	})
+}
+
+func TestECDHESGenerateAndDerive(t *testing.T) {
+	// End-to-end: generate with public key, derive with private key, keys must match
+	t.Run("ecdh P-256 round-trip", func(t *testing.T) {
+		priv, err := ecdh.P256().GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		gen, err := jwebb.NewECDHESKeyGenerator(priv.PublicKey())
+		require.NoError(t, err)
+
+		derivedEnc, epk, err := gen.GenerateECDHES("A128GCM", 16, testAPU, testAPV)
+		require.NoError(t, err)
+
+		deriver, err := jwebb.NewECDHESKeyDeriver(priv)
+		require.NoError(t, err)
+
+		derivedDec, err := deriver.DeriveECDHES("A128GCM", 16, epk, testAPU, testAPV)
+		require.NoError(t, err)
+
+		require.Equal(t, derivedEnc, derivedDec)
+	})
+
+	t.Run("ecdh X25519 round-trip", func(t *testing.T) {
+		priv, err := ecdh.X25519().GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		gen, err := jwebb.NewECDHESKeyGenerator(priv.PublicKey())
+		require.NoError(t, err)
+
+		derivedEnc, epk, err := gen.GenerateECDHES("A256GCM", 32, testAPU, testAPV)
+		require.NoError(t, err)
+
+		deriver, err := jwebb.NewECDHESKeyDeriver(priv)
+		require.NoError(t, err)
+
+		derivedDec, err := deriver.DeriveECDHES("A256GCM", 32, epk, testAPU, testAPV)
+		require.NoError(t, err)
+
+		require.Equal(t, derivedEnc, derivedDec)
+	})
+
+	t.Run("ecdsa P-256 round-trip", func(t *testing.T) {
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+
+		gen, err := jwebb.NewECDHESKeyGenerator(&priv.PublicKey)
+		require.NoError(t, err)
+
+		derivedEnc, epk, err := gen.GenerateECDHES("A128GCM", 16, testAPU, testAPV)
+		require.NoError(t, err)
+
+		deriver, err := jwebb.NewECDHESKeyDeriver(priv)
+		require.NoError(t, err)
+
+		derivedDec, err := deriver.DeriveECDHES("A128GCM", 16, epk, testAPU, testAPV)
+		require.NoError(t, err)
+
+		require.Equal(t, derivedEnc, derivedDec)
+	})
+}

--- a/jwe/jwebb/jwebb_test.go
+++ b/jwe/jwebb/jwebb_test.go
@@ -252,18 +252,17 @@ func TestKeyEncryptRSAOAEP(t *testing.T) {
 	require.NotEqual(t, cek, result.Bytes())
 }
 
-func TestKeyEncryptECDHESECDSA(t *testing.T) {
+func TestKeyEncryptECDHESCustom(t *testing.T) {
 	cek := testCEK
 
 	// Generate ECDSA key pair
 	privkey, err := jwxtest.GenerateEcdsaKey(jwa.P256())
 	require.NoError(t, err)
-	pubkey := &privkey.PublicKey
 
-	apu := testAPU
-	apv := testAPV
+	gen, err := jwebb.NewECDHESKeyGenerator(&privkey.PublicKey)
+	require.NoError(t, err)
 
-	result, err := jwebb.KeyEncryptECDHESECDSA(cek, tokens.ECDH_ES, apu, apv, pubkey, 16, tokens.A128GCM)
+	result, err := jwebb.KeyEncryptECDHESCustom(cek, tokens.ECDH_ES, testAPU, testAPV, gen, 16, tokens.A128GCM, false)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 }

--- a/jwe/jwebb/key_decrypt_asymmetric.go
+++ b/jwe/jwebb/key_decrypt_asymmetric.go
@@ -1,20 +1,16 @@
 package jwebb
 
 import (
-	"crypto"
-	"crypto/aes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
-	"encoding/binary"
 	"fmt"
 	"hash"
 
 	"github.com/lestrrat-go/jwx/v4/internal/keyconv"
 	"github.com/lestrrat-go/jwx/v4/internal/tokens"
-	"github.com/lestrrat-go/jwx/v4/jwe/internal/concatkdf"
 	"github.com/lestrrat-go/jwx/v4/jwe/internal/keygen"
 )
 
@@ -54,54 +50,6 @@ func KeyEncryptionECDHESKeySize(alg, ctalg string) (string, uint32, bool, error)
 	default:
 		return "", 0, false, fmt.Errorf(`unsupported key encryption algorithm %s`, alg)
 	}
-}
-
-func DeriveECDHES(alg string, apu, apv []byte, privkeyif, pubkeyif any, keysize uint32) ([]byte, error) {
-	pubinfo := make([]byte, 4)
-	binary.BigEndian.PutUint32(pubinfo, keysize*tokens.BitsPerByte)
-
-	privkey, err := keyconv.ECDHPrivateKey(privkeyif)
-	if err != nil {
-		return nil, fmt.Errorf(`jwebb.DeriveECDHES: %w`, err)
-	}
-	pubkey, err := keyconv.ECDHPublicKey(pubkeyif)
-	if err != nil {
-		return nil, fmt.Errorf(`jwebb.DeriveECDHES: %w`, err)
-	}
-
-	zBytes, err := privkey.ECDH(pubkey)
-	if err != nil {
-		return nil, fmt.Errorf(`jwebb.DeriveECDHES: unable to determine Z: %w`, err)
-	}
-	kdf := concatkdf.New(crypto.SHA256, []byte(alg), zBytes, apu, apv, pubinfo, []byte{})
-	key := make([]byte, keysize)
-	if _, err := kdf.Read(key); err != nil {
-		return nil, fmt.Errorf(`jwebb.DeriveECDHES: failed to read kdf: %w`, err)
-	}
-
-	return key, nil
-}
-
-func KeyDecryptECDHESKeyWrap(_, enckey []byte, alg string, apu, apv []byte, privkey, pubkey any, keysize uint32) ([]byte, error) {
-	key, err := DeriveECDHES(alg, apu, apv, privkey, pubkey, keysize)
-	if err != nil {
-		return nil, fmt.Errorf(`failed to derive ECDHES encryption key: %w`, err)
-	}
-
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, fmt.Errorf(`failed to create cipher for ECDH-ES key wrap: %w`, err)
-	}
-
-	return Unwrap(block, enckey)
-}
-
-func KeyDecryptECDHES(_, _ []byte, alg string, apu, apv []byte, privkey, pubkey any, keysize uint32) ([]byte, error) {
-	key, err := DeriveECDHES(alg, apu, apv, privkey, pubkey, keysize)
-	if err != nil {
-		return nil, fmt.Errorf(`failed to derive ECDHES encryption key: %w`, err)
-	}
-	return key, nil
 }
 
 // RSA key decryption functions

--- a/jwe/jwebb/key_encrypt_asymmetric.go
+++ b/jwe/jwebb/key_encrypt_asymmetric.go
@@ -1,9 +1,6 @@
 package jwebb
 
 import (
-	"crypto/aes"
-	"crypto/ecdh"
-	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -46,102 +43,4 @@ func KeyEncryptRSAOAEP(cek []byte, alg string, pubkey *rsa.PublicKey) (keygen.By
 		return nil, fmt.Errorf(`failed to OAEP encrypt: %w`, err)
 	}
 	return keygen.ByteKey(encrypted), nil
-}
-
-// generateECDHESKeyECDSA generates the key material for ECDSA keys using ECDH-ES
-func generateECDHESKeyECDSA(alg string, calg string, keysize uint32, pubkey *ecdsa.PublicKey, apu, apv []byte) (keygen.ByteWithECPublicKey, error) {
-	// Generate the key directly
-	kg, err := keygen.Ecdhes(alg, calg, int(keysize), pubkey, apu, apv)
-	if err != nil {
-		return keygen.ByteWithECPublicKey{}, fmt.Errorf(`failed to generate ECDSA key: %w`, err)
-	}
-
-	bwpk, ok := kg.(keygen.ByteWithECPublicKey)
-	if !ok {
-		return keygen.ByteWithECPublicKey{}, fmt.Errorf(`key generator generated invalid key (expected ByteWithECPublicKey)`)
-	}
-
-	return bwpk, nil
-}
-
-// generateECDHESKeyX25519 generates the key material for X25519 keys using ECDH-ES
-func generateECDHESKeyX25519(alg string, calg string, keysize uint32, pubkey *ecdh.PublicKey, apu, apv []byte) (keygen.ByteWithECPublicKey, error) {
-	// Generate the key directly
-	kg, err := keygen.X25519(alg, calg, int(keysize), pubkey, apu, apv)
-	if err != nil {
-		return keygen.ByteWithECPublicKey{}, fmt.Errorf(`failed to generate X25519 key: %w`, err)
-	}
-
-	bwpk, ok := kg.(keygen.ByteWithECPublicKey)
-	if !ok {
-		return keygen.ByteWithECPublicKey{}, fmt.Errorf(`key generator generated invalid key (expected ByteWithECPublicKey)`)
-	}
-
-	return bwpk, nil
-}
-
-// KeyEncryptECDHESKeyWrapECDSA encrypts the CEK using ECDH-ES with key wrapping for ECDSA keys
-func KeyEncryptECDHESKeyWrapECDSA(cek []byte, alg string, apu, apv []byte, pubkey *ecdsa.PublicKey, keysize uint32, calg string) (keygen.ByteSource, error) {
-	bwpk, err := generateECDHESKeyECDSA(alg, calg, keysize, pubkey, apu, apv)
-	if err != nil {
-		return nil, err
-	}
-
-	// For key wrapping algorithms, wrap the CEK with the generated key
-	block, err := aes.NewCipher(bwpk.Bytes())
-	if err != nil {
-		return nil, fmt.Errorf(`failed to generate cipher from generated key: %w`, err)
-	}
-
-	jek, err := Wrap(block, cek)
-	if err != nil {
-		return nil, fmt.Errorf(`failed to wrap data: %w`, err)
-	}
-
-	bwpk.ByteKey = keygen.ByteKey(jek)
-	return bwpk, nil
-}
-
-// KeyEncryptECDHESKeyWrapX25519 encrypts the CEK using ECDH-ES with key wrapping for X25519 keys
-func KeyEncryptECDHESKeyWrapX25519(cek []byte, alg string, apu []byte, apv []byte, pubkey *ecdh.PublicKey, keysize uint32, calg string) (keygen.ByteSource, error) {
-	bwpk, err := generateECDHESKeyX25519(alg, calg, keysize, pubkey, apu, apv)
-	if err != nil {
-		return nil, err
-	}
-
-	// For key wrapping algorithms, wrap the CEK with the generated key
-	block, err := aes.NewCipher(bwpk.Bytes())
-	if err != nil {
-		return nil, fmt.Errorf(`failed to generate cipher from generated key: %w`, err)
-	}
-
-	jek, err := Wrap(block, cek)
-	if err != nil {
-		return nil, fmt.Errorf(`failed to wrap data: %w`, err)
-	}
-
-	bwpk.ByteKey = keygen.ByteKey(jek)
-	return bwpk, nil
-}
-
-// KeyEncryptECDHESECDSA encrypts using ECDH-ES direct (no key wrapping) for ECDSA keys
-func KeyEncryptECDHESECDSA(_ []byte, alg string, apu, apv []byte, pubkey *ecdsa.PublicKey, keysize uint32, calg string) (keygen.ByteSource, error) {
-	bwpk, err := generateECDHESKeyECDSA(alg, calg, keysize, pubkey, apu, apv)
-	if err != nil {
-		return nil, err
-	}
-
-	// For direct ECDH-ES, return the generated key directly
-	return bwpk, nil
-}
-
-// KeyEncryptECDHESX25519 encrypts using ECDH-ES direct (no key wrapping) for X25519 keys
-func KeyEncryptECDHESX25519(_ []byte, alg string, apu, apv []byte, pubkey *ecdh.PublicKey, keysize uint32, calg string) (keygen.ByteSource, error) {
-	bwpk, err := generateECDHESKeyX25519(alg, calg, keysize, pubkey, apu, apv)
-	if err != nil {
-		return nil, err
-	}
-
-	// For direct ECDH-ES, return the generated key directly
-	return bwpk, nil
 }


### PR DESCRIPTION
Add ECDHESKeyGenerator and ECDHESKeyDeriver interfaces to jwe/jwebb, allowing external modules (e.g. X448) to plug into ECDH-ES encrypt/decrypt without modifying the core library.