### PR TITLE
restructure .companions/ layout for CI templates

### DIFF
--- a/.claude/docs/companions.md
+++ b/.claude/docs/companions.md
@@ -1,0 +1,77 @@
+# Companion Modules
+
+## Overview
+
+Extension modules under `github.com/jwx-go/*` (asmbase64, ed448, es256k, examples,
+jwkcache, mldsa, x448, benchmarks) are managed as "companion modules." They live in
+separate repos but share CI workflows, dependabot config, and development tooling.
+
+## Directory Layout
+
+```
+companions.yaml          # Module registry (tracked in git)
+.companions/
+  repo/                  # Cloned companion repos (gitignored)
+    asmbase64/
+    ed448/
+    ...
+  templates/             # Standardized workflow templates (tracked in git)
+    ci.yml
+    lint.yml
+    dependabot.yml
+    ...
+```
+
+- `companions.yaml` — lists every companion module: name, repo URL, default branch,
+  and flags (e.g. `runtests: false` for benchmarks).
+- `.companions/repo/` — shallow clones, managed by scripts and skills. Gitignored.
+- `.companions/templates/` — canonical CI/config files that get synced to all modules.
+  Tracked in git — these are the source of truth.
+
+## Tools
+
+### `scripts/test-companion.sh`
+
+Runs `go test -race ./...` against companion modules using the local jwx checkout
+via a temporary `go.work` file. Clones are placed in `.companions/repo/`.
+
+```bash
+# Test all companion modules
+./scripts/test-companion.sh
+
+# Test specific modules
+./scripts/test-companion.sh "ed448,x448"
+```
+
+### `/jwx-companion-bulk` skill
+
+Applies bulk operations (CI sync, dependency bumps, file updates) across all or
+selected companion modules. See `.claude/skills/jwx-companion-bulk/SKILL.md` for
+full documentation.
+
+```
+/jwx-companion-bulk sync ci.yml and lint.yml from templates --pr
+/jwx-companion-bulk bump jwx dependency to latest --modules=ed448,x448
+```
+
+## Template Workflow
+
+To standardize a workflow file across companion modules:
+
+1. Edit the template in `.companions/templates/` (e.g. `ci.yml`).
+2. Use `/jwx-companion-bulk` to sync it across modules.
+3. Templates may contain placeholders that get adapted per module (branch patterns,
+   module-specific paths). The skill handles adaptation automatically.
+
+## companions.yaml Schema
+
+```yaml
+modules:
+  - name: asmbase64                          # Directory name under .companions/repo/
+    repo: git@github.com:jwx-go/asmbase64.git
+    branch: develop/v4                       # Default branch
+  - name: benchmarks
+    repo: git@github.com:jwx-go/benchmarks.git
+    branch: main
+    runtests: false                          # Skip in test-companion.sh
+```

--- a/.claude/skills/jwx-companion-bulk/SKILL.md
+++ b/.claude/skills/jwx-companion-bulk/SKILL.md
@@ -33,15 +33,15 @@ If instructions are ambiguous, ask the user before proceeding.
 
 For each module in the (filtered) list:
 
-1. If `$PROJECT/.companions/<name>/` does not exist:
+1. If `$PROJECT/.companions/repo/<name>/` does not exist:
    ```
    cd $PROJECT
-   git clone <repo> .companions/<name>
+   git clone <repo> .companions/repo/<name>
    ```
 
 2. If it already exists, update it:
    ```
-   cd $PROJECT/.companions/<name>
+   cd $PROJECT/.companions/repo/<name>
    git fetch origin
    ```
 
@@ -49,7 +49,7 @@ For each module in the (filtered) list:
    - If `branch` is set in the config, use that.
    - Otherwise, read `origin/HEAD`:
      ```
-     cd $PROJECT/.companions/<name>
+     cd $PROJECT/.companions/repo/<name>
      git symbolic-ref refs/remotes/origin/HEAD
      ```
      This returns e.g. `refs/remotes/origin/develop/v4` — strip the prefix.
@@ -60,11 +60,11 @@ For each module in the (filtered) list:
 
 4. Checkout the default branch:
    ```
-   cd $PROJECT/.companions/<name>
+   cd $PROJECT/.companions/repo/<name>
    git checkout <default-branch>
    ```
    ```
-   cd $PROJECT/.companions/<name>
+   cd $PROJECT/.companions/repo/<name>
    git pull --ff-only
    ```
 
@@ -101,18 +101,18 @@ When unsure, ask the user: "Same mechanical change per module, or independent wo
 1. Pick first module from list (or `--ref-module` if specified).
 2. Create a feature branch from the module's default branch:
    ```
-   cd $PROJECT/.companions/<name>
+   cd $PROJECT/.companions/repo/<name>
    git checkout -b <branch-name> <default-branch>
    ```
    Use ordinary branch naming: `<category>-<short-description>` (e.g. `chore-bump-jwx-dep`).
 3. Apply instructions to this module.
 4. Verify (if module has `go.mod`):
    ```
-   cd $PROJECT/.companions/<name>
+   cd $PROJECT/.companions/repo/<name>
    go build ./...
    ```
    ```
-   cd $PROJECT/.companions/<name>
+   cd $PROJECT/.companions/repo/<name>
    golangci-lint run ./...
    ```
 5. Record exactly what changed: files modified/added/deleted, nature of change.
@@ -128,7 +128,7 @@ When unsure, ask the user: "Same mechanical change per module, or independent wo
 
 1. Spawn one Agent per module, all in a single parallel block.
 2. Each agent receives:
-   - Module path: `$PROJECT/.companions/<name>`
+   - Module path: `$PROJECT/.companions/repo/<name>`
    - Default branch name
    - The instructions
    - Directions to: create a feature branch, do the work, verify, commit.
@@ -141,7 +141,7 @@ For each module where changes were made and verification passed:
 
 1. Stage relevant files:
    ```
-   cd $PROJECT/.companions/<name>
+   cd $PROJECT/.companions/repo/<name>
    git add <files>
    ```
 2. Commit following standard commit message rules.
@@ -152,12 +152,12 @@ For each module where changes were committed:
 
 1. Push the feature branch:
    ```
-   cd $PROJECT/.companions/<name>
+   cd $PROJECT/.companions/repo/<name>
    git push -u origin <branch-name>
    ```
 2. Create PR:
    ```
-   cd $PROJECT/.companions/<name>
+   cd $PROJECT/.companions/repo/<name>
    gh pr create --title "<title>" --body "<body>"
    ```
    Target the module's default branch.
@@ -218,7 +218,7 @@ When replicating changes across modules, adapt these patterns:
 - ALWAYS run pre-flight on ALL modules before modifying ANY.
 - ALWAYS verify `go build ./...` and `golangci-lint run ./...` before committing (for modules with go.mod).
 - ALWAYS report per-module results even on partial failure.
-- ALWAYS `cd` into `$PROJECT/.companions/<name>` before running ANY command (git, go, golangci-lint, etc.) for that module. Using `--git-dir`/`--work-tree` does NOT work — the parent jwx repo's git context leaks through.
+- ALWAYS `cd` into `$PROJECT/.companions/repo/<name>` before running ANY command (git, go, golangci-lint, etc.) for that module. Using `--git-dir`/`--work-tree` does NOT work — the parent jwx repo's git context leaks through.
 - NEVER use `git -C`.
 - NEVER use compound commands (`&&`, `||`, `;`) in Bash calls.
 - PRs are OFF by default. Only push/create PRs when `--pr` is specified.

--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ go.work.sum
 scripts/.jwxcodegen
 
 # Companion module checkouts (test-companion.sh, /jwx-companion-bulk skill)
-.companions/
+.companions/repo/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,7 @@ Read linked doc BEFORE working in that area. No exceptions.
 | Working with errors, error handling patterns | `.claude/docs/error-formatting.md` |
 | Code generation, options pattern, extension points, JSON/base64 backends | `.claude/docs/internals.md` |
 | Extension modules (ES256K, Ed448, ML-DSA, X448, asmbase64, jwkcache) | `docs/10-extensions.md` |
+| Companion modules, CI templates, `/jwx-companion-bulk` | `.claude/docs/companions.md` |
 
 ## Cache Maintenance
 
@@ -259,3 +260,4 @@ These docs cache repository state. Still read source before modifying code.
 | `.claude/docs/dependencies.md` | New internal imports between packages, new external dependencies |
 | `.claude/docs/error-formatting.md` | New sentinel errors, changes to error wrapping patterns |
 | `.claude/docs/internals.md` | Changes to generators, options YAML schema, registration points, multi-module layout |
+| `.claude/docs/companions.md` | Changes to companion module tooling, templates, `companions.yaml`, or `.companions/` layout |

--- a/scripts/test-companion.sh
+++ b/scripts/test-companion.sh
@@ -38,7 +38,7 @@ else
 	filter="$1"
 fi
 
-WORKDIR="$JWX_ROOT/.companions"
+WORKDIR="$JWX_ROOT/.companions/repo"
 mkdir -p "$WORKDIR"
 
 failures=0


### PR DESCRIPTION
- move cloned repos from .companions/<name> to .companions/repo/<name>
- reserve .companions/templates/ for tracked CI workflow templates
- add .claude/docs/companions.md pre-read doc
- update test-companion.sh, jwx-companion-bulk skill, .gitignore

Ref #1697