### PR TITLE
fix README package links to use relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,11 @@ This module implements the following specifications:
 
 | Package | Specification |
 |---------|---------------|
-| [jwa](https://github.com/lestrrat-go/jwx/tree/v4/jwa) | [RFC 7518](https://tools.ietf.org/html/rfc7518) (JSON Web Algorithms) |
-| [jwk](https://github.com/lestrrat-go/jwx/tree/v4/jwk) | [RFC 7517](https://tools.ietf.org/html/rfc7517) (JSON Web Key), [RFC 7638](https://tools.ietf.org/html/rfc7638) (JWK Thumbprint), [RFC 8037](https://tools.ietf.org/html/rfc8037) (CFRG Curves) |
-| [jws](https://github.com/lestrrat-go/jwx/tree/v4/jws) | [RFC 7515](https://tools.ietf.org/html/rfc7515) (JSON Web Signature), [RFC 7797](https://tools.ietf.org/html/rfc7797) (Unencoded Payload) |
-| [jwe](https://github.com/lestrrat-go/jwx/tree/v4/jwe) | [RFC 7516](https://tools.ietf.org/html/rfc7516) (JSON Web Encryption), [draft-ietf-jose-hpke-encrypt](https://datatracker.ietf.org/doc/draft-ietf-jose-hpke-encrypt/) (HPKE) |
-| [jwt](https://github.com/lestrrat-go/jwx/tree/v4/jwt) | [RFC 7519](https://tools.ietf.org/html/rfc7519) (JSON Web Token) |
+| [jwa](./jwa) | [RFC 7518](https://tools.ietf.org/html/rfc7518) (JSON Web Algorithms) |
+| [jwk](./jwk) | [RFC 7517](https://tools.ietf.org/html/rfc7517) (JSON Web Key), [RFC 7638](https://tools.ietf.org/html/rfc7638) (JWK Thumbprint), [RFC 8037](https://tools.ietf.org/html/rfc8037) (CFRG Curves) |
+| [jws](./jws) | [RFC 7515](https://tools.ietf.org/html/rfc7515) (JSON Web Signature), [RFC 7797](https://tools.ietf.org/html/rfc7797) (Unencoded Payload) |
+| [jwe](./jwe) | [RFC 7516](https://tools.ietf.org/html/rfc7516) (JSON Web Encryption), [draft-ietf-jose-hpke-encrypt](https://datatracker.ietf.org/doc/draft-ietf-jose-hpke-encrypt/) (HPKE) |
+| [jwt](./jwt) | [RFC 7519](https://tools.ietf.org/html/rfc7519) (JSON Web Token) |
 
 Additionally supported via the main module or [extension modules](docs/10-extensions.md):
 


### PR DESCRIPTION
- Use relative paths (./jwa, ./jwk, etc.) instead of absolute GitHub URLs with nonexistent v4 branch
