### PR TITLE
reject empty ciphertext/iv/tag in jwe.Message.UnmarshalJSON

### DIFF
--- a/jwe/message.go
+++ b/jwe/message.go
@@ -407,29 +407,36 @@ func (m *Message) UnmarshalJSON(buf []byte) error {
 		m.authenticatedData = v
 	}
 
-	if src := proxy.CipherText; len(src) > 0 {
-		v, err := base64.DecodeString(src)
-		if err != nil {
-			return fmt.Errorf(`failed to decode "ciphertext": %w`, err)
-		}
-		m.cipherText = v
+	// RFC 7516 §7.2: "ciphertext", "iv", and "tag" MUST be present and
+	// non-empty for any AEAD-protected JWE. Reject missing/empty values
+	// here so that a zero-length authentication tag cannot reach the
+	// AEAD verification code path.
+	if len(proxy.CipherText) == 0 {
+		return fmt.Errorf(`missing or empty "ciphertext" field`)
 	}
+	ctbuf, err := base64.DecodeString(proxy.CipherText)
+	if err != nil {
+		return fmt.Errorf(`failed to decode "ciphertext": %w`, err)
+	}
+	m.cipherText = ctbuf
 
-	if src := proxy.InitializationVector; len(src) > 0 {
-		v, err := base64.DecodeString(src)
-		if err != nil {
-			return fmt.Errorf(`failed to decode "iv": %w`, err)
-		}
-		m.initializationVector = v
+	if len(proxy.InitializationVector) == 0 {
+		return fmt.Errorf(`missing or empty "iv" field`)
 	}
+	ivbuf, err := base64.DecodeString(proxy.InitializationVector)
+	if err != nil {
+		return fmt.Errorf(`failed to decode "iv": %w`, err)
+	}
+	m.initializationVector = ivbuf
 
-	if src := proxy.Tag; len(src) > 0 {
-		v, err := base64.DecodeString(src)
-		if err != nil {
-			return fmt.Errorf(`failed to decode "tag": %w`, err)
-		}
-		m.tag = v
+	if len(proxy.Tag) == 0 {
+		return fmt.Errorf(`missing or empty "tag" field`)
 	}
+	tagbuf, err := base64.DecodeString(proxy.Tag)
+	if err != nil {
+		return fmt.Errorf(`failed to decode "tag": %w`, err)
+	}
+	m.tag = tagbuf
 
 	m.protectedHeaders = h
 	if m.storeProtectedHeaders {

--- a/jwe/message_test.go
+++ b/jwe/message_test.go
@@ -21,3 +21,28 @@ func TestRecipient(t *testing.T) {
 		require.Equal(t, []byte(src), buf, `json representation should match`)
 	})
 }
+
+// TestJWEJSONRejectsEmptyCryptoFields pins RFC 7516 §7.2 — "ciphertext", "iv",
+// and "tag" MUST be present and non-empty. Without this check, a zero-length
+// authentication tag would reach the AEAD verification code path.
+func TestJWEJSONRejectsEmptyCryptoFields(t *testing.T) {
+	// Minimal protected headers "{}" base64url-encoded = "e30".
+	testcases := []struct {
+		name string
+		body string
+	}{
+		{"missing ciphertext", `{"protected":"e30","iv":"AAAA","tag":"AAAA","recipients":[{}]}`},
+		{"empty ciphertext", `{"protected":"e30","ciphertext":"","iv":"AAAA","tag":"AAAA","recipients":[{}]}`},
+		{"missing iv", `{"protected":"e30","ciphertext":"AAAA","tag":"AAAA","recipients":[{}]}`},
+		{"empty iv", `{"protected":"e30","ciphertext":"AAAA","iv":"","tag":"AAAA","recipients":[{}]}`},
+		{"missing tag", `{"protected":"e30","ciphertext":"AAAA","iv":"AAAA","recipients":[{}]}`},
+		{"empty tag", `{"protected":"e30","ciphertext":"AAAA","iv":"AAAA","tag":"","recipients":[{}]}`},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := jwe.Parse([]byte(tc.body))
+			require.Error(t, err, `jwe.Parse should reject JWE JSON with missing/empty crypto fields`)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `jwe.Message.UnmarshalJSON` now rejects JSON serialized JWEs with missing or empty `ciphertext`, `iv`, or `tag`, per RFC 7516 §7.2
- prevents a zero length authentication tag from reaching the AEAD verification code path
- regression test `TestJWEJSONRejectsEmptyCryptoFields` in `jwe/message_test.go` pins the six missing/empty variants
