### PR TITLE
auto-declare b64 crit when WithDetachedPayload is set

### DIFF
--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -250,9 +250,13 @@ func TestCritExtensionAllowlist(t *testing.T) {
 	})
 }
 
-// TestCritDetachedB64 verifies the RFC 7797 "b64:false" detached payload
-// flow still works when crit validation is enabled and "b64" is declared.
-func TestCritDetachedB64(t *testing.T) {
+// TestCritDetachedB64AutoDeclared verifies the RFC 7797 "b64:false"
+// detached-payload flow when crit validation is enabled. The caller
+// does NOT pass jws.WithCritExtension("b64") — passing
+// jws.WithDetachedPayload auto-declares "b64" because that is the
+// canonical pairing for b64=false and the jws package implements the
+// b64=false handling natively.
+func TestCritDetachedB64AutoDeclared(t *testing.T) {
 	payload := []byte(`hello world`)
 	key, err := jwxtest.GenerateSymmetricJwk()
 	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
@@ -271,9 +275,42 @@ func TestCritDetachedB64(t *testing.T) {
 		jws.WithKey(jwa.HS256(), key),
 		jws.WithDetachedPayload(payload),
 		jws.WithCritValidation(true),
+	)
+	require.NoError(t, err, `jws.Verify should succeed; WithDetachedPayload auto-declares "b64"`)
+}
+
+// TestCritInBandB64RequiresExplicit locks the scoping rule for the b64
+// auto-declaration: the auto-declare only happens when
+// jws.WithDetachedPayload is passed. An in-band b64=false JWS with
+// crit=["b64"] still requires the caller to declare "b64" explicitly,
+// otherwise jws.Verify (with crit validation enabled) rejects it.
+func TestCritInBandB64RequiresExplicit(t *testing.T) {
+	payload := []byte(`hello`)
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+
+	hdrs := jws.NewHeaders()
+	require.NoError(t, hdrs.Set("b64", false))
+	require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"b64"}))
+
+	signed, err := jws.Sign(payload,
+		jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)),
+	)
+	require.NoError(t, err, `jws.Sign should succeed`)
+
+	_, err = jws.Verify(signed,
+		jws.WithKey(jwa.HS256(), key),
+		jws.WithCritValidation(true),
+	)
+	require.Error(t, err, `jws.Verify should reject in-band b64=false without explicit WithCritExtension("b64")`)
+	require.ErrorContains(t, err, `not declared support`)
+
+	_, err = jws.Verify(signed,
+		jws.WithKey(jwa.HS256(), key),
+		jws.WithCritValidation(true),
 		jws.WithCritExtension("b64"),
 	)
-	require.NoError(t, err, `jws.Verify should succeed when b64 is declared in allowlist`)
+	require.NoError(t, err, `explicit WithCritExtension("b64") should make in-band b64=false succeed`)
 }
 
 // TestVerifyCompactFastIgnoresCrit documents that the fast path performs

--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -97,9 +97,17 @@ options:
       Note that this option does NOT populate the `b64` header, which is sometimes
       required by other JWS implementations.
 
-       
+
       When this option is used for `jws.Sign()`, the first parameter (normally the payload)
       must be set to `nil`.
+
+      When passed to `jws.Verify()` together with `jws.WithCritValidation(true)`,
+      the RFC 7797 `"b64"` extension is automatically added to the
+      caller's allowlist as if `jws.WithCritExtension("b64")` had also
+      been passed. Detached-payload verification is the canonical
+      pairing for `b64=false`, and the jws package implements `b64=false`
+      handling natively, so there is no need to declare it explicitly.
+      Other crit extensions still require explicit declaration.
        
       If you have to verify using this option, you should know exactly how and why this works.
   - ident: Base64Encoder

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -371,6 +371,14 @@ func WithDetached(v bool) CompactOption {
 // When this option is used for `jws.Sign()`, the first parameter (normally the payload)
 // must be set to `nil`.
 //
+// When passed to `jws.Verify()` together with `jws.WithCritValidation(true)`,
+// the RFC 7797 `"b64"` extension is automatically added to the
+// caller's allowlist as if `jws.WithCritExtension("b64")` had also
+// been passed. Detached-payload verification is the canonical
+// pairing for `b64=false`, and the jws package implements `b64=false`
+// handling natively, so there is no need to declare it explicitly.
+// Other crit extensions still require explicit declaration.
+//
 // If you have to verify using this option, you should know exactly how and why this works.
 func WithDetachedPayload(v []byte) SignVerifyOption {
 	return &signVerifyOption{option.New(identDetachedPayload{}, v)}

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -65,6 +65,20 @@ func (vc *verifyContext) ProcessOptions(options []VerifyOption) error {
 			if err := option.Value(&vc.detachedPayload); err != nil {
 				return makeVerifyError(`invalid value for option WithDetachedPayload: %w`, err)
 			}
+			// RFC 7797 "b64" auto-declaration. Detached-payload
+			// verification is the canonical use case for b64=false,
+			// and the jws package implements b64=false handling
+			// natively, so requiring callers to also pass
+			// jws.WithCritExtension("b64") is busywork. We declare
+			// it implicitly here so application code stays focused
+			// on its own crit extensions. This does not relax any
+			// other validateCritical check — the b64 header still
+			// has to appear in the protected header, the crit list
+			// still has to be non-empty / no duplicates / no
+			// standard names, etc. Only the "is in the caller's
+			// allowlist" check is short-circuited for "b64", and
+			// only when WithDetachedPayload was passed.
+			vc.criticalExtensions = append(vc.criticalExtensions, "b64")
 		case identKey{}:
 			var pair *withKey
 			if err := option.Value(&pair); err != nil {
@@ -257,6 +271,12 @@ func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, ke
 // any "crit" extension they do not understand, and the only way the
 // library knows which extensions the caller understands is via the
 // allowlist (populated from jws.WithCritExtension()).
+//
+// As a convenience, the RFC 7797 "b64" extension is auto-declared into
+// allowedExtensions whenever the caller passes jws.WithDetachedPayload
+// — see the identDetachedPayload case in ProcessOptions. The auto-
+// declaration only short-circuits the allowlist check; every other
+// rule above still applies to the "b64" entry.
 func validateCritical(protected Headers, allowedExtensions []string) error {
 	if !protected.Has(CriticalKey) {
 		return nil


### PR DESCRIPTION
v3 sibling of #1746. When `jws.WithDetachedPayload` is set, append `"b64"` to the verify context's critical-extension allowlist as if the caller had also passed `jws.WithCritExtension("b64")`. Detached-payload verification is the canonical pairing for RFC 7797 `b64=false`, and the jws package implements `b64=false` natively, so requiring callers to also declare `"b64"` is busywork that leaks RFC trivia into application code.

The auto-declare only short-circuits the "is in the caller's allowlist" check inside `validateCritical`. Every other rule still applies to the `"b64"` entry: the `b64` header must be present in the protected header, the `crit` list must be non-empty, no duplicates, no standard JOSE names, etc. In-band `b64=false` (without `WithDetachedPayload`) still requires explicit `WithCritExtension("b64")` — that scoping is locked by the new `TestCritInBandB64RequiresExplicit`.

`TestCritDetachedB64` is renamed to `TestCritDetachedB64AutoDeclared` and drops its explicit `WithCritExtension("b64")` to prove the auto-declare works. The `WithDetachedPayload` doc in `options.yaml` is updated (and `options_gen.go` regenerated) to document the auto-declare behavior so callers reading godoc see it.

The in-tree `examples/jws_verify_detached_payload_example_test.go` already does not pass `WithCritValidation`, so v3's default-off behavior makes it work without change. No example file modifications are required for this PR.
