### PR TITLE
add companion module CI and test script

### DIFF
--- a/.github/workflows/companion-tests.yml
+++ b/.github/workflows/companion-tests.yml
@@ -1,0 +1,74 @@
+name: Companion Tests
+on:
+  push:
+    branches:
+      - develop/v4
+  workflow_dispatch:
+    inputs:
+      modules:
+        description: 'Comma-separated list of modules to test, or "all"'
+        required: false
+        default: 'all'
+        type: string
+
+env:
+  GOEXPERIMENT: jsonv2
+
+jobs:
+  resolve-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout jwx
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: companions.yaml
+          sparse-checkout-cone-mode: false
+      - id: set-matrix
+        env:
+          INPUT_MODULES: ${{ github.event.inputs.modules || 'all' }}
+        run: |
+          ALL=$(python3 -c "
+          import yaml, json, sys
+          with open('companions.yaml') as f:
+              data = yaml.safe_load(f)
+          names = [m['name'] for m in data.get('modules', []) if m.get('runtests', True) is not False]
+          print(json.dumps(names))
+          ")
+          if [ "$INPUT_MODULES" = "all" ]; then
+            echo "matrix={\"module\":$ALL}" >> "$GITHUB_OUTPUT"
+          else
+            JSON=$(echo "$INPUT_MODULES" | tr ',' '\n' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//' | jq -R . | jq -s .)
+            echo "matrix={\"module\":$JSON}" >> "$GITHUB_OUTPUT"
+          fi
+
+  test:
+    needs: resolve-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.resolve-matrix.outputs.matrix) }}
+    name: "Companion [ ${{ matrix.module }} ]"
+    steps:
+      - name: Checkout jwx
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Rewrite companion URLs to HTTPS for CI
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+      - name: Cache Go modules
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-companion-${{ matrix.module }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-companion-${{ matrix.module }}-
+            ${{ runner.os }}-go-
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          check-latest: true
+      - name: Test companion module
+        run: ./scripts/test-companion.sh "${{ matrix.module }}"

--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,5 @@ go.work.sum
 # Cached codegen binary
 scripts/.jwxcodegen
 
-# Companion module clones (managed by /jwx-companion-bulk skill)
+# Companion module checkouts (test-companion.sh, /jwx-companion-bulk skill)
 .companions/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: generate realclean cover viewcover test lint check_diffs imports tidy jwx fuzz fuzz-jwt fuzz-jws fuzz-jwe fuzz-jwk
+.PHONY: generate realclean cover viewcover test lint check_diffs imports tidy jwx fuzz fuzz-jwt fuzz-jws fuzz-jwe fuzz-jwk companion-test
 
 export GOEXPERIMENT := jsonv2
 
@@ -66,6 +66,9 @@ fuzz-jwk:
 	go test ./jwk/ -run "^$$" -fuzz "^FuzzParseKey$$" -fuzztime $(FUZZTIME)
 	go test ./jwk/ -run "^$$" -fuzz "^FuzzParse$$" -fuzztime $(FUZZTIME)
 	go test ./jwk/ -run "^$$" -fuzz FuzzParseKeyRoundtrip -fuzztime $(FUZZTIME)
+
+companion-test:
+	./scripts/test-companion.sh $(or $(MODULES),all)
 
 jwx:
 	@./scripts/install-jwx.sh

--- a/scripts/test-companion.sh
+++ b/scripts/test-companion.sh
@@ -109,6 +109,8 @@ GOWORK
 		results+=("FAIL $name")
 	fi
 
+	rm -f go.work go.work.sum
+
 	popd > /dev/null
 done < <(parse_modules)
 

--- a/scripts/test-companion.sh
+++ b/scripts/test-companion.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export GOEXPERIMENT=jsonv2
+
+JWX_ROOT=$(cd "$(dirname "$0")/.."; pwd -P)
+COMPANIONS_YAML="$JWX_ROOT/companions.yaml"
+
+if [ ! -f "$JWX_ROOT/go.mod" ]; then
+	echo "ERROR: cannot find go.mod in $JWX_ROOT"
+	exit 1
+fi
+
+if [ ! -f "$COMPANIONS_YAML" ]; then
+	echo "ERROR: cannot find companions.yaml in $JWX_ROOT"
+	exit 1
+fi
+
+# Parse companions.yaml: emit "name repo branch runtests" per testable module.
+# Modules with runtests: false are excluded.
+parse_modules() {
+	python3 -c "
+import yaml, sys
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f)
+for m in data.get('modules', []):
+    if m.get('runtests', True) is False:
+        continue
+    print(m['name'], m['repo'], m.get('branch', 'main'))
+" "$COMPANIONS_YAML"
+}
+
+# Resolve which modules to test
+if [ $# -eq 0 ]; then
+	filter="all"
+else
+	filter="$1"
+fi
+
+WORKDIR="$JWX_ROOT/.companions"
+mkdir -p "$WORKDIR"
+
+failures=0
+results=()
+
+while read -r name repo branch; do
+	if [ "$filter" != "all" ]; then
+		# Check if this module is in the filter list
+		match=false
+		IFS=', ' read -ra selected <<< "$filter"
+		for s in "${selected[@]}"; do
+			if [ "$s" = "$name" ]; then
+				match=true
+				break
+			fi
+		done
+		if [ "$match" = false ]; then
+			continue
+		fi
+	fi
+
+	echo ""
+	echo "===== Testing companion module: $name ====="
+	echo ""
+
+	moddir="$WORKDIR/$name"
+
+	if [ -d "$moddir/.git" ]; then
+		actual_url=$(git -C "$moddir" remote get-url origin 2>/dev/null || true)
+		if [ "$actual_url" != "$repo" ]; then
+			echo "Remote URL mismatch: expected $repo, got $actual_url"
+			echo "Removing and re-cloning..."
+			rm -rf "$moddir"
+		else
+			echo "Reusing existing checkout, pulling latest..."
+			git -C "$moddir" fetch --depth=1 origin "$branch"
+			git -C "$moddir" reset --hard FETCH_HEAD
+		fi
+	fi
+
+	if [ ! -d "$moddir/.git" ]; then
+		if ! git clone --depth=1 --branch "$branch" "$repo" "$moddir"; then
+			echo "FAIL: could not clone $name"
+			failures=$((failures + 1))
+			results+=("FAIL $name (clone failed)")
+			continue
+		fi
+	fi
+
+	pushd "$moddir" > /dev/null
+
+	# Use go.work to redirect jwx/v4 to the local checkout.
+	# This avoids modifying go.mod, which would show up in git diff
+	# and risk accidental commits.
+	cat > go.work <<GOWORK
+go $(go env GOVERSION | sed 's/^go//')
+
+use (
+	.
+	$JWX_ROOT
+)
+GOWORK
+
+	if go test -race ./...; then
+		results+=("PASS $name")
+	else
+		failures=$((failures + 1))
+		results+=("FAIL $name")
+	fi
+
+	popd > /dev/null
+done < <(parse_modules)
+
+echo ""
+echo "===== Companion Test Summary ====="
+for r in "${results[@]}"; do
+	echo "  $r"
+done
+echo "=================================="
+
+if [ "$failures" -ne 0 ]; then
+	echo "$failures module(s) failed"
+	exit 1
+fi
+
+echo "All companion modules passed"


### PR DESCRIPTION
- Add scripts/test-companion.sh: reads companions.yaml, clones into .companions/, uses go.work for local jwx/v4 resolution, runs go test -race
- Add .github/workflows/companion-tests.yml: triggers on push to develop/v4 and manual dispatch with module selection, matrix strategy per module
- Add make companion-test target
