### PR TITLE
add jwsbb SignWithOpts/VerifyWithOpts

### DIFF
--- a/cmd/jwx/go.mod
+++ b/cmd/jwx/go.mod
@@ -10,7 +10,7 @@ require (
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
-	github.com/lestrrat-go/dsig v1.1.0 // indirect
+	github.com/lestrrat-go/dsig v1.3.0 // indirect
 	github.com/lestrrat-go/option/v3 v3.0.0-alpha1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/valyala/fastjson v1.6.10 // indirect

--- a/cmd/jwx/go.sum
+++ b/cmd/jwx/go.sum
@@ -2,8 +2,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0q
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/lestrrat-go/dsig v1.1.0 h1:FF7ApqV/r5IQoRdd6LDev/ctP8uz7eIvoGw+ZZvry/8=
-github.com/lestrrat-go/dsig v1.1.0/go.mod h1:dEgoOYYEJvW6XGbLasr8TFcAxoWrKlbQvmJgCR0qkDo=
+github.com/lestrrat-go/dsig v1.3.0 h1:phjMOCXvYzhuIgn7Voe2rex8z166vGfxRxmqM25P9/Q=
+github.com/lestrrat-go/dsig v1.3.0/go.mod h1:RD2eOaidyPvpc7IJQoO3Qq52RWdy8ZcJs8lrOnoa1Kc=
 github.com/lestrrat-go/option/v3 v3.0.0-alpha1 h1:dvdzLwm/Ba5CJUF3jQP7w/iNYSLfy7yyh9XXNa1WjxI=
 github.com/lestrrat-go/option/v3 v3.0.0-alpha1/go.mod h1:5KSg20dfsKkNJtjDmaQRLZVXuUrzuCCcz/gbDK0pfKk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/lestrrat-go/jwx/v4
 go 1.26.0
 
 require (
-	github.com/lestrrat-go/dsig v1.1.0
+	github.com/lestrrat-go/dsig v1.3.0
 	github.com/lestrrat-go/option/v3 v3.0.0-alpha1
 	github.com/stretchr/testify v1.11.1
 	github.com/valyala/fastjson v1.6.10

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/lestrrat-go/dsig v1.1.0 h1:FF7ApqV/r5IQoRdd6LDev/ctP8uz7eIvoGw+ZZvry/8=
-github.com/lestrrat-go/dsig v1.1.0/go.mod h1:dEgoOYYEJvW6XGbLasr8TFcAxoWrKlbQvmJgCR0qkDo=
+github.com/lestrrat-go/dsig v1.3.0 h1:phjMOCXvYzhuIgn7Voe2rex8z166vGfxRxmqM25P9/Q=
+github.com/lestrrat-go/dsig v1.3.0/go.mod h1:RD2eOaidyPvpc7IJQoO3Qq52RWdy8ZcJs8lrOnoa1Kc=
 github.com/lestrrat-go/option/v3 v3.0.0-alpha1 h1:dvdzLwm/Ba5CJUF3jQP7w/iNYSLfy7yyh9XXNa1WjxI=
 github.com/lestrrat-go/option/v3 v3.0.0-alpha1/go.mod h1:5KSg20dfsKkNJtjDmaQRLZVXuUrzuCCcz/gbDK0pfKk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/jws/jwsbb/sign.go
+++ b/jws/jwsbb/sign.go
@@ -20,7 +20,31 @@ import (
 // rr is an io.Reader that provides randomness for signing. If rr is nil, it defaults to rand.Reader.
 // Not all algorithms require this parameter, but it is included for consistency.
 // 99% of the time, you can pass nil for rr, and it will work fine.
+//
+// Deprecated in spirit: in the next major release of jwx (v5), the
+// signature of Sign will change to match [SignWithOpts], i.e. it will
+// accept an additional [crypto.SignerOpts] parameter immediately before
+// rr. Callers that need to pass per-call options today should use
+// [SignWithOpts]; callers that do not can keep using Sign and migrate
+// when v5 ships by threading a nil opts argument through at the call
+// site.
 func Sign(key any, alg string, payload []byte, rr io.Reader) ([]byte, error) {
+	return SignWithOpts(key, alg, payload, nil, rr)
+}
+
+// SignWithOpts is like [Sign] but threads an optional
+// [crypto.SignerOpts] through to the underlying dsig signer. The
+// canonical use case is composite ML-DSA signatures, where a per-call
+// domain-separation context (`*mldsa.Options`) must reach
+// `filippo.io/mldsa` via the `dsig.SignerWithOpts` interface
+// implemented by `github.com/jwx-go/mldsa/v4`. For built-in families
+// (HMAC, RSA, ECDSA, EdDSA) the opts argument is ignored.
+//
+// This function exists as a transitional API. In the next major release
+// of jwx (v5) it will be removed and its signature will become the
+// canonical shape of [Sign]. Code that uses SignWithOpts today will
+// need a mechanical rename to Sign (and nothing else) when v5 ships.
+func SignWithOpts(key any, alg string, payload []byte, opts crypto.SignerOpts, rr io.Reader) ([]byte, error) {
 	dsigAlg, ok := getDsigAlgorithm(alg)
 	if !ok {
 		// For custom algorithms registered with dsig, JWS name = dsig name
@@ -30,7 +54,7 @@ func Sign(key any, alg string, payload []byte, rr io.Reader) ([]byte, error) {
 	// Get dsig algorithm info to determine key conversion strategy
 	dsigInfo, ok := dsig.GetAlgorithmInfo(dsigAlg)
 	if !ok {
-		return nil, fmt.Errorf(`jwsbb.Sign: dsig algorithm %q not registered`, dsigAlg)
+		return nil, fmt.Errorf(`jwsbb.SignWithOpts: dsig algorithm %q not registered`, dsigAlg)
 	}
 
 	switch dsigInfo.Family {
@@ -43,9 +67,9 @@ func Sign(key any, alg string, payload []byte, rr io.Reader) ([]byte, error) {
 	case dsig.EdDSAFamily:
 		return dispatchEdDSASign(key, alg, dsigAlg, payload, rr)
 	case dsig.Custom:
-		return dsig.Sign(key, dsigAlg, payload, rr)
+		return dsig.SignWithOpts(key, dsigAlg, payload, opts, rr)
 	default:
-		return nil, fmt.Errorf(`jwsbb.Sign: unsupported dsig algorithm family %q`, dsigInfo.Family)
+		return nil, fmt.Errorf(`jwsbb.SignWithOpts: unsupported dsig algorithm family %q`, dsigInfo.Family)
 	}
 }
 

--- a/jws/jwsbb/verify.go
+++ b/jws/jwsbb/verify.go
@@ -15,7 +15,22 @@ import (
 //
 // This function loads the verifier registered in the jwsbb package _ONLY_.
 // It does not support custom verifiers that the user might have registered.
+//
+// Deprecated in spirit: in the next major release of jwx (v5), the
+// signature of Verify will change to match [VerifyWithOpts], i.e. it
+// will accept an additional [crypto.SignerOpts] parameter at the end.
+// Callers that need to pass per-call options today should use
+// [VerifyWithOpts]; callers that do not can keep using Verify and
+// migrate when v5 ships by threading a nil opts argument through at
+// the call site.
 func Verify(key any, alg string, payload, signature []byte) error {
+	return VerifyWithOpts(key, alg, payload, signature, nil)
+}
+
+// VerifyWithOpts is like [Verify] but threads an optional
+// [crypto.SignerOpts] through to the underlying dsig verifier. See
+// [SignWithOpts] for the rationale and the migration story.
+func VerifyWithOpts(key any, alg string, payload, signature []byte, opts crypto.SignerOpts) error {
 	dsigAlg, ok := getDsigAlgorithm(alg)
 	if !ok {
 		// For custom algorithms registered with dsig, JWS name = dsig name
@@ -25,7 +40,7 @@ func Verify(key any, alg string, payload, signature []byte) error {
 	// Get dsig algorithm info to determine key conversion strategy
 	dsigInfo, ok := dsig.GetAlgorithmInfo(dsigAlg)
 	if !ok {
-		return fmt.Errorf(`jwsbb.Verify: dsig algorithm %q not registered`, dsigAlg)
+		return fmt.Errorf(`jwsbb.VerifyWithOpts: dsig algorithm %q not registered`, dsigAlg)
 	}
 
 	switch dsigInfo.Family {
@@ -38,9 +53,9 @@ func Verify(key any, alg string, payload, signature []byte) error {
 	case dsig.EdDSAFamily:
 		return dispatchEdDSAVerify(key, alg, dsigAlg, payload, signature)
 	case dsig.Custom:
-		return dsig.Verify(key, dsigAlg, payload, signature)
+		return dsig.VerifyWithOpts(key, dsigAlg, payload, signature, opts)
 	default:
-		return fmt.Errorf(`jwsbb.Verify: unsupported dsig algorithm family %q`, dsigInfo.Family)
+		return fmt.Errorf(`jwsbb.VerifyWithOpts: unsupported dsig algorithm family %q`, dsigInfo.Family)
 	}
 }
 


### PR DESCRIPTION
Third step in the EXT-006 chain (after dsig v1.3.0 and jwx-go/mldsa#13). Lets `jwx-go/compsig` plumb composite ML-DSA's per-call domain-separation context (`*mldsa.Options{Context: Label}`) all the way through `jwsbb.SignWithOpts` → `dsig.SignWithOpts` → the mldsa adapter → `filippo.io/mldsa`.

- `jwsbb.SignWithOpts` and `jwsbb.VerifyWithOpts` carry the canonical family-dispatch switch. `jwsbb.Sign` / `jwsbb.Verify` collapse to one-line wrappers that call the WithOpts variant with `opts=nil`. Public signatures of `Sign`/`Verify` are unchanged.
- The `dsig.Custom` branch now calls `dsig.SignWithOpts` / `dsig.VerifyWithOpts`, which is what surfaces the per-call opts to custom adapters that implement `dsig.SignerWithOpts` / `dsig.VerifierWithOpts` (currently: `jwx-go/mldsa`).
- Built-in families (HMAC, RSA, ECDSA, EdDSA) ignore opts at this layer — same rationale as in dsig: jwsbb must control hash/PSS for correctness, so caller-supplied opts can't safely override.
- Doc comments on `Sign` / `Verify` flag the upcoming v5 migration: in jwx v5 the WithOpts variants will go away and `Sign` / `Verify` will absorb the opts parameter directly.
- Bump `github.com/lestrrat-go/dsig` from v1.1.0 to v1.3.0.
