### PR TITLE
reduce allocations in JWE encrypt path

### DIFF
--- a/jwe/bench_encrypt_test.go
+++ b/jwe/bench_encrypt_test.go
@@ -50,6 +50,12 @@ func BenchmarkEncryptKey(b *testing.B) {
 			enc:  jwa.A256GCM(),
 			key:  symKey,
 		},
+		{
+			name: "DIRECT",
+			alg:  jwa.DIRECT(),
+			enc:  jwa.A256GCM(),
+			key:  symKey,
+		},
 	}
 
 	for _, tc := range testcases {
@@ -108,6 +114,13 @@ func BenchmarkDecryptKey(b *testing.B) {
 		{
 			name:   "A256KW",
 			alg:    jwa.A256KW(),
+			enc:    jwa.A256GCM(),
+			encKey: symKey,
+			decKey: symKey,
+		},
+		{
+			name:   "DIRECT",
+			alg:    jwa.DIRECT(),
 			enc:    jwa.A256GCM(),
 			encKey: symKey,
 			decKey: symKey,

--- a/jwe/encrypt.go
+++ b/jwe/encrypt.go
@@ -10,32 +10,64 @@ import (
 	"github.com/lestrrat-go/jwx/v4/jwe/jwebb"
 )
 
-// encrypter is responsible for taking various components to encrypt a key.
-// its operation is not concurrency safe. You must provide locking yourself
-//
-//nolint:govet
-type encrypter struct {
-	apu    []byte
-	apv    []byte
-	ctalg  jwa.ContentEncryptionAlgorithm
-	keyalg jwa.KeyEncryptionAlgorithm
-	key    any
-}
+// encryptKey dispatches key encryption to the appropriate algorithm-specific
+// function. This is a standalone function to avoid allocating an encrypter struct.
+func encryptKey(cek []byte, keyalg jwa.KeyEncryptionAlgorithm, ctalg jwa.ContentEncryptionAlgorithm, key any, apu, apv []byte) (keygen.ByteSource, error) {
+	algStr := keyalg.String()
+	ctalgStr := ctalg.String()
 
-// newEncrypter creates a new Encrypter instance with all required parameters.
-//
-// key must be a resolved key in its "raw" format (e.g. *rsa.PublicKey,
-// []byte, etc.) — not a jwk.Key. The caller is responsible for resolving
-// jwk.Key to raw form before calling this function.
-//
-// You should consider this object immutable once created.
-func newEncrypter(keyalg jwa.KeyEncryptionAlgorithm, ctalg jwa.ContentEncryptionAlgorithm, key any, apu, apv []byte) *encrypter {
-	return &encrypter{
-		apu:    apu,
-		apv:    apv,
-		ctalg:  ctalg,
-		keyalg: keyalg,
-		key:    key,
+	switch {
+	case jwebb.IsDirect(algStr):
+		sharedkey, err := requireByteKey(key, algStr)
+		if err != nil {
+			return nil, err
+		}
+		return jwebb.KeyEncryptDirect(cek, algStr, sharedkey)
+	case jwebb.IsPBES2(algStr):
+		password, err := requireByteKey(key, algStr)
+		if err != nil {
+			return nil, err
+		}
+		return jwebb.KeyEncryptPBES2(cek, algStr, password)
+	case jwebb.IsAESGCMKW(algStr):
+		sharedkey, err := requireByteKey(key, algStr)
+		if err != nil {
+			return nil, err
+		}
+		return jwebb.KeyEncryptAESGCMKW(cek, algStr, sharedkey)
+	case jwebb.IsECDHES(algStr):
+		_, keysize, keywrap, err := jwebb.KeyEncryptionECDHESKeySize(algStr, ctalgStr)
+		if err != nil {
+			return nil, fmt.Errorf(`jwe: encrypt key: failed to determine ECDH-ES key size: %w`, err)
+		}
+		gen, err := jwebb.NewECDHESKeyGenerator(key)
+		if err != nil {
+			return nil, fmt.Errorf(`jwe: encrypt key: %w`, err)
+		}
+		return jwebb.KeyEncryptECDHESCustom(cek, algStr, apu, apv, gen, keysize, ctalgStr, keywrap)
+	case jwebb.IsMLKEM(algStr):
+		if jwebb.IsMLKEMDirect(algStr) {
+			return jwebb.KeyEncryptMLKEM(cek, algStr, ctalgStr, key)
+		}
+		return jwebb.KeyEncryptMLKEMKeyWrap(cek, algStr, ctalgStr, key)
+	case jwebb.IsHPKE(algStr):
+		result, err := jwebb.KeyEncryptHPKEKE(cek, algStr, ctalgStr, key)
+		if err != nil {
+			return nil, makeHPKEError(`encrypt key (HPKE): %w`, err)
+		}
+		return result, nil
+	case jwebb.IsRSA15(algStr):
+		return encryptKeyRSA(cek, algStr, key, jwebb.KeyEncryptRSA15)
+	case jwebb.IsRSAOAEP(algStr):
+		return encryptKeyRSA(cek, algStr, key, jwebb.KeyEncryptRSAOAEP)
+	case jwebb.IsAESKW(algStr):
+		sharedkey, err := requireByteKey(key, algStr)
+		if err != nil {
+			return nil, err
+		}
+		return jwebb.KeyEncryptAESKW(cek, algStr, sharedkey)
+	default:
+		return nil, fmt.Errorf(`jwe: encrypt key: unsupported algorithm (%s)`, algStr)
 	}
 }
 
@@ -47,104 +79,13 @@ func requireByteKey(key any, alg string) ([]byte, error) {
 	return b, nil
 }
 
-func (e *encrypter) EncryptKey(cek []byte) (keygen.ByteSource, error) {
-	algStr := e.keyalg.String()
-	ctalgStr := e.ctalg.String()
-
-	switch {
-	case jwebb.IsDirect(algStr):
-		return e.encryptKeyDirect(cek, algStr)
-	case jwebb.IsPBES2(algStr):
-		return e.encryptKeyPBES2(cek, algStr)
-	case jwebb.IsAESGCMKW(algStr):
-		return e.encryptKeyAESGCMKW(cek, algStr)
-	case jwebb.IsECDHES(algStr):
-		return e.encryptKeyECDHES(cek, algStr, ctalgStr)
-	case jwebb.IsMLKEM(algStr):
-		return e.encryptKeyMLKEM(cek, algStr, ctalgStr)
-	case jwebb.IsHPKE(algStr):
-		return e.encryptKeyHPKE(cek, algStr, ctalgStr)
-	case jwebb.IsRSA15(algStr):
-		return e.encryptKeyRSA(cek, algStr, jwebb.KeyEncryptRSA15)
-	case jwebb.IsRSAOAEP(algStr):
-		return e.encryptKeyRSA(cek, algStr, jwebb.KeyEncryptRSAOAEP)
-	case jwebb.IsAESKW(algStr):
-		return e.encryptKeyAESKW(cek, algStr)
-	default:
-		return nil, fmt.Errorf(`jwe: encrypt key: unsupported algorithm (%s)`, algStr)
-	}
-}
-
-func (e *encrypter) encryptKeyDirect(cek []byte, alg string) (keygen.ByteSource, error) {
-	sharedkey, err := requireByteKey(e.key, alg)
-	if err != nil {
-		return nil, err
-	}
-	return jwebb.KeyEncryptDirect(cek, alg, sharedkey)
-}
-
-func (e *encrypter) encryptKeyPBES2(cek []byte, alg string) (keygen.ByteSource, error) {
-	password, err := requireByteKey(e.key, alg)
-	if err != nil {
-		return nil, err
-	}
-	return jwebb.KeyEncryptPBES2(cek, alg, password)
-}
-
-func (e *encrypter) encryptKeyAESGCMKW(cek []byte, alg string) (keygen.ByteSource, error) {
-	sharedkey, err := requireByteKey(e.key, alg)
-	if err != nil {
-		return nil, err
-	}
-	return jwebb.KeyEncryptAESGCMKW(cek, alg, sharedkey)
-}
-
-func (e *encrypter) encryptKeyAESKW(cek []byte, alg string) (keygen.ByteSource, error) {
-	sharedkey, err := requireByteKey(e.key, alg)
-	if err != nil {
-		return nil, err
-	}
-	return jwebb.KeyEncryptAESKW(cek, alg, sharedkey)
-}
-
-func (e *encrypter) encryptKeyECDHES(cek []byte, alg, ctalg string) (keygen.ByteSource, error) {
-	_, keysize, keywrap, err := jwebb.KeyEncryptionECDHESKeySize(alg, ctalg)
-	if err != nil {
-		return nil, fmt.Errorf(`jwe: encrypt key: failed to determine ECDH-ES key size: %w`, err)
-	}
-
-	gen, err := jwebb.NewECDHESKeyGenerator(e.key)
-	if err != nil {
-		return nil, fmt.Errorf(`jwe: encrypt key: %w`, err)
-	}
-
-	return jwebb.KeyEncryptECDHESCustom(cek, alg, e.apu, e.apv, gen, keysize, ctalg, keywrap)
-}
-
-func (e *encrypter) encryptKeyHPKE(cek []byte, alg, ctalg string) (keygen.ByteSource, error) {
-	result, err := jwebb.KeyEncryptHPKEKE(cek, alg, ctalg, e.key)
-	if err != nil {
-		return nil, makeHPKEError(`encrypt key (HPKE): %w`, err)
-	}
-	return result, nil
-}
-
-func (e *encrypter) encryptKeyMLKEM(cek []byte, alg, ctalg string) (keygen.ByteSource, error) {
-	if jwebb.IsMLKEMDirect(alg) {
-		return jwebb.KeyEncryptMLKEM(cek, alg, ctalg, e.key)
-	}
-	return jwebb.KeyEncryptMLKEMKeyWrap(cek, alg, ctalg, e.key)
-}
-
-func (e *encrypter) encryptKeyRSA(cek []byte, alg string, encryptFn func([]byte, string, *rsa.PublicKey) (keygen.ByteSource, error)) (keygen.ByteSource, error) {
-	keyToUse := e.key
-
+func encryptKeyRSA(cek []byte, alg string, key any, encryptFn func([]byte, string, *rsa.PublicKey) (keygen.ByteSource, error)) (keygen.ByteSource, error) {
 	// Handle rsa.PublicKey by value - convert to pointer
-	if pk, ok := keyToUse.(rsa.PublicKey); ok {
-		keyToUse = &pk
+	if pk, ok := key.(rsa.PublicKey); ok {
+		key = &pk
 	}
 
-	pubkey, err := keyconv.RSAPublicKey(keyToUse)
+	pubkey, err := keyconv.RSAPublicKey(key)
 	if err != nil {
 		return nil, fmt.Errorf(`jwe: encrypt key: failed to convert to RSA public key: %w`, err)
 	}

--- a/jwe/headers.go
+++ b/jwe/headers.go
@@ -54,6 +54,73 @@ func (h *stdHeaders) Merge(h2 Headers) (Headers, error) {
 	return h3, nil
 }
 
+// mergeIntoNoLock copies non-nil fields from h into dst without acquiring
+// any mutexes. Both h and dst must be exclusively owned by the caller.
+// Unlike cloneFrom, this only overwrites fields that are set in h,
+// leaving existing values in dst untouched.
+func (h *stdHeaders) mergeIntoNoLock(dst *stdHeaders) {
+	if h.agreementPartyUInfo != nil {
+		dst.agreementPartyUInfo = h.agreementPartyUInfo
+	}
+	if h.agreementPartyVInfo != nil {
+		dst.agreementPartyVInfo = h.agreementPartyVInfo
+	}
+	if h.algorithm != nil {
+		dst.algorithm = h.algorithm
+	}
+	if h.compression != nil {
+		dst.compression = h.compression
+	}
+	if h.contentEncryption != nil {
+		dst.contentEncryption = h.contentEncryption
+	}
+	if h.contentType != nil {
+		dst.contentType = h.contentType
+	}
+	if h.critical != nil {
+		dst.critical = h.critical
+	}
+	if h.encapsulatedKey != nil {
+		dst.encapsulatedKey = h.encapsulatedKey
+	}
+	if h.ephemeralPublicKey != nil {
+		dst.ephemeralPublicKey = h.ephemeralPublicKey
+	}
+	if h.jwk != nil {
+		dst.jwk = h.jwk
+	}
+	if h.jwkSetURL != nil {
+		dst.jwkSetURL = h.jwkSetURL
+	}
+	if h.keyID != nil {
+		dst.keyID = h.keyID
+	}
+	if h.pskID != nil {
+		dst.pskID = h.pskID
+	}
+	if h.typ != nil {
+		dst.typ = h.typ
+	}
+	if h.x509CertChain != nil {
+		dst.x509CertChain = h.x509CertChain
+	}
+	if h.x509CertThumbprint != nil {
+		dst.x509CertThumbprint = h.x509CertThumbprint
+	}
+	if h.x509CertThumbprintS256 != nil {
+		dst.x509CertThumbprintS256 = h.x509CertThumbprintS256
+	}
+	if h.x509URL != nil {
+		dst.x509URL = h.x509URL
+	}
+	for k, v := range h.privateParams {
+		if dst.privateParams == nil {
+			dst.privateParams = make(map[string]any)
+		}
+		dst.privateParams[k] = v
+	}
+}
+
 func (h *stdHeaders) Encode() ([]byte, error) {
 	buf, err := json.Marshal(h)
 	if err != nil {

--- a/jwe/internal/cipher/cipher.go
+++ b/jwe/internal/cipher/cipher.go
@@ -95,16 +95,17 @@ func (c AesContentCipher) Encrypt(cek, plaintext, aad []byte) (iv, ciphertxt, ta
 		return nil, nil, nil, fmt.Errorf(`failed to fetch AEAD: %w`, err)
 	}
 
-	// Seal may panic (argh!), so protect ourselves from that
+	// CBC+HMAC's Seal may panic (buffer size limits, auth tag errors),
+	// so we must recover. GCM's Seal from the stdlib does not panic
+	// with valid inputs, but we protect uniformly for safety.
 	defer func() {
 		if e := recover(); e != nil {
-			switch e := e.(type) {
+			switch v := e.(type) {
 			case error:
-				err = e
+				err = fmt.Errorf(`failed to encrypt: %w`, v)
 			default:
-				err = fmt.Errorf("%s", e)
+				err = fmt.Errorf("failed to encrypt: %s", v)
 			}
-			err = fmt.Errorf(`failed to encrypt: %w`, err)
 		}
 	}()
 
@@ -124,10 +125,6 @@ func (c AesContentCipher) Encrypt(cek, plaintext, aad []byte) (iv, ciphertxt, ta
 	combined := aead.Seal(nil, iv, plaintext, aad)
 	tagoffset := len(combined) - c.TagSize()
 
-	if tagoffset < 0 {
-		panic(fmt.Sprintf("tag offset is less than 0 (combined len = %d, tagsize = %d)", len(combined), c.TagSize()))
-	}
-
 	ciphertxt = combined[:tagoffset:tagoffset]
 	tag = combined[tagoffset:]
 
@@ -140,17 +137,15 @@ func (c AesContentCipher) Decrypt(cek, iv, ciphertxt, tag, aad []byte) (plaintex
 		return nil, fmt.Errorf(`failed to fetch AEAD data: %w`, err)
 	}
 
-	// Open may panic (argh!), so protect ourselves from that
+	// CBC+HMAC's Open may panic (buffer size limits), so we must recover.
 	defer func() {
 		if e := recover(); e != nil {
-			switch e := e.(type) {
+			switch v := e.(type) {
 			case error:
-				err = e
+				err = fmt.Errorf(`failed to decrypt: %w`, v)
 			default:
-				err = fmt.Errorf(`%s`, e)
+				err = fmt.Errorf("failed to decrypt: %s", v)
 			}
-			err = fmt.Errorf(`failed to decrypt: %w`, err)
-			return
 		}
 	}()
 
@@ -158,11 +153,9 @@ func (c AesContentCipher) Decrypt(cek, iv, ciphertxt, tag, aad []byte) (plaintex
 	copy(combined, ciphertxt)
 	copy(combined[len(ciphertxt):], tag)
 
-	buf, aeaderr := aead.Open(nil, iv, combined, aad)
-	if aeaderr != nil {
-		err = fmt.Errorf(`aead.Open failed: %w`, aeaderr)
-		return
+	plaintext, err = aead.Open(nil, iv, combined, aad)
+	if err != nil {
+		return nil, fmt.Errorf(`aead.Open failed: %w`, err)
 	}
-	plaintext = buf
-	return
+	return plaintext, nil
 }

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -139,7 +139,9 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 
 	hdr := b.headers
 	if hdr == nil {
-		hdr = NewHeaders()
+		hdr = r.Headers()
+	} else {
+		_ = r.SetHeaders(hdr)
 	}
 
 	if val, ok := hdr.AgreementPartyUInfo(); ok {
@@ -149,10 +151,6 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 	if val, ok := hdr.AgreementPartyVInfo(); ok {
 		apv = val
 	}
-
-	enc := newEncrypter(b.alg, calg, resolvedKey, apu, apv)
-
-	_ = r.SetHeaders(hdr)
 
 	// Populate headers with stuff that we automatically set.
 	// Use setNoLock when possible since the header is either freshly
@@ -179,7 +177,7 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 
 	// Handle the encrypted key
 	var rawCEK []byte
-	enckey, err := enc.EncryptKey(cek)
+	enckey, err := encryptKey(cek, b.alg, calg, resolvedKey, apu, apv)
 	if err != nil {
 		return nil, fmt.Errorf(`failed to encrypt key: %w`, err)
 	}
@@ -544,6 +542,7 @@ type encryptContext struct {
 	format      int
 	builders    []*recipientBuilder
 	protected   Headers
+	builderBuf  [1]recipientBuilder // inline storage for common single-recipient case
 }
 
 var encryptContextPool = pool.New(allocEncryptContext, freeEncryptContext)
@@ -562,6 +561,7 @@ func freeEncryptContext(ec *encryptContext) *encryptContext {
 	ec.format = fmtCompact
 	ec.builders = ec.builders[:0]
 	ec.protected = nil
+	ec.builderBuf[0] = recipientBuilder{}
 	return ec
 }
 
@@ -579,11 +579,16 @@ func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
 			if jwebb.IsDirectCEK(v.String()) {
 				useRawCEK = true
 			}
-			ec.builders = append(ec.builders, &recipientBuilder{
-				alg:     v,
-				key:     wk.key,
-				headers: wk.headers,
-			})
+			var rb *recipientBuilder
+			if len(ec.builders) == 0 {
+				rb = &ec.builderBuf[0]
+			} else {
+				rb = &recipientBuilder{}
+			}
+			rb.alg = v
+			rb.key = wk.key
+			rb.headers = wk.headers
+			ec.builders = append(ec.builders, rb)
 		case identContentEncryptionAlgorithm{}:
 			ec.calg = option.MustGet[jwa.ContentEncryptionAlgorithm](opt)
 		case identCompress{}:
@@ -771,8 +776,11 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 		}
 
 		// when we're using compact format, we can safely merge per-recipient
-		// headers into the protected header in-place (we own it from pool)
-		if err := recipients[0].Headers().Copy(protected); err != nil {
+		// headers into the protected header in-place (we own it from pool).
+		// Fast path: both are *stdHeaders owned exclusively, skip Keys/Field/Set overhead.
+		if src, ok := recipients[0].Headers().(*stdHeaders); ok {
+			src.mergeIntoNoLock(protected)
+		} else if err := recipients[0].Headers().Copy(protected); err != nil {
 			return nil, fmt.Errorf(`failed to merge protected headers for compact serialization: %w`, err)
 		}
 	} else {

--- a/jwe/jwebb/keywrap.go
+++ b/jwe/jwebb/keywrap.go
@@ -18,27 +18,24 @@ func Wrap(kek cipher.Block, cek []byte) ([]byte, error) {
 	}
 
 	n := len(cek) / tokens.KeywrapChunkLen
-	r := make([][]byte, n)
 
-	for i := range n {
-		r[i] = make([]byte, tokens.KeywrapChunkLen)
-		copy(r[i], cek[i*tokens.KeywrapChunkLen:])
-	}
+	// Single flat buffer for register values instead of [][]byte
+	rBuf := make([]byte, n*tokens.KeywrapChunkLen)
+	copy(rBuf, cek)
 
 	buffer := pool.ByteSlice().GetCapacity(tokens.KeywrapChunkLen * 2)
 	defer pool.ByteSlice().Put(buffer)
-	// the byte slice has the capacity, but len is 0
 	buffer = buffer[:tokens.KeywrapChunkLen*2]
 
 	tBytes := pool.ByteSlice().GetCapacity(tokens.KeywrapChunkLen)
 	defer pool.ByteSlice().Put(tBytes)
-	// the byte slice has the capacity, but len is 0
 	tBytes = tBytes[:tokens.KeywrapChunkLen]
 
 	copy(buffer, keywrapDefaultIV)
 
 	for t := range tokens.KeywrapRounds * n {
-		copy(buffer[tokens.KeywrapChunkLen:], r[t%n])
+		idx := (t % n) * tokens.KeywrapChunkLen
+		copy(buffer[tokens.KeywrapChunkLen:], rBuf[idx:idx+tokens.KeywrapChunkLen])
 
 		kek.Encrypt(buffer, buffer)
 
@@ -47,14 +44,12 @@ func Wrap(kek cipher.Block, cek []byte) ([]byte, error) {
 		for i := range tokens.KeywrapChunkLen {
 			buffer[i] = buffer[i] ^ tBytes[i]
 		}
-		copy(r[t%n], buffer[tokens.KeywrapChunkLen:])
+		copy(rBuf[idx:idx+tokens.KeywrapChunkLen], buffer[tokens.KeywrapChunkLen:])
 	}
 
 	out := make([]byte, (n+1)*tokens.KeywrapChunkLen)
 	copy(out, buffer[:tokens.KeywrapChunkLen])
-	for i := range r {
-		copy(out[(i+1)*tokens.KeywrapBlockSize:], r[i])
-	}
+	copy(out[tokens.KeywrapChunkLen:], rBuf)
 
 	return out, nil
 }
@@ -65,21 +60,17 @@ func Unwrap(block cipher.Block, ciphertxt []byte) ([]byte, error) {
 	}
 
 	n := (len(ciphertxt) / tokens.KeywrapChunkLen) - 1
-	r := make([][]byte, n)
 
-	for i := range r {
-		r[i] = make([]byte, tokens.KeywrapChunkLen)
-		copy(r[i], ciphertxt[(i+1)*tokens.KeywrapChunkLen:])
-	}
+	// Single flat buffer for register values instead of [][]byte
+	rBuf := make([]byte, n*tokens.KeywrapChunkLen)
+	copy(rBuf, ciphertxt[tokens.KeywrapChunkLen:])
 
 	buffer := pool.ByteSlice().GetCapacity(tokens.KeywrapChunkLen * 2)
 	defer pool.ByteSlice().Put(buffer)
-	// the byte slice has the capacity, but len is 0
 	buffer = buffer[:tokens.KeywrapChunkLen*2]
 
 	tBytes := pool.ByteSlice().GetCapacity(tokens.KeywrapChunkLen)
 	defer pool.ByteSlice().Put(tBytes)
-	// the byte slice has the capacity, but len is 0
 	tBytes = tBytes[:tokens.KeywrapChunkLen]
 
 	copy(buffer[:tokens.KeywrapChunkLen], ciphertxt[:tokens.KeywrapChunkLen])
@@ -90,11 +81,12 @@ func Unwrap(block cipher.Block, ciphertxt []byte) ([]byte, error) {
 		for i := range tokens.KeywrapChunkLen {
 			buffer[i] = buffer[i] ^ tBytes[i]
 		}
-		copy(buffer[tokens.KeywrapChunkLen:], r[t%n])
+		idx := (t % n) * tokens.KeywrapChunkLen
+		copy(buffer[tokens.KeywrapChunkLen:], rBuf[idx:idx+tokens.KeywrapChunkLen])
 
 		block.Decrypt(buffer, buffer)
 
-		copy(r[t%n], buffer[tokens.KeywrapChunkLen:])
+		copy(rBuf[idx:idx+tokens.KeywrapChunkLen], buffer[tokens.KeywrapChunkLen:])
 	}
 
 	if subtle.ConstantTimeCompare(buffer[:tokens.KeywrapChunkLen], keywrapDefaultIV) == 0 {
@@ -102,9 +94,7 @@ func Unwrap(block cipher.Block, ciphertxt []byte) ([]byte, error) {
 	}
 
 	out := make([]byte, n*tokens.KeywrapChunkLen)
-	for i := range r {
-		copy(out[i*tokens.KeywrapChunkLen:], r[i])
-	}
+	copy(out, rBuf)
 
 	return out, nil
 }


### PR DESCRIPTION
## Summary
- Reuse pooled recipient headers instead of allocating new ones in Build()
- Flatten keywrap Wrap/Unwrap to use single flat buffer instead of [][]byte
- Eliminate encrypter struct allocation by inlining dispatch into a function
- Inline first recipientBuilder in encryptContext to avoid heap allocation
- Add mergeIntoNoLock fast-path for compact header merge
- Add DIRECT to JWE encrypt/decrypt benchmarks

## Benchmarks (8 samples, local)

```
                       │  before   │              after               │
                       │  sec/op   │   sec/op     vs base            │
EncryptKey/A256KW-24     9.259µ ±3%   7.936µ ±2%  -14.29% (p=0.000)
EncryptKey/DIRECT-24     7.527µ ±2%   6.513µ ±2%  -13.47% (p=0.000)
EncryptKey/RSA-OAEP-24   37.67µ ±3%   36.80µ ±3%   -2.33% (p=0.038)
EncryptKey/ECDH-ES-24    71.72µ ±2%   71.79µ ±2%        ~ (p=0.798)

                       │  before   │              after               │
                       │ allocs/op │ allocs/op   vs base              │
EncryptKey/A256KW-24     52.00 ±0%   42.00 ±0%  -19.23% (p=0.000)
EncryptKey/DIRECT-24     43.00 ±0%   38.00 ±0%  -11.63% (p=0.000)
EncryptKey/RSA-OAEP-24   59.00 ±0%   54.00 ±0%   -8.47% (p=0.000)
EncryptKey/ECDH-ES-24    112.0 ±0%   107.0 ±0%   -4.46% (p=0.000)
```
