### PR TITLE
fix race in jwk/ecdsa lookup functions

### DIFF
--- a/jwk/ecdsa/ecdsa.go
+++ b/jwk/ecdsa/ecdsa.go
@@ -55,6 +55,9 @@ func Algorithms() []jwa.EllipticCurveAlgorithm {
 }
 
 func AlgorithmFromCurve(crv elliptic.Curve) (jwa.EllipticCurveAlgorithm, error) {
+	muCurves.RLock()
+	defer muCurves.RUnlock()
+
 	alg, ok := curveToAlgMap[crv]
 	if !ok {
 		return jwa.InvalidEllipticCurve(), fmt.Errorf(`unknown elliptic curve: %q`, crv)
@@ -63,6 +66,9 @@ func AlgorithmFromCurve(crv elliptic.Curve) (jwa.EllipticCurveAlgorithm, error) 
 }
 
 func CurveFromAlgorithm(alg jwa.EllipticCurveAlgorithm) (elliptic.Curve, error) {
+	muCurves.RLock()
+	defer muCurves.RUnlock()
+
 	crv, ok := algToCurveMap[alg]
 	if !ok {
 		return nil, fmt.Errorf(`unknown elliptic curve algorithm: %q`, alg)
@@ -71,6 +77,9 @@ func CurveFromAlgorithm(alg jwa.EllipticCurveAlgorithm) (elliptic.Curve, error) 
 }
 
 func IsCurveAvailable(alg jwa.EllipticCurveAlgorithm) bool {
+	muCurves.RLock()
+	defer muCurves.RUnlock()
+
 	_, ok := algToCurveMap[alg]
 	return ok
 }

--- a/jwk/ecdsa/ecdsa_test.go
+++ b/jwk/ecdsa/ecdsa_test.go
@@ -1,0 +1,57 @@
+package ecdsa
+
+import (
+	"crypto/elliptic"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/jwa"
+)
+
+// TestConcurrentRegisterAndLookup is a race-detector test. It runs many
+// goroutines that call the read-side lookup functions while a writer
+// goroutine repeatedly calls RegisterCurve. Without RLock on the reads,
+// `go test -race` flags the concurrent map access; with RLock, the test
+// passes cleanly.
+//
+// The writer reuses elliptic.P256() as the curve value and registers a
+// sequence of synthetic algorithm names, so the standard-curve entries
+// (P256/P384/P521) installed in init() are preserved for any subsequent
+// tests in the same process.
+func TestConcurrentRegisterAndLookup(t *testing.T) {
+	const (
+		numReaders    = 8
+		writerEntries = 200
+	)
+
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+
+	// Readers hammer the three lookup functions.
+	for i := 0; i < numReaders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_, _ = CurveFromAlgorithm(jwa.P256())
+					_, _ = AlgorithmFromCurve(elliptic.P256())
+					_ = IsCurveAvailable(jwa.P256())
+				}
+			}
+		}()
+	}
+
+	// Writer registers synthetic algorithm names.
+	for i := 0; i < writerEntries; i++ {
+		alg := jwa.NewEllipticCurveAlgorithm(fmt.Sprintf("xcut006-test-%d", i))
+		RegisterCurve(alg, elliptic.P256())
+	}
+
+	close(done)
+	wg.Wait()
+}

--- a/jwk/ecdsa/ecdsa_test.go
+++ b/jwk/ecdsa/ecdsa_test.go
@@ -19,7 +19,7 @@ import (
 // sequence of synthetic algorithm names, so the standard-curve entries
 // (P256/P384/P521) installed in init() are preserved for any subsequent
 // tests in the same process.
-func TestConcurrentRegisterAndLookup(t *testing.T) {
+func TestConcurrentRegisterAndLookup(_ *testing.T) {
 	const (
 		numReaders    = 8
 		writerEntries = 200
@@ -28,11 +28,8 @@ func TestConcurrentRegisterAndLookup(t *testing.T) {
 	var wg sync.WaitGroup
 	done := make(chan struct{})
 
-	// Readers hammer the three lookup functions.
-	for i := 0; i < numReaders; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range numReaders {
+		wg.Go(func() {
 			for {
 				select {
 				case <-done:
@@ -43,11 +40,10 @@ func TestConcurrentRegisterAndLookup(t *testing.T) {
 					_ = IsCurveAvailable(jwa.P256())
 				}
 			}
-		}()
+		})
 	}
 
-	// Writer registers synthetic algorithm names.
-	for i := 0; i < writerEntries; i++ {
+	for i := range writerEntries {
 		alg := jwa.NewEllipticCurveAlgorithm(fmt.Sprintf("xcut006-test-%d", i))
 		RegisterCurve(alg, elliptic.P256())
 	}


### PR DESCRIPTION
## Summary

- Fix XCUT-006 (JWK-005) from the v4 review: `jwk/ecdsa`'s `AlgorithmFromCurve`, `CurveFromAlgorithm`, and `IsCurveAvailable` read the global `algToCurveMap` / `curveToAlgMap` without holding `muCurves.RLock()`, while `RegisterCurve` writes under the write lock. Any concurrent `RegisterCurve` + lookup (e.g. an extension like ES256K calling `RegisterCurve` during init while another goroutine imports a JWK) hits Go's runtime "concurrent map read and map write" fatal error.
- Three-line fix: add `muCurves.RLock() / defer muCurves.RUnlock()` to each of the three lookup functions.
- New `jwk/ecdsa/ecdsa_test.go` with `TestConcurrentRegisterAndLookup`: launches 8 reader goroutines hammering the three lookup functions while the writer registers 200 synthetic algorithm names (all pointing at `elliptic.P256()` so the standard-curve entries stay intact for subsequent tests). Written first; fails with a runtime fatal against the unpatched code and passes under `go test -race` against the patched code.

## Test plan

- [x] Write failing concurrent test, confirm runtime fatal on unpatched code
- [x] Apply the three-line fix
- [x] `go test -race ./jwk/ecdsa/ -run TestConcurrentRegisterAndLookup` — green
- [x] `go test -race ./jwk/... -count=1` — full jwk suite green under `-race`
