### PR TITLE
remove Related Modules section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,13 +253,6 @@ If you are editing auto-generated files (those files with the `_gen.go` suffix, 
 
 Please try [discussions](https://github.com/lestrrat-go/jwx/discussions) first.
 
-# Related Modules
-
-* [github.com/jwx-go/jwkcache](https://github.com/jwx-go/jwkcache) - Auto-refreshing JWK Set cache
-* [github.com/lestrrat-go/echo-middleware-jwx](https://github.com/lestrrat-go/echo-middleware-jwx) - Sample Echo middleware
-* [github.com/jwx-go/crypto-signer/gcp](https://github.com/jwx-go/crypto-signer/tree/main/gcp) - GCP KMS wrapper that implements [`crypto.Signer`](https://pkg.go.dev/crypto#Signer)
-* [github.com/jwx-go/crypto-signer/aws](https://github.com/jwx-go/crypto-signer/tree/main/aws) - AWS KMS wrapper that implements [`crypto.Signer`](https://pkg.go.dev/crypto#Signer)
-
 # Credits
 
 * Initial work on this library was generously sponsored by HDE Inc (https://www.hde.co.jp)


### PR DESCRIPTION
These modules are now listed in the extensions doc instead.