### PR TITLE
fix stale documentation in v4 branch

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -9,7 +9,6 @@ Arrows show import direction: `A → B` means A imports B.
 ```
 Application Layer
   cmd/jwx → jwt, jws, jwe, jwk, jwa
-  examples → jwt, jws, jwe, jwk, jwa
 
 Composition Layer
   jwt → jws, jwe, jwk, jwa, transform, internal/{json}
@@ -30,7 +29,7 @@ Core Layer
 Leaf Packages (no internal deps)
   jwa → internal/tokens
   cert → internal/{base64,tokens}
-  transform → (stdlib + blackmagic)
+  transform → (stdlib only)
   internal/{base64,json,ecutil,pool,tokens,jwxio}
 ```
 
@@ -40,10 +39,10 @@ Leaf Packages (no internal deps)
 |---------|-----------------|
 | `jwa` | internal/tokens |
 | `cert` | internal/{base64,tokens} |
-| `transform` | (none — external only: blackmagic) |
+| `transform` | (none — stdlib only) |
 | `jwk` | jwa, cert, transform |
 | `jwk/ecdsa` | jwa |
-| `jwk/jwkbb` | (external only: blackmagic) |
+| `jwk/jwkbb` | (stdlib only) |
 | `jws` | jwa, jwk, cert |
 | `jwe` | jwa, jwk, cert, transform |
 | `jwt` | jwa, jws, jwe, jwk, transform |
@@ -53,13 +52,7 @@ Leaf Packages (no internal deps)
 
 | Dependency | Used by | Purpose |
 |------------|---------|---------|
-| `lestrrat-go/httprc/v3` | jwk | HTTP resource caching for JWKS |
-| `lestrrat-go/blackmagic` | jwk, jws, jwe, transform | Type reflection/assertion |
-| `lestrrat-go/option/v2` | all packages | Functional options pattern |
-| `goccy/go-json` | internal/json | Optional fast JSON (build tag) |
-| `segmentio/asm` | internal/base64 | Optional fast base64 (build tag) |
-| `decred/secp256k1` | jwk (direct); jwa, jws (via build tag) | ES256K support (build tag) |
+| `lestrrat-go/dsig` | jws/jwsbb | Digital signature primitives (HMAC, RSA, ECDSA, EdDSA) |
+| `lestrrat-go/option/v3` | all packages | Functional options pattern |
 | `valyala/fastjson` | jws/jwsbb | Fast JSON header parsing |
 | `golang.org/x/crypto` | jwe | Extended crypto (PBKDF2, etc.) |
-| `lestrrat-go/dsig` | jws/jwsbb | Digital signature primitives (HMAC, RSA, ECDSA, EdDSA) |
-| `lestrrat-go/dsig-secp256k1` | jws/jwsbb | ES256K/secp256k1 signature support (build tag) |

--- a/.claude/docs/internals.md
+++ b/.claude/docs/internals.md
@@ -8,15 +8,18 @@ All `*_gen.go` files are generated. NEVER edit directly.
 
 ### Generator → Output Mapping
 
-| Generator | Input | Output |
-|-----------|-------|--------|
-| `tools/cmd/genoptions/` | `{pkg}/options.yaml` | `{pkg}/options_gen.go` |
-| `tools/cmd/genjwt/` | `tools/cmd/genjwt/objects.yml` | `jwt/*_gen.go` |
-| `tools/cmd/genheaders/` | `tools/cmd/genheaders/jws-objects.yml` | `jws/headers_gen.go` |
-| `tools/cmd/genheaders/` | `tools/cmd/genheaders/jwe-objects.yml` | `jwe/headers_gen.go` |
-| `tools/cmd/genjwk/` | `tools/cmd/genjwk/objects.yml` | `jwk/*_gen.go` |
-| `tools/cmd/genjwa/` | `tools/cmd/genjwa/objects.yml` | `jwa/*_gen.go` |
-| `tools/cmd/genreadfile/` | (none) | `{pkg}/io.go` ReadFile helpers |
+All generators live in a unified binary at `internal/jwxcodegen/cmd/jwxcodegen/`,
+invoked via subcommand through `scripts/jwxcodegen.sh`.
+
+| Generator | Subcommand | Input | Output |
+|-----------|------------|-------|--------|
+| `genoptions` | `generate-options` | `{pkg}/options.yaml` | `{pkg}/options_gen.go` |
+| `genjwt` | `generate-jwt` | `jwt/objects.yml` | `jwt/*_gen.go` |
+| `genheaders` | `generate-headers` | `jws/objects.yml` | `jws/headers_gen.go` |
+| `genheaders` | `generate-headers` | `jwe/objects.yml` | `jwe/headers_gen.go` |
+| `genjwk` | `generate-jwk` | `jwk/objects.yml` | `jwk/*_gen.go` |
+| `genjwa` | `generate-jwa` | `jwa/objects.yml` | `jwa/*_gen.go` |
+| `genreadfile` | `generate-readfile` | (none) | ReadFile helpers |
 
 ### Commands
 
@@ -67,11 +70,9 @@ Manual option functions in `{pkg}/options.go` supplement generated ones.
 
 ## JSON Backend
 
-Pluggable via build tag `jwx_goccy`:
-- Default: `encoding/json`
-- Optional: `goccy/go-json` (faster)
+Uses `encoding/json/v2` exclusively (no build-tag switching).
 
-Internal `internal/json` package abstracts the choice. Custom field registry (`json.Registry`) enables type-safe deserialization of extension fields.
+Internal `internal/json` package provides the abstraction. Custom field registry (`json.Registry`) enables type-safe deserialization of extension fields.
 
 ## Base64 Backend
 
@@ -85,10 +86,9 @@ Internal `internal/base64` package abstracts the choice.
 | Module | Path | Purpose |
 |--------|------|---------|
 | Main | `./go.mod` | Core library |
-| Examples | `./examples/go.mod` | Usage examples (has `replace` directive) |
 | CLI | `./cmd/jwx/go.mod` | Command-line tool |
-| Perf Bench | `./bench/performance/go.mod` | Performance benchmarks |
-| Comparison | `./bench/comparison/go.mod` | Library comparison |
-| Generators | `./tools/cmd/*/go.mod` | Code generators |
+| Generators | `./internal/jwxcodegen/go.mod` | Code generators |
 
-No `go.work` file. Nested modules use `replace` directives for local development.
+Examples and benchmarks are external companion repos (`github.com/jwx-go/examples`, `github.com/jwx-go/benchmarks`), locally available via `go.work` when checked out.
+
+No `go.work` file is committed. Nested modules use `replace` directives for local development.

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -22,7 +22,7 @@ Algorithm identifiers per RFC 7518. Registry pattern with thread-safe lookup.
 - **KeyAlgorithmFrom(v any) (KeyAlgorithm, error)** — convert string/typed algorithm to union interface
 - Per-type API: `New{Type}()`, `Lookup{Type}(name) (T, bool)`, `Register{Type}()`, `Unregister{Type}()`, `{Type}s() []T`
 - Constructor functions: `ES256()`, `RS256()`, `A128GCM()`, `P256()`, `Ed25519()`, etc.
-- Files: `jwa.go`, `secp2561k.go` + generated `*_gen.go`
+- Files: `jwa.go` + generated `*_gen.go`
 - Imports: internal/tokens
 
 ## jwk/

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -5,9 +5,7 @@
 ## Running Tests
 
 ```bash
-make test              # All tests, stdlib JSON, race detector
-make test-goccy        # With goccy/go-json
-make test-alltags      # All optional features
+make test              # All tests, race detector
 make smoke             # Short/smoke tests only
 make cover             # Coverage report
 make lint              # golangci-lint
@@ -15,16 +13,14 @@ make lint              # golangci-lint
 
 ## Test Script
 
-`tools/test.sh` iterates over these modules:
+`scripts/test.sh` iterates over these modules:
 - `.` (main)
-- `./examples`
-- `./bench/performance`
 - `./cmd/jwx`
 
 All run with `-race` flag. Coverage excludes `internal/jose`, `internal/jwxtest`, `internal/cmd`.
 
 Environment variables:
-- `TESTOPTS` — extra `go test` flags (e.g., `-tags jwx_goccy`)
+- `TESTOPTS` — extra `go test` flags (e.g., `-run TestFoo`)
 - `MODE` — `cover` (add coverage), `short` (add `-short`)
 
 ## Package Test Conventions
@@ -40,11 +36,7 @@ Environment variables:
 
 ## Build Tags for Tests
 
-| Tag | Effect |
-|-----|--------|
-| `jwx_goccy` | Use goccy/go-json |
-
-Other optional features (signature algorithms, base64 backend) are now activated via side-effect imports of [extension modules](../docs/10-extensions.md), not build tags.
+No build tags in v4. Optional features (signature algorithms, base64 backend) are activated via side-effect imports of [extension modules](../docs/10-extensions.md).
 
 ## Fuzz Tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ The rest of this document focuses on developing the jwx library itself.
 
 ## Go Version
 
-This project requires **Go 1.25.0** or later. Check `go.mod` for the exact version.
+This project requires **Go 1.26.0** or later. Check `go.mod` for the exact version.
 
 ## Module Path vs Physical Layout
 
@@ -118,10 +118,6 @@ No `go.work` file is committed. When working across modules (including examples 
 # Run all tests
 make test
 
-# Run tests with specific build tags
-make test-goccy       # Use goccy/go-json
-make test-alltags     # All optional features
-
 # Run short/smoke tests
 make smoke
 
@@ -166,20 +162,24 @@ Tests are run via `./scripts/test.sh` which iterates over:
 
 ## Error Handling
 
-Sentinel errors are exposed via functions. Use `errors.Is()`:
+JWT error types are struct types. Use zero-value structs with `errors.Is()`, or `errors.AsType[T]()` for structured fields:
 
 ```go
-if errors.Is(err, jwt.TokenExpiredError()) { ... }
+if errors.Is(err, jwt.TokenExpiredError{}) { ... }
+
+if expErr, ok := errors.AsType[jwt.TokenExpiredError](err); ok {
+    log.Printf("expired at %s", expErr.Expiration)
+}
 ```
 
-| Package | Function | Meaning |
-|---------|----------|---------|
-| `jwt` | `TokenExpiredError()` | `exp` claim not satisfied |
-| `jwt` | `TokenNotYetValidError()` | `nbf` claim not satisfied |
-| `jwt` | `InvalidIssuerError()` | `iss` claim not satisfied |
-| `jwt` | `InvalidAudienceError()` | `aud` claim not satisfied |
-| `jwt` | `ValidateError()` | Generic validation failure |
-| `jwt` | `ParseError()` | Parse failed |
+| Package | Type / Function | Meaning |
+|---------|----------------|---------|
+| `jwt` | `TokenExpiredError{}` | `exp` claim not satisfied |
+| `jwt` | `TokenNotYetValidError{}` | `nbf` claim not satisfied |
+| `jwt` | `InvalidIssuerError{}` | `iss` claim not satisfied |
+| `jwt` | `InvalidAudienceError{}` | `aud` claim not satisfied |
+| `jwt` | `ValidationError{}` | Generic validation failure |
+| `jwt` | `ParseError{}` | Parse failed |
 | `jws` | `VerificationError()` | Signature verification failed |
 | `jwe` | `DecryptError()` | Decryption failed |
 
@@ -189,11 +189,7 @@ Use `github.com/stretchr/testify/require` for assertions (not `assert`).
 
 ## Build Tags
 
-| Tag | Effect |
-|-----|--------|
-| `jwx_goccy` | Use `goccy/go-json` instead of `encoding/json` |
-
-Optional features (signature algorithms, backend replacements) are provided as extension modules under [`github.com/jwx-go`](https://github.com/jwx-go). See [Extension Modules](docs/10-extensions.md) for the full list.
+No build tags in v4. Optional features (signature algorithms, backend replacements) are provided as extension modules under [`github.com/jwx-go`](https://github.com/jwx-go). See [Extension Modules](docs/10-extensions.md) for the full list.
 
 ## Quick Reference: Common Modifications
 

--- a/docs/01-jwt.md
+++ b/docs/01-jwt.md
@@ -1364,7 +1364,7 @@ source: [examples/jwt_serialize_jwe_jws_example_test.go](https://github.com/jwx-
 
 When you marshal `jwt.Token` into JSON, by default the `aud` field is serialized as an array of strings. This field may take either a single string or array form, but apparently there are parsers that do not understand the array form.
 
-The examples below should both be valid, but apparently there are systems that do not understand the former ([AWS Cognito has been reported to be one such system](https://github.com/lestrrat-go/jwx/tree/v3/issues/368)).
+The examples below should both be valid, but apparently there are systems that do not understand the former ([AWS Cognito has been reported to be one such system](https://github.com/lestrrat-go/jwx/issues/368)).
 
 ```
 {
@@ -1578,7 +1578,7 @@ For pre-defined fields, `Set()` will return an error when the value cannot be co
 
 Per specification JWT should be using URL base64 encoding with no padding when generating (and by nature of the process when verifying as well) signatures. However, some systems do not necessarily adhere to the standards ([there have been reports that AWS ALB is one such system, generating User Claims JWT with padding](https://github.com/lestrrat-go/jwx/discussions/1324))
 
-In these situations, you will need to specify the base64 encoder to your `jwt.Sign` and `jwt.Parse` calls. Please note that this feature is available on v3 onwards only.
+In these situations, you will need to specify the base64 encoder to your `jwt.Sign` and `jwt.Parse` calls.
 
 <!-- INCLUDE(examples/jwt_sign_with_custom_base64_example_test.go) -->
 ```go

--- a/docs/02-jws.md
+++ b/docs/02-jws.md
@@ -736,7 +736,6 @@ Optional signature algorithms are provided as separate extension modules under [
 Per specification JWS should be using URL base64 encoding with no padding when generating (and by nature of the process when verifying as well) signatures. However, some systems do not necessarily adhere to the standards ([there have been reports that AWS ALB is one such system, generating User Claims JWT with padding](https://github.com/lestrrat-go/jwx/discussions/1324))
 
 In these situations, you will need to specify the base64 encoder to your `jws.Sign` and `jws.Verify` calls.
-Please note that this feature is available on v3 onwards only.
 
 <!-- INCLUDE(examples/jws_sign_with_custom_base64_example_test.go) -->
 ```go

--- a/docs/04-jwk.md
+++ b/docs/04-jwk.md
@@ -528,7 +528,7 @@ source: [examples/jwk_import_example_test.go](https://github.com/jwx-go/examples
 
 To parse keys stored in a remote location pointed by a HTTP(s) URL, use [`jwk.Fetch()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#Fetch)
 
-If you are going to be using this key repeatedly in a long running process, consider using [`jwk.Cache`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#Cache) or [`jwk.CachedSet`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#CachedSet) described elsewhere in this document.
+If you are going to be using this key repeatedly in a long running process, consider using [`jwkcache.Cache`](https://pkg.go.dev/github.com/jwx-go/jwkcache/v4#Cache) or [`jwkcache.CachedSet`](https://pkg.go.dev/github.com/jwx-go/jwkcache/v4#CachedSet) from the [`github.com/jwx-go/jwkcache/v4`](https://github.com/jwx-go/jwkcache) extension module, described elsewhere in this document.
 
 By default, `jwk.Fetch()` uses an HTTP client that blocks HTTPS-to-HTTP redirect downgrades and limits redirect chains to 5 hops. This prevents the most common SSRF vector where an attacker-controlled JWKS URL redirects to an internal HTTP service.
 
@@ -607,7 +607,7 @@ Normally, you should be able to simply fetch the JWK using [`jwk.Fetch()`](https
 but keys are usually routinely expired and rotated due to security reasons.
 In such cases you would need to refetch the JWK periodically, which is a pain.
 
-`github.com/lestrrat-go/jwx/v4/jwk` provides the [`jwk.Cache`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#Cache) and [`jwk.CachedSet`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#CachedSet) to do this for you.
+The [`github.com/jwx-go/jwkcache/v4`](https://github.com/jwx-go/jwkcache) extension module provides [`jwkcache.Cache`](https://pkg.go.dev/github.com/jwx-go/jwkcache/v4#Cache) and [`jwkcache.CachedSet`](https://pkg.go.dev/github.com/jwx-go/jwkcache/v4#CachedSet) to do this for you.
 
 <!-- INCLUDE(examples/jwk_cache_example_test.go) -->
 ```go
@@ -759,7 +759,7 @@ source: [examples/jwk_cached_set_example_test.go](https://github.com/jwx-go/exam
 
 If you are fetching JWK Sets from a possibly untrusted source such as the URL in the `jku` field of a JWS message,
 you may have to perform some sort of whitelist checking. You can provide a `jwk.Whitelist` object to either
-`jwk.Fetch()` or `(*jwk.Cache).Register()` methods to specify the use of a whitelist.
+`jwk.Fetch()` or `(*jwkcache.Cache).Register()` methods to specify the use of a whitelist.
 
 Currently the package provides `jwk.MapWhitelist` and `jwk.RegexpWhitelist` types for simpler cases,
 as well as `jwk.InsecureWhitelist` for when you explicitly want to allow all URLs.

--- a/docs/20-global-settings.md
+++ b/docs/20-global-settings.md
@@ -1,23 +1,5 @@
 # Global Settings
 
-## Switching to a faster JSON library
-
-By default, we use the standard library's `encoding/json` for all of our JSON needs.
-However, if performance for parsing/serializing JSON is really important to you, you might want to enable [github.com/goccy/go-json](https://github.com/goccy/go-json) by enabling the `jwx_goccy` tag.
-
-```shell
-% go build -tags jwx_goccy ...
-```
-
-[github.com/goccy/go-json](https://github.com/goccy/go-json) is *disabled* by default because it uses some really advanced black magic, and I really do not feel like debugging it **IF** it breaks. Please note that that's a big "if".
-As of github.com/goccy/go-json@v0.3.3 I haven't seen any problems, and I would say that it is mostly stable.
-
-However, it is a dependency that you can go without, and I won't be of much help if it breaks -- therefore it is not the default.
-If you know what you are doing, I highly recommend enabling this module -- all you need to do is to enable this tag.
-Disable the tag if you feel like it's not worth the hassle.
-
-And when you *do* enable [github.com/goccy/go-json](https://github.com/goccy/go-json), and you encounter some mysterious error, I also trust that you know to file an issue to [github.com/goccy/go-json](https://github.com/goccy/go-json) and **NOT** to this library.
-
 ## Using json.Number
 
 If you want to parse numbers in the incoming JSON objects as json.Number
@@ -25,7 +7,7 @@ instead of floats, you can use the following call to globally affect the behavio
 
 ```go
 func init() {
-  jwx.DecoderSettings(jwx.WithUseNumber(true))
+  jwx.Settings(jwx.WithUseNumber(true))
 }
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 # How to JWx That
 
-Here you will find bits and pieces of code explaining how to perform certain Javascript Object Signing and Encryption (JOSE) operations using [`github.com/lestrrat-go/jwx/v4`](https://github.com/lestrrat-go/jwx/tree/v3).
+Here you will find bits and pieces of code explaining how to perform certain Javascript Object Signing and Encryption (JOSE) operations using [`github.com/lestrrat-go/jwx/v4`](https://github.com/lestrrat-go/jwx/tree/v4).
 
-If you would rather see code, try the [examples directory](../examples)
+If you would rather see code, try the [examples repository](https://github.com/jwx-go/examples)
 
 * [Anatomy of JOSE](./00-anatomy.md)
 * [Working with JWT](./01-jwt.md)


### PR DESCRIPTION
- fix generator paths (tools/cmd/ → internal/jwxcodegen/), JSON backend, multi-module layout in agent docs
- remove jwx_goccy build tag references, stale make targets, wrong script paths
- fix error handling pattern in AGENTS.md (function calls → zero-value structs)
- update jwk.Cache/CachedSet refs to jwkcache extension module
- fix stale links, version notes, removed APIs in end-user docs
