### PR TITLE
drop z field from AKP keys, add godoc comments

### DIFF
--- a/internal/jwxcodegen/cmd/jwxcodegen/genjwk.go
+++ b/internal/jwxcodegen/cmd/jwxcodegen/genjwk.go
@@ -252,7 +252,11 @@ func generateObject(o *codegen.Output, kt *KeyType, obj *codegen.Object) error {
 }
 
 func generateKeyInterface(o *codegen.Output, kt *KeyType, obj *codegen.Object, ifName string) {
-	o.LL("type %s interface {", ifName)
+	if jwxcodegen.WriteComment(o, obj.Comment()) {
+		o.L("type %s interface {", ifName)
+	} else {
+		o.LL("type %s interface {", ifName)
+	}
 	o.L("Key")
 	for _, f := range obj.Fields() {
 		if f.Bool(`is_std`) {

--- a/jwk/akp.go
+++ b/jwk/akp.go
@@ -84,11 +84,9 @@ func (k *akpPrivateKey) Import(rawKeyIf any) error {
 
 	switch rawKey := rawKeyIf.(type) {
 	case *mlkem.DecapsulationKey768:
-		seed := rawKey.Bytes() // 64-byte d || z
+		seed := rawKey.Bytes() // 64-byte d || z; only d is stored
 		k.priv = make([]byte, 32)
-		copy(k.priv, seed[:32]) // d
-		k.z = make([]byte, 32)
-		copy(k.z, seed[32:]) // z
+		copy(k.priv, seed[:32])
 		k.pub = rawKey.EncapsulationKey().Bytes()
 		alg, _ := jwa.KeyAlgorithmFrom("ML-KEM-768")
 		k.algorithm = &alg
@@ -96,8 +94,6 @@ func (k *akpPrivateKey) Import(rawKeyIf any) error {
 		seed := rawKey.Bytes()
 		k.priv = make([]byte, 32)
 		copy(k.priv, seed[:32])
-		k.z = make([]byte, 32)
-		copy(k.z, seed[32:])
 		k.pub = rawKey.EncapsulationKey().Bytes()
 		alg, _ := jwa.KeyAlgorithmFrom("ML-KEM-1024")
 		k.algorithm = &alg
@@ -111,7 +107,7 @@ func makeAKPPublicKey(src Key) (Key, error) {
 	newKey := newAKPPublicKey()
 	for _, k := range src.Keys() {
 		switch k {
-		case AKPPrivKey, AKPZKey:
+		case AKPPrivKey:
 			continue
 		default:
 			v, ok := src.Field(k)
@@ -217,17 +213,12 @@ func akpJWKToRaw(key Key, _ any) (any, error) {
 		}
 
 		// Reconstruct the 64-byte seed: d || z
-		// If z is absent, generate a fresh random z
-		z, hasZ := key.Z()
-
+		// z is not stored in the JWK (the draft only defines 32-byte priv),
+		// so we generate a fresh random z for implicit rejection.
 		seed := make([]byte, 64)
 		copy(seed[:32], priv)
-		if hasZ && len(z) == 32 {
-			copy(seed[32:], z)
-		} else {
-			if _, err := rand.Read(seed[32:]); err != nil {
-				return nil, fmt.Errorf(`failed to generate random z: %w`, err)
-			}
+		if _, err := rand.Read(seed[32:]); err != nil {
+			return nil, fmt.Errorf(`failed to generate random z: %w`, err)
 		}
 
 		switch alg.String() {

--- a/jwk/akp.go
+++ b/jwk/akp.go
@@ -212,9 +212,9 @@ func akpJWKToRaw(key Key, _ any) (any, error) {
 			return nil, fmt.Errorf(`missing "alg" field`)
 		}
 
-		// Reconstruct the 64-byte seed: d || z
-		// z is not stored in the JWK (the draft only defines 32-byte priv),
-		// so we generate a fresh random z for implicit rejection.
+		// Reconstruct the 64-byte seed (d || z). The JWK only stores d
+		// (the draft defines 32-byte priv), so generate a fresh random z
+		// for implicit rejection.
 		seed := make([]byte, 64)
 		copy(seed[:32], priv)
 		if _, err := rand.Read(seed[32:]); err != nil {

--- a/jwk/akp_gen.go
+++ b/jwk/akp_gen.go
@@ -19,9 +19,10 @@ import (
 const (
 	AKPPrivKey = "priv"
 	AKPPubKey  = "pub"
-	AKPZKey    = "z"
 )
 
+// AKPPublicKey represents the public portion of an Algorithm Key Pair (AKP) JWK,
+// used by post-quantum algorithms such as ML-KEM (FIPS 203) and ML-DSA (FIPS 204).
 type AKPPublicKey interface {
 	Key
 	Pub() ([]byte, bool)
@@ -721,11 +722,31 @@ func (h *akpPublicKey) Keys() []string {
 	return keys
 }
 
+// AKPPrivateKey represents the private portion of an Algorithm Key Pair (AKP) JWK,
+// used by post-quantum algorithms such as ML-KEM (FIPS 203) and ML-DSA (FIPS 204).
+//
+// INTEROPERABILITY WARNING: ML-KEM PRIVATE KEY ROUND-TRIP LIMITATION
+//
+// FIPS 203 defines the ML-KEM private key seed as 64 bytes in the "d || z" form,
+// where d (32 bytes) generates the key pair and z (32 bytes) is the implicit
+// rejection seed used during decapsulation. However, draft-ietf-jose-pqc-kem
+// (https://datatracker.ietf.org/doc/draft-ietf-jose-pqc-kem/) mandates that
+// the "priv" field contain only d (32 bytes). Go's crypto/mlkem
+// package requires the full 64-byte seed to reconstruct a decapsulation key.
+//
+// Because the draft limits "priv" to 32 bytes, the z component is lost when a
+// private key is exported to JWK. Re-importing will produce a decapsulation key
+// with a randomly generated z. This key is functionally equivalent for all normal
+// operations — z only affects implicit rejection (the fake shared secret returned
+// for tampered ciphertexts) and does not change decapsulation of valid ciphertexts.
+//
+// This means JWK round-trips do NOT preserve bitwise key identity. If the draft
+// is revised to accommodate the full 64-byte seed, this limitation will be
+// resolved.
 type AKPPrivateKey interface {
 	Key
 	Priv() ([]byte, bool)
 	Pub() ([]byte, bool)
-	Z() ([]byte, bool)
 }
 
 type akpPrivateKey struct {
@@ -739,7 +760,6 @@ type akpPrivateKey struct {
 	x509CertThumbprint     *string     // https://tools.ietf.org/html/rfc7515#section-4.1.7
 	x509CertThumbprintS256 *string     // https://tools.ietf.org/html/rfc7515#section-4.1.8
 	x509URL                *string     // https://tools.ietf.org/html/rfc7515#section-4.1.5
-	z                      []byte
 	privateParams          map[string]any
 	mu                     sync.RWMutex
 	dc                     json.DecodeCtx
@@ -858,15 +878,6 @@ func (h *akpPrivateKey) X509URL() (string, bool) {
 	return "", false
 }
 
-func (h *akpPrivateKey) Z() ([]byte, bool) {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	if h.z != nil {
-		return h.z, true
-	}
-	return nil, false
-}
-
 func (h *akpPrivateKey) Has(name string) bool {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
@@ -893,8 +904,6 @@ func (h *akpPrivateKey) Has(name string) bool {
 		return h.x509CertThumbprintS256 != nil
 	case X509URLKey:
 		return h.x509URL != nil
-	case AKPZKey:
-		return h.z != nil
 	default:
 		_, ok := h.privateParams[name]
 		return ok
@@ -957,11 +966,6 @@ func (h *akpPrivateKey) Field(name string) (any, bool) {
 			return nil, false
 		}
 		return *(h.x509URL), true
-	case AKPZKey:
-		if h.z == nil {
-			return nil, false
-		}
-		return h.z, true
 	default:
 		v, ok := h.privateParams[name]
 		return v, ok
@@ -1064,17 +1068,6 @@ func (h *akpPrivateKey) setNoLock(name string, value any) error {
 			return nil
 		}
 		return fmt.Errorf(`invalid value for %s key: %T`, X509URLKey, value)
-	case AKPZKey:
-		if v, ok := value.([]byte); ok {
-			if v == nil {
-				h.z = nil
-			} else {
-				h.z = make([]byte, len(v))
-				copy(h.z, v)
-			}
-			return nil
-		}
-		return fmt.Errorf(`invalid value for %s key: %T`, AKPZKey, value)
 	default:
 		if h.privateParams == nil {
 			h.privateParams = map[string]any{}
@@ -1108,8 +1101,6 @@ func (k *akpPrivateKey) Remove(key string) error {
 		k.x509CertThumbprintS256 = nil
 	case X509URLKey:
 		k.x509URL = nil
-	case AKPZKey:
-		k.z = nil
 	default:
 		delete(k.privateParams, key)
 	}
@@ -1178,11 +1169,6 @@ func (dst *akpPrivateKey) cloneFrom(src *akpPrivateKey) {
 	} else {
 		dst.x509URL = nil
 	}
-	if src.z != nil {
-		dst.z = slices.Clone(src.z)
-	} else {
-		dst.z = nil
-	}
 	if len(src.privateParams) > 0 {
 		dst.privateParams = make(map[string]any, len(src.privateParams))
 		for k, v := range src.privateParams {
@@ -1224,15 +1210,12 @@ func (h *akpPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 	h.x509CertThumbprint = nil
 	h.x509CertThumbprintS256 = nil
 	h.x509URL = nil
-	h.z = nil
 	defer func() {
 		if retErr != nil {
 			clear(h.priv)
 			h.priv = nil
 			clear(h.pub)
 			h.pub = nil
-			clear(h.z)
-			h.z = nil
 		}
 	}()
 	dec := json.NewDecoder(bytes.NewReader(buf))
@@ -1306,10 +1289,6 @@ func (h *akpPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 		case X509URLKey:
 			if err := json.AssignNextStringToken(&h.x509URL, dec, h.dc); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, X509URLKey, err)
-			}
-		case AKPZKey:
-			if err := json.AssignNextBytesToken(&h.z, dec); err != nil {
-				return fmt.Errorf(`failed to decode value for key %s: %w`, AKPZKey, err)
 			}
 		default:
 			fieldName := tok.String()
@@ -1447,15 +1426,6 @@ func (h *akpPrivateKey) MarshalJSON() ([]byte, error) {
 			pairs = append(pairs, fieldPair{Name: X509URLKey, Value: v})
 		}
 	}
-	if h.z != nil {
-		{
-			v, err := json.Marshal(base64.EncodeToString(h.z))
-			if err != nil {
-				return nil, fmt.Errorf(`failed to marshal field %q: %w`, AKPZKey, err)
-			}
-			pairs = append(pairs, fieldPair{Name: AKPZKey, Value: v})
-		}
-	}
 	for k, v := range h.privateParams {
 		switch bv := v.(type) {
 		case []byte:
@@ -1498,7 +1468,7 @@ func (h *akpPrivateKey) MarshalJSON() ([]byte, error) {
 func (h *akpPrivateKey) Keys() []string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	keys := make([]string, 0, 11+len(h.privateParams))
+	keys := make([]string, 0, 10+len(h.privateParams))
 	keys = append(keys, KeyTypeKey)
 	if h.algorithm != nil {
 		keys = append(keys, AlgorithmKey)
@@ -1530,9 +1500,6 @@ func (h *akpPrivateKey) Keys() []string {
 	if h.x509URL != nil {
 		keys = append(keys, X509URLKey)
 	}
-	if h.z != nil {
-		keys = append(keys, AKPZKey)
-	}
 	for k := range h.privateParams {
 		keys = append(keys, k)
 	}
@@ -1542,7 +1509,7 @@ func (h *akpPrivateKey) Keys() []string {
 var akpStandardFields KeyFilter
 
 func init() {
-	akpStandardFields = NewFieldNameFilter(KeyTypeKey, KeyUsageKey, KeyOpsKey, AlgorithmKey, KeyIDKey, X509URLKey, X509CertChainKey, X509CertThumbprintKey, X509CertThumbprintS256Key, AKPPubKey, AKPPrivKey, AKPZKey)
+	akpStandardFields = NewFieldNameFilter(KeyTypeKey, KeyUsageKey, KeyOpsKey, AlgorithmKey, KeyIDKey, X509URLKey, X509CertChainKey, X509CertThumbprintKey, X509CertThumbprintS256Key, AKPPubKey, AKPPrivKey)
 }
 
 // AKPStandardFieldsFilter returns a KeyFilter that filters out standard AKP fields.

--- a/jwk/akp_test.go
+++ b/jwk/akp_test.go
@@ -50,17 +50,12 @@ func TestAKPKey(t *testing.T) {
 		require.True(t, ok)
 		require.Len(t, privBytes, 32, "priv should be 32 bytes (d component)")
 
-		z, ok := priv.Z()
-		require.True(t, ok)
-		require.Len(t, z, 32, "z should be 32 bytes")
-
-		// Verify d || z matches the original seed
+		// Verify d matches the original seed's first 32 bytes
 		seed := dk.Bytes()
 		require.Equal(t, seed[:32], privBytes, "priv should match d")
-		require.Equal(t, seed[32:], z, "z should match z")
 	})
 
-	t.Run("Export ML-KEM-768 DecapsulationKey round-trip", func(t *testing.T) {
+	t.Run("Export ML-KEM-768 DecapsulationKey", func(t *testing.T) {
 		dk, err := mlkem.GenerateKey768()
 		require.NoError(t, err)
 
@@ -68,12 +63,12 @@ func TestAKPKey(t *testing.T) {
 		key, err := jwk.Import[jwk.Key](dk)
 		require.NoError(t, err)
 
-		// Export
+		// Export — z is randomly generated, so the seed will differ,
+		// but the encapsulation key (derived from d alone) must match.
 		exported, err := jwk.Export[*mlkem.DecapsulationKey768](key)
 		require.NoError(t, err)
 
-		// Verify same seed
-		require.Equal(t, dk.Bytes(), exported.Bytes())
+		require.Equal(t, dk.EncapsulationKey().Bytes(), exported.EncapsulationKey().Bytes())
 	})
 
 	t.Run("Export ML-KEM-768 EncapsulationKey round-trip", func(t *testing.T) {
@@ -93,7 +88,7 @@ func TestAKPKey(t *testing.T) {
 		require.Equal(t, ek.Bytes(), exported.Bytes())
 	})
 
-	t.Run("JSON round-trip with z field", func(t *testing.T) {
+	t.Run("JSON round-trip", func(t *testing.T) {
 		dk, err := mlkem.GenerateKey768()
 		require.NoError(t, err)
 
@@ -104,13 +99,13 @@ func TestAKPKey(t *testing.T) {
 		buf, err := json.Marshal(key)
 		require.NoError(t, err)
 
-		// Verify JSON structure
+		// Verify JSON structure — no z field
 		var m map[string]any
 		require.NoError(t, json.Unmarshal(buf, &m))
 		require.Equal(t, "AKP", m["kty"])
 		require.Contains(t, m, "pub")
 		require.Contains(t, m, "priv")
-		require.Contains(t, m, "z")
+		require.NotContains(t, m, "z")
 		require.Contains(t, m, "alg")
 		require.Equal(t, "ML-KEM-768", m["alg"])
 
@@ -118,39 +113,9 @@ func TestAKPKey(t *testing.T) {
 		parsed, err := jwk.ParseKey[jwk.Key](buf)
 		require.NoError(t, err)
 
-		// Export and verify same key
+		// Export and verify encapsulation key matches (d is preserved)
 		exported, err := jwk.Export[*mlkem.DecapsulationKey768](parsed)
 		require.NoError(t, err)
-		require.Equal(t, dk.Bytes(), exported.Bytes())
-	})
-
-	t.Run("JSON round-trip without z field (interop)", func(t *testing.T) {
-		dk, err := mlkem.GenerateKey768()
-		require.NoError(t, err)
-
-		key, err := jwk.Import[jwk.Key](dk)
-		require.NoError(t, err)
-
-		// Marshal
-		buf, err := json.Marshal(key)
-		require.NoError(t, err)
-
-		// Remove the z field to simulate a JWK from another implementation
-		var m map[string]any
-		require.NoError(t, json.Unmarshal(buf, &m))
-		delete(m, "z")
-		buf, err = json.Marshal(m)
-		require.NoError(t, err)
-
-		// Parse back — should succeed, generating fresh z
-		parsed, err := jwk.ParseKey[jwk.Key](buf)
-		require.NoError(t, err)
-
-		// Export — should produce a valid DecapsulationKey (with random z)
-		exported, err := jwk.Export[*mlkem.DecapsulationKey768](parsed)
-		require.NoError(t, err)
-
-		// The encapsulation key should still match (ek depends only on d, not z)
 		require.Equal(t, dk.EncapsulationKey().Bytes(), exported.EncapsulationKey().Bytes())
 	})
 
@@ -164,9 +129,8 @@ func TestAKPKey(t *testing.T) {
 		pubKey, err := privKey.PublicKey()
 		require.NoError(t, err)
 
-		// Public key should not have priv or z
+		// Public key should not have priv
 		require.False(t, pubKey.Has("priv"))
-		require.False(t, pubKey.Has("z"))
 		require.True(t, pubKey.Has("pub"))
 
 		// Should export as EncapsulationKey
@@ -188,7 +152,7 @@ func TestAKPKey(t *testing.T) {
 
 		exported, err := jwk.Export[*mlkem.DecapsulationKey1024](key)
 		require.NoError(t, err)
-		require.Equal(t, dk.Bytes(), exported.Bytes())
+		require.Equal(t, dk.EncapsulationKey().Bytes(), exported.EncapsulationKey().Bytes())
 	})
 
 	t.Run("Validate", func(t *testing.T) {

--- a/jwk/objects.yml
+++ b/jwk/objects.yml
@@ -164,12 +164,37 @@ key_types:
     key_type: jwa.AKP()
     objects:
       - name: publicKey
+        comment: |
+          AKPPublicKey represents the public portion of an Algorithm Key Pair (AKP) JWK,
+          used by post-quantum algorithms such as ML-KEM (FIPS 203) and ML-DSA (FIPS 204).
         raw_key_type: "interface{}"
         fields:
           - name: pub
             type: "[]byte"
             required: true
       - name: privateKey
+        comment: |
+          AKPPrivateKey represents the private portion of an Algorithm Key Pair (AKP) JWK,
+          used by post-quantum algorithms such as ML-KEM (FIPS 203) and ML-DSA (FIPS 204).
+
+          INTEROPERABILITY WARNING: ML-KEM PRIVATE KEY ROUND-TRIP LIMITATION
+
+          FIPS 203 defines the ML-KEM private key seed as 64 bytes in the "d || z" form,
+          where d (32 bytes) generates the key pair and z (32 bytes) is the implicit
+          rejection seed used during decapsulation. However, draft-ietf-jose-pqc-kem
+          (https://datatracker.ietf.org/doc/draft-ietf-jose-pqc-kem/) mandates that
+          the "priv" field contain only d (32 bytes). Go's crypto/mlkem
+          package requires the full 64-byte seed to reconstruct a decapsulation key.
+
+          Because the draft limits "priv" to 32 bytes, the z component is lost when a
+          private key is exported to JWK. Re-importing will produce a decapsulation key
+          with a randomly generated z. This key is functionally equivalent for all normal
+          operations — z only affects implicit rejection (the fake shared secret returned
+          for tampered ciphertexts) and does not change decapsulation of valid ciphertexts.
+
+          This means JWK round-trips do NOT preserve bitwise key identity. If the draft
+          is revised to accommodate the full 64-byte seed, this limitation will be
+          resolved.
         raw_key_type: "interface{}"
         fields:
           - name: pub
@@ -178,5 +203,3 @@ key_types:
           - name: priv
             type: "[]byte"
             required: true
-          - name: z
-            type: "[]byte"

--- a/scripts/jwxcodegen.sh
+++ b/scripts/jwxcodegen.sh
@@ -5,11 +5,10 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$DIR/.." && pwd)"
 EXE="$DIR/.jwxcodegen"
 
-# Build once, reuse
-if [ ! -f "$EXE" ]; then
-    pushd "$ROOT/internal/jwxcodegen/cmd/jwxcodegen" > /dev/null
-    GOWORK=off go build -o "$EXE" .
-    popd > /dev/null
-fi
+# Build fresh each invocation to avoid running stale binaries
+pushd "$ROOT/internal/jwxcodegen/cmd/jwxcodegen" > /dev/null
+GOWORK=off go build -o "$EXE" .
+popd > /dev/null
 
 "$EXE" "$@"
+rm -f "$EXE"


### PR DESCRIPTION
- Remove non-standard z extension field from ML-KEM JWK private keys; generate random z on export instead
- Add godoc comments on AKPPublicKey and AKPPrivateKey interfaces documenting the round-trip limitation
- Generator now emits object-level comments from objects.yml
- jwxcodegen.sh rebuilds fresh each invocation and cleans up after