### PR TITLE
add reddy-pqchpke companion module

### DIFF
--- a/companions.yaml
+++ b/companions.yaml
@@ -27,6 +27,9 @@ modules:
   - name: mldsa
     repo: git@github.com:jwx-go/mldsa.git
     branch: develop/v4
+  - name: reddy-pqchpke
+    repo: git@github.com:jwx-go/reddy-pqchpke.git
+    branch: develop/v4
   - name: x448
     repo: git@github.com:jwx-go/x448.git
     branch: develop/v4

--- a/docs/10-extensions.md
+++ b/docs/10-extensions.md
@@ -15,6 +15,7 @@ In v4, optional features are provided as standalone modules under [`github.com/j
 | Module | Capability | Key Package |
 |:-------|:-----------|:------------|
 | [`github.com/jwx-go/x448/v4`](https://github.com/jwx-go/x448) | X448 ECDH-ES, HPKE with DHKEM(X448) | [`github.com/cloudflare/circl/dh/x448`](https://pkg.go.dev/github.com/cloudflare/circl/dh/x448) |
+| [`github.com/jwx-go/reddy-pqchpke/v4`](https://github.com/jwx-go/reddy-pqchpke) | Hybrid PQ HPKE (HPKE-10-KE, HPKE-11-KE) per draft-reddy-cose-jose-pqc-hybrid-hpke — **experimental, pre-WG-adoption** | [`github.com/cloudflare/circl/kem/xwing`](https://pkg.go.dev/github.com/cloudflare/circl/kem/xwing) |
 
 * [ML-DSA (Post-Quantum Signatures)](#ml-dsa-post-quantum-signatures)
   * [Signing and Verifying](#signing-and-verifying)


### PR DESCRIPTION
## Summary

- Register `github.com/jwx-go/reddy-pqchpke` in `companions.yaml` (alphabetical between `mldsa` and `x448`)
- Add a row to `docs/10-extensions.md` Key Agreement / Encryption table, tagged experimental

## Context

New companion implementing a subset of draft-reddy-cose-jose-pqc-hybrid-hpke (individual submission, not WG-adopted). Supports HPKE-10-KE and HPKE-11-KE — X25519+ML-KEM-768 hybrid KEM (X-Wing) with SHAKE256 HPKE key schedule. Uses `cloudflare/circl/kem/xwing` at runtime, hand-rolled RFC 9180 key schedule on SHAKE256, cross-validated byte-for-byte against `cloudflare/circl/hpke` via HKDF-SHA256. No core jwx changes required — uses existing extension seams (`jwebb.RegisterHPKEAlgorithm`, `jwk.RegisterKeyImporter`/`Exporter`, AKP JWK kind namespacing).

## Test plan

- [ ] `python3 scripts/companion-apply-settings.py --modules=reddy-pqchpke --dry-run` parses the new yaml entry cleanly
- [ ] companion module repo builds + tests pass (already verified locally)
- [ ] docs site renders the new table row