### PR TITLE
auto-declare b64 crit when WithDetachedPayload is set

### DIFF
--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -228,10 +228,13 @@ func TestCritExtensionAllowlist(t *testing.T) {
 	})
 }
 
-// TestCritDetachedB64 verifies the RFC 7797 "b64:false" detached payload
-// flow still works under the default-strict crit validation when "b64" is
-// declared via WithCritExtension.
-func TestCritDetachedB64(t *testing.T) {
+// TestCritDetachedB64AutoDeclared verifies the RFC 7797 "b64:false"
+// detached-payload flow under the default-strict crit validation. The
+// caller does NOT pass jws.WithCritExtension("b64") — passing
+// jws.WithDetachedPayload auto-declares "b64" because that is the
+// canonical pairing for b64=false and the jws package implements the
+// b64=false handling natively.
+func TestCritDetachedB64AutoDeclared(t *testing.T) {
 	payload := []byte(`hello world`)
 	key, err := jwxtest.GenerateSymmetricJwk()
 	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
@@ -249,9 +252,38 @@ func TestCritDetachedB64(t *testing.T) {
 	_, err = jws.Verify(signed,
 		jws.WithKey(jwa.HS256(), key),
 		jws.WithDetachedPayload(payload),
+	)
+	require.NoError(t, err, `jws.Verify should succeed; WithDetachedPayload auto-declares "b64"`)
+}
+
+// TestCritInBandB64RequiresExplicit locks the scoping rule for the b64
+// auto-declaration: the auto-declare only happens when
+// jws.WithDetachedPayload is passed. An in-band b64=false JWS with
+// crit=["b64"] still requires the caller to declare "b64" explicitly,
+// otherwise jws.Verify rejects it.
+func TestCritInBandB64RequiresExplicit(t *testing.T) {
+	payload := []byte(`hello`)
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+
+	hdrs := jws.NewHeaders()
+	require.NoError(t, hdrs.Set("b64", false))
+	require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"b64"}))
+
+	signed, err := jws.Sign(payload,
+		jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)),
+	)
+	require.NoError(t, err, `jws.Sign should succeed`)
+
+	_, err = jws.Verify(signed, jws.WithKey(jwa.HS256(), key))
+	require.Error(t, err, `jws.Verify should reject in-band b64=false without explicit WithCritExtension("b64")`)
+	require.ErrorContains(t, err, `not declared support`)
+
+	_, err = jws.Verify(signed,
+		jws.WithKey(jwa.HS256(), key),
 		jws.WithCritExtension("b64"),
 	)
-	require.NoError(t, err, `jws.Verify should succeed when b64 is declared in allowlist`)
+	require.NoError(t, err, `explicit WithCritExtension("b64") should make in-band b64=false succeed`)
 }
 
 // TestVerifyCompactFastIgnoresCrit documents that the fast path performs

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -960,11 +960,17 @@ func TestRFC7797(t *testing.T) {
 				payload := tc.Payload
 				signOptions := []jws.SignOption{jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs))}
 				var verifyOptions []jws.VerifyOption
-				verifyOptions = append(verifyOptions, jws.WithKey(jwa.HS256(), key), jws.WithCritExtension("b64"))
+				verifyOptions = append(verifyOptions, jws.WithKey(jwa.HS256(), key))
 				if tc.Detached {
 					signOptions = append(signOptions, jws.WithDetachedPayload(payload))
+					// WithDetachedPayload auto-declares "b64" for crit
+					// validation; no explicit WithCritExtension needed.
 					verifyOptions = append(verifyOptions, jws.WithDetachedPayload(payload))
 					payload = nil
+				} else {
+					// In-band b64=false still requires explicit
+					// WithCritExtension("b64") under default-strict.
+					verifyOptions = append(verifyOptions, jws.WithCritExtension("b64"))
 				}
 				signed, err := jws.Sign(payload, signOptions...)
 				require.NoError(t, err, `jws.Sign should succeed`)
@@ -985,7 +991,11 @@ func TestRFC7797(t *testing.T) {
 			Error         bool
 		}{
 			{
+				// In-band b64=false: requires explicit WithCritExtension("b64").
 				Name: "JSON format",
+				VerifyOptions: []jws.VerifyOption{
+					jws.WithCritExtension("b64"),
+				},
 				Input: []byte(`{
       "protected": "eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",
       "payload": "$.02",
@@ -993,6 +1003,7 @@ func TestRFC7797(t *testing.T) {
      }`),
 			},
 			{
+				// Detached: WithDetachedPayload auto-declares "b64".
 				Name: "JSON format (detached payload)",
 				VerifyOptions: []jws.VerifyOption{
 					jws.WithDetachedPayload(detached),
@@ -1003,8 +1014,14 @@ func TestRFC7797(t *testing.T) {
      }`),
 			},
 			{
+				// In-band: explicit WithCritExtension("b64") still required.
+				// The test expects an error from b64 mismatch across the two
+				// signatures, not from crit rejection.
 				Name:  "JSON Format (b64 does not match)",
 				Error: true,
+				VerifyOptions: []jws.VerifyOption{
+					jws.WithCritExtension("b64"),
+				},
 				Input: []byte(`{
 					"signatures": [
 						{
@@ -1020,6 +1037,7 @@ func TestRFC7797(t *testing.T) {
 				}`),
 			},
 			{
+				// Detached: WithDetachedPayload auto-declares "b64".
 				Name:  "Compact (detached payload)",
 				Input: []byte(`eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY`),
 				VerifyOptions: []jws.VerifyOption{
@@ -1031,7 +1049,7 @@ func TestRFC7797(t *testing.T) {
 		for _, tc := range testcases {
 			t.Run(tc.Name, func(t *testing.T) {
 				options := tc.VerifyOptions
-				options = append(options, jws.WithKey(jwa.HS256(), key), jws.WithCritExtension("b64"))
+				options = append(options, jws.WithKey(jwa.HS256(), key))
 				payload, err := jws.Verify(tc.Input, options...)
 				if tc.Error {
 					require.Error(t, err, `jws.Verify should fail`)

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -63,6 +63,20 @@ func (vc *verifyContext) ProcessOptions(options []VerifyOption) error {
 			vc.dst = option.MustGet[*Message](opt)
 		case identDetachedPayload{}:
 			vc.detachedPayload = option.MustGet[[]byte](opt)
+			// RFC 7797 "b64" auto-declaration. Detached-payload
+			// verification is the canonical use case for b64=false,
+			// and the jws package implements b64=false handling
+			// natively, so requiring callers to also pass
+			// jws.WithCritExtension("b64") is busywork. We declare
+			// it implicitly here so application code stays focused
+			// on its own crit extensions. This does not relax any
+			// other validateCritical check — the b64 header still
+			// has to appear in the protected header, the crit list
+			// still has to be non-empty / no duplicates / no
+			// standard names, etc. Only the "is in the caller's
+			// allowlist" check is short-circuited for "b64", and
+			// only when WithDetachedPayload was passed.
+			vc.criticalExtensions = append(vc.criticalExtensions, "b64")
 		case identKey{}:
 			pair := option.MustGet[*withKey](opt)
 
@@ -233,6 +247,12 @@ func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, ke
 // any "crit" extension they do not understand, and the only way the
 // library knows which extensions the caller understands is via the
 // allowlist (populated from jws.WithCritExtension()).
+//
+// As a convenience, the RFC 7797 "b64" extension is auto-declared into
+// allowedExtensions whenever the caller passes jws.WithDetachedPayload
+// — see the identDetachedPayload case in ProcessOptions. The auto-
+// declaration only short-circuits the allowlist check; every other
+// rule above still applies to the "b64" entry.
 func validateCritical(protected Headers, allowedExtensions []string) error {
 	if !protected.Has(CriticalKey) {
 		return nil


### PR DESCRIPTION
When `jws.WithDetachedPayload` is set, append `"b64"` to the verify context's critical-extension allowlist as if the caller had also passed `jws.WithCritExtension("b64")`. Detached-payload verification is the canonical pairing for RFC 7797 `b64=false`, and the jws package implements `b64=false` natively, so requiring callers to also declare `"b64"` is busywork that leaks RFC trivia into application code.

The auto-declare only short-circuits the "is in the caller's allowlist" check inside `validateCritical`. Every other rule still applies to the `"b64"` entry: the `b64` header must be present in the protected header, the `crit` list must be non-empty, no duplicates, no standard JOSE names, etc. In-band `b64=false` (without `WithDetachedPayload`) still requires explicit `WithCritExtension("b64")` — that scoping is locked by `TestCritInBandB64RequiresExplicit`.

`TestCritDetachedB64` (renamed to `TestCritDetachedB64AutoDeclared`) drops its explicit `WithCritExtension("b64")` to prove the auto-declare works. `TestRFC7797`'s detached subtests do the same; non-detached cases keep their explicit declaration.
