### PR TITLE
fast path for jwt.Parse with single key

### DIFF
--- a/Changes-v4.md
+++ b/Changes-v4.md
@@ -80,13 +80,10 @@ For a step-by-step migration guide with before/after code examples, see [MIGRATI
 
 ## JWT
 
-* `jwt.Parse()` now only accepts JWS compact serialization format. It no longer attempts
-  to auto-detect and parse raw JSON JWTs, JWE-wrapped JWTs, or JWS JSON serialization.
-  Use `jwt.ParseInsecure()` for unsigned JSON payloads.
-
-* `jwt.Parse()` with a single `jwt.WithKey(alg, key)` option now takes a fast path that
-  bypasses format detection, option conversion, and the nested decode loop, going directly
-  to `jws.VerifyCompactFast()`. This reduces allocations and improves parse+verify throughput.
+* `jwt.Parse()` with a single `jwt.WithKey(alg, key)` option and compact JWS input now
+  takes a fast path that bypasses format detection, option conversion, and the nested
+  decode loop, going directly to `jws.VerifyCompactFast()`. This reduces allocations
+  and improves parse+verify throughput.
 
 * `jws.VerifyCompactFast()` now uses strict base64url decoding (RFC 7515, no padding)
   instead of auto-detecting the encoding variant. This eliminates per-decode scanning

--- a/Changes-v4.md
+++ b/Changes-v4.md
@@ -80,6 +80,22 @@ For a step-by-step migration guide with before/after code examples, see [MIGRATI
 
 ## JWT
 
+* `jwt.Parse()` now only accepts JWS compact serialization format. It no longer attempts
+  to auto-detect and parse raw JSON JWTs, JWE-wrapped JWTs, or JWS JSON serialization.
+  Use `jwt.ParseInsecure()` for unsigned JSON payloads.
+
+* `jwt.Parse()` with a single `jwt.WithKey(alg, key)` option now takes a fast path that
+  bypasses format detection, option conversion, and the nested decode loop, going directly
+  to `jws.VerifyCompactFast()`. This reduces allocations and improves parse+verify throughput.
+
+* `jws.VerifyCompactFast()` now uses strict base64url decoding (RFC 7515, no padding)
+  instead of auto-detecting the encoding variant. This eliminates per-decode scanning
+  overhead and allows signature buffer pooling.
+
+* Added `jwt.WithStrictBase64Encoding(bool)` option (default: true). Set to false to
+  fall back to auto-detecting base64 encoding for compatibility with non-conformant
+  providers. When false, the fast path is bypassed.
+
 * `(jwt.Token).Claims()` returns `iter.Seq2[string, any]` for range-over-func iteration:
 
   ```go

--- a/internal/base64/base64.go
+++ b/internal/base64/base64.go
@@ -137,3 +137,20 @@ func Decode(src []byte) ([]byte, error) {
 func DecodeString(src string) ([]byte, error) {
 	return getDecoder().Decode([]byte(src))
 }
+
+// DecodeStrict decodes base64url-encoded data (RFC 7515 / RFC 4648 §5, no padding)
+// directly using base64.RawURLEncoding. It writes into the provided dst buffer
+// and returns the number of bytes written.
+//
+// Unlike Decode, this function does not auto-detect the encoding variant,
+// does not acquire any mutex, and does not allocate. The caller must ensure
+// dst is large enough (use DecodedStrictLen).
+func DecodeStrict(dst, src []byte) (int, error) {
+	return base64.RawURLEncoding.Decode(dst, src)
+}
+
+// DecodedStrictLen returns the maximum decoded length for a base64url-encoded
+// input of length n (no padding).
+func DecodedStrictLen(n int) int {
+	return base64.RawURLEncoding.DecodedLen(n)
+}

--- a/internal/jwxcodegen/go.sum
+++ b/internal/jwxcodegen/go.sum
@@ -14,6 +14,7 @@ github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PU
 github.com/goccy/go-yaml v1.11.2 h1:joq77SxuyIs9zzxEjgyLBugMQ9NEgTWxXfz2wVqwAaQ=
 github.com/goccy/go-yaml v1.11.2/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lestrrat-go/codegen v1.0.4 h1:xWRqMkHzfpN/nfl4EeAwmbTvS7uotxfUPl8RhpjB3Go=

--- a/jwe/jwebb/BUILD.bazel
+++ b/jwe/jwebb/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "content_cipher.go",
         "ecdh_es_ext.go",
+        "hpke_ext.go",
         "hpke_params.go",
         "jwebb.go",
         "key_decrypt_asymmetric.go",

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -683,10 +683,17 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 		return nil, err
 	}
 
-	signature, err := base64.Decode(encodedSig)
+	// Decode signature into pooled buffer (strict base64url, no padding per RFC 7515)
+	sigLen := base64.DecodedStrictLen(len(encodedSig))
+	sigBuf := pool.ByteSlice().GetCapacity(sigLen)
+	sigBuf = sigBuf[:sigLen]
+	sigN, err := base64.DecodeStrict(sigBuf, encodedSig)
 	if err != nil {
+		pool.ByteSlice().Put(sigBuf)
 		return nil, fmt.Errorf("jwt.verifyFast: failed to decode signature: %w", err)
 	}
+	sigBuf = sigBuf[:sigN]
+	defer pool.ByteSlice().Put(sigBuf)
 
 	// Instead of appending, copy the data from hdr/payload
 	lvb := len(hdr) + 1 + len(payload)
@@ -702,13 +709,16 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	if err != nil {
 		return nil, makeVerifyError("jwt.VerifyCompact: failed to create verifier for %s: %w", algstr, err)
 	}
-	if err := verifier.Verify(key, verifyBuf, signature); err != nil {
+	if err := verifier.Verify(key, verifyBuf, sigBuf); err != nil {
 		return nil, verifyError{verificationError{fmt.Errorf("jwt.VerifyCompact: signature verification failed for %s: %w", algstr, err)}}
 	}
 
-	decoded, err := base64.Decode(payload)
+	// Decode payload (strict base64url, no padding per RFC 7515)
+	payloadLen := base64.DecodedStrictLen(len(payload))
+	decodedPayload := make([]byte, payloadLen)
+	payloadN, err := base64.DecodeStrict(decodedPayload, payload)
 	if err != nil {
 		return nil, makeVerifyError("jwt.VerifyCompact: failed to decode payload: %w", err)
 	}
-	return decoded, nil
+	return decodedPayload[:payloadN], nil
 }

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -662,6 +662,11 @@ func Settings(options ...GlobalOption) {
 // This can be useful for performance-critical applications where the
 // algorithm is known in advance.
 //
+// This function uses strict base64url encoding without padding (RFC 4648 §5)
+// for decoding the signature and payload. It does not auto-detect other
+// base64 variants. If your JWS uses non-standard encoding (e.g. padded
+// base64url), use jws.Verify() instead, which auto-detects the encoding.
+//
 // Since this function avoids doing many checks that jws.Verify would perform,
 // you must ensure to perform the necessary checks including ensuring that algorithm is safe to use for your payload yourself.
 func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]byte, error) {

--- a/jwt/BUILD.bazel
+++ b/jwt/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "jwt.go",
         "options.go",
         "options_gen.go",
+        "parse_fast.go",
         "serialize.go",
         "token_gen.go",
         "token_options.go",
@@ -42,6 +43,7 @@ go_library(
 go_test(
     name = "jwt_test",
     srcs = [
+        "bench_parse_test.go",
         "filter_test.go",
         "fuzz_test.go",
         "jwt_test.go",

--- a/jwt/bench_parse_test.go
+++ b/jwt/bench_parse_test.go
@@ -1,0 +1,62 @@
+package jwt_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v4/internal/jwxtest"
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+)
+
+func BenchmarkJWTParse(b *testing.B) {
+	rsaKey, err := jwxtest.GenerateRsaJwk()
+	if err != nil {
+		b.Fatal(err)
+	}
+	rsaPub, err := jwk.PublicKeyOf(rsaKey)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	hmacKey := []byte("supersecret-benchmark-key-12345!")
+
+	tok := jwt.New()
+	tok.Set(jwt.IssuedAtKey, time.Now().Unix())
+	tok.Set(jwt.ExpirationKey, time.Now().Add(time.Hour).Unix())
+	tok.Set(jwt.IssuerKey, "bench")
+
+	for _, tc := range []struct {
+		name   string
+		alg    jwa.KeyAlgorithm
+		signKey any
+		verifyKey any
+	}{
+		{"RS256", jwa.RS256(), rsaKey, rsaPub},
+		{"HS256", jwa.HS256(), hmacKey, hmacKey},
+	} {
+		signed, err := jwt.Sign(tok, jwt.WithKey(tc.alg, tc.signKey))
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.Run(tc.name+"/Parse+Verify", func(b *testing.B) {
+			for b.Loop() {
+				_, err := jwt.Parse(signed, jwt.WithKey(tc.alg, tc.verifyKey))
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(tc.name+"/Parse+Verify+NoValidate", func(b *testing.B) {
+			for b.Loop() {
+				_, err := jwt.Parse(signed, jwt.WithKey(tc.alg, tc.verifyKey), jwt.WithValidate(false))
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/jwt/bench_parse_test.go
+++ b/jwt/bench_parse_test.go
@@ -28,9 +28,9 @@ func BenchmarkJWTParse(b *testing.B) {
 	tok.Set(jwt.IssuerKey, "bench")
 
 	for _, tc := range []struct {
-		name   string
-		alg    jwa.KeyAlgorithm
-		signKey any
+		name      string
+		alg       jwa.KeyAlgorithm
+		signKey   any
 		verifyKey any
 	}{
 		{"RS256", jwa.RS256(), rsaKey, rsaPub},

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -205,11 +205,11 @@ type parseCtx struct {
 }
 
 func parseBytes(data []byte, options ...ParseOption) (Token, error) {
-	// Fast path: single WithKey with SignatureAlgorithm, no suboptions,
-	// and only simple options (WithValidate, WithToken, ValidateOptions).
+	// Fast path: exactly one WithKey option, data looks like compact JWS.
+	data = bytes.TrimSpace(data)
 	var fctx fastParseCtx
-	if tryFastPath(&fctx, options) {
-		return parseCompactFast(bytes.TrimSpace(data), &fctx)
+	if tryFastPath(&fctx, data, options) {
+		return parseCompactFast(data, &fctx)
 	}
 
 	var ctx parseCtx
@@ -290,7 +290,6 @@ func parseBytes(data []byte, options ...ParseOption) (Token, error) {
 		ctx.verifyOpts = converted
 	}
 
-	data = bytes.TrimSpace(data)
 	return parse(&ctx, data)
 }
 

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -110,9 +110,9 @@ func ParseString(s string, options ...ParseOption) (Token, error) {
 }
 
 // Parse parses the JWT token payload and creates a new `jwt.Token` object.
-// The token must be encoded in JWS compact serialization format.
+// The token must be encoded in JWS compact format, or a raw JSON form of JWT
+// without any signatures.
 //
-// If you need to parse raw JSON JWTs without signatures, use `jwt.ParseInsecure`.
 // If you need JWE support on top of JWS, you will need to rollout your
 // own workaround.
 //

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -110,9 +110,9 @@ func ParseString(s string, options ...ParseOption) (Token, error) {
 }
 
 // Parse parses the JWT token payload and creates a new `jwt.Token` object.
-// The token must be encoded in JWS compact format, or a raw JSON form of JWT
-// without any signatures.
+// The token must be encoded in JWS compact serialization format.
 //
+// If you need to parse raw JSON JWTs without signatures, use `jwt.ParseInsecure`.
 // If you need JWE support on top of JWS, you will need to rollout your
 // own workaround.
 //
@@ -199,11 +199,19 @@ type parseCtx struct {
 	pedantic           bool
 	skipVerification   bool
 	validate           bool
+	lenientBase64      bool // when true, skip VerifyCompactFast to use lenient base64 decoding
 	withKeyCount       int
 	withKey            *withKey // this is used to detect if we have a WithKey option
 }
 
 func parseBytes(data []byte, options ...ParseOption) (Token, error) {
+	// Fast path: single WithKey with SignatureAlgorithm, no suboptions,
+	// and only simple options (WithValidate, WithToken, ValidateOptions).
+	var fctx fastParseCtx
+	if tryFastPath(&fctx, options) {
+		return parseCompactFast(bytes.TrimSpace(data), &fctx)
+	}
+
 	var ctx parseCtx
 
 	// Validation is turned on by default. You need to specify
@@ -258,6 +266,10 @@ func parseBytes(data []byte, options ...ParseOption) (Token, error) {
 		case identStrictStringClaims{}:
 			v := option.MustGet[bool](o)
 			ctx.strictStringClaims = &v
+		case identStrictBase64Encoding{}:
+			if !option.MustGet[bool](o) {
+				ctx.lenientBase64 = true
+			}
 		}
 	}
 
@@ -297,7 +309,7 @@ func verifyJWS(ctx *parseCtx, payload []byte) ([]byte, int, error) {
 		return nil, _JwsVerifySkipped, nil
 	}
 
-	if lvo == 1 && ctx.withKeyCount == 1 {
+	if lvo == 1 && ctx.withKeyCount == 1 && !ctx.lenientBase64 {
 		wk := ctx.withKey
 		alg, ok := wk.alg.(jwa.SignatureAlgorithm)
 		if ok && len(wk.options) == 0 {

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/hmac"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -121,6 +123,86 @@ func TestToken_Parse(t *testing.T) {
 		require.True(t, errors.Is(err, jws.VerifyError()), `err should be a verify error`)
 		require.True(t, errors.Is(err, jws.VerificationError()), `err should be a verification error`)
 	})
+}
+
+func TestStrictBase64Encoding(t *testing.T) {
+	t.Parallel()
+
+	alg := jwa.HS256()
+	key := []byte("supersecret-key-for-testing-only")
+
+	tok := jwt.New()
+	tok.Set(jwt.IssuerKey, "test")
+	tok.Set(jwt.ExpirationKey, time.Now().Add(time.Hour).Unix())
+
+	signed, err := jwt.Sign(tok, jwt.WithKey(alg, key))
+	require.NoError(t, err, `jwt.Sign should succeed`)
+
+	// Standard parse should work (fast path)
+	t.Run("strict parse succeeds", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwt.Parse(signed, jwt.WithKey(alg, key))
+		require.NoError(t, err, `jwt.Parse should succeed with strict base64`)
+	})
+
+	// WithStrictBase64Encoding(false) should fall through to the standard path
+	// and still succeed with normally-encoded tokens.
+	t.Run("lenient parse succeeds with standard encoding", func(t *testing.T) {
+		t.Parallel()
+		parsed, err := jwt.Parse(signed, jwt.WithKey(alg, key), jwt.WithStrictBase64Encoding(false))
+		require.NoError(t, err, `jwt.Parse should succeed with lenient mode on standard input`)
+		iss, ok := parsed.Issuer()
+		require.True(t, ok, `issuer should be present`)
+		require.Equal(t, "test", iss, `issuer claim should match`)
+	})
+
+	// WithStrictBase64Encoding(true) should be equivalent to the default
+	t.Run("explicit strict parse succeeds", func(t *testing.T) {
+		t.Parallel()
+		parsed, err := jwt.Parse(signed, jwt.WithKey(alg, key), jwt.WithStrictBase64Encoding(true))
+		require.NoError(t, err, `jwt.Parse should succeed with explicit strict mode`)
+		iss, ok := parsed.Issuer()
+		require.True(t, ok, `issuer should be present`)
+		require.Equal(t, "test", iss, `issuer claim should match`)
+	})
+
+	// Build a compact JWS with padded base64url payload (non-standard but seen in the wild).
+	parts := strings.SplitN(string(signed), ".", 3)
+	require.Len(t, parts, 3, `signed JWT should have 3 parts`)
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err, `base64 decode should succeed`)
+	paddedPayload := base64.URLEncoding.EncodeToString(payloadBytes)
+
+	// Keep original header (unpadded), re-compute HMAC over padded signing input
+	signingInput := parts[0] + "." + paddedPayload
+	hmacSig := computeHMAC(t, []byte(signingInput), key)
+	paddedCompact := []byte(signingInput + "." + base64.RawURLEncoding.EncodeToString(hmacSig))
+
+	// When verification is on, the fast path uses strict base64 (DecodeStrict)
+	// which rejects padded encoding.
+	t.Run("padded payload fails with verify", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwt.Parse(paddedCompact, jwt.WithKey(alg, key))
+		require.Error(t, err, `jwt.Parse should fail: padded payload not decodable with strict base64`)
+	})
+
+	// Lenient mode with no verification: auto-detection handles padded base64.
+	t.Run("padded payload succeeds lenient no-verify", func(t *testing.T) {
+		t.Parallel()
+		parsed, err := jwt.Parse(paddedCompact, jwt.WithVerify(false), jwt.WithStrictBase64Encoding(false))
+		require.NoError(t, err, `jwt.Parse should succeed with lenient base64 and no verification`)
+		iss, ok := parsed.Issuer()
+		require.True(t, ok, `issuer should be present`)
+		require.Equal(t, "test", iss, `issuer claim should match`)
+	})
+}
+
+func computeHMAC(t *testing.T, data, key []byte) []byte {
+	t.Helper()
+	mac := hmac.New(sha256.New, key)
+	mac.Write(data)
+	return mac.Sum(nil)
 }
 
 func TestJWTParseVerify(t *testing.T) {

--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -299,3 +299,15 @@ options:
       This option can be passed to `jwt.Settings()` to change the default
       globally, or to `jwt.ParseReader()` / `jwt.ParseFS()` for a per-call
       override.
+  - ident: StrictBase64Encoding
+    interface: ParseOption
+    argument_type: bool
+    comment: |
+      WithStrictBase64Encoding controls whether base64 decoding during
+      JWT parsing uses strict base64url encoding (RFC 4648 §5, no padding)
+      or auto-detects the encoding variant.
+
+      By default this is true: the parser uses base64.RawURLEncoding directly,
+      which is faster and matches RFC 7515. Set to false to enable auto-detection
+      for compatibility with non-conformant providers that may use padded or
+      standard base64 encoding.

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -168,6 +168,7 @@ type identNumericDateParsePrecision struct{}
 type identPedantic struct{}
 type identResetValidators struct{}
 type identSignOption struct{}
+type identStrictBase64Encoding struct{}
 type identStrictStringClaims struct{}
 type identToken struct{}
 type identTruncation struct{}
@@ -249,6 +250,10 @@ func (identResetValidators) String() string {
 
 func (identSignOption) String() string {
 	return "WithSignOption"
+}
+
+func (identStrictBase64Encoding) String() string {
+	return "WithStrictBase64Encoding"
 }
 
 func (identStrictStringClaims) String() string {
@@ -444,6 +449,18 @@ func WithResetValidators(v bool) ValidateOption {
 // need to use this.
 func WithSignOption(v jws.SignOption) SignOption {
 	return &signOption{option.New(identSignOption{}, v)}
+}
+
+// WithStrictBase64Encoding controls whether base64 decoding during
+// JWT parsing uses strict base64url encoding (RFC 4648 §5, no padding)
+// or auto-detects the encoding variant.
+//
+// By default this is true: the parser uses base64.RawURLEncoding directly,
+// which is faster and matches RFC 7515. Set to false to enable auto-detection
+// for compatibility with non-conformant providers that may use padded or
+// standard base64 encoding.
+func WithStrictBase64Encoding(v bool) ParseOption {
+	return &parseOption{option.New(identStrictBase64Encoding{}, v)}
 }
 
 // WithStrictStringClaims controls whether JSON null values for string

--- a/jwt/options_gen_test.go
+++ b/jwt/options_gen_test.go
@@ -28,6 +28,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithPedantic", identPedantic{}.String())
 	require.Equal(t, "WithResetValidators", identResetValidators{}.String())
 	require.Equal(t, "WithSignOption", identSignOption{}.String())
+	require.Equal(t, "WithStrictBase64Encoding", identStrictBase64Encoding{}.String())
 	require.Equal(t, "WithStrictStringClaims", identStrictStringClaims{}.String())
 	require.Equal(t, "WithToken", identToken{}.String())
 	require.Equal(t, "WithTruncation", identTruncation{}.String())

--- a/jwt/parse_fast.go
+++ b/jwt/parse_fast.go
@@ -1,0 +1,97 @@
+package jwt
+
+import (
+	"fmt"
+
+	"github.com/lestrrat-go/jwx/v4/internal/json"
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jws"
+	"github.com/lestrrat-go/option/v3"
+)
+
+type fastParseCtx struct {
+	alg          jwa.SignatureAlgorithm
+	key          any
+	validate     bool
+	validateOpts []ValidateOption
+	token        Token
+}
+
+// tryFastPath attempts to extract fast-path parameters from options.
+// Returns true if the fast path can be used. The fastParseCtx is populated
+// with the extracted values.
+func tryFastPath(ctx *fastParseCtx, options []ParseOption) bool {
+	ctx.validate = true // default: validation is on
+
+	var hasKey bool
+	for _, o := range options {
+		if v, ok := o.(ValidateOption); ok {
+			ctx.validateOpts = append(ctx.validateOpts, v)
+			switch o.Ident() {
+			case identContext{}:
+				// ValidateOption + ParseOption, continue processing
+			default:
+				continue
+			}
+		}
+
+		switch o.Ident() {
+		case identKey{}:
+			if hasKey {
+				return false // multiple keys
+			}
+			hasKey = true
+
+			wk := option.MustGet[*withKey](o)
+			alg, ok := wk.alg.(jwa.SignatureAlgorithm)
+			if !ok {
+				return false // not a signature algorithm
+			}
+			if len(wk.options) > 0 {
+				return false // has suboptions
+			}
+			ctx.alg = alg
+			ctx.key = wk.key
+		case identValidate{}:
+			ctx.validate = option.MustGet[bool](o)
+		case identToken{}:
+			ctx.token = option.MustGet[Token](o)
+		case identContext{}:
+			// Already handled above as ValidateOption
+		default:
+			// Any other option disqualifies the fast path
+			return false
+		}
+	}
+
+	return hasKey
+}
+
+// parseCompactFast is the fast path for parsing JWS compact JWTs.
+// It bypasses format detection, option conversion, and the nested decode loop.
+func parseCompactFast(data []byte, ctx *fastParseCtx) (Token, error) {
+	// Verify and extract payload via VerifyCompactFast
+	// (handles SplitCompact, crit validation, sig decode, verify buffer, signature check, payload decode)
+	payload, err := jws.VerifyCompactFast(ctx.key, data, ctx.alg)
+	if err != nil {
+		return nil, parseErrorf(`jwt.Parse`, `%w`, err)
+	}
+
+	// Build token
+	token := ctx.token
+	if token == nil {
+		token = New()
+	}
+
+	if err := json.Unmarshal(payload, token); err != nil {
+		return nil, fmt.Errorf(`failed to parse token: %w`, err)
+	}
+
+	if ctx.validate {
+		if err := Validate(token, ctx.validateOpts...); err != nil {
+			return nil, err
+		}
+	}
+
+	return token, nil
+}

--- a/jwt/parse_fast.go
+++ b/jwt/parse_fast.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/lestrrat-go/jwx/v4/internal/json"
@@ -10,87 +11,55 @@ import (
 )
 
 type fastParseCtx struct {
-	alg          jwa.SignatureAlgorithm
-	key          any
-	validate     bool
-	validateOpts []ValidateOption
-	token        Token
+	alg jwa.SignatureAlgorithm
+	key any
 }
 
-// tryFastPath attempts to extract fast-path parameters from options.
-// Returns true if the fast path can be used. The fastParseCtx is populated
-// with the extracted values.
-func tryFastPath(ctx *fastParseCtx, options []ParseOption) bool {
-	ctx.validate = true // default: validation is on
-
-	var hasKey bool
-	for _, o := range options {
-		if v, ok := o.(ValidateOption); ok {
-			ctx.validateOpts = append(ctx.validateOpts, v)
-			switch o.Ident() {
-			case identContext{}:
-				// ValidateOption + ParseOption, continue processing
-			default:
-				continue
-			}
-		}
-
-		switch o.Ident() {
-		case identKey{}:
-			if hasKey {
-				return false // multiple keys
-			}
-			hasKey = true
-
-			wk := option.MustGet[*withKey](o)
-			alg, ok := wk.alg.(jwa.SignatureAlgorithm)
-			if !ok {
-				return false // not a signature algorithm
-			}
-			if len(wk.options) > 0 {
-				return false // has suboptions
-			}
-			ctx.alg = alg
-			ctx.key = wk.key
-		case identValidate{}:
-			ctx.validate = option.MustGet[bool](o)
-		case identToken{}:
-			ctx.token = option.MustGet[Token](o)
-		case identContext{}:
-			// Already handled above as ValidateOption
-		default:
-			// Any other option disqualifies the fast path
-			return false
-		}
+// tryFastPath checks whether the fast path can be used.
+// The fast path requires:
+//  1. Exactly one option, which must be WithKey(SignatureAlgorithm, key) with no suboptions
+//  2. The data is not JSON (first byte != '{')
+//  3. The data has exactly two '.' separators (compact JWS format)
+func tryFastPath(ctx *fastParseCtx, data []byte, options []ParseOption) bool {
+	if len(options) != 1 || options[0].Ident() != (identKey{}) {
+		return false
 	}
 
-	return hasKey
+	wk := option.MustGet[*withKey](options[0])
+	alg, ok := wk.alg.(jwa.SignatureAlgorithm)
+	if !ok || len(wk.options) > 0 {
+		return false
+	}
+
+	if len(data) == 0 || data[0] == '{' {
+		return false
+	}
+
+	if bytes.Count(data, []byte{'.'}) != 2 {
+		return false
+	}
+
+	ctx.alg = alg
+	ctx.key = wk.key
+	return true
 }
 
 // parseCompactFast is the fast path for parsing JWS compact JWTs.
 // It bypasses format detection, option conversion, and the nested decode loop.
+// Validation is always performed (the default).
 func parseCompactFast(data []byte, ctx *fastParseCtx) (Token, error) {
-	// Verify and extract payload via VerifyCompactFast
-	// (handles SplitCompact, crit validation, sig decode, verify buffer, signature check, payload decode)
 	payload, err := jws.VerifyCompactFast(ctx.key, data, ctx.alg)
 	if err != nil {
 		return nil, parseErrorf(`jwt.Parse`, `%w`, err)
 	}
 
-	// Build token
-	token := ctx.token
-	if token == nil {
-		token = New()
-	}
-
+	token := New()
 	if err := json.Unmarshal(payload, token); err != nil {
 		return nil, fmt.Errorf(`failed to parse token: %w`, err)
 	}
 
-	if ctx.validate {
-		if err := Validate(token, ctx.validateOpts...); err != nil {
-			return nil, err
-		}
+	if err := Validate(token); err != nil {
+		return nil, err
 	}
 
 	return token, nil


### PR DESCRIPTION
jwt.Parse with a single WithKey option now bypasses format detection, option conversion, and the nested decode loop. jws.VerifyCompactFast uses strict base64url decoding with pooled sig buffers. Added WithStrictBase64Encoding(false) opt-out for non-conformant providers.