### PR TITLE
fail loudly on rand.Reader errors in key gen helpers

### DIFF
--- a/cmd/jwx/jwk.go
+++ b/cmd/jwx/jwk.go
@@ -164,7 +164,9 @@ func makeJwkGenerateCmd() *cli.Command {
 			rawkey = v
 		case jwa.OctetSeq():
 			octets := make([]byte, c.Int("keysize"))
-			io.ReadFull(rand.Reader, octets)
+			if _, err := io.ReadFull(rand.Reader, octets); err != nil {
+				return fmt.Errorf(`failed to generate octet seq key: %w`, err)
+			}
 
 			rawkey = octets
 		case jwa.OKP():

--- a/internal/jwxtest/jwxtest.go
+++ b/internal/jwxtest/jwxtest.go
@@ -85,7 +85,9 @@ func GenerateEcdsaPublicJwk() (jwk.Key, error) {
 
 func GenerateSymmetricKey() []byte {
 	sharedKey := make([]byte, 64)
-	rand.Read(sharedKey)
+	if _, err := rand.Read(sharedKey); err != nil {
+		panic(fmt.Sprintf("jwxtest.GenerateSymmetricKey: rand.Read failed: %v", err))
+	}
 	return sharedKey
 }
 


### PR DESCRIPTION
## Summary

- Fix XCUT-015 from the v4 review: two call sites silently ignored `rand.Reader` errors during key generation, producing all-zero keys with no indication of failure.
- `cmd/jwx/jwk.go:167` (`jwx jwk gen --type=oct`): `io.ReadFull(rand.Reader, octets)` now checks the error and returns a wrapped `failed to generate octet seq key` to the CLI caller.
- `internal/jwxtest/jwxtest.go` `GenerateSymmetricKey`: now panics on `rand.Read` failure. Used only by test helpers; a panic surfaces the condition instead of letting tests pass with degenerate randomness.

## No tests added

Both sites use the package-level `crypto/rand.Reader`, which does not fail on any supported OS. Exercising the error path would require refactoring the functions to accept an `io.Reader` parameter (out of scope for a defensive fix). The fix is mechanical and straightforward to audit visually.

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go test ./... -count=1` — full v4 suite green
- [x] `go build ./cmd/jwx/...` — CLI compiles
- [x] `go vet ./...` — clean
