### PR TITLE
update ed448 default branch to develop/v4

### DIFF
--- a/companions.yaml
+++ b/companions.yaml
@@ -11,7 +11,7 @@ modules:
     runtests: false
   - name: ed448
     repo: git@github.com:jwx-go/ed448.git
-    branch: v4
+    branch: develop/v4
   - name: es256k
     repo: git@github.com:jwx-go/es256k.git
     branch: develop/v4


### PR DESCRIPTION
- Update ed448 default branch from `v4` to `develop/v4` in companions.yaml

Refs #1697