### PR TITLE
document b64 auto-declare in WithDetachedPayload godoc

### DIFF
--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -91,10 +91,18 @@ options:
       Note that this option does NOT populate the `b64` header, which is sometimes
       required by other JWS implementations.
 
-       
+
       When this option is used for `jws.Sign()`, the first parameter (normally the payload)
       must be set to `nil`.
-       
+
+      When passed to `jws.Verify()`, the RFC 7797 `"b64"` extension is
+      automatically added to the caller's crit allowlist as if
+      `jws.WithCritExtension("b64")` had also been passed.
+      Detached-payload verification is the canonical pairing for
+      `b64=false`, and the jws package implements `b64=false` handling
+      natively, so there is no need to declare it explicitly. Other
+      crit extensions still require explicit declaration.
+
       If you have to verify using this option, you should know exactly how and why this works.
   - ident: Base64Encoder
     interface: SignVerifyCompactOption

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -340,6 +340,14 @@ func WithDetached(v bool) CompactOption {
 // When this option is used for `jws.Sign()`, the first parameter (normally the payload)
 // must be set to `nil`.
 //
+// When passed to `jws.Verify()`, the RFC 7797 `"b64"` extension is
+// automatically added to the caller's crit allowlist as if
+// `jws.WithCritExtension("b64")` had also been passed.
+// Detached-payload verification is the canonical pairing for
+// `b64=false`, and the jws package implements `b64=false` handling
+// natively, so there is no need to declare it explicitly. Other
+// crit extensions still require explicit declaration.
+//
 // If you have to verify using this option, you should know exactly how and why this works.
 func WithDetachedPayload(v []byte) SignVerifyOption {
 	return &signVerifyOption{option.New(identDetachedPayload{}, v)}


### PR DESCRIPTION
Follow-up to #1746. The auto-declare logic landed but the `WithDetachedPayload` godoc wasn't updated to mention it, so callers reading the option's documentation still wouldn't know `b64` is auto-declared on the verify path. Update `jws/options.yaml` and regenerate `options_gen.go` with the same wording I added to v3 in #1748.
