### PR TITLE
skip benchmarks in dependabot.yml template scope

### DIFF
--- a/.companions/templates.yaml
+++ b/.companions/templates.yaml
@@ -10,6 +10,7 @@
 templates:
   dependabot.yml:
     dest: .github/dependabot.yml
+    skip: [benchmarks]
   lint.yml:
     dest: .github/workflows/lint.yml
     skip: [benchmarks]


### PR DESCRIPTION
Benchmarks has per-suite gomod entries for /suites/* that the standard template doesn't cover. Ref #1697