### PR TITLE
clone per-recipient headers, recycle via headerPool

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -739,10 +739,14 @@ func freeHeaders(h Headers) Headers {
 var recipientPool = pool.New(NewRecipient, freeRecipient)
 
 func freeRecipient(r Recipient) Recipient {
+	// Return the recipient's headers to headerPool and install a fresh
+	// instance so the next recipientPool.Get() never hands out a
+	// pointer the caller may still hold a reference to. This is safe
+	// because WithPerRecipientHeaders clones the caller-supplied
+	// Headers, so anything we receive here is already library-owned.
 	if h := r.Headers(); h != nil {
-		if c, ok := h.(interface{ clear() }); ok {
-			c.clear()
-		}
+		headerPool.Put(h)
+		_ = r.SetHeaders(headerPool.Get())
 	}
 
 	if sr, ok := r.(*stdRecipient); ok {

--- a/jwe/options.go
+++ b/jwe/options.go
@@ -73,7 +73,16 @@ func (*withKeySuboption) withKeySuboption() {}
 
 // WithPerRecipientHeaders is used to pass header values for each recipient.
 // Note that these headers are by definition _unprotected_.
+//
+// The supplied Headers is cloned before being stored in the option, so the
+// caller retains exclusive ownership of the original instance and the
+// library never mutates or pools it.
 func WithPerRecipientHeaders(hdr Headers) WithKeySuboption {
+	if hdr != nil {
+		if cloned, err := hdr.Clone(); err == nil {
+			hdr = cloned
+		}
+	}
 	return &withKeySuboption{option.New(identPerRecipientHeaders{}, hdr)}
 }
 

--- a/jwe/recipient_headers_test.go
+++ b/jwe/recipient_headers_test.go
@@ -1,0 +1,42 @@
+package jwe_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwe"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPerRecipientHeadersIsolation is a regression test for the pool-leak
+// bug where WithPerRecipientHeaders stored the caller's Headers pointer
+// directly: freeRecipient would later clear() it (zeroing a value the
+// caller still held), and the pooled recipient retained the same pointer
+// for the next Encrypt to mutate. After the fix, WithPerRecipientHeaders
+// clones the caller's Headers, and freeRecipient returns the clone to
+// headerPool while installing a fresh placeholder on the recipient.
+func TestPerRecipientHeadersIsolation(t *testing.T) {
+	key, err := jwk.Import[jwk.SymmetricKey]([]byte(`0123456789abcdef`))
+	require.NoError(t, err, `jwk.Import should succeed`)
+
+	caller := jwe.NewHeaders()
+	require.NoError(t, caller.Set(jwe.KeyIDKey, "user-kid"))
+
+	// Two back-to-back encrypts so any pool reuse of the recipient
+	// would re-touch caller on the second pass.
+	for range 2 {
+		_, err := jwe.Encrypt([]byte(`hello`),
+			jwe.WithKey(jwa.A128KW(), key, jwe.WithPerRecipientHeaders(caller)),
+			jwe.WithContentEncryption(jwa.A128CBC_HS256()),
+		)
+		require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+		kid, ok := caller.KeyID()
+		require.True(t, ok, `caller.KeyID should still be set after Encrypt`)
+		require.Equal(t, "user-kid", kid, `caller.KeyID must not be mutated by Encrypt`)
+
+		alg, ok := caller.Algorithm()
+		require.False(t, ok, `caller.Algorithm should not have been written by Encrypt (got %q)`, alg)
+	}
+}


### PR DESCRIPTION
Port of #1739 to develop/v4.

- `WithPerRecipientHeaders` stored the caller's `Headers` pointer directly. `recipientBuilder.Build` installed it on a pooled recipient, then `freeRecipient.clear()` zeroed the caller's instance, and the pool kept the pointer for the next `Encrypt` to re-mutate.
- Fix: `WithPerRecipientHeaders` clones the caller's `Headers` before storing it, so the pool only ever owns its own instance. `freeRecipient` returns the clone to `headerPool` and installs a fresh placeholder.
- Adds `TestPerRecipientHeadersIsolation` to lock the contract: caller's `KeyID` survives back-to-back `Encrypt` calls, and `Algorithm` is never written into the caller's `Headers`.
