### PR TITLE
docs: list v4 as supported in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,7 @@ Most recent two major versions will receive security updates
 
 | Version  | Supported          |
 | -------- | ------------------ |
+| v4.x.x   | :white_check_mark: (preview) |
 | v3.x.x   | :white_check_mark: |
 | v2.x.x   | :white_check_mark: |
 | < v2.0.0 | :x:                |


### PR DESCRIPTION
Adds v4.x.x (preview) to the supported versions table. Closes DOC-004.