### PR TITLE
fix more stale v4 docs

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -32,16 +32,16 @@ JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 - **Parse(src []byte, ...ParseOption) (Set, error)** / **ParseKey(data []byte, ...ParseOption) (Key, error)** — parse JWK/JWKS
 - **Fetch(ctx, url, ...FetchOption) (Set, error)** — HTTP fetch with optional whitelist, body size limit (default 10 MB via `WithMaxFetchBodySize`)
 - **DefaultHTTPClient() \*http.Client** — returns a new http.Client with library defaults (30s timeout, redirect policy)
-- **Import(raw any) (Key, error)** / **Export(key Key, dst any) error** — convert between Go crypto types and JWK
+- **Import[T Key](raw any) (T, error)** / **Export[T any](key Key) (T, error)** — convert between Go crypto types and JWK (generic)
 - **PublicKeyOf(v any) (Key, error)** / **PublicSetOf(v Set) (Set, error)** — extract public keys
-- **NewCache(ctx, client) (*Cache, error)** — auto-refreshing JWKS cache
 - **AssignKeyID(key Key, ...AssignKeyIDOption) error** — compute and set kid via thumbprint
 - **Pem(v any) ([]byte, error)** — PEM encode
-- Key interfaces: `Key`, `Set`, `RSAPublicKey`, `RSAPrivateKey`, `ECDSAPublicKey`, `ECDSAPrivateKey`, `OKPPublicKey`, `OKPPrivateKey`, `SymmetricKey`
+- JWKS caching moved to `github.com/jwx-go/jwkcache` — see [Extension Modules](../../docs/10-extensions.md)
+- Key interfaces: `Key`, `Set`, `RSAPublicKey`, `RSAPrivateKey`, `ECDSAPublicKey`, `ECDSAPrivateKey`, `OKPPublicKey`, `OKPPrivateKey`, `SymmetricKey`, `AKPPublicKey`, `AKPPrivateKey` (post-quantum, used by mldsa/mlkem extensions)
 - Extension: `RegisterCustomField[T]()`, `RegisterCustomDecoder[T]()`, `RegisterKeyParser()`, `RegisterKeyImporter()`, `RegisterKeyExporter()`
 - Error sentinels: `ImportError()`, `ParseError()`, `WhitelistError()`, `ContinueError()`
-- Files: `jwk.go`, `set.go`, `parser.go`, `convert.go`, `fetch.go`, `cache.go`, `interface.go`, `errors.go`, `x509.go`, `filter.go`, `rsa.go`, `ecdsa.go`, `okp.go`, `symmetric.go`
-- Sub-packages: `jwk/ecdsa` — elliptic curve registration (`RegisterCurve`, `CurveFromAlgorithm`, `AlgorithmFromCurve`); `jwk/jwkbb` — X.509/PEM encoding building blocks (`EncodeX509`, `DecodeX509`)
+- Files: `jwk.go`, `set.go`, `parser.go`, `convert.go`, `fetch.go`, `interface.go`, `errors.go`, `x509.go`, `filter.go`, `rsa.go`, `ecdsa.go`, `okp.go`, `symmetric.go`, `akp.go`, `accessors.go`, `io.go`
+- Sub-packages: `jwk/ecdsa` — elliptic curve registration (`RegisterCurve`, `CurveFromAlgorithm`, `AlgorithmFromCurve`); `jwk/jwkbb` — X.509/PEM encoding building blocks (`EncodeX509`, `DecodeX509`); `jwk/jwkunsafe` — low-level key constructors (`NewKey`, `NewPublicKey`) for extension modules
 - Imports: jwa, cert, transform, internal/{base64,json,ecutil}
 
 ## jws/
@@ -67,8 +67,10 @@ JSON Web Signatures per RFC 7515. Sign, verify, parse.
 JSON Web Encryption per RFC 7516. Encrypt, decrypt, parse.
 
 - **Encrypt(payload []byte, ...EncryptOption) ([]byte, error)** — encrypt payload
+- **EncryptStatic(payload, cek []byte, ...EncryptOption) ([]byte, error)** — encrypt with caller-supplied content encryption key
 - **Decrypt(buf []byte, ...DecryptOption) ([]byte, error)** — decrypt message
 - **Parse(buf []byte, ...ParseOption) (*Message, error)** — parse without decryption
+- **Settings(options ...GlobalOption)** — configure global jwe settings
 - Key types: `Message`, `Recipient`, `Headers`, `KeyProvider`, `KeyEncrypter`, `KeyDecrypter`
 - Options: `WithKey()`, `WithKeySet()`, `WithContentEncryption()`, `WithCompress()`, `WithJSON()`, `WithProtectedHeaders()`
 - Global/per-call settings: `WithMaxPBES2Count()`, `WithMinPBES2Count()`, `WithMaxDecompressBufferSize()`, `WithMaxRecipients()` (usable in both `Settings()` and `Decrypt()`); `WithMaxParseInputSize()` (usable in both `Settings()` and `ParseReader()`/`ReadFile()`); `WithCBCBufferSize()` (global only)
@@ -85,7 +87,8 @@ JSON Web Tokens per RFC 7519. Parse, sign, validate.
 - **ParseInsecure(s []byte, ...ParseOption) (Token, error)** — parse without verification/validation
 - **Sign(t Token, ...SignOption) ([]byte, error)** — sign token to compact serialization
 - **Validate(t Token, ...ValidateOption) error** — validate claims (exp, nbf, iat, iss, aud, etc.)
-- **New() Token** — create empty token
+- **Equal(t1, t2 Token) bool** — deep-compare two tokens
+- **New() Token** / **NewBuilder() *Builder** — create empty token or use fluent builder
 - HTTP helpers: `ParseCookie()`, `ParseHeader()`, `ParseForm()`, `ParseRequest()`
 - Validator factories: `IsExpirationValid()`, `IsIssuedAtValid()`, `IsNbfValid()`, `IsRequired()`, `ClaimValueIs()`, `ClaimContainsString()`
 - Key types: `Token` (interface), `Validator`, `ValidatorFunc`, `Clock`, `ClockFunc`, `Serializer`, `TokenFilter`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,7 +239,7 @@ Read linked doc BEFORE working in that area. No exceptions.
 | Understanding package relationships, imports | `.claude/docs/dependencies.md` |
 | Working with errors, error handling patterns | `.claude/docs/error-formatting.md` |
 | Code generation, options pattern, extension points, JSON/base64 backends | `.claude/docs/internals.md` |
-| Extension modules (ES256K, Ed448, ML-DSA, X448, asmbase64, jwkcache) | `docs/10-extensions.md` |
+| Extension modules (ES256K, Ed448, ML-DSA, ML-KEM, X448, compsig, asmbase64, jwkcache) | `docs/10-extensions.md` |
 | Companion modules, CI templates, `/jwx-companion-bulk` | `.claude/docs/companions.md` |
 
 ## Cache Maintenance

--- a/docs/21-frameworks.md
+++ b/docs/21-frameworks.md
@@ -10,32 +10,38 @@ type Server struct {
 }
 ```
 
-The first step is to decide on the signature algorithm. Here we will show examples for using `jwa.HS256` and `jwa.RS256`. Choose the appropriate signature for your particular use case. You can find the full list of supported signature algorithms in the documentation or the source code for the [`jwa`](../jwa) package (remember that there are some [optional algorithms](./20-global-settings.md#enabling-optional-signature-methods)).
+The first step is to decide on the signature algorithm. Here we will show examples for using `jwa.HS256()` and `jwa.RS256()`. Choose the appropriate signature for your particular use case. You can find the full list of supported signature algorithms in the documentation or the source code for the [`jwa`](../jwa) package. Some post-quantum and curve-specific algorithms are available only via [extension modules](./10-extensions.md).
 
 
 ### Using HS256
 
-`jwa.HS256` is a symmetric algorithm, therefore the signing key should be exactly the same as the verifying key.
+`jwa.HS256()` is a symmetric algorithm, therefore the signing key should be exactly the same as the verifying key.
 
 ```go
-s.alg = jwa.HS256
-s.signKey = jwk.New([]byte("Hello, World!"))
+s.alg = jwa.HS256()
+symKey, err := jwk.Import[jwk.SymmetricKey]([]byte("Hello, World!"))
+if err != nil {
+  // handle error
+}
+s.signKey = symKey
 s.verifyKey = s.signKey
 ```
 
 ### Using RS256
 
-In this example we assume that your keys are stored in PEM-encoded files `private-key.pem` and `public-key.pem.
+In this example we assume that your keys are stored in PEM-encoded files `private-key.pem` and `public-key.pem`.
 
 ```go
-s.alg = jwa.RS256
+s.alg = jwa.RS256()
 
 {
   v, err := jwk.ParseFS(os.DirFS("."), `private-key.pem`, jwk.WithPEM(true))
   if err != nil {
     // handle error
   }
-  s.signKey = v
+  // ParseFS returns a Set; grab the first key
+  key, _ := v.Key(0)
+  s.signKey = key
 }
 
 {
@@ -43,7 +49,8 @@ s.alg = jwa.RS256
   if err != nil {
     // handle error
   }
-  s.verifyKey = v
+  key, _ := v.Key(0)
+  s.verifyKey = key
 }
 ```
 
@@ -77,7 +84,13 @@ In this example we are writing the token to the response body of the response.
 
 ```go
 func (s *Server) HandleBar(w http.ResponseWriter, req *http.Request) {
-  var token jwt.Token
+  token, err := jwt.NewBuilder().
+    Issuer(`example.com`).
+    IssuedAt(time.Now()).
+    Build()
+  if err != nil {
+    // handle errors
+  }
 
   signed, err := jwt.Sign(token, jwt.WithKey(s.alg, s.signKey))
   if err != nil {

--- a/jwk/README.md
+++ b/jwk/README.md
@@ -32,7 +32,8 @@ import (
 )
 
 func Example_jwk_usage() {
-  // Use jwk.Cache if you intend to keep reuse the JWKS over and over
+  // For repeated access to a remote JWKS, consider the jwkcache extension module
+  // (github.com/jwx-go/jwkcache) which keeps a JWKS auto-refreshed in the background.
   set, err := jwk.Fetch(context.Background(), "https://www.googleapis.com/oauth2/v3/certs")
   if err != nil {
     log.Printf("failed to parse JWK: %s", err)


### PR DESCRIPTION
## Summary

- `.claude/docs/packages.md`: drop removed `jwk.NewCache`/`cache.go`, update `Import`/`Export` to generics, add `AKPPublicKey`/`AKPPrivateKey`, `jwe.EncryptStatic`/`Settings`, `jwt.Equal`/`NewBuilder`, `jwk/jwkunsafe` sub-package
- `docs/21-frameworks.md`: fix v3 API leakage (`jwa.HS256`/`RS256` → `HS256()`/`RS256()`, `jwk.New` → `jwk.Import[jwk.SymmetricKey]`, nil `jwt.Token` → `jwt.NewBuilder`, `ParseFS` Set unwrap), fix broken anchor link
- `AGENTS.md`: add `ML-KEM`, `compsig` to extension modules pre-read trigger
- `jwk/README.md`: replace stale `jwk.Cache` comment with `jwkcache` extension pointer
