### PR TITLE
add lint.yml companion template

### DIFF
--- a/.companions/templates/lint.yml
+++ b/.companions/templates/lint.yml
@@ -1,0 +1,25 @@
+name: lint
+on:
+  pull_request:
+    branches:
+      - develop/v*
+  push:
+    branches:
+      - develop/v*
+env:
+  GOEXPERIMENT: jsonv2
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.11.4
+      - name: Run go vet
+        run: go vet ./...


### PR DESCRIPTION
- add standardized lint.yml template for companion modules
- push+PR triggers on `develop/v*`, GOEXPERIMENT at workflow level
- scope: all modules except benchmarks (per templates.yaml)

Depends on #1701
Ref #1697