### PR TITLE
rework jws crit header validation

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -688,6 +688,11 @@ func Settings(options ...GlobalOption) {
 //
 // Since this function avoids doing many checks that jws.Verify would perform,
 // you must ensure to perform the necessary checks including ensuring that algorithm is safe to use for your payload yourself.
+//
+// In particular, VerifyCompactFast does NOT enforce the RFC 7515 Section
+// 4.1.11 "crit" (Critical) header validation. If your application processes
+// messages that may carry a "crit" header, use jws.Verify() with
+// jws.WithCritValidation and jws.WithCritExtension instead.
 func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]byte, error) {
 	if err := validateAlgorithmForKey(alg, key); err != nil {
 		return nil, makeVerifyError(`%w`, err)
@@ -699,12 +704,6 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	hdr, payload, encodedSig, err := jwsbb.SplitCompact(compact)
 	if err != nil {
 		return nil, makeVerifyError("failed to split compact: %w", err)
-	}
-
-	// Validate the "crit" header per RFC 7515 Section 4.1.11
-	parsedHdr := jwsbb.HeaderParseCompact(hdr)
-	if err := validateCriticalFast(parsedHdr); err != nil {
-		return nil, err
 	}
 
 	// Decode signature into pooled buffer (strict base64url, no padding per RFC 7515)

--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -9,240 +9,290 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCriticalHeaderValidation(t *testing.T) {
-	payload := []byte(`hello world`)
+// signWith returns a JWS-compact serialization of payload signed with key
+// using HS256 and the given protected headers.
+func signWith(t *testing.T, key any, payload []byte, hdrs jws.Headers) []byte {
+	t.Helper()
+	signed, err := jws.Sign(payload, jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)))
+	require.NoError(t, err, `jws.Sign should succeed`)
+	return signed
+}
 
+// TestCritValidationDefaultStrict covers the v4 default: jws.Verify enforces
+// RFC 7515 Section 4.1.11 with the WithCritExtension allowlist as the only
+// way to declare which extensions the recipient understands.
+func TestCritValidationDefaultStrict(t *testing.T) {
+	payload := []byte(`hello world`)
 	key, err := jwxtest.GenerateSymmetricJwk()
 	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
 
-	// Helper to sign with given protected headers
-	sign := func(t *testing.T, hdrs jws.Headers) []byte {
-		t.Helper()
-		signed, err := jws.Sign(payload, jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)))
-		require.NoError(t, err, `jws.Sign should succeed`)
-		return signed
-	}
-
-	t.Run("No crit header", func(t *testing.T) {
+	t.Run("no crit header", func(t *testing.T) {
 		hdrs := jws.NewHeaders()
-		signed := sign(t, hdrs)
-		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
-		require.NoError(t, err, `jws.Verify should succeed without crit header`)
-	})
-
-	t.Run("crit with b64 present in header", func(t *testing.T) {
-		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set("b64", false))
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"b64"}))
-
-		signed, err := jws.Sign(nil, jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)), jws.WithDetachedPayload(payload))
-		require.NoError(t, err, `jws.Sign should succeed`)
-
-		_, err = jws.Verify(signed, jws.WithKey(jwa.HS256(), key), jws.WithDetachedPayload(payload))
-		require.NoError(t, err, `jws.Verify should succeed when crit-listed header is present`)
-	})
-
-	t.Run("crit with custom header present succeeds", func(t *testing.T) {
-		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set("x-custom", "custom-value"))
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-custom"}))
-		signed := sign(t, hdrs)
+		signed := signWith(t, key, payload, hdrs)
 
 		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
-		require.NoError(t, err, `jws.Verify should succeed when crit-listed header is present`)
+		require.NoError(t, err, `jws.Verify should succeed when no crit header is present`)
 	})
 
-	t.Run("crit references header not present fails", func(t *testing.T) {
-		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-missing"}))
-		signed := sign(t, hdrs)
-
-		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
-		require.Error(t, err, `jws.Verify should fail when crit references absent header`)
-		require.ErrorContains(t, err, `not present in the protected header`)
-	})
-
-	t.Run("crit with standard header name fails", func(t *testing.T) {
-		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"alg"}))
-		signed := sign(t, hdrs)
-
-		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
-		require.Error(t, err, `jws.Verify should fail when crit contains standard header name`)
-		require.ErrorContains(t, err, `standard header parameter`)
-	})
-
-	t.Run("crit with empty array fails", func(t *testing.T) {
+	t.Run("empty crit array rejected", func(t *testing.T) {
 		hdrs := jws.NewHeaders()
 		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{}))
-		signed := sign(t, hdrs)
+		signed := signWith(t, key, payload, hdrs)
 
 		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
-		require.Error(t, err, `jws.Verify should fail when crit is empty`)
+		require.Error(t, err, `jws.Verify should reject empty crit array`)
 		require.ErrorContains(t, err, `must not be empty`)
 	})
 
-	t.Run("crit with multiple headers all present succeeds", func(t *testing.T) {
+	t.Run("empty extension name rejected", func(t *testing.T) {
 		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set("x-one", "v1"))
-		require.NoError(t, hdrs.Set("x-two", "v2"))
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-one", "x-two"}))
-		signed := sign(t, hdrs)
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{""}))
+		signed := signWith(t, key, payload, hdrs)
 
 		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
-		require.NoError(t, err, `jws.Verify should succeed when all crit-listed headers are present`)
+		require.Error(t, err, `jws.Verify should reject empty extension name`)
+		require.ErrorContains(t, err, `empty extension name`)
 	})
 
-	t.Run("crit with multiple headers one missing fails", func(t *testing.T) {
+	t.Run("duplicate extension rejected", func(t *testing.T) {
 		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set("x-present", "value"))
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-present", "x-absent"}))
-		signed := sign(t, hdrs)
+		require.NoError(t, hdrs.Set("x-foo", "v"))
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-foo", "x-foo"}))
+		signed := signWith(t, key, payload, hdrs)
 
-		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
-		require.Error(t, err, `jws.Verify should fail when any crit-listed header is missing`)
-		require.ErrorContains(t, err, `x-absent`)
-	})
-}
-
-func TestCriticalHeaderValidationFastPath(t *testing.T) {
-	payload := []byte(`hello world`)
-
-	key, err := jwxtest.GenerateSymmetricJwk()
-	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
-
-	sign := func(t *testing.T, hdrs jws.Headers) []byte {
-		t.Helper()
-		signed, err := jws.Sign(payload, jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)))
-		require.NoError(t, err, `jws.Sign should succeed`)
-		return signed
-	}
-
-	t.Run("No crit header", func(t *testing.T) {
-		hdrs := jws.NewHeaders()
-		signed := sign(t, hdrs)
-		_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
-		require.NoError(t, err, `VerifyCompactFast should succeed without crit header`)
+		_, err := jws.Verify(signed,
+			jws.WithKey(jwa.HS256(), key),
+			jws.WithCritExtension("x-foo"),
+		)
+		require.Error(t, err, `jws.Verify should reject duplicate crit entry`)
+		require.ErrorContains(t, err, `duplicate`)
 	})
 
-	t.Run("crit with custom header present succeeds", func(t *testing.T) {
-		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set("x-custom", "custom-value"))
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-custom"}))
-		signed := sign(t, hdrs)
-
-		_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
-		require.NoError(t, err, `VerifyCompactFast should succeed when crit-listed header is present`)
-	})
-
-	t.Run("crit references header not present fails", func(t *testing.T) {
-		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-missing"}))
-		signed := sign(t, hdrs)
-
-		_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
-		require.Error(t, err, `VerifyCompactFast should fail when crit references absent header`)
-		require.ErrorContains(t, err, `not present in the protected header`)
-	})
-
-	t.Run("crit with standard header name fails", func(t *testing.T) {
+	t.Run("standard header name rejected", func(t *testing.T) {
 		hdrs := jws.NewHeaders()
 		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"alg"}))
-		signed := sign(t, hdrs)
+		signed := signWith(t, key, payload, hdrs)
 
-		_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
-		require.Error(t, err, `VerifyCompactFast should fail when crit contains standard header name`)
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
+		require.Error(t, err, `jws.Verify should reject standard header name in crit`)
 		require.ErrorContains(t, err, `standard header parameter`)
 	})
 
-	t.Run("crit with empty array fails", func(t *testing.T) {
+	t.Run("missing from protected header rejected", func(t *testing.T) {
 		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{}))
-		signed := sign(t, hdrs)
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-missing"}))
+		signed := signWith(t, key, payload, hdrs)
 
-		_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
-		require.Error(t, err, `VerifyCompactFast should fail when crit is empty`)
-		require.ErrorContains(t, err, `must not be empty`)
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
+		require.Error(t, err, `jws.Verify should reject crit entry not present in protected header`)
+		require.ErrorContains(t, err, `not present in the protected header`)
 	})
 
-	t.Run("crit with multiple headers all present succeeds", func(t *testing.T) {
+	t.Run("undeclared extension rejected", func(t *testing.T) {
 		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set("x-one", "v1"))
-		require.NoError(t, hdrs.Set("x-two", "v2"))
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-one", "x-two"}))
-		signed := sign(t, hdrs)
+		require.NoError(t, hdrs.Set("x-foo", "v"))
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-foo"}))
+		signed := signWith(t, key, payload, hdrs)
 
-		_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
-		require.NoError(t, err, `VerifyCompactFast should succeed when all crit-listed headers are present`)
+		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
+		require.Error(t, err, `jws.Verify should reject undeclared crit extension by default`)
+		require.ErrorContains(t, err, `not declared support`)
+		require.ErrorContains(t, err, `x-foo`)
 	})
 
-	t.Run("crit with multiple headers one missing fails", func(t *testing.T) {
+	t.Run("declared extension accepted", func(t *testing.T) {
 		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set("x-present", "value"))
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-present", "x-absent"}))
-		signed := sign(t, hdrs)
+		require.NoError(t, hdrs.Set("x-foo", "v"))
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-foo"}))
+		signed := signWith(t, key, payload, hdrs)
 
-		_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
-		require.Error(t, err, `VerifyCompactFast should fail when any crit-listed header is missing`)
-		require.ErrorContains(t, err, `x-absent`)
+		_, err := jws.Verify(signed,
+			jws.WithKey(jwa.HS256(), key),
+			jws.WithCritExtension("x-foo"),
+		)
+		require.NoError(t, err, `jws.Verify should accept declared crit extension`)
 	})
 }
 
-func TestWithStrictCriticalHeaders(t *testing.T) {
+// TestCritValidationOptOut verifies that jws.WithCritValidation(false) makes
+// jws.Verify silently ignore the "crit" header, restoring the v3.0.13 lax
+// behavior. Each scenario would otherwise fail under the v4 default.
+func TestCritValidationOptOut(t *testing.T) {
 	payload := []byte(`hello world`)
-
 	key, err := jwxtest.GenerateSymmetricJwk()
 	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
 
-	sign := func(t *testing.T, hdrs jws.Headers) []byte {
-		t.Helper()
-		signed, err := jws.Sign(payload, jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)))
-		require.NoError(t, err, `jws.Sign should succeed`)
-		return signed
+	cases := []struct {
+		name string
+		set  func(jws.Headers)
+	}{
+		{
+			name: "crit references missing extension",
+			set: func(h jws.Headers) {
+				require.NoError(t, h.Set(jws.CriticalKey, []string{"x-missing"}))
+			},
+		},
+		{
+			name: "crit references standard header name",
+			set: func(h jws.Headers) {
+				require.NoError(t, h.Set(jws.CriticalKey, []string{"alg"}))
+			},
+		},
+		{
+			name: "empty crit array",
+			set: func(h jws.Headers) {
+				require.NoError(t, h.Set(jws.CriticalKey, []string{}))
+			},
+		},
+		{
+			name: "duplicate crit entry",
+			set: func(h jws.Headers) {
+				require.NoError(t, h.Set("x-foo", "v"))
+				require.NoError(t, h.Set(jws.CriticalKey, []string{"x-foo", "x-foo"}))
+			},
+		},
+		{
+			name: "undeclared extension",
+			set: func(h jws.Headers) {
+				require.NoError(t, h.Set("x-foo", "v"))
+				require.NoError(t, h.Set(jws.CriticalKey, []string{"x-foo"}))
+			},
+		},
 	}
 
-	t.Run("empty crit rejected by default", func(t *testing.T) {
-		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{}))
-		signed := sign(t, hdrs)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hdrs := jws.NewHeaders()
+			tc.set(hdrs)
+			signed := signWith(t, key, payload, hdrs)
 
-		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
-		require.Error(t, err, `jws.Verify should fail with strict crit by default`)
+			_, err := jws.Verify(signed,
+				jws.WithKey(jwa.HS256(), key),
+				jws.WithCritValidation(false),
+			)
+			require.NoError(t, err, `jws.Verify should succeed when crit validation is disabled`)
+		})
+	}
+}
+
+// TestCritExtensionAllowlist exercises the WithCritExtension allowlist
+// behavior — the central RFC 7515 §4.1.11 requirement that recipients
+// MUST reject any extension they have not declared support for.
+func TestCritExtensionAllowlist(t *testing.T) {
+	payload := []byte(`hello world`)
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+
+	t.Run("variadic single call registers many", func(t *testing.T) {
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set("x-foo", "v1"))
+		require.NoError(t, hdrs.Set("x-bar", "v2"))
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-foo", "x-bar"}))
+		signed := signWith(t, key, payload, hdrs)
+
+		_, err := jws.Verify(signed,
+			jws.WithKey(jwa.HS256(), key),
+			jws.WithCritExtension("x-foo", "x-bar"),
+		)
+		require.NoError(t, err, `jws.Verify should accept multi-name single call`)
 	})
 
-	t.Run("empty crit accepted when strict disabled", func(t *testing.T) {
+	t.Run("multiple calls accumulate", func(t *testing.T) {
 		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{}))
-		signed := sign(t, hdrs)
+		require.NoError(t, hdrs.Set("x-foo", "v1"))
+		require.NoError(t, hdrs.Set("x-bar", "v2"))
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-foo", "x-bar"}))
+		signed := signWith(t, key, payload, hdrs)
 
-		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key), jws.WithStrictCriticalHeaders(false))
-		require.NoError(t, err, `jws.Verify should succeed when strict crit is disabled`)
+		_, err := jws.Verify(signed,
+			jws.WithKey(jwa.HS256(), key),
+			jws.WithCritExtension("x-foo"),
+			jws.WithCritExtension("x-bar"),
+		)
+		require.NoError(t, err, `jws.Verify should accept across multiple WithCritExtension calls`)
 	})
 
-	t.Run("missing crit extension accepted when strict disabled", func(t *testing.T) {
+	t.Run("partial allowlist rejects unmatched entry", func(t *testing.T) {
 		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-missing"}))
-		signed := sign(t, hdrs)
+		require.NoError(t, hdrs.Set("x-foo", "v1"))
+		require.NoError(t, hdrs.Set("x-bar", "v2"))
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-foo", "x-bar"}))
+		signed := signWith(t, key, payload, hdrs)
 
-		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key), jws.WithStrictCriticalHeaders(false))
-		require.NoError(t, err, `jws.Verify should succeed when strict crit is disabled`)
+		_, err := jws.Verify(signed,
+			jws.WithKey(jwa.HS256(), key),
+			jws.WithCritExtension("x-foo"),
+		)
+		require.Error(t, err, `jws.Verify should reject when allowlist is incomplete`)
+		require.ErrorContains(t, err, `x-bar`)
 	})
+}
 
-	t.Run("standard header in crit accepted when strict disabled", func(t *testing.T) {
-		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"alg"}))
-		signed := sign(t, hdrs)
+// TestCritDetachedB64 verifies the RFC 7797 "b64:false" detached payload
+// flow still works under the default-strict crit validation when "b64" is
+// declared via WithCritExtension.
+func TestCritDetachedB64(t *testing.T) {
+	payload := []byte(`hello world`)
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
 
-		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key), jws.WithStrictCriticalHeaders(false))
-		require.NoError(t, err, `jws.Verify should succeed when strict crit is disabled`)
-	})
+	hdrs := jws.NewHeaders()
+	require.NoError(t, hdrs.Set("b64", false))
+	require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"b64"}))
 
-	t.Run("explicit true still validates", func(t *testing.T) {
-		hdrs := jws.NewHeaders()
-		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{}))
-		signed := sign(t, hdrs)
+	signed, err := jws.Sign(nil,
+		jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)),
+		jws.WithDetachedPayload(payload),
+	)
+	require.NoError(t, err, `jws.Sign should succeed`)
 
-		_, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), key), jws.WithStrictCriticalHeaders(true))
-		require.Error(t, err, `jws.Verify should fail with explicit strict crit`)
-	})
+	_, err = jws.Verify(signed,
+		jws.WithKey(jwa.HS256(), key),
+		jws.WithDetachedPayload(payload),
+		jws.WithCritExtension("b64"),
+	)
+	require.NoError(t, err, `jws.Verify should succeed when b64 is declared in allowlist`)
+}
+
+// TestVerifyCompactFastIgnoresCrit documents that the fast path performs
+// no crit validation regardless of message contents.
+func TestVerifyCompactFastIgnoresCrit(t *testing.T) {
+	payload := []byte(`hello world`)
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+
+	cases := []struct {
+		name string
+		set  func(jws.Headers)
+	}{
+		{
+			name: "crit references missing extension",
+			set: func(h jws.Headers) {
+				require.NoError(t, h.Set(jws.CriticalKey, []string{"x-missing"}))
+			},
+		},
+		{
+			name: "crit references standard header name",
+			set: func(h jws.Headers) {
+				require.NoError(t, h.Set(jws.CriticalKey, []string{"alg"}))
+			},
+		},
+		{
+			name: "empty crit array",
+			set: func(h jws.Headers) {
+				require.NoError(t, h.Set(jws.CriticalKey, []string{}))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hdrs := jws.NewHeaders()
+			tc.set(hdrs)
+			signed := signWith(t, key, payload, hdrs)
+
+			_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
+			require.NoError(t, err, `VerifyCompactFast does not enforce crit; should succeed`)
+		})
+	}
 }

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -959,7 +959,7 @@ func TestRFC7797(t *testing.T) {
 				payload := tc.Payload
 				signOptions := []jws.SignOption{jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs))}
 				var verifyOptions []jws.VerifyOption
-				verifyOptions = append(verifyOptions, jws.WithKey(jwa.HS256(), key))
+				verifyOptions = append(verifyOptions, jws.WithKey(jwa.HS256(), key), jws.WithCritExtension("b64"))
 				if tc.Detached {
 					signOptions = append(signOptions, jws.WithDetachedPayload(payload))
 					verifyOptions = append(verifyOptions, jws.WithDetachedPayload(payload))
@@ -1030,7 +1030,7 @@ func TestRFC7797(t *testing.T) {
 		for _, tc := range testcases {
 			t.Run(tc.Name, func(t *testing.T) {
 				options := tc.VerifyOptions
-				options = append(options, jws.WithKey(jwa.HS256(), key))
+				options = append(options, jws.WithKey(jwa.HS256(), key), jws.WithCritExtension("b64"))
 				payload, err := jws.Verify(tc.Input, options...)
 				if tc.Error {
 					require.Error(t, err, `jws.Verify should fail`)
@@ -1055,12 +1055,12 @@ func TestGH485(t *testing.T) {
     "signatures": [{"protected": %q, "signature": %q}]
 }`, payload, protected, signature)
 
-	verified, err := jws.Verify([]byte(signed), jws.WithKey(jwa.HS256(), []byte("secret")))
+	verified, err := jws.Verify([]byte(signed), jws.WithKey(jwa.HS256(), []byte("secret")), jws.WithCritExtension("exp"))
 	require.NoError(t, err, `jws.Verify should succeed`)
 	require.Equal(t, expected, string(verified), `verified payload should match`)
 
 	compact := strings.Join([]string{protected, payload, signature}, ".")
-	verified, err = jws.Verify([]byte(compact), jws.WithKey(jwa.HS256(), []byte("secret")))
+	verified, err = jws.Verify([]byte(compact), jws.WithKey(jwa.HS256(), []byte("secret")), jws.WithCritExtension("exp"))
 	require.NoError(t, err, `jws.Verify should succeed`)
 	require.Equal(t, expected, string(verified), `verified payload should match`)
 }

--- a/jws/options.go
+++ b/jws/options.go
@@ -7,6 +7,42 @@ import (
 )
 
 type identInsecureNoSignature struct{}
+type identCritExtension struct{}
+
+// WithCritExtension declares that the caller understands and will process
+// the named "crit" (Critical) header parameter extension(s) per RFC 7515
+// Section 4.1.11. The option is variadic and accumulating: a single call
+// may register any number of extension names, and the option may be
+// passed multiple times to add more.
+//
+// This option takes effect when jws.WithCritValidation is enabled (the
+// default in v4). With validation enabled, jws.Verify() rejects any JWS
+// whose protected header lists a "crit" extension that has not been
+// declared via this option, satisfying the RFC's requirement that
+// recipients MUST reject any "crit" extension they do not understand.
+//
+// IMPORTANT: declaring an extension here is a promise to the library
+// that the caller knows what the extension means and will perform any
+// validation, side effect, or policy enforcement the extension requires
+// AFTER jws.Verify() returns successfully. The library cannot inspect
+// or enforce the semantics of an extension; it only checks that every
+// "crit" entry in the message has been declared. If you register an
+// extension and then forget to act on its value, you have effectively
+// disabled the protection the producer was trying to obtain by listing
+// the extension as critical.
+//
+// Concretely, the post-verify code path for a declared extension must:
+//
+//  1. Read the value of the named header from the verified message.
+//  2. Apply whatever check or transformation the extension specifies
+//     (e.g. for an "x-tenant-binding" extension, refuse to act on the
+//     payload unless the binding matches the current tenant).
+//  3. Treat any failure of that check as a verification failure for
+//     the application's purposes, even though jws.Verify() returned
+//     no error.
+func WithCritExtension(names ...string) VerifyOption {
+	return &verifyOption{option.New(identCritExtension{}, names)}
+}
 
 // WithJSON specifies that the result of `jws.Sign()` is serialized in
 // JSON format.

--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -241,13 +241,33 @@ options:
       This option can be passed to `jws.Settings()` to change the default
       globally, or to `jws.Parse()` / `jws.ParseFS()` for a per-call
       override.
-  - ident: StrictCriticalHeaders
+  - ident: CritValidation
     interface: VerifyOption
     argument_type: bool
     comment: |
-      WithStrictCriticalHeaders specifies whether the "crit" (Critical)
-      header parameter should be validated per RFC 7515 Section 4.1.11
-      during verification. The default is true.
+      WithCritValidation controls RFC 7515 Section 4.1.11 validation of the
+      "crit" (Critical) header parameter during verification. The default
+      is true: jws.Verify() rejects any JWS whose protected header lists
+      "crit" entries that the recipient has not declared support for via
+      jws.WithCritExtension(). It will also reject structurally invalid
+      "crit" lists: empty arrays, duplicate names, empty extension names,
+      names of standard JOSE header parameters, and names that do not
+      appear as header parameters in the protected header.
 
-      When set to false, the "crit" header is silently ignored during
-      jws.Verify(), matching the behavior of v3.0.13 and earlier.
+      Pass jws.WithCritValidation(false) to silently ignore the "crit"
+      header entirely, matching the lax pre-v3.0.14 behavior. This opt-out
+      is discouraged: per RFC 7515 Section 4.1.11, recipients MUST reject a
+      JWS whose "crit" list names extensions they do not understand, and
+      the only way to satisfy that requirement with this library is to
+      keep validation enabled and declare the extensions you support.
+
+      IMPORTANT: with validation enabled, the library checks that every
+      "crit" entry has been declared via jws.WithCritExtension(), but the
+      library cannot perform the actual extension-specific processing on
+      your behalf. After jws.Verify() returns successfully, your code
+      MUST read each declared extension header and apply whatever check
+      or side effect the extension semantics demand. If you declare an
+      extension and then forget to act on its value, you have defeated
+      the protection the producer was trying to obtain by marking that
+      extension critical. See the documentation on jws.WithCritExtension
+      for details.

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -185,6 +185,7 @@ func (*withKeySuboption) withKeySuboption() {}
 
 type identBase64Encoder struct{}
 type identContext struct{}
+type identCritValidation struct{}
 type identDetached struct{}
 type identDetachedPayload struct{}
 type identInferAlgorithmFromKey struct{}
@@ -200,7 +201,6 @@ type identProtectedHeaders struct{}
 type identPublicHeaders struct{}
 type identRequireKid struct{}
 type identSerialization struct{}
-type identStrictCriticalHeaders struct{}
 type identUseDefault struct{}
 type identValidateKey struct{}
 
@@ -210,6 +210,10 @@ func (identBase64Encoder) String() string {
 
 func (identContext) String() string {
 	return "WithContext"
+}
+
+func (identCritValidation) String() string {
+	return "WithCritValidation"
 }
 
 func (identDetached) String() string {
@@ -272,10 +276,6 @@ func (identSerialization) String() string {
 	return "WithSerialization"
 }
 
-func (identStrictCriticalHeaders) String() string {
-	return "WithStrictCriticalHeaders"
-}
-
 func (identUseDefault) String() string {
 	return "WithUseDefault"
 }
@@ -293,6 +293,36 @@ func WithBase64Encoder(v Base64Encoder) SignVerifyCompactOption {
 
 func WithContext(v context.Context) VerifyOption {
 	return &verifyOption{option.New(identContext{}, v)}
+}
+
+// WithCritValidation controls RFC 7515 Section 4.1.11 validation of the
+// "crit" (Critical) header parameter during verification. The default
+// is true: jws.Verify() rejects any JWS whose protected header lists
+// "crit" entries that the recipient has not declared support for via
+// jws.WithCritExtension(). It will also reject structurally invalid
+// "crit" lists: empty arrays, duplicate names, empty extension names,
+// names of standard JOSE header parameters, and names that do not
+// appear as header parameters in the protected header.
+//
+// Pass jws.WithCritValidation(false) to silently ignore the "crit"
+// header entirely, matching the lax pre-v3.0.14 behavior. This opt-out
+// is discouraged: per RFC 7515 Section 4.1.11, recipients MUST reject a
+// JWS whose "crit" list names extensions they do not understand, and
+// the only way to satisfy that requirement with this library is to
+// keep validation enabled and declare the extensions you support.
+//
+// IMPORTANT: with validation enabled, the library checks that every
+// "crit" entry has been declared via jws.WithCritExtension(), but the
+// library cannot perform the actual extension-specific processing on
+// your behalf. After jws.Verify() returns successfully, your code
+// MUST read each declared extension header and apply whatever check
+// or side effect the extension semantics demand. If you declare an
+// extension and then forget to act on its value, you have defeated
+// the protection the producer was trying to obtain by marking that
+// extension critical. See the documentation on jws.WithCritExtension
+// for details.
+func WithCritValidation(v bool) VerifyOption {
+	return &verifyOption{option.New(identCritValidation{}, v)}
 }
 
 // WithDetached specifies that the `jws.Message` should be serialized in
@@ -431,16 +461,6 @@ func WithRequireKid(v bool) WithKeySetSuboption {
 // do not need to specify this option other than to be explicit about it
 func WithCompact() SignVerifyParseOption {
 	return &signVerifyParseOption{option.New(identSerialization{}, fmtCompact)}
-}
-
-// WithStrictCriticalHeaders specifies whether the "crit" (Critical)
-// header parameter should be validated per RFC 7515 Section 4.1.11
-// during verification. The default is true.
-//
-// When set to false, the "crit" header is silently ignored during
-// jws.Verify(), matching the behavior of v3.0.13 and earlier.
-func WithStrictCriticalHeaders(v bool) VerifyOption {
-	return &verifyOption{option.New(identStrictCriticalHeaders{}, v)}
 }
 
 // WithUseDefault specifies that if and only if a jwk.Key contains

--- a/jws/options_gen_test.go
+++ b/jws/options_gen_test.go
@@ -11,6 +11,7 @@ import (
 func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithBase64Encoder", identBase64Encoder{}.String())
 	require.Equal(t, "WithContext", identContext{}.String())
+	require.Equal(t, "WithCritValidation", identCritValidation{}.String())
 	require.Equal(t, "WithDetached", identDetached{}.String())
 	require.Equal(t, "WithDetachedPayload", identDetachedPayload{}.String())
 	require.Equal(t, "WithInferAlgorithmFromKey", identInferAlgorithmFromKey{}.String())
@@ -26,7 +27,6 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithPublicHeaders", identPublicHeaders{}.String())
 	require.Equal(t, "WithRequireKid", identRequireKid{}.String())
 	require.Equal(t, "WithSerialization", identSerialization{}.String())
-	require.Equal(t, "WithStrictCriticalHeaders", identStrictCriticalHeaders{}.String())
 	require.Equal(t, "WithUseDefault", identUseDefault{}.String())
 	require.Equal(t, "WithValidateKey", identValidateKey{}.String())
 }

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -18,14 +18,15 @@ import (
 
 // verifyContext holds the state during JWS verification
 type verifyContext struct {
-	parseOptions    []ParseOption
-	dst             *Message
-	detachedPayload []byte
-	keyProviders    []KeyProvider
-	keyUsed         *any
-	validateKey     bool
-	strictCritical  bool
-	encoder         Base64Encoder
+	parseOptions       []ParseOption
+	dst                *Message
+	detachedPayload    []byte
+	keyProviders       []KeyProvider
+	keyUsed            *any
+	validateKey        bool
+	critValidation     bool
+	criticalExtensions []string
+	encoder            Base64Encoder
 	//nolint:containedctx
 	ctx context.Context
 }
@@ -34,7 +35,7 @@ var verifyContextPool = pool.New[*verifyContext](allocVerifyContext, freeVerifyC
 
 func allocVerifyContext() *verifyContext {
 	return &verifyContext{
-		strictCritical: true,
+		critValidation: true,
 		encoder:        base64.DefaultEncoder(),
 		ctx:            context.Background(),
 	}
@@ -47,7 +48,8 @@ func freeVerifyContext(vc *verifyContext) *verifyContext {
 	vc.keyProviders = vc.keyProviders[:0]
 	vc.keyUsed = nil
 	vc.validateKey = false
-	vc.strictCritical = true
+	vc.critValidation = true
+	vc.criticalExtensions = vc.criticalExtensions[:0]
 	vc.encoder = base64.DefaultEncoder()
 	vc.ctx = context.Background()
 	return vc
@@ -85,8 +87,10 @@ func (vc *verifyContext) ProcessOptions(options []VerifyOption) error {
 			ctxOpt = option.MustGet[context.Context](opt) //nolint:fatcontext // not nesting; selecting from options
 		case identValidateKey{}:
 			vc.validateKey = option.MustGet[bool](opt)
-		case identStrictCriticalHeaders{}:
-			vc.strictCritical = option.MustGet[bool](opt)
+		case identCritValidation{}:
+			vc.critValidation = option.MustGet[bool](opt)
+		case identCritExtension{}:
+			vc.criticalExtensions = append(vc.criticalExtensions, option.MustGet[[]string](opt)...)
 		case identSerialization{}:
 			po, ok := opt.(ParseOption)
 			if !ok {
@@ -156,8 +160,8 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 			rawHeaders = protected
 		}
 
-		if vc.strictCritical {
-			if err := validateCritical(sig.protected); err != nil {
+		if vc.critValidation {
+			if err := validateCritical(sig.protected, vc.criticalExtensions); err != nil {
 				errs = append(errs, makeVerifyError(`signature #%d has invalid "crit" header: %w`, idx+1, err))
 				continue
 			}
@@ -217,9 +221,19 @@ func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, ke
 }
 
 // validateCritical checks the "crit" header per RFC 7515 Section 4.1.11.
-// It verifies that all header names listed in "crit" are present in the
-// protected header and are not standard JWS header parameters.
-func validateCritical(protected Headers) error {
+// It enforces:
+//   - the list is non-empty
+//   - no entry is the empty string
+//   - no entry duplicates another
+//   - no entry names a standard JOSE header parameter
+//   - every entry appears as a header parameter in the protected header
+//   - every entry is in the caller-supplied allowedExtensions allowlist
+//
+// The last check is the central RFC requirement: recipients MUST reject
+// any "crit" extension they do not understand, and the only way the
+// library knows which extensions the caller understands is via the
+// allowlist (populated from jws.WithCritExtension()).
+func validateCritical(protected Headers, allowedExtensions []string) error {
 	if !protected.Has(CriticalKey) {
 		return nil
 	}
@@ -229,45 +243,30 @@ func validateCritical(protected Headers) error {
 		return makeVerifyError(`"crit" header must not be empty`)
 	}
 
+	seen := make(map[string]struct{}, len(crit))
 	for _, name := range crit {
+		if name == "" {
+			return makeVerifyError(`"crit" header must not contain an empty extension name`)
+		}
+		if _, dup := seen[name]; dup {
+			return makeVerifyError(`"crit" header must not contain duplicate extension %q`, name)
+		}
+		seen[name] = struct{}{}
+
 		// RFC 7515 Section 4.1.11: "crit" MUST NOT include names defined
 		// by the JOSE Header specification itself.
 		if slices.Contains(stdHeaderNames, name) {
 			return makeVerifyError(`"crit" header must not contain standard header parameter %q`, name)
 		}
 
-		// The extension must be present in the protected header
+		// The extension must be present in the protected header.
 		if !protected.Has(name) {
 			return makeVerifyError(`"crit" header references extension %q, but it is not present in the protected header`, name)
 		}
-	}
 
-	return nil
-}
-
-// validateCriticalFast is the fastjson-based equivalent of validateCritical,
-// used by VerifyCompactFast to validate the "crit" header without full
-// message parsing.
-func validateCriticalFast(hdr jwsbb.Header) error {
-	crit, err := jwsbb.HeaderGetStringArray(hdr, CriticalKey)
-	if err != nil {
-		if errors.Is(err, jwsbb.ErrHeaderNotFound()) {
-			return nil
-		}
-		return makeVerifyError(`failed to read "crit" header: %w`, err)
-	}
-
-	if len(crit) == 0 {
-		return makeVerifyError(`"crit" header must not be empty`)
-	}
-
-	for _, name := range crit {
-		if slices.Contains(stdHeaderNames, name) {
-			return makeVerifyError(`"crit" header must not contain standard header parameter %q`, name)
-		}
-
-		if !jwsbb.HeaderHas(hdr, name) {
-			return makeVerifyError(`"crit" header references extension %q, but it is not present in the protected header`, name)
+		// The recipient must have declared support for the extension.
+		if !slices.Contains(allowedExtensions, name) {
+			return makeVerifyError(`"crit" header references extension %q, but the recipient has not declared support for it (use jws.WithCritExtension(%q))`, name, name)
 		}
 	}
 


### PR DESCRIPTION
Port of #1733 to develop/v4. The one v4-specific change is that `WithCritValidation` defaults to **true** (v3 kept it off for wire compatibility); everything else matches the v3 design.

## Summary

- Rename `WithStrictCriticalHeaders` → `WithCritValidation`. v4 default is `true`: `jws.Verify` rejects undeclared `crit` extensions out of the box. Pass `jws.WithCritValidation(false)` to restore the lax pre-v3.0.14 behavior.
- Add `jws.WithCritExtension(names ...string)` (variadic, accumulating). Declares the extension names the application understands. Any `crit` entry not declared this way is rejected, closing the RFC 7515 §4.1.11 "MUST be understood" gap.
- Tighten `validateCritical` to also reject empty extension names and duplicate entries.
- `VerifyCompactFast` no longer enforces `crit` (the fast path takes no options); doc updated to point callers at `jws.Verify` + `WithCritValidation` / `WithCritExtension`.
- `jws_test.go` (TestRFC7797, TestGH485) updated to declare `b64` / `exp` via `WithCritExtension` since v4's default is strict.
- `jws_crit_test.go` rewritten: `TestCritValidationDefaultStrict`, `TestCritValidationOptOut`, `TestCritExtensionAllowlist`, `TestCritDetachedB64`, `TestVerifyCompactFastIgnoresCrit`.

Companion examples (`examples/jws_verify_with_crit_example_test.go`) will be ported in a follow-up PR against the `jwx-go/examples` repo.

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go test ./jws/... -run Crit -v`
- [x] `GOEXPERIMENT=jsonv2 go test ./...`
- [x] `GOEXPERIMENT=jsonv2 go vet ./...`
- [x] `golangci-lint run ./...`
