### PR TITLE
Split AKP key type and ML-KEM entries in Changes-v4.md

### DIFF
--- a/Changes-v4.md
+++ b/Changes-v4.md
@@ -78,8 +78,12 @@ For a step-by-step migration guide with before/after code examples, see [MIGRATI
   jwk.RegisterProbeField[string]("MyHint", "my_hint")
   ```
 
-* ML-KEM key type (`jwk.AKP`) has been added for post-quantum key encapsulation
-  (FIPS 203). This supports ML-KEM-768 and ML-KEM-1024.
+* The `jwk.AKP` key type (Algorithm Key Pair, RFC 9802) has been added.
+  This is a generic key type for post-quantum algorithms and is used by both
+  ML-DSA (signature) and ML-KEM (key encapsulation) support.
+
+* ML-KEM (FIPS 203) key type support has been added via `jwk.AKP`, covering
+  ML-KEM-768 and ML-KEM-1024.
 
 * `jwk.Set` now supports range-over-func iteration:
 

--- a/Changes-v4.md
+++ b/Changes-v4.md
@@ -78,12 +78,13 @@ For a step-by-step migration guide with before/after code examples, see [MIGRATI
   jwk.RegisterProbeField[string]("MyHint", "my_hint")
   ```
 
-* The `jwk.AKP` key type (Algorithm Key Pair, RFC 9802) has been added.
-  This is a generic key type for post-quantum algorithms and is used by both
-  ML-DSA (signature) and ML-KEM (key encapsulation) support.
+* The `AKP` key type (Algorithm Key Pair, RFC 9802) has been added, exposed as
+  `jwa.AKP()` with `jwk.AKPPublicKey` / `jwk.AKPPrivateKey`. This is a generic
+  key type for post-quantum algorithms and is used by both ML-DSA (signature)
+  and ML-KEM (key encapsulation) support.
 
-* ML-KEM (FIPS 203) key type support has been added via `jwk.AKP`, covering
-  ML-KEM-768 and ML-KEM-1024.
+* ML-KEM (FIPS 203) key support has been added via the `AKP` key type,
+  covering ML-KEM-768 and ML-KEM-1024.
 
 * `jwk.Set` now supports range-over-func iteration:
 


### PR DESCRIPTION
The previous entry conflated the `AKP` key type addition with ML-KEM support. `AKP` (RFC 9802) is a generic post-quantum key type also used by ML-DSA, so it deserves a separate entry from ML-KEM algorithm support. Also corrects the type references (`jwa.AKP()` / `jwk.AKPPublicKey` / `jwk.AKPPrivateKey`).