### PR TITLE
clear fieldPair list before returning to pool

### DIFF
--- a/jwk/interface_gen.go
+++ b/jwk/interface_gen.go
@@ -38,8 +38,8 @@ func getFieldPairList() []fieldPair {
 }
 
 func putFieldPairList(list []fieldPair) {
-	list = list[:0]
-	fieldPairPool.Put(list)
+	clear(list) // zero fieldPair entries so pooled values don't retain references across Put/Get
+	fieldPairPool.Put(list[:0])
 }
 
 // Key defines the minimal interface for each of the

--- a/tools/cmd/genjwk/main.go
+++ b/tools/cmd/genjwk/main.go
@@ -838,8 +838,8 @@ func generateGenericHeaders(fields codegen.FieldList, keyTypes []*KeyType) error
 	o.L("}")
 
 	o.LL("func putFieldPairList(list []fieldPair) {")
-	o.L("list = list[:0]")
-	o.L("fieldPairPool.Put(list)")
+	o.L("clear(list) // zero fieldPair entries so pooled values don't retain references across Put/Get")
+	o.L("fieldPairPool.Put(list[:0])")
 	o.L("}")
 
 	o.LL("// Key defines the minimal interface for each of the")


### PR DESCRIPTION
- `putFieldPairList` sliced the list to zero before returning it to `fieldPairPool`, leaving `fieldPair.Value` entries reachable via the pool's backing array until overwritten.
- Call `clear(list)` before `Put(list[:0])` in the `genjwk` template and regenerate.
