### PR TITLE
fix nil-aware ok return in typed header accessors

### DIFF
--- a/internal/jwxcodegen/cmd/jwxcodegen/genheaders.go
+++ b/internal/jwxcodegen/cmd/jwxcodegen/genheaders.go
@@ -216,7 +216,14 @@ func generateHeaders(cfg *HeaderConfig, obj *codegen.Object) error {
 	o.L("return &stdHeaders{}")
 	o.L("}")
 
-	// Getter implementations
+	// Getter implementations.
+	//
+	// All non-indirect storage types in this codebase are nilable
+	// (slices, pointers, or interfaces marked direct_storage), so both
+	// branches emit the same nil-guard that returns ok=false when the
+	// field has never been set. Without this guard, callers that defend
+	// against missing fields with `if !ok` see ok=true plus a nil value
+	// — silently broken contract.
 	for _, f := range obj.Fields() {
 		o.LL("func (h *stdHeaders) %s() (%s, bool) {", f.GetterMethod(true), f.Type())
 		o.L("h.mu.RLock()")
@@ -227,6 +234,9 @@ func generateHeaders(cfg *HeaderConfig, obj *codegen.Object) error {
 			o.L("}")
 			o.L("return *(h.%s), true", f.Name(false))
 		} else {
+			o.L("if h.%s == nil {", f.Name(false))
+			o.L("return %s, false", codegen.ZeroVal(f.Type()))
+			o.L("}")
 			o.L("return h.%s, true", f.Name(false))
 		}
 		o.L("}") // func (h *stdHeaders) %s() %s

--- a/jwe/headers_gen.go
+++ b/jwe/headers_gen.go
@@ -117,12 +117,18 @@ func NewHeaders() Headers {
 func (h *stdHeaders) AgreementPartyUInfo() ([]byte, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	if h.agreementPartyUInfo == nil {
+		return nil, false
+	}
 	return h.agreementPartyUInfo, true
 }
 
 func (h *stdHeaders) AgreementPartyVInfo() ([]byte, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	if h.agreementPartyVInfo == nil {
+		return nil, false
+	}
 	return h.agreementPartyVInfo, true
 }
 
@@ -165,24 +171,36 @@ func (h *stdHeaders) ContentType() (string, bool) {
 func (h *stdHeaders) Critical() ([]string, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	if h.critical == nil {
+		return nil, false
+	}
 	return h.critical, true
 }
 
 func (h *stdHeaders) EncapsulatedKey() ([]byte, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	if h.encapsulatedKey == nil {
+		return nil, false
+	}
 	return h.encapsulatedKey, true
 }
 
 func (h *stdHeaders) EphemeralPublicKey() (jwk.Key, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	if h.ephemeralPublicKey == nil {
+		return nil, false
+	}
 	return h.ephemeralPublicKey, true
 }
 
 func (h *stdHeaders) JWK() (jwk.Key, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	if h.jwk == nil {
+		return nil, false
+	}
 	return h.jwk, true
 }
 
@@ -207,6 +225,9 @@ func (h *stdHeaders) KeyID() (string, bool) {
 func (h *stdHeaders) PSKID() ([]byte, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	if h.pskID == nil {
+		return nil, false
+	}
 	return h.pskID, true
 }
 
@@ -222,6 +243,9 @@ func (h *stdHeaders) Type() (string, bool) {
 func (h *stdHeaders) X509CertChain() (*cert.Chain, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	if h.x509CertChain == nil {
+		return nil, false
+	}
 	return h.x509CertChain, true
 }
 

--- a/jwe/headers_nil_test.go
+++ b/jwe/headers_nil_test.go
@@ -1,0 +1,212 @@
+package jwe_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/cert"
+	"github.com/lestrrat-go/jwx/v4/jwe"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHeadersNilAccessorContract pins down the contract for typed
+// accessors when the corresponding field has never been set: each
+// accessor MUST return ok=false. This is what callers rely on to guard
+// against missing-field bugs (e.g. jwe/decrypt.go HPKE checks "ek").
+//
+// Background: JWE-002 in .tmp/review/03-core-b-jwe.md reports that the
+// generated typed accessors for byte-slice / interface fields return
+// ok=true unconditionally, defeating those guards. This test exercises
+// the contract for every affected accessor and is expected to FAIL
+// against the broken generator output.
+func TestHeadersNilAccessorContract(t *testing.T) {
+	t.Run("AgreementPartyUInfo", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		require.False(t, h.Has(jwe.AgreementPartyUInfoKey), `Has should report absent`)
+		v, ok := h.AgreementPartyUInfo()
+		require.False(t, ok, `accessor must return ok=false when unset`)
+		require.Nil(t, v, `accessor must return nil value when unset`)
+	})
+
+	t.Run("AgreementPartyVInfo", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		require.False(t, h.Has(jwe.AgreementPartyVInfoKey), `Has should report absent`)
+		v, ok := h.AgreementPartyVInfo()
+		require.False(t, ok, `accessor must return ok=false when unset`)
+		require.Nil(t, v, `accessor must return nil value when unset`)
+	})
+
+	t.Run("Critical", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		require.False(t, h.Has(jwe.CriticalKey), `Has should report absent`)
+		v, ok := h.Critical()
+		require.False(t, ok, `accessor must return ok=false when unset`)
+		require.Nil(t, v, `accessor must return nil value when unset`)
+	})
+
+	t.Run("EncapsulatedKey", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		require.False(t, h.Has(jwe.EncapsulatedKeyKey), `Has should report absent`)
+		v, ok := h.EncapsulatedKey()
+		require.False(t, ok, `accessor must return ok=false when unset`)
+		require.Nil(t, v, `accessor must return nil value when unset`)
+	})
+
+	t.Run("EphemeralPublicKey", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		require.False(t, h.Has(jwe.EphemeralPublicKeyKey), `Has should report absent`)
+		v, ok := h.EphemeralPublicKey()
+		require.False(t, ok, `accessor must return ok=false when unset`)
+		require.Nil(t, v, `accessor must return nil value when unset`)
+	})
+
+	t.Run("JWK", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		require.False(t, h.Has(jwe.JWKKey), `Has should report absent`)
+		v, ok := h.JWK()
+		require.False(t, ok, `accessor must return ok=false when unset`)
+		require.Nil(t, v, `accessor must return nil value when unset`)
+	})
+
+	t.Run("PSKID", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		require.False(t, h.Has(jwe.PSKIDKey), `Has should report absent`)
+		v, ok := h.PSKID()
+		require.False(t, ok, `accessor must return ok=false when unset`)
+		require.Nil(t, v, `accessor must return nil value when unset`)
+	})
+
+	t.Run("X509CertChain", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		require.False(t, h.Has(jwe.X509CertChainKey), `Has should report absent`)
+		v, ok := h.X509CertChain()
+		require.False(t, ok, `accessor must return ok=false when unset`)
+		require.Nil(t, v, `accessor must return nil value when unset`)
+	})
+}
+
+// TestHeadersNilAccessorAgreesWithGet verifies that the typed accessors
+// and the generic Get() / Field() path agree when a field is not set.
+// Today the typed accessors say "ok=true, value=nil" while Get() and
+// Field() correctly say "not present" — an internal inconsistency that
+// this test pins down.
+func TestHeadersNilAccessorAgreesWithGet(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{"AgreementPartyUInfo", jwe.AgreementPartyUInfoKey},
+		{"AgreementPartyVInfo", jwe.AgreementPartyVInfoKey},
+		{"Critical", jwe.CriticalKey},
+		{"EncapsulatedKey", jwe.EncapsulatedKeyKey},
+		{"EphemeralPublicKey", jwe.EphemeralPublicKeyKey},
+		{"JWK", jwe.JWKKey},
+		{"PSKID", jwe.PSKIDKey},
+		{"X509CertChain", jwe.X509CertChainKey},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := jwe.NewHeaders()
+
+			// Has() and Field() are the trusted source of truth.
+			require.False(t, h.Has(tc.key), `Has should report absent`)
+			_, fieldOk := h.Field(tc.key)
+			require.False(t, fieldOk, `Field should report absent`)
+
+			// The typed accessor must agree with Has/Get. We can't
+			// dispatch on a string, so call them by name.
+			var ok bool
+			switch tc.key {
+			case jwe.AgreementPartyUInfoKey:
+				_, ok = h.AgreementPartyUInfo()
+			case jwe.AgreementPartyVInfoKey:
+				_, ok = h.AgreementPartyVInfo()
+			case jwe.CriticalKey:
+				_, ok = h.Critical()
+			case jwe.EncapsulatedKeyKey:
+				_, ok = h.EncapsulatedKey()
+			case jwe.EphemeralPublicKeyKey:
+				_, ok = h.EphemeralPublicKey()
+			case jwe.JWKKey:
+				_, ok = h.JWK()
+			case jwe.PSKIDKey:
+				_, ok = h.PSKID()
+			case jwe.X509CertChainKey:
+				_, ok = h.X509CertChain()
+			}
+			require.False(t, ok, `typed accessor must agree with Has/Get`)
+		})
+	}
+}
+
+// TestHeadersTypedAccessorOkWhenSet covers the positive path for the
+// same accessors: after setting a value, the accessor returns ok=true
+// and the original value. This guards against a future "fix" that
+// over-corrects to always returning false.
+func TestHeadersTypedAccessorOkWhenSet(t *testing.T) {
+	t.Run("AgreementPartyUInfo", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		want := []byte("apu")
+		require.NoError(t, h.Set(jwe.AgreementPartyUInfoKey, want))
+		v, ok := h.AgreementPartyUInfo()
+		require.True(t, ok)
+		require.Equal(t, want, v)
+	})
+
+	t.Run("AgreementPartyVInfo", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		want := []byte("apv")
+		require.NoError(t, h.Set(jwe.AgreementPartyVInfoKey, want))
+		v, ok := h.AgreementPartyVInfo()
+		require.True(t, ok)
+		require.Equal(t, want, v)
+	})
+
+	t.Run("Critical", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		want := []string{"x-foo"}
+		require.NoError(t, h.Set(jwe.CriticalKey, want))
+		v, ok := h.Critical()
+		require.True(t, ok)
+		require.Equal(t, want, v)
+	})
+
+	t.Run("EncapsulatedKey", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		want := []byte("ek")
+		require.NoError(t, h.Set(jwe.EncapsulatedKeyKey, want))
+		v, ok := h.EncapsulatedKey()
+		require.True(t, ok)
+		require.Equal(t, want, v)
+	})
+
+	t.Run("PSKID", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		want := []byte("psk-id")
+		require.NoError(t, h.Set(jwe.PSKIDKey, want))
+		v, ok := h.PSKID()
+		require.True(t, ok)
+		require.Equal(t, want, v)
+	})
+
+	t.Run("X509CertChain", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		var chain cert.Chain
+		require.NoError(t, h.Set(jwe.X509CertChainKey, &chain))
+		v, ok := h.X509CertChain()
+		require.True(t, ok)
+		require.NotNil(t, v)
+	})
+
+	t.Run("JWK", func(t *testing.T) {
+		h := jwe.NewHeaders()
+		raw := []byte("0123456789abcdef")
+		key, err := jwk.Import[jwk.Key](raw)
+		require.NoError(t, err)
+		require.NoError(t, h.Set(jwe.JWKKey, key))
+		v, ok := h.JWK()
+		require.True(t, ok)
+		require.NotNil(t, v)
+	})
+}

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -111,12 +111,18 @@ func (h *stdHeaders) ContentType() (string, bool) {
 func (h *stdHeaders) Critical() ([]string, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	if h.critical == nil {
+		return nil, false
+	}
 	return h.critical, true
 }
 
 func (h *stdHeaders) JWK() (jwk.Key, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	if h.jwk == nil {
+		return nil, false
+	}
 	return h.jwk, true
 }
 
@@ -150,6 +156,9 @@ func (h *stdHeaders) Type() (string, bool) {
 func (h *stdHeaders) X509CertChain() (*cert.Chain, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	if h.x509CertChain == nil {
+		return nil, false
+	}
 	return h.x509CertChain, true
 }
 

--- a/jws/headers_nil_test.go
+++ b/jws/headers_nil_test.go
@@ -1,0 +1,74 @@
+package jws_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/cert"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/lestrrat-go/jwx/v4/jws"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHeadersNilAccessorContract pins the contract for typed accessors
+// when the corresponding field has never been set: each accessor MUST
+// return ok=false. v4 jws regressed from v3's correct behavior at the
+// same time v4 jwe did (see JWE-002 in the v4 review). The generator
+// fix for jwe also corrects jws — these tests guard against future
+// regressions.
+func TestHeadersNilAccessorContract(t *testing.T) {
+	t.Run("Critical", func(t *testing.T) {
+		h := jws.NewHeaders()
+		require.False(t, h.Has(jws.CriticalKey))
+		v, ok := h.Critical()
+		require.False(t, ok, `accessor must return ok=false when unset`)
+		require.Nil(t, v)
+	})
+
+	t.Run("JWK", func(t *testing.T) {
+		h := jws.NewHeaders()
+		require.False(t, h.Has(jws.JWKKey))
+		v, ok := h.JWK()
+		require.False(t, ok, `accessor must return ok=false when unset`)
+		require.Nil(t, v)
+	})
+
+	t.Run("X509CertChain", func(t *testing.T) {
+		h := jws.NewHeaders()
+		require.False(t, h.Has(jws.X509CertChainKey))
+		v, ok := h.X509CertChain()
+		require.False(t, ok, `accessor must return ok=false when unset`)
+		require.Nil(t, v)
+	})
+}
+
+// TestHeadersTypedAccessorOkWhenSet covers the positive path so a
+// future "fix" can't over-correct to always returning false.
+func TestHeadersTypedAccessorOkWhenSet(t *testing.T) {
+	t.Run("Critical", func(t *testing.T) {
+		h := jws.NewHeaders()
+		want := []string{"x-foo"}
+		require.NoError(t, h.Set(jws.CriticalKey, want))
+		v, ok := h.Critical()
+		require.True(t, ok)
+		require.Equal(t, want, v)
+	})
+
+	t.Run("JWK", func(t *testing.T) {
+		h := jws.NewHeaders()
+		key, err := jwk.Import[jwk.Key]([]byte("0123456789abcdef"))
+		require.NoError(t, err)
+		require.NoError(t, h.Set(jws.JWKKey, key))
+		v, ok := h.JWK()
+		require.True(t, ok)
+		require.NotNil(t, v)
+	})
+
+	t.Run("X509CertChain", func(t *testing.T) {
+		h := jws.NewHeaders()
+		var chain cert.Chain
+		require.NoError(t, h.Set(jws.X509CertChainKey, &chain))
+		v, ok := h.X509CertChain()
+		require.True(t, ok)
+		require.NotNil(t, v)
+	})
+}


### PR DESCRIPTION
## Summary

- Fix [JWE-002] in the v4 review: typed header accessors for byte-slice / interface-valued fields returned `ok=true` unconditionally, defeating caller guards like `if !ok { return error }`. The bug was in the shared `genheaders` generator: the indirect-storage branch correctly emitted a nil check, but the direct-storage branch emitted `return h.foo, true` unconditionally. All non-indirect storage types in this codebase are nilable (slices, pointers, or `direct_storage`-marked interfaces), so the guard is now emitted in both branches.
- The same regression existed in v4 jws for `Critical`, `JWK`, `X509CertChain` (v3 jws had it right; v4 silently regressed alongside jwe). The generator fix corrects both packages — 8 jwe accessors + 3 jws accessors = 11 total.
- Failing tests written first, then the fix. `jwe/headers_nil_test.go` pins the contract for all 8 jwe accessors (nil-contract + agrees-with-Field + positive-path matrices). `jws/headers_nil_test.go` pins the same contract for the 3 jws accessors.

## Test plan

- [x] Write failing tests, run them, observe failure
- [x] Apply fix to `internal/jwxcodegen/cmd/jwxcodegen/genheaders.go`
- [x] `make generate-jwe`, `make generate-jws` regenerates 11 accessors
- [x] `go test ./jwe/ -run TestHeadersNil` and `./jws/ -run TestHeadersNil` — green
- [x] `go test ./... -count=1` — full v4 suite green
- [x] `go vet ./...` — clean
