### PR TITLE
reject ecdh keys in AlgorithmsForKey

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -606,10 +606,10 @@ func AlgorithmsForKey(key any) ([]jwa.SignatureAlgorithm, error) {
 		crv = jwa.Ed25519()
 		hasCrv = true
 	case *ecdh.PublicKey, ecdh.PublicKey, *ecdh.PrivateKey, ecdh.PrivateKey:
-		kty = jwa.OKP()
 		// ecdh keys are for key agreement (X25519/X448), not signing.
-		// We still resolve kty so the caller gets a meaningful error
-		// or an empty curve-filtered result.
+		// Reject at the API boundary instead of returning a misleading
+		// algorithm list that would fail deeper in the signing stack.
+		return nil, fmt.Errorf(`key type %T cannot be used for signing (ecdh keys are key-agreement only)`, key)
 	case []byte:
 		kty = jwa.OctetSeq()
 	default:

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/asn1"
@@ -1368,11 +1369,6 @@ func TestAlgorithmsForKey(t *testing.T) {
 			Expected: []jwa.SignatureAlgorithm{jwa.EdDSA(), jwa.EdDSAEd25519()},
 		},
 		{
-			Name:     "ecdh.PublicKey (no curve filtering)",
-			Key:      &ecdh.PublicKey{},
-			Expected: []jwa.SignatureAlgorithm{jwa.EdDSA()},
-		},
-		{
 			Name:     "jwk.OKPPublicKey (X25519)",
 			Key:      x25519pubkey,
 			Expected: []jwa.SignatureAlgorithm{jwa.EdDSA()},
@@ -1402,6 +1398,35 @@ func TestAlgorithmsForKey(t *testing.T) {
 				return algs[i].String() < algs[j].String()
 			})
 			require.Equal(t, tc.Expected, algs, `results should match`)
+		})
+	}
+}
+
+// TestAlgorithmsForKeyECDHRejects is a regression test for JWS-004:
+// ecdh.{Public,Private}Key values are for key agreement (X25519/X448),
+// not signing. AlgorithmsForKey must reject them instead of handing back
+// the generic OKP algorithm list and deferring the type error to the
+// signing stack.
+func TestAlgorithmsForKeyECDHRejects(t *testing.T) {
+	x25519priv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	require.NoError(t, err, `ecdh.X25519().GenerateKey should succeed`)
+	x25519pub := x25519priv.PublicKey()
+
+	testcases := []struct {
+		Name string
+		Key  any
+	}{
+		{Name: "*ecdh.PrivateKey", Key: x25519priv},
+		{Name: "ecdh.PrivateKey (value)", Key: *x25519priv},
+		{Name: "*ecdh.PublicKey", Key: x25519pub},
+		{Name: "ecdh.PublicKey (value)", Key: *x25519pub},
+		{Name: "empty *ecdh.PublicKey", Key: &ecdh.PublicKey{}},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, err := jws.AlgorithmsForKey(tc.Key)
+			require.Error(t, err, `AlgorithmsForKey should reject ecdh keys`)
 		})
 	}
 }


### PR DESCRIPTION
`AlgorithmsForKey` resolved `crypto/ecdh` public/private keys to `kty = jwa.OKP()` with no curve set, so it returned the full OKP algorithm list (`[EdDSA]` + extensions) even though ecdh keys are key-agreement only and cannot sign. The comment claimed "an empty curve-filtered result" but `hasCrv` was never set, so the error was deferred into the crypto layer.

- Reject `*ecdh.{Public,Private}Key` and value variants outright from `AlgorithmsForKey` with a clear `key type %T cannot be used for signing` error.
- Adds `TestAlgorithmsForKeyECDHRejects` covering pointer/value × public/private × generated + zero-value cases.
- Removes the stale `"ecdh.PublicKey (no curve filtering)"` row from the happy-path table that was locking in the buggy `[EdDSA]` result.
