### PR TITLE
clean up jws sign/verify key selection code

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -528,6 +528,11 @@ func RegisterCustomField(name string, object any) {
 	registry.Register(name, object)
 }
 
+// curver is implemented by jwk.Key types that carry curve information.
+type curver interface {
+	Crv() (jwa.EllipticCurveAlgorithm, bool)
+}
+
 // Helpers for signature verification
 var muAlgorithmMaps sync.RWMutex
 var keyTypeToAlgorithms = make(map[jwa.KeyType][]jwa.SignatureAlgorithm)
@@ -589,9 +594,6 @@ func AlgorithmsForKey(key any) ([]jwa.SignatureAlgorithm, error) {
 	switch key := key.(type) {
 	case jwk.Key:
 		kty = key.KeyType()
-		type curver interface {
-			Crv() (jwa.EllipticCurveAlgorithm, bool)
-		}
 		if ck, ok := key.(curver); ok {
 			crv, hasCrv = ck.Crv()
 		}
@@ -630,9 +632,6 @@ func AlgorithmsForKey(key any) ([]jwa.SignatureAlgorithm, error) {
 			return nil, fmt.Errorf(`unknown key type %T`, key)
 		}
 		kty = imported.KeyType()
-		type curver interface {
-			Crv() (jwa.EllipticCurveAlgorithm, bool)
-		}
 		if ck, ok := imported.(curver); ok {
 			crv, hasCrv = ck.Crv()
 		}

--- a/jws/key_provider.go
+++ b/jws/key_provider.go
@@ -109,110 +109,127 @@ type keySetProvider struct {
 	multipleKeysPerKeyID bool // true if we should attempt to match multiple keys per key ID. if false we assume that only one key exists for a given key ID
 }
 
-func (kp *keySetProvider) selectKey(sink KeySink, key jwk.Key, sig *Signature, _ *Message) error {
+// selectKey examines a single key and, if it is suitable for the given
+// signature, adds one or more (algorithm, key) pairs to the sink.
+// It returns true if at least one pair was added, false if the key was
+// filtered out (e.g. wrong usage, no matching algorithm).
+func (kp *keySetProvider) selectKey(sink KeySink, key jwk.Key, sig *Signature, _ *Message) (bool, error) {
 	if usage, ok := key.KeyUsage(); ok {
 		// it's okay if use: "". we'll assume it's "sig"
 		if usage != "" && usage != jwk.ForSignature.String() {
-			return nil
+			return false, nil
 		}
 	}
 
 	if v, ok := key.Algorithm(); ok {
 		salg, ok := jwa.LookupSignatureAlgorithm(v.String())
 		if !ok {
-			return fmt.Errorf(`invalid signature algorithm %q`, v)
+			return false, fmt.Errorf(`invalid signature algorithm %q`, v)
 		}
 
 		sink.Key(salg, key)
-		return nil
+		return true, nil
 	}
 
-	if kp.inferAlgorithm {
-		algs, err := AlgorithmsForKey(key)
-		if err != nil {
-			return fmt.Errorf(`failed to get a list of signature methods for key type %s: %w`, key.KeyType(), err)
-		}
+	if !kp.inferAlgorithm {
+		return false, nil
+	}
 
-		// bail out if the JWT has a `alg` field, and it doesn't match
-		if tokAlg, ok := sig.ProtectedHeaders().Algorithm(); ok {
-			for _, alg := range algs {
-				if tokAlg == alg {
-					sink.Key(alg, key)
-					return nil
-				}
-			}
-			return fmt.Errorf(`algorithm in the message does not match any of the inferred algorithms`)
-		}
+	algs, err := AlgorithmsForKey(key)
+	if err != nil {
+		return false, fmt.Errorf(`failed to get a list of signature methods for key type %s: %w`, key.KeyType(), err)
+	}
 
-		// Yes, you get to try them all!!!!!!!
+	// bail out if the JWT has a `alg` field, and it doesn't match
+	if tokAlg, ok := sig.ProtectedHeaders().Algorithm(); ok {
 		for _, alg := range algs {
-			sink.Key(alg, key)
+			if tokAlg == alg {
+				sink.Key(alg, key)
+				return true, nil
+			}
 		}
-		return nil
+		return false, fmt.Errorf(`algorithm in the message does not match any of the inferred algorithms`)
 	}
-	return nil
+
+	// Yes, you get to try them all!!!!!!!
+	for _, alg := range algs {
+		sink.Key(alg, key)
+	}
+	return len(algs) > 0, nil
 }
 
 func (kp *keySetProvider) FetchKeys(_ context.Context, sink KeySink, sig *Signature, msg *Message) error {
 	if kp.requireKid {
 		wantedKid, ok := sig.ProtectedHeaders().KeyID()
 		if !ok {
-			// If the kid is NOT specified... kp.useDefault needs to be true, and the
-			// JWKs must have exactly one key in it
-			if !kp.useDefault {
-				return fmt.Errorf(`failed to find matching key: no key ID ("kid") specified in token`)
-			} else if kp.useDefault && kp.set.Len() > 1 {
-				return fmt.Errorf(`failed to find matching key: no key ID ("kid") specified in token but multiple keys available in key set`)
-			}
-
-			// if we got here, then useDefault == true AND there is exactly
-			// one key in the set.
-			key, ok := kp.set.Key(0)
-			if !ok {
-				return fmt.Errorf(`failed to get key at index 0 (empty JWKS?)`)
-			}
-			return kp.selectKey(sink, key, sig, msg)
+			return kp.fetchDefaultKey(sink, sig, msg)
 		}
+		return kp.fetchKeysByKid(sink, sig, msg, wantedKid)
+	}
+	return kp.fetchAllKeys(sink, sig, msg)
+}
 
-		// Otherwise we better be able to look up the key.
-		// <= v2.0.3 backwards compatible case: only match a single key
-		// whose key ID matches `wantedKid`
-		if !kp.multipleKeysPerKeyID {
-			key, ok := kp.set.LookupKeyID(wantedKid)
-			if !ok {
-				return fmt.Errorf(`failed to find key with key ID %q in key set`, wantedKid)
-			}
-			return kp.selectKey(sink, key, sig, msg)
-		}
-
-		// if multipleKeysPerKeyID is true, we attempt all keys whose key ID matches
-		// the wantedKey
-		found := false
-		for i := range kp.set.Len() {
-			key, _ := kp.set.Key(i)
-			if kid, ok := key.KeyID(); !ok || kid != wantedKid {
-				continue
-			}
-
-			if err := kp.selectKey(sink, key, sig, msg); err != nil {
-				continue
-			}
-			found = true
-			// continue processing so that we try all keys with the same key ID
-		}
-		if !found {
-			return fmt.Errorf(`failed to find key with key ID %q in key set`, wantedKid)
-		}
-		return nil
+// fetchDefaultKey handles the case where kid is required but the token
+// has no kid field. It uses the sole key in the set when useDefault is true.
+func (kp *keySetProvider) fetchDefaultKey(sink KeySink, sig *Signature, msg *Message) error {
+	if !kp.useDefault {
+		return fmt.Errorf(`failed to find matching key: no key ID ("kid") specified in token`)
+	}
+	if kp.set.Len() > 1 {
+		return fmt.Errorf(`failed to find matching key: no key ID ("kid") specified in token but multiple keys available in key set`)
 	}
 
-	// Otherwise just try all keys
+	key, ok := kp.set.Key(0)
+	if !ok {
+		return fmt.Errorf(`failed to get key at index 0 (empty JWKS?)`)
+	}
+	_, err := kp.selectKey(sink, key, sig, msg)
+	return err
+}
+
+// fetchKeysByKid looks up keys by their key ID and adds matching ones to the sink.
+func (kp *keySetProvider) fetchKeysByKid(sink KeySink, sig *Signature, msg *Message, wantedKid string) error {
+	// <= v2.0.3 backwards compatible case: only match a single key
+	// whose key ID matches `wantedKid`
+	if !kp.multipleKeysPerKeyID {
+		key, ok := kp.set.LookupKeyID(wantedKid)
+		if !ok {
+			return fmt.Errorf(`failed to find key with key ID %q in key set`, wantedKid)
+		}
+		_, err := kp.selectKey(sink, key, sig, msg)
+		return err
+	}
+
+	// multipleKeysPerKeyID: attempt all keys whose key ID matches
+	found := false
+	for i := range kp.set.Len() {
+		key, _ := kp.set.Key(i)
+		if kid, ok := key.KeyID(); !ok || kid != wantedKid {
+			continue
+		}
+
+		added, err := kp.selectKey(sink, key, sig, msg)
+		if err != nil {
+			continue
+		}
+		if added {
+			found = true
+		}
+	}
+	if !found {
+		return fmt.Errorf(`failed to find key with key ID %q in key set`, wantedKid)
+	}
+	return nil
+}
+
+// fetchAllKeys iterates all keys in the set and adds suitable ones to the sink.
+func (kp *keySetProvider) fetchAllKeys(sink KeySink, sig *Signature, msg *Message) error {
 	for i := range kp.set.Len() {
 		key, ok := kp.set.Key(i)
 		if !ok {
 			return fmt.Errorf(`failed to get key at index %d`, i)
 		}
-		if err := kp.selectKey(sink, key, sig, msg); err != nil {
+		if _, err := kp.selectKey(sink, key, sig, msg); err != nil {
 			continue
 		}
 	}

--- a/jws/sign_context.go
+++ b/jws/sign_context.go
@@ -103,7 +103,7 @@ func (sc *signContext) ProcessOptions(options []SignOption) error {
 			sc.sigbuilders = append(sc.sigbuilders, sb)
 		case identDetachedPayload{}:
 			if sc.payload != nil {
-				return makeSignError(`payload must be nil when jws.WithDetachedPayload() is specified`)
+				return makeSignError(`the first argument to jws.Sign() must be nil when jws.WithDetachedPayload() is used`)
 			}
 			if err := option.Value(&sc.payload); err != nil {
 				return makeSignError(`failed to retrieve detached payload option value: %w`, err)

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -178,6 +178,7 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 
 		verifyBuf = verifyBuf[:0]
 		verifyBuf = jwsbb.SignBuffer(verifyBuf, rawHeaders, msg.payload, vc.encoder, msg.b64)
+		keysAttempted := 0
 		for i, kp := range vc.keyProviders {
 			var sink algKeySink
 			if err := kp.FetchKeys(vc.ctx, &sink, sig, msg); err != nil {
@@ -187,6 +188,7 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 			for _, pair := range sink.list {
 				alg := pair.alg
 				key := pair.key
+				keysAttempted++
 
 				if err := vc.tryKey(verifyBuf, alg, key, msg, sig); err != nil {
 					errs = append(errs, makeVerifyError(`failed to verify signature #%d with key %T: %w`, idx+1, key, err))
@@ -196,7 +198,11 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 				return msg.payload, nil
 			}
 		}
-		errs = append(errs, makeVerifyError(`signature #%d could not be verified with any of the keys`, idx+1))
+		if keysAttempted == 0 {
+			errs = append(errs, makeVerifyError(`signature #%d: no matching keys were provided by any key provider`, idx+1))
+		} else {
+			errs = append(errs, makeVerifyError(`signature #%d: tried %d key(s) but none verified successfully`, idx+1, keysAttempted))
+		}
 	}
 	return nil, makeVerifyError(`could not verify message using any of the signatures or keys: %w`, errors.Join(errs...))
 }


### PR DESCRIPTION
Extract helpers from keySetProvider.FetchKeys() to flatten nesting, improve verification failure diagnostics (distinguish 'no keys matched' from 'N keys tried'), de-duplicate curver interface, fix error messages in tryKey and detached payload handling.