### PR TITLE
document VerifyCompactFast b64:true assumption

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -754,6 +754,15 @@ func Settings(options ...GlobalOption) {
 // 4.1.11 "crit" (Critical) header validation. If your application processes
 // messages that may carry a "crit" header, use jws.Verify() with
 // jws.WithCritValidation(true) and jws.WithCritExtension(...) instead.
+//
+// VerifyCompactFast also assumes the JWS uses the default "b64":true
+// (base64url-encoded) payload encoding. JWSs that declare "b64":false
+// (RFC 7797), carry a detached payload, or otherwise rely on "crit"
+// semantics must be verified with jws.Verify() instead — jws.Verify()
+// handles all RFC 7797 and "crit" cases, including auto-allowlisting
+// "b64" in "crit" when jws.WithDetachedPayload is used. A conforming
+// b64:false JWS is required by RFC 7797 Section 5 to list "b64" in
+// "crit", so it is already outside VerifyCompactFast's contract.
 func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]byte, error) {
 	if err := validateAlgorithmForKey(alg, key); err != nil {
 		return nil, makeVerifyError(`%w`, err)


### PR DESCRIPTION
## Summary
- document that `VerifyCompactFast` assumes `b64:true` and that RFC 7797 / detached / `crit` callers must use `jws.Verify`
- no code change: the fast path has no options parameter, so detached callers already can't reach it; RFC 7797 `b64:false` JWSs are required to list `"b64"` in `crit`, which the fast path already excludes by contract

Closes JWS-001 (verify side) as documented scope.
