### PR TITLE
add ci.yml companion template

### DIFF
--- a/.companions/templates/ci.yml
+++ b/.companions/templates/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+on:
+  pull_request:
+    branches:
+      - develop/v*
+  push:
+    branches:
+      - develop/v*
+env:
+  GOEXPERIMENT: jsonv2
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: "Test"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          check-latest: true
+      - name: Test with coverage
+        run: go test -v -race -coverprofile=coverage.out ./...
+      - name: Check go mod tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum


### PR DESCRIPTION
- add standardized ci.yml template for companion modules
- push+PR triggers on `develop/v*`, GOEXPERIMENT at workflow level
- adds `go mod tidy` check to all modules
- scope: all modules except benchmarks (per templates.yaml)

Ref #1697