### PR TITLE
reslice pooled jwe buffers before defer

### DIFF
--- a/jwe/internal/aescbc/aescbc.go
+++ b/jwe/internal/aescbc/aescbc.go
@@ -248,9 +248,8 @@ func (c Hmac) Open(dst, nonce, ciphertext, data []byte) ([]byte, error) {
 	}
 
 	cbc := cipher.NewCBCDecrypter(c.blockCipher, nonce)
-	buf := pool.ByteSlice().GetCapacity(tagOffset)
+	buf := pool.ByteSlice().GetCapacity(tagOffset)[:tagOffset]
 	defer pool.ByteSlice().Put(buf)
-	buf = buf[:tagOffset]
 
 	cbc.CryptBlocks(buf, ciphertext)
 

--- a/jwe/jwebb/keywrap.go
+++ b/jwe/jwebb/keywrap.go
@@ -23,13 +23,11 @@ func Wrap(kek cipher.Block, cek []byte) ([]byte, error) {
 	rBuf := make([]byte, n*tokens.KeywrapChunkLen)
 	copy(rBuf, cek)
 
-	buffer := pool.ByteSlice().GetCapacity(tokens.KeywrapChunkLen * 2)
+	buffer := pool.ByteSlice().GetCapacity(tokens.KeywrapChunkLen * 2)[:tokens.KeywrapChunkLen*2]
 	defer pool.ByteSlice().Put(buffer)
-	buffer = buffer[:tokens.KeywrapChunkLen*2]
 
-	tBytes := pool.ByteSlice().GetCapacity(tokens.KeywrapChunkLen)
+	tBytes := pool.ByteSlice().GetCapacity(tokens.KeywrapChunkLen)[:tokens.KeywrapChunkLen]
 	defer pool.ByteSlice().Put(tBytes)
-	tBytes = tBytes[:tokens.KeywrapChunkLen]
 
 	copy(buffer, keywrapDefaultIV)
 
@@ -65,13 +63,11 @@ func Unwrap(block cipher.Block, ciphertxt []byte) ([]byte, error) {
 	rBuf := make([]byte, n*tokens.KeywrapChunkLen)
 	copy(rBuf, ciphertxt[tokens.KeywrapChunkLen:])
 
-	buffer := pool.ByteSlice().GetCapacity(tokens.KeywrapChunkLen * 2)
+	buffer := pool.ByteSlice().GetCapacity(tokens.KeywrapChunkLen * 2)[:tokens.KeywrapChunkLen*2]
 	defer pool.ByteSlice().Put(buffer)
-	buffer = buffer[:tokens.KeywrapChunkLen*2]
 
-	tBytes := pool.ByteSlice().GetCapacity(tokens.KeywrapChunkLen)
+	tBytes := pool.ByteSlice().GetCapacity(tokens.KeywrapChunkLen)[:tokens.KeywrapChunkLen]
 	defer pool.ByteSlice().Put(tBytes)
-	tBytes = tBytes[:tokens.KeywrapChunkLen]
 
 	copy(buffer[:tokens.KeywrapChunkLen], ciphertxt[:tokens.KeywrapChunkLen])
 


### PR DESCRIPTION
## Summary
- JWE-INT-001: `defer pool.ByteSlice().Put(buf)` captured `buf` before the subsequent reslice, returning a zero-length view to the pool
- reslice the pool buffer in the same statement as `GetCapacity` so the defer sees the correct length
- affects `jwe/internal/aescbc/aescbc.go` (Open) and `jwe/jwebb/keywrap.go` (Wrap/Unwrap)
- latent only: `freeByteSlice` already scrubs `[0:cap)`, so this is defense-in-depth against a future destructor regression
