### PR TITLE
cache bazelisk binary in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
             ~/.cache/bazel
+            ~/.cache/bazelisk
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -30,6 +30,7 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
             ~/.cache/bazel
+            ~/.cache/bazelisk
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-


### PR DESCRIPTION
- Add ~/.cache/bazelisk to CI cache paths in ci.yml and smoke.yml
- Bazelisk downloads the Bazel binary to ~/.cache/bazelisk/, which was not cached, causing a fresh ~200MB download every run