### PR TITLE
stop pooling escaping big.Int in buildRSAPublicKey

### DIFF
--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1362,6 +1362,31 @@ c4wOvhbalcX0FqTM3mXCgMFRbibquhwdxbU=
 	require.Equal(t, 65537, pubkey.E, `value for E should amtch`)
 }
 
+// TestRSAExportIndependentN is a regression guard for JWK-INT-004:
+// buildRSAPublicKey used to assign a pool-borrowed *big.Int to
+// rsa.PublicKey.N. Any future "fix" that returned that pooled value via
+// defer Put would zero the caller's N on return. Each export must own
+// its own independent big.Int, and mutating one result must not affect
+// another.
+func TestRSAExportIndependentN(t *testing.T) {
+	priv, err := jwxtest.GenerateRsaJwk()
+	require.NoError(t, err, `jwxtest.GenerateRsaJwk should succeed`)
+	key, err := priv.PublicKey()
+	require.NoError(t, err, `PublicKey should succeed`)
+
+	var pub1 rsa.PublicKey
+	require.NoError(t, jwk.Export(key, &pub1), `first Export should succeed`)
+	var pub2 rsa.PublicKey
+	require.NoError(t, jwk.Export(key, &pub2), `second Export should succeed`)
+
+	require.Equal(t, 0, pub1.N.Cmp(pub2.N), `both exports must decode to the same modulus`)
+	require.NotSame(t, pub1.N, pub2.N, `each export must own an independent *big.Int`)
+
+	original := new(big.Int).Set(pub1.N)
+	pub2.N.SetInt64(0)
+	require.Equal(t, 0, pub1.N.Cmp(original), `mutating pub2.N must not corrupt pub1.N`)
+}
+
 type typedField struct {
 	Foo string
 	Bar int64

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -103,10 +103,12 @@ func (k *rsaPublicKey) Import(rawKey *rsa.PublicKey) error {
 }
 
 func buildRSAPublicKey(key *rsa.PublicKey, n, e []byte) {
-	bin := pool.BigInt().Get()
 	bie := pool.BigInt().Get()
 	defer pool.BigInt().Put(bie)
 
+	// Do not pool bin: it escapes via key.N, so any future `defer Put(bin)`
+	// would zero the caller's modulus after return.
+	bin := new(big.Int)
 	bin.SetBytes(n)
 	bie.SetBytes(e)
 


### PR DESCRIPTION
Cherry-pick of #1744 to develop/v3. Test tweaked for v3's non-generic `jwk.Export(key, &dst)` signature; fix itself is identical.

`buildRSAPublicKey` acquired `bin` from `pool.BigInt()` and then assigned it directly to `key.N`, so the pooled `*big.Int` escaped and was never `Put` back — every RSA public-key export drained one entry from the pool permanently. Worse, the code was one naive "fix" away from corruption: `pool.BigInt().Put` zeros the big.Int, so any future `defer Put(bin)` would zero the caller's modulus on return.

- Drop `bin` from the pool and use `new(big.Int)` directly; keep `bie` pooled since it's strictly local.
- Adds `TestRSAExportIndependentN` regression guard: asserts each Export owns an independent `*big.Int` and that mutating one result does not corrupt another.
