### PR TITLE
Register* functions return error for future-proofing

### DIFF
--- a/.claude/docs/companions.md
+++ b/.claude/docs/companions.md
@@ -6,6 +6,14 @@ Extension modules under `github.com/jwx-go/*` (asmbase64, compsig, ed448, es256k
 jwkcache, jwxmigrate, mlkem, mldsa, reddy-pqchpke, x448, benchmarks) are managed as "companion modules." They live in
 separate repos but share CI workflows, dependabot config, and development tooling.
 
+## House style: `init()` and Register\* failures
+
+Companion modules that register algorithms, signers, verifiers, or key
+handlers do so from `init()`, and **must panic** if any `Register*` call
+returns an error. See `.claude/docs/internals.md` (Register\* API
+convention) for the full rule and rationale. This applies uniformly
+across every companion — do not demote to `log.Printf` + continue.
+
 ## Directory Layout
 
 ```

--- a/.claude/docs/internals.md
+++ b/.claude/docs/internals.md
@@ -68,6 +68,43 @@ Manual option functions in `{pkg}/options.go` supplement generated ones.
 | Custom signers | `jws.RegisterSigner()` | jws |
 | Custom verifiers | `jws.RegisterVerifier()` | jws |
 
+### Register\* API convention (v4)
+
+All `Register*` functions **must return `error`**, even if the current
+implementation has no failure path. This reserves the ability to codify
+error modes (duplicate detection, identifier validation, freeze-point
+enforcement, etc.) in the future without another API break.
+
+When adding a new `Register*` function or touching an existing one:
+
+- Signature must be `func Register...(...) error`. Do not drop the
+  return in the name of "it can't fail today."
+- Unused error returns in callers must not be silently dropped — see
+  the companion-module rule below.
+
+### Companion modules: panic on Register\* failure
+
+Companion modules under `github.com/jwx-go/*` register their algorithms
+from `init()`. The house style is:
+
+```go
+func init() {
+    if err := jws.RegisterSigner(alg, mySigner{}); err != nil {
+        panic(fmt.Sprintf("jwx-go/<mod>: failed to register signer: %s", err))
+    }
+}
+```
+
+Rationale: `init()` runs once at import time. A registration failure
+means the extension is unusable, and every subsequent call that relies
+on it would fail in a confusing way far from the real cause. Crashing
+at import surfaces the problem immediately and loudly.
+
+This is intentional and uniform across all companion modules — do not
+demote these to `log.Printf` + continue. Package godoc on companion
+modules should mention that importing the package can panic if jwx
+rejects the registration.
+
 ## JSON Backend
 
 Uses `encoding/json/v2` exclusively (no build-tag switching).

--- a/docs/10-extensions.md
+++ b/docs/10-extensions.md
@@ -2,6 +2,8 @@
 
 In v4, optional features are provided as standalone modules under [`github.com/jwx-go`](https://github.com/jwx-go). Each module registers itself automatically via `init()` — just import the module for its side effects.
 
+> **Note**: Extension modules register their algorithms from `init()` and **panic** if registration fails. This is intentional: a failed registration means the extension is unusable, and panicking at import time surfaces the problem immediately rather than at a later, confusing call site. See each module's package godoc for details.
+
 ### Signature Algorithms
 
 | Module | Algorithm | Key Package |

--- a/internal/jwxcodegen/cmd/jwxcodegen/genjwa.go
+++ b/internal/jwxcodegen/cmd/jwxcodegen/genjwa.go
@@ -182,7 +182,9 @@ func generateAlgInit(o *codegen.Output, t Algorithm) {
 		o.R(")")
 	}
 
-	o.LL("Register%s(algorithms...)", t.Name)
+	o.LL("if err := Register%s(algorithms...); err != nil {", t.Name)
+	o.L("panic(fmt.Sprintf(%q, err))", fmt.Sprintf("jwa: failed to register builtin %s: %%s", t.Name))
+	o.L("}")
 	o.L("}") // end init
 }
 
@@ -304,13 +306,20 @@ func generateAlgRegistration(o *codegen.Output, t Algorithm) {
 
 	o.LL("// Register%[1]s registers a new %[1]s. The signature value must be immutable", t.Name)
 	o.L("// and safe to be used by multiple goroutines, as it is going to be shared with all other users of this library.")
-	o.L("func Register%[1]s(algorithms ...%[1]s) {", t.Name)
+	o.L("//")
+	o.L("// The error return is reserved for future validation (duplicate detection,")
+	o.L("// identifier rules, freeze-point enforcement, etc). The current implementation")
+	o.L("// always returns nil, but callers — especially extension modules calling this")
+	o.L("// from init() — must check the return value and panic on failure to stay")
+	o.L("// forward-compatible.")
+	o.L("func Register%[1]s(algorithms ...%[1]s) error {", t.Name)
 	o.L("muAll%[1]s.Lock()", t.Name)
 	o.L("for _, alg := range algorithms {")
 	o.L("all%[1]s[alg.String()] = alg", t.Name)
 	o.L("}")
 	o.L("muAll%[1]s.Unlock()", t.Name)
 	o.L("rebuild%[1]s()", t.Name)
+	o.L("return nil")
 	o.L("}")
 
 	o.LL("// Unregister%[1]s unregisters a %[1]s from its known database.", t.Name)
@@ -520,7 +529,7 @@ func generateAlgTestCustomAlgorithm(o *codegen.Output, t Algorithm) {
 	o.L("jwa.Unregister%[1]s(customAlgorithm)", t.Name)
 	o.L("})")
 	o.L("t.Run(`with custom algorithm registered`, func(t *testing.T) {")
-	o.L("jwa.Register%[1]s(customAlgorithm)", t.Name)
+	o.L("require.NoError(t, jwa.Register%[1]s(customAlgorithm))", t.Name)
 	o.L("t.Run(`Lookup the object`, func(t *testing.T) {")
 	o.L("t.Parallel()")
 	o.L("v, ok := jwa.Lookup%[1]s(customAlgorithmValue)", t.Name)

--- a/jwa/compression_gen.go
+++ b/jwa/compression_gen.go
@@ -24,7 +24,9 @@ func init() {
 	algorithms[0] = NewCompressionAlgorithm("DEF")
 	algorithms[1] = NewCompressionAlgorithm("")
 
-	RegisterCompressionAlgorithm(algorithms...)
+	if err := RegisterCompressionAlgorithm(algorithms...); err != nil {
+		panic(fmt.Sprintf("jwa: failed to register builtin CompressionAlgorithm: %s", err))
+	}
 }
 
 // Deflate returns an object representing the "DEF" content compression algorithm value. Using this value specifies that the content should be compressed using DEFLATE (RFC 1951).
@@ -89,13 +91,20 @@ func LookupCompressionAlgorithm(name string) (CompressionAlgorithm, bool) {
 
 // RegisterCompressionAlgorithm registers a new CompressionAlgorithm. The signature value must be immutable
 // and safe to be used by multiple goroutines, as it is going to be shared with all other users of this library.
-func RegisterCompressionAlgorithm(algorithms ...CompressionAlgorithm) {
+//
+// The error return is reserved for future validation (duplicate detection,
+// identifier rules, freeze-point enforcement, etc). The current implementation
+// always returns nil, but callers — especially extension modules calling this
+// from init() — must check the return value and panic on failure to stay
+// forward-compatible.
+func RegisterCompressionAlgorithm(algorithms ...CompressionAlgorithm) error {
 	muAllCompressionAlgorithm.Lock()
 	for _, alg := range algorithms {
 		allCompressionAlgorithm[alg.String()] = alg
 	}
 	muAllCompressionAlgorithm.Unlock()
 	rebuildCompressionAlgorithm()
+	return nil
 }
 
 // UnregisterCompressionAlgorithm unregisters a CompressionAlgorithm from its known database.

--- a/jwa/compression_gen_test.go
+++ b/jwa/compression_gen_test.go
@@ -75,7 +75,7 @@ func TestCompressionAlgorithmCustomAlgorithm(t *testing.T) {
 		jwa.UnregisterCompressionAlgorithm(customAlgorithm)
 	})
 	t.Run(`with custom algorithm registered`, func(t *testing.T) {
-		jwa.RegisterCompressionAlgorithm(customAlgorithm)
+		require.NoError(t, jwa.RegisterCompressionAlgorithm(customAlgorithm))
 		t.Run(`Lookup the object`, func(t *testing.T) {
 			t.Parallel()
 			v, ok := jwa.LookupCompressionAlgorithm(customAlgorithmValue)

--- a/jwa/content_encryption_gen.go
+++ b/jwa/content_encryption_gen.go
@@ -29,7 +29,9 @@ func init() {
 	algorithms[4] = NewContentEncryptionAlgorithm(tokens.A256CBC_HS512)
 	algorithms[5] = NewContentEncryptionAlgorithm(tokens.A256GCM)
 
-	RegisterContentEncryptionAlgorithm(algorithms...)
+	if err := RegisterContentEncryptionAlgorithm(algorithms...); err != nil {
+		panic(fmt.Sprintf("jwa: failed to register builtin ContentEncryptionAlgorithm: %s", err))
+	}
 }
 
 // A128CBC_HS256 returns an object representing A128CBC-HS256. Using this value specifies that the content should be encrypted using AES-CBC + HMAC-SHA256 (128).
@@ -114,13 +116,20 @@ func LookupContentEncryptionAlgorithm(name string) (ContentEncryptionAlgorithm, 
 
 // RegisterContentEncryptionAlgorithm registers a new ContentEncryptionAlgorithm. The signature value must be immutable
 // and safe to be used by multiple goroutines, as it is going to be shared with all other users of this library.
-func RegisterContentEncryptionAlgorithm(algorithms ...ContentEncryptionAlgorithm) {
+//
+// The error return is reserved for future validation (duplicate detection,
+// identifier rules, freeze-point enforcement, etc). The current implementation
+// always returns nil, but callers — especially extension modules calling this
+// from init() — must check the return value and panic on failure to stay
+// forward-compatible.
+func RegisterContentEncryptionAlgorithm(algorithms ...ContentEncryptionAlgorithm) error {
 	muAllContentEncryptionAlgorithm.Lock()
 	for _, alg := range algorithms {
 		allContentEncryptionAlgorithm[alg.String()] = alg
 	}
 	muAllContentEncryptionAlgorithm.Unlock()
 	rebuildContentEncryptionAlgorithm()
+	return nil
 }
 
 // UnregisterContentEncryptionAlgorithm unregisters a ContentEncryptionAlgorithm from its known database.

--- a/jwa/content_encryption_gen_test.go
+++ b/jwa/content_encryption_gen_test.go
@@ -143,7 +143,7 @@ func TestContentEncryptionAlgorithmCustomAlgorithm(t *testing.T) {
 		jwa.UnregisterContentEncryptionAlgorithm(customAlgorithm)
 	})
 	t.Run(`with custom algorithm registered`, func(t *testing.T) {
-		jwa.RegisterContentEncryptionAlgorithm(customAlgorithm)
+		require.NoError(t, jwa.RegisterContentEncryptionAlgorithm(customAlgorithm))
 		t.Run(`Lookup the object`, func(t *testing.T) {
 			t.Parallel()
 			v, ok := jwa.LookupContentEncryptionAlgorithm(customAlgorithmValue)

--- a/jwa/elliptic_gen.go
+++ b/jwa/elliptic_gen.go
@@ -28,7 +28,9 @@ func init() {
 	algorithms[4] = NewEllipticCurveAlgorithm("X25519")
 	algorithms[5] = NewEllipticCurveAlgorithm("X448")
 
-	RegisterEllipticCurveAlgorithm(algorithms...)
+	if err := RegisterEllipticCurveAlgorithm(algorithms...); err != nil {
+		panic(fmt.Sprintf("jwa: failed to register builtin EllipticCurveAlgorithm: %s", err))
+	}
 }
 
 // Ed25519 returns an object representing Ed25519 algorithm for EdDSA operations.
@@ -120,13 +122,20 @@ func LookupEllipticCurveAlgorithm(name string) (EllipticCurveAlgorithm, bool) {
 
 // RegisterEllipticCurveAlgorithm registers a new EllipticCurveAlgorithm. The signature value must be immutable
 // and safe to be used by multiple goroutines, as it is going to be shared with all other users of this library.
-func RegisterEllipticCurveAlgorithm(algorithms ...EllipticCurveAlgorithm) {
+//
+// The error return is reserved for future validation (duplicate detection,
+// identifier rules, freeze-point enforcement, etc). The current implementation
+// always returns nil, but callers — especially extension modules calling this
+// from init() — must check the return value and panic on failure to stay
+// forward-compatible.
+func RegisterEllipticCurveAlgorithm(algorithms ...EllipticCurveAlgorithm) error {
 	muAllEllipticCurveAlgorithm.Lock()
 	for _, alg := range algorithms {
 		allEllipticCurveAlgorithm[alg.String()] = alg
 	}
 	muAllEllipticCurveAlgorithm.Unlock()
 	rebuildEllipticCurveAlgorithm()
+	return nil
 }
 
 // UnregisterEllipticCurveAlgorithm unregisters a EllipticCurveAlgorithm from its known database.

--- a/jwa/elliptic_gen_test.go
+++ b/jwa/elliptic_gen_test.go
@@ -148,7 +148,7 @@ func TestEllipticCurveAlgorithmCustomAlgorithm(t *testing.T) {
 		jwa.UnregisterEllipticCurveAlgorithm(customAlgorithm)
 	})
 	t.Run(`with custom algorithm registered`, func(t *testing.T) {
-		jwa.RegisterEllipticCurveAlgorithm(customAlgorithm)
+		require.NoError(t, jwa.RegisterEllipticCurveAlgorithm(customAlgorithm))
 		t.Run(`Lookup the object`, func(t *testing.T) {
 			t.Parallel()
 			v, ok := jwa.LookupEllipticCurveAlgorithm(customAlgorithmValue)

--- a/jwa/key_encryption_gen.go
+++ b/jwa/key_encryption_gen.go
@@ -48,7 +48,9 @@ func init() {
 	algorithms[23] = NewKeyEncryptionAlgorithm(tokens.RSA_OAEP_384)
 	algorithms[24] = NewKeyEncryptionAlgorithm(tokens.RSA_OAEP_512)
 
-	RegisterKeyEncryptionAlgorithm(algorithms...)
+	if err := RegisterKeyEncryptionAlgorithm(algorithms...); err != nil {
+		panic(fmt.Sprintf("jwa: failed to register builtin KeyEncryptionAlgorithm: %s", err))
+	}
 }
 
 // A128GCMKW returns an object representing AES-GCM key wrap (128) key encryption algorithm.
@@ -237,13 +239,20 @@ func LookupKeyEncryptionAlgorithm(name string) (KeyEncryptionAlgorithm, bool) {
 
 // RegisterKeyEncryptionAlgorithm registers a new KeyEncryptionAlgorithm. The signature value must be immutable
 // and safe to be used by multiple goroutines, as it is going to be shared with all other users of this library.
-func RegisterKeyEncryptionAlgorithm(algorithms ...KeyEncryptionAlgorithm) {
+//
+// The error return is reserved for future validation (duplicate detection,
+// identifier rules, freeze-point enforcement, etc). The current implementation
+// always returns nil, but callers — especially extension modules calling this
+// from init() — must check the return value and panic on failure to stay
+// forward-compatible.
+func RegisterKeyEncryptionAlgorithm(algorithms ...KeyEncryptionAlgorithm) error {
 	muAllKeyEncryptionAlgorithm.Lock()
 	for _, alg := range algorithms {
 		allKeyEncryptionAlgorithm[alg.String()] = alg
 	}
 	muAllKeyEncryptionAlgorithm.Unlock()
 	rebuildKeyEncryptionAlgorithm()
+	return nil
 }
 
 // UnregisterKeyEncryptionAlgorithm unregisters a KeyEncryptionAlgorithm from its known database.

--- a/jwa/key_encryption_gen_test.go
+++ b/jwa/key_encryption_gen_test.go
@@ -545,7 +545,7 @@ func TestKeyEncryptionAlgorithmCustomAlgorithm(t *testing.T) {
 			jwa.UnregisterKeyEncryptionAlgorithm(customAlgorithm)
 		})
 		t.Run(`with custom algorithm registered`, func(t *testing.T) {
-			jwa.RegisterKeyEncryptionAlgorithm(customAlgorithm)
+			require.NoError(t, jwa.RegisterKeyEncryptionAlgorithm(customAlgorithm))
 			t.Run(`Lookup the object`, func(t *testing.T) {
 				t.Parallel()
 				v, ok := jwa.LookupKeyEncryptionAlgorithm(customAlgorithmValue)

--- a/jwa/key_type_gen.go
+++ b/jwa/key_type_gen.go
@@ -27,7 +27,9 @@ func init() {
 	algorithms[3] = NewKeyType("oct")
 	algorithms[4] = NewKeyType("RSA")
 
-	RegisterKeyType(algorithms...)
+	if err := RegisterKeyType(algorithms...); err != nil {
+		panic(fmt.Sprintf("jwa: failed to register builtin KeyType: %s", err))
+	}
 }
 
 // AKP returns an object representing AKP. Algorithm Key Pair (post-quantum KEM/signature keys)
@@ -114,13 +116,20 @@ func LookupKeyType(name string) (KeyType, bool) {
 
 // RegisterKeyType registers a new KeyType. The signature value must be immutable
 // and safe to be used by multiple goroutines, as it is going to be shared with all other users of this library.
-func RegisterKeyType(algorithms ...KeyType) {
+//
+// The error return is reserved for future validation (duplicate detection,
+// identifier rules, freeze-point enforcement, etc). The current implementation
+// always returns nil, but callers — especially extension modules calling this
+// from init() — must check the return value and panic on failure to stay
+// forward-compatible.
+func RegisterKeyType(algorithms ...KeyType) error {
 	muAllKeyType.Lock()
 	for _, alg := range algorithms {
 		allKeyType[alg.String()] = alg
 	}
 	muAllKeyType.Unlock()
 	rebuildKeyType()
+	return nil
 }
 
 // UnregisterKeyType unregisters a KeyType from its known database.

--- a/jwa/key_type_gen_test.go
+++ b/jwa/key_type_gen_test.go
@@ -126,7 +126,7 @@ func TestKeyTypeCustomAlgorithm(t *testing.T) {
 		jwa.UnregisterKeyType(customAlgorithm)
 	})
 	t.Run(`with custom algorithm registered`, func(t *testing.T) {
-		jwa.RegisterKeyType(customAlgorithm)
+		require.NoError(t, jwa.RegisterKeyType(customAlgorithm))
 		t.Run(`Lookup the object`, func(t *testing.T) {
 			t.Parallel()
 			v, ok := jwa.LookupKeyType(customAlgorithmValue)

--- a/jwa/signature_gen.go
+++ b/jwa/signature_gen.go
@@ -37,7 +37,9 @@ func init() {
 	algorithms[13] = NewSignatureAlgorithm("RS384")
 	algorithms[14] = NewSignatureAlgorithm("RS512")
 
-	RegisterSignatureAlgorithm(algorithms...)
+	if err := RegisterSignatureAlgorithm(algorithms...); err != nil {
+		panic(fmt.Sprintf("jwa: failed to register builtin SignatureAlgorithm: %s", err))
+	}
 }
 
 // ES256 returns an object representing ECDSA signature algorithm using P-256 curve and SHA-256.
@@ -176,13 +178,20 @@ func LookupSignatureAlgorithm(name string) (SignatureAlgorithm, bool) {
 
 // RegisterSignatureAlgorithm registers a new SignatureAlgorithm. The signature value must be immutable
 // and safe to be used by multiple goroutines, as it is going to be shared with all other users of this library.
-func RegisterSignatureAlgorithm(algorithms ...SignatureAlgorithm) {
+//
+// The error return is reserved for future validation (duplicate detection,
+// identifier rules, freeze-point enforcement, etc). The current implementation
+// always returns nil, but callers — especially extension modules calling this
+// from init() — must check the return value and panic on failure to stay
+// forward-compatible.
+func RegisterSignatureAlgorithm(algorithms ...SignatureAlgorithm) error {
 	muAllSignatureAlgorithm.Lock()
 	for _, alg := range algorithms {
 		allSignatureAlgorithm[alg.String()] = alg
 	}
 	muAllSignatureAlgorithm.Unlock()
 	rebuildSignatureAlgorithm()
+	return nil
 }
 
 // UnregisterSignatureAlgorithm unregisters a SignatureAlgorithm from its known database.

--- a/jwa/signature_gen_test.go
+++ b/jwa/signature_gen_test.go
@@ -345,7 +345,7 @@ func TestSignatureAlgorithmCustomAlgorithm(t *testing.T) {
 			jwa.UnregisterSignatureAlgorithm(customAlgorithm)
 		})
 		t.Run(`with custom algorithm registered`, func(t *testing.T) {
-			jwa.RegisterSignatureAlgorithm(customAlgorithm)
+			require.NoError(t, jwa.RegisterSignatureAlgorithm(customAlgorithm))
 			t.Run(`Lookup the object`, func(t *testing.T) {
 				t.Parallel()
 				v, ok := jwa.LookupSignatureAlgorithm(customAlgorithmValue)

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -1134,8 +1134,14 @@ type CustomDecodeFunc[T any] = json.CustomDecodeFunc[T]
 //
 // For more fine-tuned control over the decoding process,
 // use RegisterCustomDecoder instead.
-func RegisterCustomField[T any](name string) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterCustomField[T any](name string) error {
 	json.RegisterTyped[T](registry, name)
+	return nil
 }
 
 // RegisterCustomDecoder registers a private field with a custom decoder
@@ -1148,8 +1154,14 @@ func RegisterCustomField[T any](name string) {
 //	  }
 //	  return time.Parse(time.RFC1123, s)
 //	}))
-func RegisterCustomDecoder[T any](name string, dec CustomDecodeFunc[T]) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterCustomDecoder[T any](name string, dec CustomDecodeFunc[T]) error {
 	json.RegisterCustomDecoder[T](registry, name, dec)
+	return nil
 }
 
 // UnregisterCustomField removes the registration for a custom field.

--- a/jwe/jwebb/hpke_ext.go
+++ b/jwe/jwebb/hpke_ext.go
@@ -75,17 +75,25 @@ func init() {
 		tokens.HPKE_4_KE,
 		tokens.HPKE_7_KE,
 	} {
-		RegisterHPKEAlgorithm(alg)
+		if err := RegisterHPKEAlgorithm(alg); err != nil {
+			panic(fmt.Sprintf("jwebb: failed to register builtin HPKE algorithm: %s", err))
+		}
 	}
 }
 
 // RegisterHPKEAlgorithm registers an algorithm identifier as an HPKE
 // algorithm. After registration, IsHPKE returns true for this identifier,
 // causing the JWE encrypt/decrypt dispatch to route it through the HPKE path.
-func RegisterHPKEAlgorithm(alg string) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterHPKEAlgorithm(alg string) error {
 	muHPKEAlgs.Lock()
 	defer muHPKEAlgs.Unlock()
 	hpkeAlgSet[alg] = struct{}{}
+	return nil
 }
 
 func unregisterHPKEAlgorithm(alg string) {

--- a/jwe/jwebb/mlkem_ext.go
+++ b/jwe/jwebb/mlkem_ext.go
@@ -71,20 +71,32 @@ var (
 // algorithm. After registration, IsMLKEM returns true for this identifier,
 // causing the JWE encrypt/decrypt dispatch to route it through the
 // ML-KEM path.
-func RegisterMLKEMAlgorithm(alg string) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterMLKEMAlgorithm(alg string) error {
 	muMLKEMAlgs.Lock()
 	defer muMLKEMAlgs.Unlock()
 	mlkemAlgSet[alg] = struct{}{}
+	return nil
 }
 
 // RegisterMLKEMDirectAlgorithm registers an algorithm identifier as a
 // direct (non-key-wrapping) ML-KEM algorithm. Direct algorithms use the
 // derived shared secret as the CEK. Implementations should also call
 // RegisterMLKEMAlgorithm for the same identifier.
-func RegisterMLKEMDirectAlgorithm(alg string) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterMLKEMDirectAlgorithm(alg string) error {
 	muMLKEMAlgs.Lock()
 	defer muMLKEMAlgs.Unlock()
 	mlkemDirectAlgSet[alg] = struct{}{}
+	return nil
 }
 
 func isRegisteredMLKEM(alg string) bool {

--- a/jwk/convert.go
+++ b/jwk/convert.go
@@ -202,21 +202,31 @@ func init() {
 	normalizedOKP = KeyKind(jwa.OKP().String()).normalize()
 	normalizedOCT = KeyKind(jwa.OctetSeq().String()).normalize()
 
-	RegisterKeyImporter(importRSAPrivateKey)
-	RegisterKeyImporter(importRSAPrivateKeyPtr)
-	RegisterKeyImporter(importRSAPublicKey)
-	RegisterKeyImporter(importRSAPublicKeyPtr)
-	RegisterKeyImporter(importECDSAPrivateKey)
-	RegisterKeyImporter(importECDSAPrivateKeyPtr)
-	RegisterKeyImporter(importECDSAPublicKey)
-	RegisterKeyImporter(importECDSAPublicKeyPtr)
-	RegisterKeyImporter(importEd25519PrivateKey)
-	RegisterKeyImporter(importECDHPrivateKey)
-	RegisterKeyImporter(importECDHPrivateKeyPtr)
-	RegisterKeyImporter(importEd25519PublicKey)
-	RegisterKeyImporter(importECDHPublicKey)
-	RegisterKeyImporter(importECDHPublicKeyPtr)
-	RegisterKeyImporter(importSymmetricKey)
+	panicOnRegistrationError(RegisterKeyImporter(importRSAPrivateKey))
+	panicOnRegistrationError(RegisterKeyImporter(importRSAPrivateKeyPtr))
+	panicOnRegistrationError(RegisterKeyImporter(importRSAPublicKey))
+	panicOnRegistrationError(RegisterKeyImporter(importRSAPublicKeyPtr))
+	panicOnRegistrationError(RegisterKeyImporter(importECDSAPrivateKey))
+	panicOnRegistrationError(RegisterKeyImporter(importECDSAPrivateKeyPtr))
+	panicOnRegistrationError(RegisterKeyImporter(importECDSAPublicKey))
+	panicOnRegistrationError(RegisterKeyImporter(importECDSAPublicKeyPtr))
+	panicOnRegistrationError(RegisterKeyImporter(importEd25519PrivateKey))
+	panicOnRegistrationError(RegisterKeyImporter(importECDHPrivateKey))
+	panicOnRegistrationError(RegisterKeyImporter(importECDHPrivateKeyPtr))
+	panicOnRegistrationError(RegisterKeyImporter(importEd25519PublicKey))
+	panicOnRegistrationError(RegisterKeyImporter(importECDHPublicKey))
+	panicOnRegistrationError(RegisterKeyImporter(importECDHPublicKeyPtr))
+	panicOnRegistrationError(RegisterKeyImporter(importSymmetricKey))
+}
+
+// panicOnRegistrationError converts a non-nil error returned by a Register*
+// call during jwk's own init() into a panic. Registration cannot actually
+// fail today, but the API reserves the error return for future validation
+// and this helper keeps builtin bootstrap honest if that ever changes.
+func panicOnRegistrationError(err error) {
+	if err != nil {
+		panic(fmt.Sprintf("jwk: failed to register builtin: %s", err))
+	}
 }
 
 // normalizedKeyKindForType returns the pre-computed normalized KeyKind

--- a/jwk/convert.go
+++ b/jwk/convert.go
@@ -63,19 +63,31 @@ var muKeyExporters sync.RWMutex
 //
 // When `jwk.Import()` is called, the library will look up the appropriate importer
 // for the given raw key type (via `reflect`) and execute it.
-func RegisterKeyImporter[T any](fn func(T) (Key, error)) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterKeyImporter[T any](fn func(T) (Key, error)) error {
 	muKeyImporters.Lock()
 	defer muKeyImporters.Unlock()
 	keyImporters[reflect.TypeFor[T]()] = &keyImportAdapter[T]{fn: fn}
+	return nil
 }
 
 // RegisterKeyImporterI registers a KeyImporter interface for the given raw key type.
 // This is the interface-based variant for cases where a full KeyImporter implementation
 // is needed instead of a simple function.
-func RegisterKeyImporterI(from any, conv KeyImporter) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterKeyImporterI(from any, conv KeyImporter) error {
 	muKeyImporters.Lock()
 	defer muKeyImporters.Unlock()
 	keyImporters[reflect.TypeOf(from)] = conv
+	return nil
 }
 
 // RegisterKeyExporter registers a [KeyExporter] for the given [KeyKind] identity.
@@ -110,7 +122,12 @@ func RegisterKeyImporterI(from any, conv KeyImporter) {
 // Multiple exporters can be registered for the same identity. They are tried
 // in reverse registration order (last registered is tried first). An exporter
 // can return [ContinueError] to decline a key and let the next exporter try.
-func RegisterKeyExporter(ident KeyKind, conv KeyExporter) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterKeyExporter(ident KeyKind, conv KeyExporter) error {
 	muKeyExporters.Lock()
 	defer muKeyExporters.Unlock()
 	norm := ident.normalize()
@@ -121,6 +138,7 @@ func RegisterKeyExporter(ident KeyKind, conv KeyExporter) {
 		convs = append([]KeyExporter{conv}, convs...)
 	}
 	keyExporters[norm] = convs
+	return nil
 }
 
 // KeyImporter is used to convert from a raw key to a `jwk.Key`. mneumonic: from the PoV of the `jwk.Key`,

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -16,11 +16,11 @@ import (
 )
 
 func init() {
-	ourecdsa.RegisterCurve(jwa.P256(), elliptic.P256())
-	ourecdsa.RegisterCurve(jwa.P384(), elliptic.P384())
-	ourecdsa.RegisterCurve(jwa.P521(), elliptic.P521())
+	panicOnRegistrationError(ourecdsa.RegisterCurve(jwa.P256(), elliptic.P256()))
+	panicOnRegistrationError(ourecdsa.RegisterCurve(jwa.P384(), elliptic.P384()))
+	panicOnRegistrationError(ourecdsa.RegisterCurve(jwa.P521(), elliptic.P521()))
 
-	RegisterKeyExporter(KeyKind(jwa.EC().String()), KeyExportFunc(ecdsaJWKToRaw))
+	panicOnRegistrationError(RegisterKeyExporter(KeyKind(jwa.EC().String()), KeyExportFunc(ecdsaJWKToRaw)))
 }
 
 func (k *ecdsaPublicKey) Import(rawKey *ecdsa.PublicKey) error {

--- a/jwk/ecdsa/ecdsa.go
+++ b/jwk/ecdsa/ecdsa.go
@@ -22,14 +22,20 @@ func init() {
 
 // RegisterCurve registers a jwa.EllipticCurveAlgorithm constant and its
 // corresponding elliptic.Curve object. Users do not need to call this unless
-// they are registering a new ECDSA key type
-func RegisterCurve(alg jwa.EllipticCurveAlgorithm, crv elliptic.Curve) {
+// they are registering a new ECDSA key type.
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterCurve(alg jwa.EllipticCurveAlgorithm, crv elliptic.Curve) error {
 	muCurves.Lock()
 	defer muCurves.Unlock()
 
 	algToCurveMap[alg] = crv
 	curveToAlgMap[crv] = alg
 	rebuildCurves()
+	return nil
 }
 
 func rebuildCurves() {

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -597,8 +597,14 @@ type CustomDecodeFunc[T any] = json.CustomDecodeFunc[T]
 // and you try to roundtrip from an object to JSON, and then back to an object.
 // To avoid this, it's always better to use a custom type
 // that wraps your desired type and implement MarshalJSON and UnmarshalJSON.
-func RegisterCustomField[T any](name string) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterCustomField[T any](name string) error {
 	json.RegisterTyped[T](fieldRegistry, name)
+	return nil
 }
 
 // RegisterCustomDecoder registers a private field with a custom decoder
@@ -614,8 +620,14 @@ func RegisterCustomField[T any](name string) {
 //	  }
 //	  return time.Parse(time.RFC1123, s)
 //	}))
-func RegisterCustomDecoder[T any](name string, dec CustomDecodeFunc[T]) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterCustomDecoder[T any](name string, dec CustomDecodeFunc[T]) error {
 	json.RegisterCustomDecoder[T](fieldRegistry, name, dec)
+	return nil
 }
 
 // UnregisterCustomField removes the registration for a custom field.

--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -136,10 +136,16 @@ var muOKPRawKeyImporters sync.RWMutex
 var okpRawKeyImporters []OKPRawKeyImporter
 
 // RegisterOKPRawKeyImporter registers a function that can import raw keys as OKP keys.
-func RegisterOKPRawKeyImporter(fn OKPRawKeyImporter) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterOKPRawKeyImporter(fn OKPRawKeyImporter) error {
 	muOKPRawKeyImporters.Lock()
 	defer muOKPRawKeyImporters.Unlock()
 	okpRawKeyImporters = append(okpRawKeyImporters, fn)
+	return nil
 }
 
 func buildOKPPublicKey(alg jwa.EllipticCurveAlgorithm, xbuf []byte) (any, error) {

--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	RegisterKeyExporter(KeyKind(jwa.OKP().String()), KeyExportFunc(okpJWKToRaw))
+	panicOnRegistrationError(RegisterKeyExporter(KeyKind(jwa.OKP().String()), KeyExportFunc(okpJWKToRaw)))
 }
 
 // Pre-computed normalized KeyKind values for built-in OKP curves.

--- a/jwk/parser.go
+++ b/jwk/parser.go
@@ -47,10 +47,16 @@ var keyParsers = []KeyParser{KeyParseFunc(defaultParseKey)}
 // RegisterKeyParser adds a new KeyParser. Parsers are called in FILO order.
 // That is, the last parser to be registered is called first. There is no
 // check for duplicate entries.
-func RegisterKeyParser(kp KeyParser) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterKeyParser(kp KeyParser) error {
 	muKeyParser.Lock()
 	defer muKeyParser.Unlock()
 	keyParsers = append(keyParsers, kp)
+	return nil
 }
 
 func defaultParseKey(probe *KeyProbe, unmarshaler KeyUnmarshaler, data []byte) (Key, error) {

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	RegisterKeyExporter(KeyKind(jwa.RSA().String()), KeyExportFunc(rsaJWKToRaw))
+	panicOnRegistrationError(RegisterKeyExporter(KeyKind(jwa.RSA().String()), KeyExportFunc(rsaJWKToRaw)))
 }
 
 func (k *rsaPrivateKey) Import(rawKey *rsa.PrivateKey) error {

--- a/jwk/symmetric.go
+++ b/jwk/symmetric.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	RegisterKeyExporter(KeyKind(jwa.OctetSeq().String()), KeyExportFunc(octetSeqToRaw))
+	panicOnRegistrationError(RegisterKeyExporter(KeyKind(jwa.OctetSeq().String()), KeyExportFunc(octetSeqToRaw)))
 }
 
 func (k *symmetricKey) Import(rawKey []byte) error {

--- a/jwk/usage.go
+++ b/jwk/usage.go
@@ -20,10 +20,16 @@ var muKeyUsageName sync.RWMutex
 //
 // Furthermore, the check against registered values can be completely turned off
 // by setting the global option `jwk.WithStrictKeyUsage(false)`.
-func RegisterKeyUsage(v string) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterKeyUsage(v string) error {
 	muKeyUsageName.Lock()
 	defer muKeyUsageName.Unlock()
 	keyUsageNames[v] = struct{}{}
+	return nil
 }
 
 func UnregisterKeyUsage(v string) {
@@ -34,8 +40,12 @@ func UnregisterKeyUsage(v string) {
 
 func init() {
 	strictKeyUsage.Store(true)
-	RegisterKeyUsage("sig")
-	RegisterKeyUsage("enc")
+	if err := RegisterKeyUsage("sig"); err != nil {
+		panic(fmt.Sprintf("jwk: failed to register builtin KeyUsage: %s", err))
+	}
+	if err := RegisterKeyUsage("enc"); err != nil {
+		panic(fmt.Sprintf("jwk: failed to register builtin KeyUsage: %s", err))
+	}
 }
 
 func isValidUsage(v string) bool {

--- a/jwk/x509.go
+++ b/jwk/x509.go
@@ -158,9 +158,11 @@ var x509DecoderList = []X509Decoder{}
 type identDefaultX509Decoder struct{}
 
 func init() {
-	RegisterX509Decoder(identDefaultX509Decoder{}, X509DecodeFunc(func(block *pem.Block) (any, error) {
+	if err := RegisterX509Decoder(identDefaultX509Decoder{}, X509DecodeFunc(func(block *pem.Block) (any, error) {
 		return jwkbb.DecodeX509(block)
-	}))
+	})); err != nil {
+		panic(fmt.Sprintf("jwk: failed to register default X509 decoder: %s", err))
+	}
 }
 
 // RegisterX509Decoder registers a new X509Decoder that can decode PEM encoded ASN.1 DER format.
@@ -168,7 +170,12 @@ func init() {
 // as a map key to identify the decoder.
 //
 // This function is experimental, and may change in the future.
-func RegisterX509Decoder(ident any, decoder X509Decoder) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterX509Decoder(ident any, decoder X509Decoder) error {
 	if decoder == nil {
 		panic(`jwk.RegisterX509Decoder: decoder cannot be nil`)
 	}
@@ -176,11 +183,12 @@ func RegisterX509Decoder(ident any, decoder X509Decoder) {
 	muX509Decoders.Lock()
 	defer muX509Decoders.Unlock()
 	if _, ok := x509Decoders[ident]; ok {
-		return // already registered
+		return nil // already registered
 	}
 
 	x509Decoders[ident] = len(x509DecoderList)
 	x509DecoderList = append(x509DecoderList, decoder)
+	return nil
 }
 
 // UnregisterX509Decoder unregisters the X509Decoder identified by the given identifier.

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -448,8 +448,14 @@ type CustomDecodeFunc[T any] = json.CustomDecodeFunc[T]
 //
 // For more fine-tuned control over the decoding process,
 // use RegisterCustomDecoder instead.
-func RegisterCustomField[T any](name string) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterCustomField[T any](name string) error {
 	json.RegisterTyped[T](registry, name)
+	return nil
 }
 
 // RegisterCustomDecoder registers a private field with a custom decoder
@@ -462,8 +468,14 @@ func RegisterCustomField[T any](name string) {
 //	  }
 //	  return time.Parse(time.RFC1123, s)
 //	}))
-func RegisterCustomDecoder[T any](name string, dec CustomDecodeFunc[T]) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterCustomDecoder[T any](name string, dec CustomDecodeFunc[T]) error {
 	json.RegisterCustomDecoder[T](registry, name, dec)
+	return nil
 }
 
 // UnregisterCustomField removes the registration for a custom field.
@@ -477,26 +489,44 @@ var keyTypeToAlgorithms = make(map[jwa.KeyType][]jwa.SignatureAlgorithm)
 var curveToAlgorithms = make(map[jwa.EllipticCurveAlgorithm][]jwa.SignatureAlgorithm)
 
 func init() {
-	RegisterAlgorithmForKeyType(jwa.OKP(), jwa.EdDSA())
-	RegisterAlgorithmForCurve(jwa.Ed25519(), jwa.EdDSAEd25519())
+	mustRegisterAlgorithmForKeyType(jwa.OKP(), jwa.EdDSA())
+	mustRegisterAlgorithmForCurve(jwa.Ed25519(), jwa.EdDSAEd25519())
 	for _, alg := range []jwa.SignatureAlgorithm{jwa.HS256(), jwa.HS384(), jwa.HS512()} {
-		RegisterAlgorithmForKeyType(jwa.OctetSeq(), alg)
+		mustRegisterAlgorithmForKeyType(jwa.OctetSeq(), alg)
 	}
 	for _, alg := range []jwa.SignatureAlgorithm{jwa.RS256(), jwa.RS384(), jwa.RS512(), jwa.PS256(), jwa.PS384(), jwa.PS512()} {
-		RegisterAlgorithmForKeyType(jwa.RSA(), alg)
+		mustRegisterAlgorithmForKeyType(jwa.RSA(), alg)
 	}
 	for _, alg := range []jwa.SignatureAlgorithm{jwa.ES256(), jwa.ES384(), jwa.ES512()} {
-		RegisterAlgorithmForKeyType(jwa.EC(), alg)
+		mustRegisterAlgorithmForKeyType(jwa.EC(), alg)
+	}
+}
+
+func mustRegisterAlgorithmForKeyType(kty jwa.KeyType, alg jwa.SignatureAlgorithm) {
+	if err := RegisterAlgorithmForKeyType(kty, alg); err != nil {
+		panic(fmt.Sprintf("jws: failed to register builtin algorithm for key type: %s", err))
+	}
+}
+
+func mustRegisterAlgorithmForCurve(crv jwa.EllipticCurveAlgorithm, alg jwa.SignatureAlgorithm) {
+	if err := RegisterAlgorithmForCurve(crv, alg); err != nil {
+		panic(fmt.Sprintf("jws: failed to register builtin algorithm for curve: %s", err))
 	}
 }
 
 // RegisterAlgorithmForKeyType registers an additional algorithm as valid for
 // the given key type. This is used internally by init() and can also be called
 // from external modules that provide support for additional algorithms (e.g. Ed448).
-func RegisterAlgorithmForKeyType(kty jwa.KeyType, alg jwa.SignatureAlgorithm) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterAlgorithmForKeyType(kty jwa.KeyType, alg jwa.SignatureAlgorithm) error {
 	muAlgorithmMaps.Lock()
 	defer muAlgorithmMaps.Unlock()
 	keyTypeToAlgorithms[kty] = append(keyTypeToAlgorithms[kty], alg)
+	return nil
 }
 
 // RegisterAlgorithmForCurve registers an algorithm as valid for the given
@@ -506,13 +536,19 @@ func RegisterAlgorithmForKeyType(kty jwa.KeyType, alg jwa.SignatureAlgorithm) {
 //
 // This function is append-only and deduplicates entries, so builtin
 // registrations cannot be overwritten by external modules.
-func RegisterAlgorithmForCurve(crv jwa.EllipticCurveAlgorithm, alg jwa.SignatureAlgorithm) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterAlgorithmForCurve(crv jwa.EllipticCurveAlgorithm, alg jwa.SignatureAlgorithm) error {
 	muAlgorithmMaps.Lock()
 	defer muAlgorithmMaps.Unlock()
 	if slices.Contains(curveToAlgorithms[crv], alg) {
-		return
+		return nil
 	}
 	curveToAlgorithms[crv] = append(curveToAlgorithms[crv], alg)
+	return nil
 }
 
 // AlgorithmsForKey returns the possible signature algorithms that can

--- a/jws/jwsbb/jwsbb.go
+++ b/jws/jwsbb/jwsbb.go
@@ -95,8 +95,14 @@ func init() {
 // RegisterDsigAlgorithm registers a mapping from a JWS algorithm name
 // to a dsig algorithm name. This allows extension modules to add support
 // for new algorithms that use the default signer/verifier dispatch.
-func RegisterDsigAlgorithm(jwsAlg, dsigAlg string) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterDsigAlgorithm(jwsAlg, dsigAlg string) error {
 	dsigAlgorithmDB.Store(jwsAlg, dsigAlg)
+	return nil
 }
 
 // getDsigAlgorithm returns the dsig algorithm name for a JWS algorithm

--- a/jws/signer.go
+++ b/jws/signer.go
@@ -61,8 +61,16 @@ func SignerFor(alg jwa.SignatureAlgorithm) (Signer, error) {
 // If you want to completely remove an algorithm, you must call
 // jwa.UnregisterSignatureAlgorithm yourself after calling
 // UnregisterSigner.
+//
+// The error return is reserved for future validation (duplicate detection,
+// identifier rules, freeze-point enforcement, etc). The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
 func RegisterSigner(alg jwa.SignatureAlgorithm, s Signer) error {
-	jwa.RegisterSignatureAlgorithm(alg)
+	if err := jwa.RegisterSignatureAlgorithm(alg); err != nil {
+		return fmt.Errorf(`jws.RegisterSigner: failed to register signature algorithm: %w`, err)
+	}
 	signerDB.Store(alg, s)
 	return nil
 }

--- a/jws/verifier.go
+++ b/jws/verifier.go
@@ -1,6 +1,7 @@
 package jws
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/lestrrat-go/jwx/v4/jwa"
@@ -49,8 +50,16 @@ func VerifierFor(alg jwa.SignatureAlgorithm) (Verifier, error) {
 //
 // This function also calls jwa.RegisterSignatureAlgorithm to register
 // the algorithm in this module's algorithm database.
+//
+// The error return is reserved for future validation (duplicate detection,
+// identifier rules, freeze-point enforcement, etc). The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
 func RegisterVerifier(alg jwa.SignatureAlgorithm, v Verifier) error {
-	jwa.RegisterSignatureAlgorithm(alg)
+	if err := jwa.RegisterSignatureAlgorithm(alg); err != nil {
+		return fmt.Errorf(`jws.RegisterVerifier: failed to register signature algorithm: %w`, err)
+	}
 	verifierDB.Store(alg, v)
 	return nil
 }

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -562,8 +562,14 @@ type CustomDecodeFunc[T any] = json.CustomDecodeFunc[T]
 //
 // For more fine-tuned control over the decoding process,
 // use RegisterCustomDecoder instead.
-func RegisterCustomField[T any](name string) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterCustomField[T any](name string) error {
 	json.RegisterTyped[T](registry, name)
+	return nil
 }
 
 // RegisterCustomDecoder registers a private claim with a custom decoder
@@ -576,8 +582,14 @@ func RegisterCustomField[T any](name string) {
 //	  }
 //	  return time.Parse(time.RFC1123, s)
 //	}))
-func RegisterCustomDecoder[T any](name string, dec CustomDecodeFunc[T]) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterCustomDecoder[T any](name string, dec CustomDecodeFunc[T]) error {
 	json.RegisterCustomDecoder[T](registry, name, dec)
+	return nil
 }
 
 // UnregisterCustomField removes the registration for a custom field.

--- a/jwt/openid/openid.go
+++ b/jwt/openid/openid.go
@@ -24,14 +24,26 @@ func (t *stdToken) Clone() (jwt.Token, error) {
 // using json.Unmarshal. This option has a global effect.
 //
 //	openid.RegisterCustomField[time.Time](`x-birthday`)
-func RegisterCustomField[T any](name string) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterCustomField[T any](name string) error {
 	json.RegisterTyped[T](registry, name)
+	return nil
 }
 
 // RegisterCustomDecoder registers a private claim with a custom decoder
 // function. This option has a global effect.
-func RegisterCustomDecoder[T any](name string, dec json.CustomDecodeFunc[T]) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func RegisterCustomDecoder[T any](name string, dec json.CustomDecodeFunc[T]) error {
 	json.RegisterCustomDecoder[T](registry, name, dec)
+	return nil
 }
 
 // UnregisterCustomField removes the registration for a custom field.


### PR DESCRIPTION
Every public `Register*` across `jwa`, `jwk`, `jws`, `jwsbb`, `jwe`, `jwebb`, `jwt`, and `jwt/openid` now returns `error`. Today every body still returns `nil`, but the signature reserves room to codify future error modes (duplicate detection, identifier validation, freeze-point enforcement) without another API break.

The `jwa` generator template and the generated `jwa/*_gen.go` files are updated to match. `jws.RegisterSigner` / `jws.RegisterVerifier` already returned error; they now also propagate failures from the underlying `jwa.RegisterSignatureAlgorithm`.

Convention captured in `.claude/docs/internals.md` and `.claude/docs/companions.md` — extension modules must check the return value and panic on failure during `init()`. User-facing note added to `docs/10-extensions.md`. Companion modules are updated in separate PRs in their respective repos.

Motivated by review finding EXT-104.
