### PR TITLE
add jwx.Settings with WithUseNumber option

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -9,8 +9,9 @@ Module: `github.com/lestrrat-go/jwx/v4` — flat layout, no physical `v3/` direc
 Format detection and global JSON decoder settings.
 
 - **GuessFormat(payload []byte) FormatKind** — heuristic detection of JWE/JWS/JWK/JWKS/JWT
-- **DecoderSettings(options ...JSONOption)** — configure global JSON decoder
-- Key types: `FormatKind` (InvalidFormat, UnknownFormat, JWE, JWS, JWK, JWKS, JWT)
+- **Settings(options ...GlobalOption)** — configure global settings (e.g., `WithUseNumber`)
+- **WithUseNumber(v bool) GlobalOption** — decode JSON numbers as `json.Number` instead of `float64`
+- Key types: `FormatKind` (InvalidFormat, UnknownFormat, JWE, JWS, JWK, JWKS, JWT), `GlobalOption`
 - Files: `jwx.go`, `format.go`, `options.go`
 
 ## jwa/

--- a/BUILD
+++ b/BUILD
@@ -19,6 +19,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//internal/base64",
+        "//internal/json",
         "//internal/tokens",
         "@com_github_lestrrat_go_option_v3//:option",
     ],
@@ -37,6 +38,7 @@ go_test(
         "//jwk",
         "//jwk/ecdsa",
         "//jws",
+        "//jwt",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/Changes-v4.md
+++ b/Changes-v4.md
@@ -44,6 +44,10 @@ For a step-by-step migration guide with before/after code examples, see [MIGRATI
 
 * Internal JSON handling now uses `encoding/json/v2`.
 
+* `jwx.DecoderSettings()` has been renamed to `jwx.Settings()` to match the
+  sub-package convention. `jwx.Settings(jwx.WithUseNumber(true))` preserves
+  JSON numbers as `json.Number` in private/custom fields.
+
 * `github.com/lestrrat-go/blackmagic` has been removed. Reflection-based conversions
   have been replaced with generics.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -50,7 +50,7 @@ Text output labels each finding as `(auto)` or `(manual)`, with migration notes 
 | `jws.Verifier2` | `jws.Verifier` | Interface renamed |
 | `jws.RegisterSigner(alg, any)` | `jws.RegisterSigner(alg, Signer)` | Typed parameter |
 | `jws.RegisterVerifier(alg, any)` | `jws.RegisterVerifier(alg, Verifier)` | Typed parameter |
-| `jwx.DecoderSettings(...)` | _(removed)_ | json/v2 handles this |
+| `jwx.DecoderSettings(jwx.WithUseNumber(true))` | `jwx.Settings(jwx.WithUseNumber(true))` | API renamed |
 | `-tags=jwx_goccy` | _(removed)_ | json/v2 is the only backend |
 | `-tags=jwx_es256k` | `github.com/jwx-go/es256k/v4` | Extension module |
 | `-tags=jwx_asmbase64` | `github.com/jwx-go/asmbase64/v4` | Extension module |
@@ -320,7 +320,7 @@ These changes cannot be mechanically transformed and need human judgment:
 
 2. **Complex cache configurations**: If you used `WithHttprcResourceOption`, `WithConstantInterval`, or other httprc-specific options with jwk.Cache, review the jwkcache extension module's API for equivalents.
 
-3. **`json.Number` usage**: If you stored custom numeric fields and relied on `json.Number` type preservation via `jwx.WithUseNumber(true)`, your code needs to handle `float64` instead, or use a custom decoder.
+3. **`json.Number` usage**: If you relied on `json.Number` type preservation via `jwx.WithUseNumber(true)`, use `jwx.Settings(jwx.WithUseNumber(true))` instead. The API was renamed from `DecoderSettings` to `Settings` to match the sub-package convention.
 
 4. **Code that catches specific error messages**: If you matched on error message strings from the crypto layer (e.g., during JWS signing), those errors may now occur earlier (at `WithKey()` time) due to algorithm-key validation.
 

--- a/docs/design/v4-json-v2-migration.md
+++ b/docs/design/v4-json-v2-migration.md
@@ -12,7 +12,7 @@ v3 maintained a build-tag abstraction (`internal/json/`) to switch between `enco
 - Single `json.go` imports `encoding/json/v2` and `encoding/json/jsontext`.
 - Type aliases: `Decoder = jsontext.Decoder`, `Encoder = jsontext.Encoder`, `RawMessage = jsontext.Value`.
 - Removed: `Delim`, `Number`, `Marshaler`, `Unmarshaler` type aliases.
-- Removed: `DecoderSettings()`, `UseNumber()`, global `useNumber` atomic.
+- Replaced: `DecoderSettings()` → `SetUseNumber()`/`GetUseNumber()` (global atomic bool).
 - Added: `MarshalEncode()`, `UnmarshalDecode()` wrappers.
 - Helper functions (`AssignNextBytesToken`, `ReadNextStringToken`, etc.) adapted to use `jsontext.Decoder` API (`ReadToken()`, `PeekKind()`) instead of `json.Decoder` API (`Token()`, `Decode()`).
 
@@ -37,9 +37,9 @@ MarshalJSON templates changed:
 
 | Removed | Replacement |
 |---------|-------------|
-| `jwx.DecoderSettings()` | None needed; json/v2 preserves numeric precision natively |
-| `jwx.WithUseNumber()` | None needed |
-| `json.Number` type | `float64` (default) or `string` via json/v2 options |
+| `jwx.DecoderSettings()` | `jwx.Settings()` |
+| `jwx.WithUseNumber()` | `jwx.WithUseNumber()` (same name, works with `jwx.Settings`) |
+| `json.Number` type | `encoding/json.Number` (available when `jwx.WithUseNumber(true)` is set) |
 | `json.Delim` type | `jsontext.Kind` constants (`'{'`, `'}'`, etc.) |
 | `jwx_goccy` build tag | Removed entirely |
 
@@ -55,7 +55,8 @@ v4 will ship when json/v2 graduates to default in a future Go release.
 // v3
 jwx.DecoderSettings(jwx.WithUseNumber(true))
 
-// v4 — remove entirely, json/v2 handles numeric precision natively
+// v4
+jwx.Settings(jwx.WithUseNumber(true))
 ```
 
 ```go
@@ -63,9 +64,9 @@ jwx.DecoderSettings(jwx.WithUseNumber(true))
 var n json.Number
 token.Get("custom-num", &n)
 
-// v4
-var f float64
-token.Get("custom-num", &f)
-// or use the new generic accessor:
+// v4 (with UseNumber enabled)
+n, err := jwt.Get[json.Number](token, "custom-num")
+
+// v4 (without UseNumber — default)
 f, err := jwt.Get[float64](token, "custom-num")
 ```

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -6,9 +6,23 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync/atomic"
 
 	"github.com/lestrrat-go/jwx/v4/internal/base64"
 )
+
+var globalUseNumber atomic.Bool
+
+// SetUseNumber controls whether JSON numbers in private/custom fields
+// should be decoded as json.Number instead of float64.
+func SetUseNumber(v bool) {
+	globalUseNumber.Store(v)
+}
+
+// GetUseNumber returns the current UseNumber setting.
+func GetUseNumber() bool {
+	return globalUseNumber.Load()
+}
 
 type (
 	Decoder    = jsontext.Decoder

--- a/internal/json/registry.go
+++ b/internal/json/registry.go
@@ -1,6 +1,9 @@
 package json
 
 import (
+	stdjson "encoding/json"
+	"encoding/json/jsontext"
+	jsonv2 "encoding/json/v2"
 	"fmt"
 	"reflect"
 	"sync"
@@ -60,6 +63,23 @@ func (dec *TypedDecoder[T]) Decode(data []byte) (any, error) {
 	}
 	return v, nil
 }
+
+// useNumberUnmarshalers is a pre-built json/v2 option that intercepts
+// unmarshalling of JSON numbers into any, producing json.Number instead
+// of float64.
+var useNumberUnmarshalers = jsonv2.WithUnmarshalers(
+	jsonv2.UnmarshalFromFunc(func(dec *jsontext.Decoder, val *any) error {
+		if dec.PeekKind() != '0' {
+			return jsonv2.SkipFunc
+		}
+		raw, err := dec.ReadValue()
+		if err != nil {
+			return err
+		}
+		*val = stdjson.Number(raw.String())
+		return nil
+	}),
+)
 
 type Registry struct {
 	mu   *sync.RWMutex
@@ -135,8 +155,14 @@ func (r *Registry) Decode(name string, raw RawMessage) (any, error) {
 	}
 
 	var decoded any
-	if err := Unmarshal([]byte(raw), &decoded); err != nil {
-		return nil, fmt.Errorf(`failed to decode field %s: %w`, name, err)
+	if GetUseNumber() {
+		if err := jsonv2.Unmarshal([]byte(raw), &decoded, useNumberUnmarshalers); err != nil {
+			return nil, fmt.Errorf(`failed to decode field %s: %w`, name, err)
+		}
+	} else {
+		if err := Unmarshal([]byte(raw), &decoded); err != nil {
+			return nil, fmt.Errorf(`failed to decode field %s: %w`, name, err)
+		}
 	}
 	return decoded, nil
 }

--- a/jwe/decrypt.go
+++ b/jwe/decrypt.go
@@ -2,6 +2,7 @@ package jwe
 
 import (
 	"crypto/ecdsa"
+	stdjson "encoding/json"
 	"fmt"
 
 	"github.com/lestrrat-go/jwx/v4/internal/base64"
@@ -81,8 +82,17 @@ func decryptKeyPBES2(recipientKey []byte, alg string, key any, headers Headers, 
 	if !ok {
 		return nil, fmt.Errorf(`jwe: decrypt key: missing %q field for PBES2`, CountKey)
 	}
-	countFlt, ok := countV.(float64)
-	if !ok {
+	var countFlt float64
+	switch v := countV.(type) {
+	case float64:
+		countFlt = v
+	case stdjson.Number:
+		var err error
+		countFlt, err = v.Float64()
+		if err != nil {
+			return nil, fmt.Errorf(`jwe: decrypt key: %q field is not a valid number: %w`, CountKey, err)
+		}
+	default:
 		return nil, fmt.Errorf(`jwe: decrypt key: %q field is not a number`, CountKey)
 	}
 

--- a/jwx.go
+++ b/jwx.go
@@ -21,3 +21,19 @@
 //
 // FAQ style documentation can be found in the repository (https://github.com/lestrrat-go/jwx/tree/develop/v3/docs)
 package jwx
+
+import (
+	"github.com/lestrrat-go/jwx/v4/internal/json"
+	"github.com/lestrrat-go/option/v3"
+)
+
+// Settings configures global settings for the jwx package.
+func Settings(options ...GlobalOption) {
+	for _, opt := range options {
+		//nolint:forcetypeassert
+		switch opt.Ident() {
+		case identUseNumber{}:
+			json.SetUseNumber(option.MustGet[bool](opt))
+		}
+	}
+}

--- a/jwx.go
+++ b/jwx.go
@@ -30,7 +30,6 @@ import (
 // Settings configures global settings for the jwx package.
 func Settings(options ...GlobalOption) {
 	for _, opt := range options {
-		//nolint:forcetypeassert
 		switch opt.Ident() {
 		case identUseNumber{}:
 			json.SetUseNumber(option.MustGet[bool](opt))

--- a/jwx_test.go
+++ b/jwx_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/rsa"
+	stdjson "encoding/json"
 	"fmt"
 	"testing"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/lestrrat-go/jwx/v4/jwk"
 	ourecdsa "github.com/lestrrat-go/jwx/v4/jwk/ecdsa"
 	"github.com/lestrrat-go/jwx/v4/jws"
+	"github.com/lestrrat-go/jwx/v4/jwt"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,8 +32,106 @@ func TestShowBuildInfo(t *testing.T) {
 	}
 }
 
-// TestDecoderSetting was removed in v4: DecoderSettings/WithUseNumber no longer exist.
-// json/v2 preserves numeric precision natively.
+// DO NOT MAKE THIS TEST PARALLEL. This test uses features with global side effects.
+func TestUseNumber(t *testing.T) {
+	const src = `{"iss":"github.com/lestrrat-go/jwx","bignum":9223372036854775807,"nested":{"num":42},"list":[1,2,3]}`
+
+	t.Run("Default (float64)", func(t *testing.T) {
+		tok, err := jwt.Parse([]byte(src), jwt.WithVerify(false))
+		require.NoError(t, err, `jwt.Parse should succeed`)
+
+		_, err = jwt.Get[float64](tok, "bignum")
+		require.NoError(t, err, `jwt.Get[float64] should succeed`)
+	})
+	t.Run("UseNumber (json.Number)", func(t *testing.T) {
+		jwx.Settings(jwx.WithUseNumber(true))
+		defer jwx.Settings(jwx.WithUseNumber(false))
+
+		tok, err := jwt.Parse([]byte(src), jwt.WithVerify(false))
+		require.NoError(t, err, `jwt.Parse should succeed`)
+
+		num, err := jwt.Get[stdjson.Number](tok, "bignum")
+		require.NoError(t, err, `jwt.Get[json.Number] should succeed`)
+		require.Equal(t, "9223372036854775807", num.String(), `number string should be exact`)
+
+		i64, err := num.Int64()
+		require.NoError(t, err, `Int64() should succeed`)
+		require.Equal(t, int64(9223372036854775807), i64, `Int64 value should be exact`)
+	})
+	t.Run("UseNumber Get[float64] fails", func(t *testing.T) {
+		jwx.Settings(jwx.WithUseNumber(true))
+		defer jwx.Settings(jwx.WithUseNumber(false))
+
+		tok, err := jwt.Parse([]byte(src), jwt.WithVerify(false))
+		require.NoError(t, err, `jwt.Parse should succeed`)
+
+		// When UseNumber is on, values are json.Number, not float64.
+		// jwt.Get[float64] should fail, jwt.Get[json.Number] should succeed.
+		_, err = jwt.Get[float64](tok, "bignum")
+		require.Error(t, err, `jwt.Get[float64] should fail with UseNumber`)
+
+		num, err := jwt.Get[stdjson.Number](tok, "bignum")
+		require.NoError(t, err, `jwt.Get[json.Number] should succeed`)
+		require.Equal(t, "9223372036854775807", num.String())
+	})
+	t.Run("UseNumber nested object", func(t *testing.T) {
+		jwx.Settings(jwx.WithUseNumber(true))
+		defer jwx.Settings(jwx.WithUseNumber(false))
+
+		tok, err := jwt.Parse([]byte(src), jwt.WithVerify(false))
+		require.NoError(t, err, `jwt.Parse should succeed`)
+
+		m, err := jwt.Get[map[string]any](tok, "nested")
+		require.NoError(t, err, `jwt.Get[map[string]any] should succeed`)
+		num, ok := m["num"].(stdjson.Number)
+		require.True(t, ok, `nested.num should be json.Number, got %T`, m["num"])
+		require.Equal(t, "42", num.String())
+	})
+	t.Run("UseNumber array", func(t *testing.T) {
+		jwx.Settings(jwx.WithUseNumber(true))
+		defer jwx.Settings(jwx.WithUseNumber(false))
+
+		tok, err := jwt.Parse([]byte(src), jwt.WithVerify(false))
+		require.NoError(t, err, `jwt.Parse should succeed`)
+
+		list, err := jwt.Get[[]any](tok, "list")
+		require.NoError(t, err, `jwt.Get[[]any] should succeed`)
+		require.Len(t, list, 3)
+		for i, expected := range []string{"1", "2", "3"} {
+			num, ok := list[i].(stdjson.Number)
+			require.True(t, ok, `list[%d] should be json.Number, got %T`, i, list[i])
+			require.Equal(t, expected, num.String())
+		}
+	})
+	t.Run("JWK private fields", func(t *testing.T) {
+		jwx.Settings(jwx.WithUseNumber(true))
+		defer jwx.Settings(jwx.WithUseNumber(false))
+
+		const jwkSrc = `{"kty":"oct","k":"c2VjcmV0","x-custom-num":12345}`
+		key, err := jwk.ParseKey[jwk.Key]([]byte(jwkSrc))
+		require.NoError(t, err, `jwk.ParseKey should succeed`)
+
+		num, err := jwk.Get[stdjson.Number](key, "x-custom-num")
+		require.NoError(t, err, `jwk.Get[json.Number] should succeed`)
+		require.Equal(t, "12345", num.String())
+	})
+	t.Run("PBES2 roundtrip with UseNumber", func(t *testing.T) {
+		jwx.Settings(jwx.WithUseNumber(true))
+		defer jwx.Settings(jwx.WithUseNumber(false))
+
+		key, err := jwk.Import[jwk.Key]([]byte("secure-key"))
+		require.NoError(t, err, `jwk.Import should succeed`)
+
+		encrypted, err := jwe.Encrypt(
+			[]byte("test-payload"),
+			jwe.WithKey(jwa.PBES2_HS256_A128KW(), key),
+		)
+		require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+		_, err = jwe.Decrypt(encrypted, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+		require.NoError(t, err, `jwe.Decrypt should succeed`)
+	})
+}
 
 // Test compatibility against `jose` tool
 func TestJoseCompatibility(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -3,3 +3,26 @@ package jwx
 import "github.com/lestrrat-go/option/v3"
 
 type Option = option.Interface
+
+// GlobalOption describes an Option that can be passed to `jwx.Settings()`.
+type GlobalOption interface {
+	Option
+	globalOption()
+}
+
+type globalOption struct {
+	Option
+}
+
+func (*globalOption) globalOption() {}
+
+type identUseNumber struct{}
+
+// WithUseNumber controls whether the jwx package should unmarshal
+// JSON numbers in private/custom fields as json.Number instead of
+// float64. This preserves numeric precision for large integers.
+//
+// Default is false.
+func WithUseNumber(v bool) GlobalOption {
+	return &globalOption{option.New(identUseNumber{}, v)}
+}


### PR DESCRIPTION
- ~add~ bring back jwx.Settings(jwx.WithUseNumber(true)) to preserve JSON numbers as json.Number in private/custom fields
- fix jwe p2c header to handle json.Number when UseNumber is enabled
- update MIGRATION.md, Changes-v4.md, design doc