### PR TITLE
defer RUnlock in generated jwk MarshalJSON

### DIFF
--- a/internal/jwxcodegen/cmd/jwxcodegen/genjwk.go
+++ b/internal/jwxcodegen/cmd/jwxcodegen/genjwk.go
@@ -719,6 +719,7 @@ func generateKeyMarshalJSON(o *codegen.Output, kt *KeyType, obj *codegen.Object,
 	appendMarshaledPair("KeyTypeKey", kt.KeyType)
 
 	o.L("h.mu.RLock()")
+	o.L("defer h.mu.RUnlock()")
 	for _, f := range obj.Fields() {
 		keyName := keyConstantName(f, kt.Prefix)
 		o.L("if h.%s != nil {", f.Name(false))
@@ -757,7 +758,6 @@ func generateKeyMarshalJSON(o *codegen.Output, kt *KeyType, obj *codegen.Object,
 	o.L("pairs = append(pairs, fieldPair{Name: k, Value: encoded})")
 	o.L("}")
 	o.L("}")
-	o.L("h.mu.RUnlock()")
 
 	// Sort and assemble: values are already []byte, so just concatenate
 	o.LL("slices.SortFunc(pairs, fieldPairLess)")

--- a/jwk/akp_gen.go
+++ b/jwk/akp_gen.go
@@ -565,6 +565,7 @@ func (h *akpPublicKey) MarshalJSON() ([]byte, error) {
 		pairs = append(pairs, fieldPair{Name: KeyTypeKey, Value: v})
 	}
 	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		{
 			v, err := json.Marshal(*(h.algorithm))
@@ -662,7 +663,6 @@ func (h *akpPublicKey) MarshalJSON() ([]byte, error) {
 			pairs = append(pairs, fieldPair{Name: k, Value: encoded})
 		}
 	}
-	h.mu.RUnlock()
 
 	slices.SortFunc(pairs, fieldPairLess)
 	buf := pool.BytesBuffer().Get()
@@ -1319,6 +1319,7 @@ func (h *akpPrivateKey) MarshalJSON() ([]byte, error) {
 		pairs = append(pairs, fieldPair{Name: KeyTypeKey, Value: v})
 	}
 	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		{
 			v, err := json.Marshal(*(h.algorithm))
@@ -1425,7 +1426,6 @@ func (h *akpPrivateKey) MarshalJSON() ([]byte, error) {
 			pairs = append(pairs, fieldPair{Name: k, Value: encoded})
 		}
 	}
-	h.mu.RUnlock()
 
 	slices.SortFunc(pairs, fieldPairLess)
 	buf := pool.BytesBuffer().Get()

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -650,6 +650,7 @@ func (h *ecdsaPublicKey) MarshalJSON() ([]byte, error) {
 		pairs = append(pairs, fieldPair{Name: KeyTypeKey, Value: v})
 	}
 	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		{
 			v, err := json.Marshal(*(h.algorithm))
@@ -765,7 +766,6 @@ func (h *ecdsaPublicKey) MarshalJSON() ([]byte, error) {
 			pairs = append(pairs, fieldPair{Name: k, Value: encoded})
 		}
 	}
-	h.mu.RUnlock()
 
 	slices.SortFunc(pairs, fieldPairLess)
 	buf := pool.BytesBuffer().Get()
@@ -1513,6 +1513,7 @@ func (h *ecdsaPrivateKey) MarshalJSON() ([]byte, error) {
 		pairs = append(pairs, fieldPair{Name: KeyTypeKey, Value: v})
 	}
 	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		{
 			v, err := json.Marshal(*(h.algorithm))
@@ -1637,7 +1638,6 @@ func (h *ecdsaPrivateKey) MarshalJSON() ([]byte, error) {
 			pairs = append(pairs, fieldPair{Name: k, Value: encoded})
 		}
 	}
-	h.mu.RUnlock()
 
 	slices.SortFunc(pairs, fieldPairLess)
 	buf := pool.BytesBuffer().Get()

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -605,6 +605,7 @@ func (h *okpPublicKey) MarshalJSON() ([]byte, error) {
 		pairs = append(pairs, fieldPair{Name: KeyTypeKey, Value: v})
 	}
 	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		{
 			v, err := json.Marshal(*(h.algorithm))
@@ -711,7 +712,6 @@ func (h *okpPublicKey) MarshalJSON() ([]byte, error) {
 			pairs = append(pairs, fieldPair{Name: k, Value: encoded})
 		}
 	}
-	h.mu.RUnlock()
 
 	slices.SortFunc(pairs, fieldPairLess)
 	buf := pool.BytesBuffer().Get()
@@ -1410,6 +1410,7 @@ func (h *okpPrivateKey) MarshalJSON() ([]byte, error) {
 		pairs = append(pairs, fieldPair{Name: KeyTypeKey, Value: v})
 	}
 	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		{
 			v, err := json.Marshal(*(h.algorithm))
@@ -1525,7 +1526,6 @@ func (h *okpPrivateKey) MarshalJSON() ([]byte, error) {
 			pairs = append(pairs, fieldPair{Name: k, Value: encoded})
 		}
 	}
-	h.mu.RUnlock()
 
 	slices.SortFunc(pairs, fieldPairLess)
 	buf := pool.BytesBuffer().Get()

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -612,6 +612,7 @@ func (h *rsaPublicKey) MarshalJSON() ([]byte, error) {
 		pairs = append(pairs, fieldPair{Name: KeyTypeKey, Value: v})
 	}
 	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		{
 			v, err := json.Marshal(*(h.algorithm))
@@ -718,7 +719,6 @@ func (h *rsaPublicKey) MarshalJSON() ([]byte, error) {
 			pairs = append(pairs, fieldPair{Name: k, Value: encoded})
 		}
 	}
-	h.mu.RUnlock()
 
 	slices.SortFunc(pairs, fieldPairLess)
 	buf := pool.BytesBuffer().Get()
@@ -1636,6 +1636,7 @@ func (h *rsaPrivateKey) MarshalJSON() ([]byte, error) {
 		pairs = append(pairs, fieldPair{Name: KeyTypeKey, Value: v})
 	}
 	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		{
 			v, err := json.Marshal(*(h.algorithm))
@@ -1796,7 +1797,6 @@ func (h *rsaPrivateKey) MarshalJSON() ([]byte, error) {
 			pairs = append(pairs, fieldPair{Name: k, Value: encoded})
 		}
 	}
-	h.mu.RUnlock()
 
 	slices.SortFunc(pairs, fieldPairLess)
 	buf := pool.BytesBuffer().Get()

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -563,6 +563,7 @@ func (h *symmetricKey) MarshalJSON() ([]byte, error) {
 		pairs = append(pairs, fieldPair{Name: KeyTypeKey, Value: v})
 	}
 	h.mu.RLock()
+	defer h.mu.RUnlock()
 	if h.algorithm != nil {
 		{
 			v, err := json.Marshal(*(h.algorithm))
@@ -660,7 +661,6 @@ func (h *symmetricKey) MarshalJSON() ([]byte, error) {
 			pairs = append(pairs, fieldPair{Name: k, Value: encoded})
 		}
 	}
-	h.mu.RUnlock()
 
 	slices.SortFunc(pairs, fieldPairLess)
 	buf := pool.BytesBuffer().Get()


### PR DESCRIPTION
- Generated `jwk/*_gen.go` `MarshalJSON` took `h.mu.RLock()` without a matching defer; any per-field `json.Marshal` error leaked the reader lock and deadlocked the next writer (XCUT-003 / JWK-002 lock half).
- Fix the `genjwk` template to emit `defer h.mu.RUnlock()` immediately after the `RLock`, regenerate all five key types.
