### PR TITLE
clone protected headers in signatureBuilder.Build

### DIFF
--- a/jws/signature_builder.go
+++ b/jws/signature_builder.go
@@ -52,8 +52,17 @@ func freeSignatureBuilder(sb *signatureBuilder) *signatureBuilder {
 }
 
 func (sb *signatureBuilder) Build(sc *signContext, payload []byte) (*Signature, error) {
-	protected := sb.protected
-	if protected == nil {
+	// Clone caller-provided headers before mutating so that re-using the
+	// same Headers instance across multiple Sign calls does not cause
+	// cross-contamination of alg/kid.
+	var protected Headers
+	if sb.protected != nil {
+		cloned, err := sb.protected.Clone()
+		if err != nil {
+			return nil, makeSignError(`failed to clone protected headers: %w`, err)
+		}
+		protected = cloned
+	} else {
 		protected = NewHeaders()
 	}
 


### PR DESCRIPTION
`signatureBuilder.Build` set `alg` and `kid` directly on `sb.protected`, the caller-provided `Headers`. Callers re-using the same instance across multiple `Sign` calls saw cross-contamination. Clone before mutating so each sign produces an independent result.