### PR TITLE
document ClaimValidationError value sensitivity

### DIFF
--- a/jwt/errors.go
+++ b/jwt/errors.go
@@ -292,14 +292,23 @@ func missingRequiredClaimErrorf(name string) error {
 
 // ClaimValidationError is returned when a generic claim validator
 // (ClaimValueIs, ClaimContainsString) detects a mismatch.
+//
+// The Error() message intentionally omits the Expected and Actual
+// values so that arbitrary claim payloads do not end up in log output
+// via "%v"/"%s" formatting. Callers that need to inspect the mismatched
+// values can access the fields directly, but should treat them as
+// potentially sensitive (PII, secrets, etc.) and avoid logging them
+// verbatim.
 type ClaimValidationError struct {
 	error
 
 	// Claim is the name of the claim that failed validation.
 	Claim string
-	// Expected is the value the validator expected.
+	// Expected is the value the validator expected. May contain
+	// sensitive data; see the type-level godoc.
 	Expected any
-	// Actual is the value found in the token.
+	// Actual is the value found in the token. May contain sensitive
+	// data (PII, secrets, etc.); see the type-level godoc.
 	Actual any
 }
 

--- a/jwt/structured_errors_test.go
+++ b/jwt/structured_errors_test.go
@@ -2,6 +2,7 @@ package jwt_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -93,6 +94,14 @@ func TestStructuredErrors(t *testing.T) {
 		require.Equal(t, jwt.SubjectKey, claimErr.Claim)
 		require.Equal(t, "expected-subject", claimErr.Expected)
 		require.Equal(t, "actual-subject", claimErr.Actual)
+
+		// Error() message must not leak claim values via fmt verbs.
+		// See ClaimValidationError godoc.
+		for _, verb := range []string{"%s", "%v", "%+v"} {
+			msg := fmt.Sprintf(verb, err)
+			require.NotContains(t, msg, "expected-subject", verb)
+			require.NotContains(t, msg, "actual-subject", verb)
+		}
 	})
 
 	t.Run("ClaimValidationError from ClaimContainsString", func(t *testing.T) {
@@ -113,6 +122,12 @@ func TestStructuredErrors(t *testing.T) {
 		require.Equal(t, "groups", claimErr.Claim)
 		require.Equal(t, "superadmin", claimErr.Expected)
 		require.Equal(t, []string{"admin", "user"}, claimErr.Actual)
+
+		for _, verb := range []string{"%s", "%v", "%+v"} {
+			msg := fmt.Sprintf(verb, err)
+			require.NotContains(t, msg, "superadmin", verb)
+			require.NotContains(t, msg, "admin", verb)
+		}
 	})
 
 	t.Run("issuer/audience still use typed errors not ClaimValidationError", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Godoc on `ClaimValidationError` and its `Expected`/`Actual` fields warning callers to treat values as potentially sensitive (PII, secrets) and avoid logging them verbatim.
- Regression test asserting `%s`/`%v`/`%+v` formatting of the error never leaks claim values.

Addresses JWT-003 from the internal review. `Error()` already omits values; only direct field access exposes them, which is the intended programmatic API — docs + a lock-in test are the appropriate fix.
