### PR TITLE
skip fuzz templates for jwxmigrate

### DIFF
--- a/.companions/templates.yaml
+++ b/.companions/templates.yaml
@@ -25,7 +25,7 @@ templates:
     dest: .github/auto-assign-pr.yml
   fuzz.yml:
     dest: .github/workflows/fuzz.yml
-    skip: [benchmarks, examples, jwkcache, x448]
+    skip: [benchmarks, examples, jwkcache, jwxmigrate, x448]
   fuzz-pr.yml:
     dest: .github/workflows/fuzz-pr.yml
-    skip: [benchmarks, examples, jwkcache, x448]
+    skip: [benchmarks, examples, jwkcache, jwxmigrate, x448]


### PR DESCRIPTION
jwxmigrate has no fuzz tests — exclude it from the fuzz and fuzz-pr template scope.