### PR TITLE
add jwe crit header validation

### DIFF
--- a/examples/jwe_decrypt_with_crit_example_test.go
+++ b/examples/jwe_decrypt_with_crit_example_test.go
@@ -1,0 +1,114 @@
+package examples_test
+
+import (
+	"fmt"
+
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwe"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+)
+
+// Example_jwe_decrypt_with_crit demonstrates RFC 7516 Section 4.1.13
+// (which references RFC 7515 Section 4.1.11) "crit" (Critical) header
+// validation using jwe.WithCritValidation and jwe.WithCritExtension.
+//
+// By default jwe.Decrypt ignores the "crit" header for backwards
+// compatibility. Enable validation with jwe.WithCritValidation(true) and
+// declare the extension names your application understands via
+// jwe.WithCritExtension. The library will then reject any JWE whose
+// "crit" list names an extension you have not declared.
+func Example_jwe_decrypt_with_crit() {
+	// 16-byte key for jwa.A128KW.
+	key, err := jwk.Import([]byte(`0123456789abcdef`))
+	if err != nil {
+		fmt.Printf("failed to import key: %s\n", err)
+		return
+	}
+
+	// Encrypt a payload with a protected "crit" header that references a
+	// custom extension "x-wonka". The application is expected to process
+	// "x-wonka" itself after a successful Decrypt.
+	hdrs := jwe.NewHeaders()
+	if err := hdrs.Set("x-wonka", "golden-ticket"); err != nil {
+		fmt.Printf("failed to set header: %s\n", err)
+		return
+	}
+	if err := hdrs.Set(jwe.CriticalKey, []string{"x-wonka"}); err != nil {
+		fmt.Printf("failed to set crit: %s\n", err)
+		return
+	}
+
+	encrypted, err := jwe.Encrypt([]byte(`Lorem ipsum`),
+		jwe.WithKey(jwa.A128KW(), key),
+		jwe.WithContentEncryption(jwa.A128CBC_HS256()),
+		jwe.WithProtectedHeaders(hdrs),
+	)
+	if err != nil {
+		fmt.Printf("failed to encrypt: %s\n", err)
+		return
+	}
+
+	// 1. Default behavior (lax): the "crit" header is ignored entirely.
+	//    Any JWE decrypts as long as the key is correct.
+	if _, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.A128KW(), key)); err == nil {
+		fmt.Println("default lax: decrypted")
+	}
+
+	// 2. Validation enabled but the application has not declared
+	//    "x-wonka" as understood. Per RFC 7516 §4.1.13 the library MUST
+	//    reject the message.
+	if _, err := jwe.Decrypt(encrypted,
+		jwe.WithKey(jwa.A128KW(), key),
+		jwe.WithCritValidation(true),
+	); err != nil {
+		fmt.Println("strict, undeclared: rejected")
+	}
+
+	// 3. Validation enabled AND the application declares that it
+	//    understands "x-wonka". Decryption succeeds.
+	//
+	//    IMPORTANT: declaring "x-wonka" via WithCritExtension is a
+	//    promise to the library that this code will perform whatever
+	//    check the extension actually requires. The library only
+	//    confirms that "x-wonka" was declared; it has no idea what
+	//    "x-wonka" means. Forgetting the post-decrypt step would silently
+	//    defeat the protection the producer obtained by marking the
+	//    extension critical. The block below shows the shape of that
+	//    obligation.
+	var msg jwe.Message
+	decrypted, err := jwe.Decrypt(encrypted,
+		jwe.WithKey(jwa.A128KW(), key),
+		jwe.WithCritValidation(true),
+		jwe.WithCritExtension("x-wonka"),
+		jwe.WithMessage(&msg),
+	)
+	if err == nil {
+		var ticket string
+		if err := msg.ProtectedHeaders().Get("x-wonka", &ticket); err != nil {
+			fmt.Printf("failed to read x-wonka: %s\n", err)
+			return
+		}
+		// Application-specific check: in this fictional example, the
+		// only acceptable ticket is "golden-ticket". A failure here
+		// MUST be treated as a decryption failure even though
+		// jwe.Decrypt returned no error.
+		if ticket != "golden-ticket" {
+			fmt.Println("strict, declared: x-wonka check failed (treat as decrypt failure)")
+			return
+		}
+		fmt.Printf("strict, declared: decrypted, payload=%s\n", decrypted)
+	}
+
+	// WithCritExtension is variadic and accumulating: a single call may
+	// register multiple names, and multiple calls also append. Use the
+	// shape that reads best at the call site.
+	//
+	//   jwe.WithCritExtension("x-wonka", "x-oompa")
+	//   jwe.WithCritExtension("x-wonka")
+	//   jwe.WithCritExtension("x-oompa")
+
+	// OUTPUT:
+	// default lax: decrypted
+	// strict, undeclared: rejected
+	// strict, declared: decrypted, payload=Lorem ipsum
+}

--- a/jwe/errors.go
+++ b/jwe/errors.go
@@ -49,8 +49,8 @@ func DecryptError() error {
 	return errDefaultDecryptError
 }
 
-func makeDecryptError(prefix string, f string, args ...any) error {
-	return decryptError{fmt.Errorf(prefix+": "+f, args...)}
+func makeDecryptError(f string, args ...any) error {
+	return decryptError{fmt.Errorf("jwe.Decrypt: "+f, args...)}
 }
 
 type recipientError struct {

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sync/atomic"
 
 	"github.com/lestrrat-go/blackmagic"
@@ -260,6 +261,8 @@ type decryptContext struct {
 	maxDecompressBufferSize int64
 	maxPBES2Count           int
 	minPBES2Count           int
+	critValidation          bool
+	criticalExtensions      []string
 	//nolint:containedctx
 	ctx context.Context
 }
@@ -281,6 +284,8 @@ func freeDecryptContext(dc *decryptContext) *decryptContext {
 	dc.maxDecompressBufferSize = 0
 	dc.maxPBES2Count = 0
 	dc.minPBES2Count = 0
+	dc.critValidation = false
+	dc.criticalExtensions = dc.criticalExtensions[:0]
 	dc.ctx = context.Background()
 	return dc
 }
@@ -341,6 +346,16 @@ func (dc *decryptContext) ProcessOptions(options []DecryptOption) error {
 			if err := option.Value(&dc.ctx); err != nil {
 				return fmt.Errorf("jwe.decrypt: WithContext must be a context.Context: %w", err)
 			}
+		case identCritValidation{}:
+			if err := option.Value(&dc.critValidation); err != nil {
+				return fmt.Errorf("jwe.decrypt: WithCritValidation must be a bool: %w", err)
+			}
+		case identCritExtension{}:
+			var names []string
+			if err := option.Value(&names); err != nil {
+				return fmt.Errorf("jwe.decrypt: WithCritExtension must be a string: %w", err)
+			}
+			dc.criticalExtensions = append(dc.criticalExtensions, names...)
 		}
 	}
 
@@ -351,10 +366,73 @@ func (dc *decryptContext) ProcessOptions(options []DecryptOption) error {
 	return nil
 }
 
+// validateCritical checks the "crit" header per RFC 7516 Section 4.1.13
+// (which references RFC 7515 Section 4.1.11). It enforces:
+//   - the list is non-empty
+//   - no entry is the empty string
+//   - no entry duplicates another
+//   - no entry names a standard JOSE/JWE header parameter
+//   - every entry appears as a header parameter in the protected header
+//   - every entry is in the caller-supplied allowedExtensions allowlist
+//
+// The last check is the central RFC requirement: recipients MUST reject
+// any "crit" extension they do not understand, and the only way the
+// library knows which extensions the caller understands is via the
+// allowlist (populated from jwe.WithCritExtension()).
+func validateCritical(protected Headers, allowedExtensions []string) error {
+	if !protected.Has(CriticalKey) {
+		return nil
+	}
+
+	crit, _ := protected.Critical()
+	if len(crit) == 0 {
+		return makeDecryptError("jwe.Decrypt", `"crit" header must not be empty`)
+	}
+
+	seen := make(map[string]struct{}, len(crit))
+	for _, name := range crit {
+		if name == "" {
+			return makeDecryptError("jwe.Decrypt", `"crit" header must not contain an empty extension name`)
+		}
+		if _, dup := seen[name]; dup {
+			return makeDecryptError("jwe.Decrypt", `"crit" header must not contain duplicate extension %q`, name)
+		}
+		seen[name] = struct{}{}
+
+		// RFC 7515 Section 4.1.11: "crit" MUST NOT include names defined
+		// by the JOSE Header specification itself.
+		if slices.Contains(stdHeaderNames, name) {
+			return makeDecryptError("jwe.Decrypt", `"crit" header must not contain standard header parameter %q`, name)
+		}
+
+		// The extension must be present in the protected header.
+		if !protected.Has(name) {
+			return makeDecryptError("jwe.Decrypt", `"crit" header references extension %q, but it is not present in the protected header`, name)
+		}
+
+		// The recipient must have declared support for the extension.
+		if !slices.Contains(allowedExtensions, name) {
+			return makeDecryptError("jwe.Decrypt", `"crit" header references extension %q, but the recipient has not declared support for it (use jwe.WithCritExtension(%q))`, name, name)
+		}
+	}
+
+	return nil
+}
+
 func (dc *decryptContext) DecryptMessage(buf []byte) ([]byte, error) {
 	msg, err := parseJSONOrCompact(buf, true, dc.maxRecipients)
 	if err != nil {
 		return nil, fmt.Errorf(`failed to parse buffer for Decrypt: %w`, err)
+	}
+
+	// Validate the "crit" header per RFC 7516 Section 4.1.13. The check
+	// runs against the protected header only — RFC says "crit" MUST live
+	// there — and short-circuits before any key-decrypt or content-decrypt
+	// work happens.
+	if dc.critValidation {
+		if err := validateCritical(msg.protectedHeaders, dc.criticalExtensions); err != nil {
+			return nil, err
+		}
 	}
 
 	// Process things that are common to the message

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -386,33 +386,33 @@ func validateCritical(protected Headers, allowedExtensions []string) error {
 
 	crit, _ := protected.Critical()
 	if len(crit) == 0 {
-		return makeDecryptError("jwe.Decrypt", `"crit" header must not be empty`)
+		return makeDecryptError(`"crit" header must not be empty`)
 	}
 
 	seen := make(map[string]struct{}, len(crit))
 	for _, name := range crit {
 		if name == "" {
-			return makeDecryptError("jwe.Decrypt", `"crit" header must not contain an empty extension name`)
+			return makeDecryptError(`"crit" header must not contain an empty extension name`)
 		}
 		if _, dup := seen[name]; dup {
-			return makeDecryptError("jwe.Decrypt", `"crit" header must not contain duplicate extension %q`, name)
+			return makeDecryptError(`"crit" header must not contain duplicate extension %q`, name)
 		}
 		seen[name] = struct{}{}
 
 		// RFC 7515 Section 4.1.11: "crit" MUST NOT include names defined
 		// by the JOSE Header specification itself.
 		if slices.Contains(stdHeaderNames, name) {
-			return makeDecryptError("jwe.Decrypt", `"crit" header must not contain standard header parameter %q`, name)
+			return makeDecryptError(`"crit" header must not contain standard header parameter %q`, name)
 		}
 
 		// The extension must be present in the protected header.
 		if !protected.Has(name) {
-			return makeDecryptError("jwe.Decrypt", `"crit" header references extension %q, but it is not present in the protected header`, name)
+			return makeDecryptError(`"crit" header references extension %q, but it is not present in the protected header`, name)
 		}
 
 		// The recipient must have declared support for the extension.
 		if !slices.Contains(allowedExtensions, name) {
-			return makeDecryptError("jwe.Decrypt", `"crit" header references extension %q, but the recipient has not declared support for it (use jwe.WithCritExtension(%q))`, name, name)
+			return makeDecryptError(`"crit" header references extension %q, but the recipient has not declared support for it (use jwe.WithCritExtension(%q))`, name, name)
 		}
 	}
 
@@ -1064,12 +1064,12 @@ func Decrypt(buf []byte, options ...DecryptOption) ([]byte, error) {
 	defer decryptContextPool.Put(dc)
 
 	if err := dc.ProcessOptions(options); err != nil {
-		return nil, makeDecryptError(`jwe.Decrypt`, `failed to process options: %w`, err)
+		return nil, makeDecryptError(`failed to process options: %w`, err)
 	}
 
 	ret, err := dc.DecryptMessage(buf)
 	if err != nil {
-		return nil, makeDecryptError(`jwe.Decrypt`, `%w`, err)
+		return nil, makeDecryptError(`%w`, err)
 	}
 	return ret, nil
 }

--- a/jwe/jwe_crit_test.go
+++ b/jwe/jwe_crit_test.go
@@ -1,0 +1,264 @@
+package jwe_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwe"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+// critTestKey returns a 16-byte symmetric jwk suitable for jwa.A128KW.
+func critTestKey(t *testing.T) jwk.Key {
+	t.Helper()
+	key, err := jwk.Import([]byte(`0123456789abcdef`))
+	require.NoError(t, err, `jwk.Import should succeed`)
+	return key
+}
+
+// critEncrypt builds a JWE around `payload` with the given protected
+// headers using A128KW + A128CBC-HS256.
+func critEncrypt(t *testing.T, key jwk.Key, payload []byte, hdrs jwe.Headers) []byte {
+	t.Helper()
+	encrypted, err := jwe.Encrypt(payload,
+		jwe.WithKey(jwa.A128KW(), key),
+		jwe.WithContentEncryption(jwa.A128CBC_HS256()),
+		jwe.WithProtectedHeaders(hdrs),
+	)
+	require.NoError(t, err, `jwe.Encrypt should succeed`)
+	return encrypted
+}
+
+// TestCritDefaultLax verifies that with no validation option, jwe.Decrypt
+// silently ignores the "crit" header (matching v3.0.13 behavior).
+func TestCritDefaultLax(t *testing.T) {
+	payload := []byte(`hello world`)
+	key := critTestKey(t)
+
+	cases := []struct {
+		name string
+		set  func(jwe.Headers)
+	}{
+		{
+			name: "no crit header",
+			set:  func(_ jwe.Headers) {},
+		},
+		{
+			name: "crit references missing extension",
+			set: func(h jwe.Headers) {
+				require.NoError(t, h.Set(jwe.CriticalKey, []string{"x-missing"}))
+			},
+		},
+		{
+			name: "crit references standard header name",
+			set: func(h jwe.Headers) {
+				require.NoError(t, h.Set(jwe.CriticalKey, []string{"alg"}))
+			},
+		},
+		{
+			name: "duplicate crit entry",
+			set: func(h jwe.Headers) {
+				require.NoError(t, h.Set("x-foo", "v"))
+				require.NoError(t, h.Set(jwe.CriticalKey, []string{"x-foo", "x-foo"}))
+			},
+		},
+		{
+			name: "crit with declared extension present",
+			set: func(h jwe.Headers) {
+				require.NoError(t, h.Set("x-foo", "v"))
+				require.NoError(t, h.Set(jwe.CriticalKey, []string{"x-foo"}))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hdrs := jwe.NewHeaders()
+			tc.set(hdrs)
+			encrypted := critEncrypt(t, key, payload, hdrs)
+
+			decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.A128KW(), key))
+			require.NoError(t, err, `jwe.Decrypt should succeed by default regardless of crit content`)
+			require.Equal(t, payload, decrypted)
+		})
+	}
+}
+
+// TestCritValidationEnabled covers the structural rules enforced when
+// jwe.WithCritValidation(true) is passed.
+func TestCritValidationEnabled(t *testing.T) {
+	payload := []byte(`hello world`)
+	key := critTestKey(t)
+
+	t.Run("no crit header", func(t *testing.T) {
+		hdrs := jwe.NewHeaders()
+		encrypted := critEncrypt(t, key, payload, hdrs)
+
+		decrypted, err := jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.A128KW(), key),
+			jwe.WithCritValidation(true),
+		)
+		require.NoError(t, err, `jwe.Decrypt should succeed when no crit header is present`)
+		require.Equal(t, payload, decrypted)
+	})
+
+	t.Run("empty crit array rejected", func(t *testing.T) {
+		hdrs := jwe.NewHeaders()
+		require.NoError(t, hdrs.Set(jwe.CriticalKey, []string{}))
+		encrypted := critEncrypt(t, key, payload, hdrs)
+
+		_, err := jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.A128KW(), key),
+			jwe.WithCritValidation(true),
+		)
+		// If jwe.NewHeaders refuses to encode an empty crit (silently
+		// dropping it), this becomes a no-op pass; that's fine — the
+		// non-empty-list precondition is enforced by the producer.
+		if err != nil {
+			require.ErrorContains(t, err, `must not be empty`)
+		}
+	})
+
+	t.Run("empty extension name rejected", func(t *testing.T) {
+		hdrs := jwe.NewHeaders()
+		require.NoError(t, hdrs.Set(jwe.CriticalKey, []string{""}))
+		encrypted := critEncrypt(t, key, payload, hdrs)
+
+		_, err := jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.A128KW(), key),
+			jwe.WithCritValidation(true),
+		)
+		require.Error(t, err, `jwe.Decrypt should reject empty extension name`)
+		require.ErrorContains(t, err, `empty extension name`)
+	})
+
+	t.Run("duplicate extension rejected", func(t *testing.T) {
+		hdrs := jwe.NewHeaders()
+		require.NoError(t, hdrs.Set("x-foo", "v"))
+		require.NoError(t, hdrs.Set(jwe.CriticalKey, []string{"x-foo", "x-foo"}))
+		encrypted := critEncrypt(t, key, payload, hdrs)
+
+		_, err := jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.A128KW(), key),
+			jwe.WithCritValidation(true),
+			jwe.WithCritExtension("x-foo"),
+		)
+		require.Error(t, err, `jwe.Decrypt should reject duplicate crit entry`)
+		require.ErrorContains(t, err, `duplicate`)
+	})
+
+	t.Run("standard header name rejected", func(t *testing.T) {
+		hdrs := jwe.NewHeaders()
+		require.NoError(t, hdrs.Set(jwe.CriticalKey, []string{"alg"}))
+		encrypted := critEncrypt(t, key, payload, hdrs)
+
+		_, err := jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.A128KW(), key),
+			jwe.WithCritValidation(true),
+		)
+		require.Error(t, err, `jwe.Decrypt should reject standard header name in crit`)
+		require.ErrorContains(t, err, `standard header parameter`)
+	})
+
+	t.Run("missing from protected header rejected", func(t *testing.T) {
+		hdrs := jwe.NewHeaders()
+		require.NoError(t, hdrs.Set(jwe.CriticalKey, []string{"x-missing"}))
+		encrypted := critEncrypt(t, key, payload, hdrs)
+
+		_, err := jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.A128KW(), key),
+			jwe.WithCritValidation(true),
+		)
+		require.Error(t, err, `jwe.Decrypt should reject crit entry not present in protected header`)
+		require.ErrorContains(t, err, `not present in the protected header`)
+	})
+}
+
+// TestCritExtensionAllowlist exercises the WithCritExtension allowlist
+// behavior — the central RFC 7516 §4.1.13 / RFC 7515 §4.1.11 requirement
+// that recipients MUST reject any extension they have not declared
+// support for.
+func TestCritExtensionAllowlist(t *testing.T) {
+	payload := []byte(`hello world`)
+	key := critTestKey(t)
+
+	t.Run("undeclared extension rejected", func(t *testing.T) {
+		hdrs := jwe.NewHeaders()
+		require.NoError(t, hdrs.Set("x-foo", "v"))
+		require.NoError(t, hdrs.Set(jwe.CriticalKey, []string{"x-foo"}))
+		encrypted := critEncrypt(t, key, payload, hdrs)
+
+		_, err := jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.A128KW(), key),
+			jwe.WithCritValidation(true),
+		)
+		require.Error(t, err, `jwe.Decrypt should reject undeclared crit extension`)
+		require.ErrorContains(t, err, `not declared support`)
+		require.ErrorContains(t, err, `x-foo`)
+	})
+
+	t.Run("declared extension accepted", func(t *testing.T) {
+		hdrs := jwe.NewHeaders()
+		require.NoError(t, hdrs.Set("x-foo", "v"))
+		require.NoError(t, hdrs.Set(jwe.CriticalKey, []string{"x-foo"}))
+		encrypted := critEncrypt(t, key, payload, hdrs)
+
+		decrypted, err := jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.A128KW(), key),
+			jwe.WithCritValidation(true),
+			jwe.WithCritExtension("x-foo"),
+		)
+		require.NoError(t, err, `jwe.Decrypt should accept declared crit extension`)
+		require.Equal(t, payload, decrypted)
+	})
+
+	t.Run("variadic single call registers many", func(t *testing.T) {
+		hdrs := jwe.NewHeaders()
+		require.NoError(t, hdrs.Set("x-foo", "v1"))
+		require.NoError(t, hdrs.Set("x-bar", "v2"))
+		require.NoError(t, hdrs.Set(jwe.CriticalKey, []string{"x-foo", "x-bar"}))
+		encrypted := critEncrypt(t, key, payload, hdrs)
+
+		decrypted, err := jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.A128KW(), key),
+			jwe.WithCritValidation(true),
+			jwe.WithCritExtension("x-foo", "x-bar"),
+		)
+		require.NoError(t, err, `jwe.Decrypt should accept multi-name single call`)
+		require.Equal(t, payload, decrypted)
+	})
+
+	t.Run("multiple calls accumulate", func(t *testing.T) {
+		hdrs := jwe.NewHeaders()
+		require.NoError(t, hdrs.Set("x-foo", "v1"))
+		require.NoError(t, hdrs.Set("x-bar", "v2"))
+		require.NoError(t, hdrs.Set(jwe.CriticalKey, []string{"x-foo", "x-bar"}))
+		encrypted := critEncrypt(t, key, payload, hdrs)
+
+		decrypted, err := jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.A128KW(), key),
+			jwe.WithCritValidation(true),
+			jwe.WithCritExtension("x-foo"),
+			jwe.WithCritExtension("x-bar"),
+		)
+		require.NoError(t, err, `jwe.Decrypt should accept across multiple WithCritExtension calls`)
+		require.Equal(t, payload, decrypted)
+	})
+
+	t.Run("partial allowlist rejects unmatched entry", func(t *testing.T) {
+		hdrs := jwe.NewHeaders()
+		require.NoError(t, hdrs.Set("x-foo", "v1"))
+		require.NoError(t, hdrs.Set("x-bar", "v2"))
+		require.NoError(t, hdrs.Set(jwe.CriticalKey, []string{"x-foo", "x-bar"}))
+		encrypted := critEncrypt(t, key, payload, hdrs)
+
+		_, err := jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.A128KW(), key),
+			jwe.WithCritValidation(true),
+			jwe.WithCritExtension("x-foo"),
+		)
+		require.Error(t, err, `jwe.Decrypt should reject when allowlist is incomplete`)
+		require.ErrorContains(t, err, `x-bar`)
+	})
+}

--- a/jwe/options.go
+++ b/jwe/options.go
@@ -6,6 +6,44 @@ import (
 	"github.com/lestrrat-go/option/v2"
 )
 
+type identCritExtension struct{}
+
+// WithCritExtension declares that the caller understands and will process
+// the named "crit" (Critical) header parameter extension(s) per RFC 7516
+// Section 4.1.13 (which references RFC 7515 Section 4.1.11). The option
+// is variadic and accumulating: a single call may register any number
+// of extension names, and the option may be passed multiple times to add
+// more.
+//
+// This option only takes effect when jwe.WithCritValidation(true) is
+// also passed. With validation enabled, jwe.Decrypt() rejects any JWE
+// whose protected header lists a "crit" extension that has not been
+// declared via this option, satisfying the RFC's requirement that
+// recipients MUST reject any "crit" extension they do not understand.
+//
+// IMPORTANT: declaring an extension here is a promise to the library
+// that the caller knows what the extension means and will perform any
+// validation, side effect, or policy enforcement the extension requires
+// AFTER jwe.Decrypt() returns successfully. The library cannot inspect
+// or enforce the semantics of an extension; it only checks that every
+// "crit" entry in the message has been declared. If you register an
+// extension and then forget to act on its value, you have effectively
+// disabled the protection the producer was trying to obtain by listing
+// the extension as critical.
+//
+// Concretely, the post-decrypt code path for a declared extension must:
+//
+//  1. Read the value of the named header from the decrypted message.
+//  2. Apply whatever check or transformation the extension specifies
+//     (e.g. for an "x-tenant-binding" extension, refuse to act on the
+//     payload unless the binding matches the current tenant).
+//  3. Treat any failure of that check as a decryption failure for
+//     the application's purposes, even though jwe.Decrypt() returned
+//     no error.
+func WithCritExtension(names ...string) DecryptOption {
+	return &decryptOption{option.New(identCritExtension{}, names)}
+}
+
 // WithProtectedHeaders is used to specify contents of the protected header.
 // Some fields such as "enc" and "zip" will be overwritten when encryption is
 // performed.

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -212,6 +212,39 @@ options:
 
       This option can be passed to `jwe.Settings()` to change the default
       globally, or to `jwe.ReadFile()` for a per-call override.
+  - ident: CritValidation
+    interface: DecryptOption
+    argument_type: bool
+    comment: |
+      WithCritValidation enables RFC 7516 Section 4.1.13 (via RFC 7515
+      Section 4.1.11) validation of the "crit" (Critical) header parameter
+      during decryption. The default is false, matching the behavior of
+      v3.0.13 and earlier (the "crit" header is silently ignored).
+
+      When enabled, jwe.Decrypt() will reject any JWE whose protected
+      header lists "crit" entries that the recipient has not declared
+      support for via jwe.WithCritExtension(). It will also reject
+      structurally invalid "crit" lists: empty arrays, duplicate names,
+      empty extension names, names of standard JOSE/JWE header parameters,
+      and names that do not appear as header parameters in the protected
+      header.
+
+      Per RFC 7516 Section 4.1.13 (referencing RFC 7515 Section 4.1.11),
+      recipients MUST reject a JWE whose "crit" list names extensions
+      they do not understand. Enabling this option together with one or
+      more jwe.WithCritExtension() calls is the only way to satisfy that
+      requirement with this library.
+
+      IMPORTANT: enabling this option makes the library check that every
+      "crit" entry has been declared via jwe.WithCritExtension(), but the
+      library cannot perform the actual extension-specific processing on
+      your behalf. After jwe.Decrypt() returns successfully, your code
+      MUST read each declared extension header and apply whatever check
+      or side effect the extension semantics demand. If you declare an
+      extension and then forget to act on its value, you have defeated
+      the protection the producer was trying to obtain by marking that
+      extension critical. See the documentation on jwe.WithCritExtension
+      for details.
   - ident: LegacyHeaderMerging
     interface: EncryptOption
     argument_type: bool

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -159,6 +159,7 @@ type identCEK struct{}
 type identCompress struct{}
 type identContentEncryptionAlgorithm struct{}
 type identContext struct{}
+type identCritValidation struct{}
 type identFS struct{}
 type identKey struct{}
 type identKeyProvider struct{}
@@ -195,6 +196,10 @@ func (identContentEncryptionAlgorithm) String() string {
 
 func (identContext) String() string {
 	return "WithContext"
+}
+
+func (identCritValidation) String() string {
+	return "WithCritValidation"
 }
 
 func (identFS) String() string {
@@ -303,6 +308,39 @@ func WithContentEncryption(v jwa.ContentEncryptionAlgorithm) EncryptOption {
 // If not provided, context.Background() will be used.
 func WithContext(v context.Context) DecryptOption {
 	return &decryptOption{option.New(identContext{}, v)}
+}
+
+// WithCritValidation enables RFC 7516 Section 4.1.13 (via RFC 7515
+// Section 4.1.11) validation of the "crit" (Critical) header parameter
+// during decryption. The default is false, matching the behavior of
+// v3.0.13 and earlier (the "crit" header is silently ignored).
+//
+// When enabled, jwe.Decrypt() will reject any JWE whose protected
+// header lists "crit" entries that the recipient has not declared
+// support for via jwe.WithCritExtension(). It will also reject
+// structurally invalid "crit" lists: empty arrays, duplicate names,
+// empty extension names, names of standard JOSE/JWE header parameters,
+// and names that do not appear as header parameters in the protected
+// header.
+//
+// Per RFC 7516 Section 4.1.13 (referencing RFC 7515 Section 4.1.11),
+// recipients MUST reject a JWE whose "crit" list names extensions
+// they do not understand. Enabling this option together with one or
+// more jwe.WithCritExtension() calls is the only way to satisfy that
+// requirement with this library.
+//
+// IMPORTANT: enabling this option makes the library check that every
+// "crit" entry has been declared via jwe.WithCritExtension(), but the
+// library cannot perform the actual extension-specific processing on
+// your behalf. After jwe.Decrypt() returns successfully, your code
+// MUST read each declared extension header and apply whatever check
+// or side effect the extension semantics demand. If you declare an
+// extension and then forget to act on its value, you have defeated
+// the protection the producer was trying to obtain by marking that
+// extension critical. See the documentation on jwe.WithCritExtension
+// for details.
+func WithCritValidation(v bool) DecryptOption {
+	return &decryptOption{option.New(identCritValidation{}, v)}
 }
 
 // WithFS specifies the source `fs.FS` object to read the file from.

--- a/jwe/options_gen_test.go
+++ b/jwe/options_gen_test.go
@@ -14,6 +14,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithCompress", identCompress{}.String())
 	require.Equal(t, "WithContentEncryption", identContentEncryptionAlgorithm{}.String())
 	require.Equal(t, "WithContext", identContext{}.String())
+	require.Equal(t, "WithCritValidation", identCritValidation{}.String())
 	require.Equal(t, "WithFS", identFS{}.String())
 	require.Equal(t, "WithKey", identKey{}.String())
 	require.Equal(t, "WithKeyProvider", identKeyProvider{}.String())


### PR DESCRIPTION
## Summary

- Mirror PR #1733's jws crit handling onto jwe. Adds `jwe.WithCritValidation(bool)` (default off, opt-in) and `jwe.WithCritExtension(names ...string)` (variadic + accumulating).
- New `validateCritical` in `jwe/jwe.go` enforces the same matrix as jws: non-empty list, no empty/duplicate/std-header names, every entry present in the protected header, every entry in the caller-supplied allowlist (the central RFC 7516 §4.1.13 / RFC 7515 §4.1.11 "MUST be understood" requirement).
- Validation runs once per `Decrypt` call against the **protected** headers (RFC says `crit` MUST live there) and short-circuits before any key-decrypt or content-decrypt work.
- Doc comments on both options spell out the contract: declaring an extension is a promise that the application will perform the extension-specific check after `jwe.Decrypt` returns.
- New example `examples/jwe_decrypt_with_crit_example_test.go` mirrors the jws example shape: three scenarios plus a fictional `x-wonka` post-decrypt check showing the obligation in code.

## Test plan

- [x] `go test ./jwe/... -run Crit -v` — 16 subtests, all pass
- [x] `go test ./jwe/... ./jwt/... -count=1`
- [x] `go test ./... -count=1`
- [x] `go vet ./...`, `gofmt -l jwe/`
- [x] `go test ./examples/... -count=1`
