### PR TITLE
reduce allocations in JWS sign compact path

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -26,6 +26,7 @@
 package jws
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdh"
 	"crypto/ecdsa"
@@ -158,8 +159,8 @@ func Sign(payload []byte, options ...SignOption) ([]byte, error) {
 
 	// For compact single-signature (the overwhelmingly common case),
 	// bypass Message construction and Compact() entirely.
-	// Build() already has the raw header bytes and signature, so we
-	// can use jwsbb.JoinCompact directly.
+	// Build() returns the signing input buffer (base64(hdr).base64(payload))
+	// so we can append the signature directly without re-encoding.
 	if sc.format == fmtCompact {
 		sb := sc.sigbuilders[0]
 		if sc.validateKey {
@@ -168,23 +169,23 @@ func Sign(payload []byte, options ...SignOption) ([]byte, error) {
 			}
 		}
 
-		// Build() needs the actual payload to sign (which may differ from
-		// the Sign() parameter when detached payloads are used).
 		br, err := sb.Build(sc, sc.payload)
 		if err != nil {
 			return nil, makeSignError(`failed to build signature: %w`, err)
 		}
 
-		// For the compact output, include payload only when not detached.
-		outputPayload := sc.payload
 		if sc.detached {
-			outputPayload = nil
+			// Detached: output is base64(hdr)..base64(sig) (empty payload segment).
+			// The combined buffer is base64(hdr).base64(payload), so slice
+			// up to and including the period to get base64(hdr). and append
+			// the signature after that.
+			idx := bytes.IndexByte(br.combined, '.')
+			result := jwsbb.AppendSignature(br.combined[:idx+1], br.sig.signature, sc.encoder)
+			return result, nil
 		}
 
-		result, err := jwsbb.JoinCompact(nil, br.hdrbuf, outputPayload, br.sig.signature, sc.encoder, getB64Value(br.sig.protected))
-		if err != nil {
-			return nil, makeSignError(`failed to serialize compact: %w`, err)
-		}
+		// Non-detached: append .base64(sig) to the existing signing buffer.
+		result := jwsbb.AppendSignature(br.combined, br.sig.signature, sc.encoder)
 		return result, nil
 	}
 

--- a/jws/options.go
+++ b/jws/options.go
@@ -30,10 +30,12 @@ func WithJSON(options ...WithJSONSuboption) SignVerifyParseOption {
 }
 
 type withKey struct {
-	alg       jwa.KeyAlgorithm
-	key       any
-	protected Headers
-	public    Headers
+	alg             jwa.KeyAlgorithm
+	key             any
+	protected       Headers
+	public          Headers
+	cachedHdrJSON   []byte // precomputed header JSON when no custom headers and no kid
+	keyPrevalidated bool   // true if algorithm-key validation was done at construction time
 }
 
 // Protected exists as an escape hatch to modify the header values after the fact
@@ -106,13 +108,37 @@ func WithKey(alg jwa.KeyAlgorithm, key any, options ...WithKeySuboption) SignVer
 		}
 	}
 
+	wk := &withKey{
+		alg:       alg,
+		key:       key,
+		protected: protected,
+		public:    public,
+	}
+
+	// Precompute header JSON and validate algorithm-key compatibility
+	// at construction time so we can skip this work on every Sign() call.
+	if salg, ok := alg.(jwa.SignatureAlgorithm); ok {
+		if validateAlgorithmForKey(salg, key) == nil {
+			wk.keyPrevalidated = true
+		}
+
+		// Cache header JSON when there are no custom headers and the key
+		// won't inject a kid (only jwk.Key with a non-empty kid does that).
+		if protected == nil && public == nil {
+			needsKid := false
+			if jwkKey, ok := key.(jwk.Key); ok {
+				if kid, ok := jwkKey.KeyID(); ok && kid != "" {
+					needsKid = true
+				}
+			}
+			if !needsKid {
+				wk.cachedHdrJSON = buildAlgHeaderJSON(salg.String())
+			}
+		}
+	}
+
 	return &signVerifyOption{
-		option.New(identKey{}, &withKey{
-			alg:       alg,
-			key:       key,
-			protected: protected,
-			public:    public,
-		}),
+		option.New(identKey{}, wk),
 	}
 }
 

--- a/jws/sign_context.go
+++ b/jws/sign_context.go
@@ -72,8 +72,10 @@ func (sc *signContext) ProcessOptions(options []SignOption) error {
 				return makeSignError(`"none" (jwa.NoSignature) cannot be used with jws.WithKey`)
 			}
 
-			if err := validateAlgorithmForKey(alg, data.key); err != nil {
-				return makeSignError(`%w`, err)
+			if !data.keyPrevalidated {
+				if err := validateAlgorithmForKey(alg, data.key); err != nil {
+					return makeSignError(`%w`, err)
+				}
 			}
 
 			sb := signatureBuilderPool.Get()
@@ -82,6 +84,7 @@ func (sc *signContext) ProcessOptions(options []SignOption) error {
 			sb.key = data.key
 			sb.public = data.public
 			sb.signer, _ = SignerFor(alg)
+			sb.cachedHdrJSON = data.cachedHdrJSON
 
 			sc.sigbuilders = append(sc.sigbuilders, sb)
 		case identDetachedPayload{}:

--- a/jws/signature_builder.go
+++ b/jws/signature_builder.go
@@ -40,12 +40,12 @@ var signatureBuilderPool = pool.New[*signatureBuilder](allocSignatureBuilder, fr
 // This object does NOT take care of any synchronization, because it is
 // meant to be used in a single-threaded context.
 type signatureBuilder struct {
-	alg            jwa.SignatureAlgorithm
-	signer         Signer
-	key            any
-	protected      Headers
-	public         Headers
-	cachedHdrJSON  []byte // precomputed header JSON when no custom headers
+	alg             jwa.SignatureAlgorithm
+	signer          Signer
+	key             any
+	protected       Headers
+	public          Headers
+	cachedHdrJSON   []byte // precomputed header JSON when no custom headers
 	keyPrevalidated bool   // true if algorithm-key validation was done at WithKey time
 }
 

--- a/jws/signature_builder.go
+++ b/jws/signature_builder.go
@@ -12,6 +12,17 @@ import (
 	"github.com/lestrrat-go/jwx/v4/jws/jwsbb"
 )
 
+// buildAlgHeaderJSON constructs the JSON for a protected header containing
+// only the "alg" field. This is used by the precomputed header fast path.
+func buildAlgHeaderJSON(alg string) []byte {
+	// Construct {"alg":"<alg>"} without going through json.Marshal
+	buf := make([]byte, 0, 9+len(alg))
+	buf = append(buf, `{"alg":"`...)
+	buf = append(buf, alg...)
+	buf = append(buf, `"}`...)
+	return buf
+}
+
 var signatureBuilderPool = pool.New[*signatureBuilder](allocSignatureBuilder, freeSignatureBuilder)
 
 // signatureBuilder is a transient object that is used to build
@@ -29,11 +40,13 @@ var signatureBuilderPool = pool.New[*signatureBuilder](allocSignatureBuilder, fr
 // This object does NOT take care of any synchronization, because it is
 // meant to be used in a single-threaded context.
 type signatureBuilder struct {
-	alg       jwa.SignatureAlgorithm
-	signer    Signer
-	key       any
-	protected Headers
-	public    Headers
+	alg            jwa.SignatureAlgorithm
+	signer         Signer
+	key            any
+	protected      Headers
+	public         Headers
+	cachedHdrJSON  []byte // precomputed header JSON when no custom headers
+	keyPrevalidated bool   // true if algorithm-key validation was done at WithKey time
 }
 
 func allocSignatureBuilder() *signatureBuilder {
@@ -46,32 +59,58 @@ func freeSignatureBuilder(sb *signatureBuilder) *signatureBuilder {
 	sb.key = nil
 	sb.protected = nil
 	sb.public = nil
+	sb.cachedHdrJSON = nil
+	sb.keyPrevalidated = false
 	return sb
 }
 
 // buildResult holds the output of signatureBuilder.Build. In addition to
-// the Signature object, it retains the raw JSON-encoded header bytes so
-// callers (such as the compact serialization fast path) can avoid
-// re-marshaling the protected headers.
+// the Signature object, it retains the raw JSON-encoded header bytes and
+// the signing input buffer so callers (such as the compact serialization
+// fast path) can avoid re-marshaling and re-encoding.
 type buildResult struct {
-	sig    Signature
-	hdrbuf []byte
+	sig      Signature
+	hdrbuf   []byte // raw JSON-encoded protected header
+	combined []byte // signing input: base64(hdr).base64(payload)
+	b64      bool   // whether payload was base64-encoded
 }
 
-func (sb *signatureBuilder) Build(sc *signContext, payload []byte) (*buildResult, error) {
+func (sb *signatureBuilder) Build(sc *signContext, payload []byte) (buildResult, error) {
+	var br buildResult
+
+	// Fast path: when header JSON is precomputed (no custom headers, no kid)
+	// and we're producing compact serialization, skip NewHeaders(), Set(),
+	// and MarshalJSON() entirely. The JSON serialization path needs
+	// br.sig.protected to be populated, so we can't use this shortcut there.
+	if sb.cachedHdrJSON != nil && sc.format == fmtCompact {
+		hdrbuf := sb.cachedHdrJSON
+		combined := jwsbb.SignBuffer(nil, hdrbuf, payload, sc.encoder, true)
+
+		signature, err := sb.signer.Sign(sb.key, combined)
+		if err != nil {
+			return br, fmt.Errorf(`failed to sign payload: %w`, err)
+		}
+
+		br.hdrbuf = hdrbuf
+		br.combined = combined
+		br.sig.signature = signature
+		br.b64 = true
+		return br, nil
+	}
+
 	protected := sb.protected
 	if protected == nil {
 		protected = NewHeaders()
 	}
 
 	if err := protected.Set(AlgorithmKey, sb.alg); err != nil {
-		return nil, makeSignError(`failed to set "alg" header: %w`, err)
+		return br, makeSignError(`failed to set "alg" header: %w`, err)
 	}
 
 	if key, ok := sb.key.(jwk.Key); ok {
 		if kid, ok := key.KeyID(); ok && kid != "" {
 			if err := protected.Set(KeyIDKey, kid); err != nil {
-				return nil, makeSignError(`failed to set "kid" header: %w`, err)
+				return br, makeSignError(`failed to set "kid" header: %w`, err)
 			}
 		}
 	}
@@ -83,36 +122,37 @@ func (sb *signatureBuilder) Build(sc *signContext, payload []byte) (*buildResult
 		var err error
 		hdrs, err = mergeHeaders(sb.public, protected)
 		if err != nil {
-			return nil, makeSignError(`failed to merge headers: %w`, err)
+			return br, makeSignError(`failed to merge headers: %w`, err)
 		}
 	}
 
 	// raw, json format headers
 	hdrbuf, err := json.Marshal(hdrs)
 	if err != nil {
-		return nil, fmt.Errorf(`failed to marshal headers: %w`, err)
+		return br, fmt.Errorf(`failed to marshal headers: %w`, err)
 	}
 
 	// check if we need to base64 encode the payload
 	b64 := getB64Value(hdrs)
 	if !b64 && !sc.detached {
 		if bytes.IndexByte(payload, tokens.Period) != -1 {
-			return nil, fmt.Errorf(`payload must not contain a "."`)
+			return br, fmt.Errorf(`payload must not contain a "."`)
 		}
 	}
 
 	combined := jwsbb.SignBuffer(nil, hdrbuf, payload, sc.encoder, b64)
 
-	var br buildResult
 	br.sig.protected = protected
 	br.sig.headers = sb.public
 	br.hdrbuf = hdrbuf
+	br.combined = combined
+	br.b64 = b64
 
 	signature, err := sb.signer.Sign(sb.key, combined)
 	if err != nil {
-		return nil, fmt.Errorf(`failed to sign payload: %w`, err)
+		return br, fmt.Errorf(`failed to sign payload: %w`, err)
 	}
 	br.sig.signature = signature
 
-	return &br, nil
+	return br, nil
 }


### PR DESCRIPTION
Precompute header JSON at WithKey() time, use AppendSignature instead of JoinCompact to avoid double-encoding header+payload, return buildResult by value, cache algorithm-key validation. HS256 sign goes from ~1930ns/23allocs to ~840ns/9allocs locally.