### PR TITLE
clean up jws sign/verify code for legibility

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -757,10 +757,10 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 
 	algstr := alg.String()
 
-	// Split the serialized JWT into its components
+	// Split the serialized JWS into its components
 	hdr, payload, encodedSig, err := jwsbb.SplitCompact(compact)
 	if err != nil {
-		return nil, fmt.Errorf("jwt.verifyFast: failed to split compact: %w", err)
+		return nil, makeVerifyError("failed to split compact: %w", err)
 	}
 
 	// Validate the "crit" header per RFC 7515 Section 4.1.11
@@ -771,7 +771,7 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 
 	signature, err := base64.Decode(encodedSig)
 	if err != nil {
-		return nil, fmt.Errorf("jwt.verifyFast: failed to decode signature: %w", err)
+		return nil, makeVerifyError("failed to decode signature: %w", err)
 	}
 
 	// Instead of appending, copy the data from hdr/payload
@@ -786,21 +786,21 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	// Verify the signature
 	if verifier2, err := VerifierFor(alg); err == nil {
 		if err := verifier2.Verify(key, verifyBuf, signature); err != nil {
-			return nil, verifyError{verificationError{fmt.Errorf("jwt.VerifyCompact: signature verification failed for %s: %w", algstr, err)}}
+			return nil, verifyError{verificationError{fmt.Errorf("signature verification failed for %s: %w", algstr, err)}}
 		}
 	} else {
 		legacyVerifier, err := NewVerifier(alg)
 		if err != nil {
-			return nil, makeVerifyError("jwt.VerifyCompact: failed to create verifier for %s: %w", algstr, err)
+			return nil, makeVerifyError("failed to create verifier for %s: %w", algstr, err)
 		}
 		if err := legacyVerifier.Verify(verifyBuf, signature, key); err != nil {
-			return nil, verifyError{verificationError{fmt.Errorf("jwt.VerifyCompact: signature verification failed for %s: %w", algstr, err)}}
+			return nil, verifyError{verificationError{fmt.Errorf("signature verification failed for %s: %w", algstr, err)}}
 		}
 	}
 
 	decoded, err := base64.Decode(payload)
 	if err != nil {
-		return nil, makeVerifyError("jwt.VerifyCompact: failed to decode payload: %w", err)
+		return nil, makeVerifyError("failed to decode payload: %w", err)
 	}
 	return decoded, nil
 }

--- a/jws/key_provider.go
+++ b/jws/key_provider.go
@@ -76,7 +76,7 @@ type KeySink interface {
 }
 
 type algKeyPair struct {
-	alg jwa.KeyAlgorithm
+	alg jwa.SignatureAlgorithm
 	key any
 }
 
@@ -187,7 +187,7 @@ func (kp *keySetProvider) FetchKeys(_ context.Context, sink KeySink, sig *Signat
 
 		// if multipleKeysPerKeyID is true, we attempt all keys whose key ID matches
 		// the wantedKey
-		ok = false
+		found := false
 		for i := range kp.set.Len() {
 			key, _ := kp.set.Key(i)
 			if kid, ok := key.KeyID(); !ok || kid != wantedKid {
@@ -197,10 +197,10 @@ func (kp *keySetProvider) FetchKeys(_ context.Context, sink KeySink, sig *Signat
 			if err := kp.selectKey(sink, key, sig, msg); err != nil {
 				continue
 			}
-			ok = true
+			found = true
 			// continue processing so that we try all keys with the same key ID
 		}
-		if !ok {
+		if !found {
 			return fmt.Errorf(`failed to find key with key ID %q in key set`, wantedKid)
 		}
 		return nil
@@ -266,19 +266,22 @@ func (kp jkuProvider) FetchKeys(ctx context.Context, sink KeySink, sig *Signatur
 	}
 
 	hdrAlg, ok := sig.ProtectedHeaders().Algorithm()
-	if ok {
-		for _, alg := range algs {
-			// if we have an "alg" field in the JWS, we can only proceed if
-			// the inferred algorithm matches
-			if hdrAlg != alg {
-				continue
-			}
-
-			sink.Key(alg, key)
-			break
-		}
+	if !ok {
+		// No algorithm in the JWS header. The jku provider requires both
+		// kid and alg to match, so we don't send any keys without alg.
+		return nil
 	}
-	return nil
+
+	for _, alg := range algs {
+		if hdrAlg != alg {
+			continue
+		}
+
+		sink.Key(alg, key)
+		return nil
+	}
+
+	return fmt.Errorf(`algorithm %q in JWS header does not match any algorithm for key type %s from jku`, hdrAlg, key.KeyType())
 }
 
 // KeyProviderFunc is a type of KeyProvider that is implemented by

--- a/jws/options.go
+++ b/jws/options.go
@@ -38,7 +38,10 @@ type withKey struct {
 	public    Headers
 }
 
-// Protected exists as an escape hatch to modify the header values after the fact
+// Protected returns the protected headers. If w.protected is nil and v is
+// non-nil, v is stored as the protected headers before returning. This allows
+// callers to provide a default Headers that is used only when none was
+// explicitly configured via WithProtectedHeaders.
 func (w *withKey) Protected(v Headers) Headers {
 	if w.protected == nil && v != nil {
 		w.protected = v
@@ -221,7 +224,10 @@ type withInsecureNoSignature struct {
 	protected Headers
 }
 
-// Protected exists as an escape hatch to modify the header values after the fact
+// Protected returns the protected headers. If w.protected is nil and v is
+// non-nil, v is stored as the protected headers before returning. This allows
+// callers to provide a default Headers that is used only when none was
+// explicitly configured via WithProtectedHeaders.
 func (w *withInsecureNoSignature) Protected(v Headers) Headers {
 	if w.protected == nil && v != nil {
 		w.protected = v

--- a/jws/sign_context.go
+++ b/jws/sign_context.go
@@ -2,6 +2,7 @@ package jws
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/lestrrat-go/jwx/v3/internal/base64"
 	"github.com/lestrrat-go/jwx/v3/internal/pool"
@@ -116,6 +117,8 @@ func (sc *signContext) ProcessOptions(options []SignOption) error {
 			if err := option.Value(&sc.encoder); err != nil {
 				return makeSignError(`failed to retrieve base64-encoder option value: %w`, err)
 			}
+		default:
+			return makeSignError(`invalid jws.SignOption %q passed`, `With`+strings.TrimPrefix(fmt.Sprintf(`%T`, option.Ident()), `jws.ident`))
 		}
 	}
 	return nil

--- a/jws/verifier.go
+++ b/jws/verifier.go
@@ -17,10 +17,7 @@ func (v defaultVerifier) Algorithm() jwa.SignatureAlgorithm {
 }
 
 func (v defaultVerifier) Verify(key any, payload, signature []byte) error {
-	if err := jwsbb.Verify(key, v.alg.String(), payload, signature); err != nil {
-		return verifyError{verificationError{err}}
-	}
-	return nil
+	return jwsbb.Verify(key, v.alg.String(), payload, signature)
 }
 
 type Verifier2 interface {
@@ -35,10 +32,7 @@ type verifierAdapter struct {
 }
 
 func (v verifierAdapter) Verify(key any, payload, signature []byte) error {
-	if err := v.v.Verify(payload, signature, key); err != nil {
-		return verifyError{verificationError{err}}
-	}
-	return nil
+	return v.v.Verify(payload, signature, key)
 }
 
 // VerifierFor returns a Verifier2 for the given signature algorithm.

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -185,11 +185,7 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 			}
 
 			for _, pair := range sink.list {
-				// alg is converted here because pair.alg is of type jwa.KeyAlgorithm.
-				// this may seem ugly, but we're trying to avoid declaring separate
-				// structs for `alg jwa.KeyEncryptionAlgorithm` and `alg jwa.SignatureAlgorithm`
-				//nolint:forcetypeassert
-				alg := pair.alg.(jwa.SignatureAlgorithm)
+				alg := pair.alg
 				key := pair.key
 
 				if err := vc.tryKey(verifyBuf, alg, key, msg, sig); err != nil {
@@ -208,7 +204,7 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, key any, msg *Message, sig *Signature) error {
 	if vc.validateKey {
 		if err := validateKeyBeforeUse(key); err != nil {
-			return fmt.Errorf(`failed to validate key before signing: %w`, err)
+			return fmt.Errorf(`failed to validate key before verification: %w`, err)
 		}
 	}
 


### PR DESCRIPTION
Fix wrong error messages, remove excessive error wrapping, tighten types, and add missing default case in sign option processing.