### PR TITLE
fail loudly on rand.Reader errors in key gen helpers

### DIFF
--- a/cmd/jwx/jwk.go
+++ b/cmd/jwx/jwk.go
@@ -164,7 +164,9 @@ func makeJwkGenerateCmd() *cli.Command {
 			rawkey = v
 		case jwa.OctetSeq():
 			octets := make([]byte, c.Int("keysize"))
-			io.ReadFull(rand.Reader, octets)
+			if _, err := io.ReadFull(rand.Reader, octets); err != nil {
+				return fmt.Errorf(`failed to generate octet seq key: %w`, err)
+			}
 
 			rawkey = octets
 		case jwa.OKP():

--- a/internal/jwxtest/jwxtest.go
+++ b/internal/jwxtest/jwxtest.go
@@ -85,7 +85,9 @@ func GenerateEcdsaPublicJwk() (jwk.Key, error) {
 
 func GenerateSymmetricKey() []byte {
 	sharedKey := make([]byte, 64)
-	rand.Read(sharedKey)
+	if _, err := rand.Read(sharedKey); err != nil {
+		panic(fmt.Sprintf("jwxtest.GenerateSymmetricKey: rand.Read failed: %v", err))
+	}
 	return sharedKey
 }
 


### PR DESCRIPTION
Cherry-pick of #1747 to develop/v3. Applies cleanly.

Two key-generation helpers dropped their `rand.Reader` errors and silently returned all-zero bytes on entropy failure:

- `cmd/jwx/jwk.go:167` — `io.ReadFull(rand.Reader, octets)` result ignored; the CLI's `jwx jwk gen` would emit an all-zero OctetSeq key with no signal.
- `internal/jwxtest/jwxtest.go:86-90` — `GenerateSymmetricKey` swallowed `rand.Read`'s error; downstream tests would run with degenerate randomness.

CLI now returns an error; test helper panics loudly. Same shape as the v4 fix.
