### PR TITLE
docs: note ES256K low-S non-enforcement

### DIFF
--- a/docs/20-global-settings.md
+++ b/docs/20-global-settings.md
@@ -11,6 +11,12 @@ To enable these, you must explicitly provide a build tag.
 
 If you do not provide these tags, the program will still compile, but it will return an error during runtime saying that these algorithms are not supported.
 
+### Note on ES256K signature malleability (low-S)
+
+ES256K signatures produced and accepted by `jwx` do not enforce low-S canonicalization. The underlying `crypto/ecdsa` implementation may emit either of the two mathematically valid `(r, s)` / `(r, n-s)` pairs, and verification accepts both. This matches the behavior of every other ECDSA algorithm in `jwx` (ES256, ES384, ES512) and is appropriate for JWS, where signatures are bound to a specific payload and are not used as unique identifiers.
+
+If you are bridging JWS-signed material into a system that treats ECDSA signatures as unique identifiers (e.g. Bitcoin-style transaction hashes, or signature-equality caches), you are responsible for applying low-S normalization yourself. Do not assume two verifiable ES256K signatures over the same payload are byte-equal.
+
 ## Switching to a faster JSON library
 
 By default, we use the standard library's `encoding/json` for all of our JSON needs.


### PR DESCRIPTION
## Summary

Document in `docs/20-global-settings.md` that ES256K (enabled via `jwx_es256k` build tag) does not enforce low-S canonicalization. Matches other ECDSA algorithms in jwx and is fine for JWS, but callers bridging to systems that treat ECDSA signatures as unique identifiers (e.g. Bitcoin-style tx hashes) must normalize themselves.

Addresses EXT-107. v4 equivalent: #1762
