### PR TITLE
add jwe.WithPBES2Count encrypt option

### DIFF
--- a/examples/jwe_encrypt_pbes2_count_example_test.go
+++ b/examples/jwe_encrypt_pbes2_count_example_test.go
@@ -1,0 +1,35 @@
+package examples_test
+
+import (
+	"fmt"
+
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwe"
+)
+
+func Example_jwe_encrypt_pbes2_count() {
+	password := []byte(`supersecret`)
+	payload := []byte(`Lorem ipsum`)
+
+	// Raise the PBKDF2 iteration count on the encrypt side. For
+	// round-tripping with jwe.Decrypt the default max (10000) must also
+	// be raised; see jwe.WithMaxPBES2Count.
+	encrypted, err := jwe.Encrypt(
+		payload,
+		jwe.WithKey(jwa.PBES2_HS256_A128KW(), password),
+		jwe.WithPBES2Count(8192),
+	)
+	if err != nil {
+		fmt.Printf("failed to encrypt payload: %s\n", err)
+		return
+	}
+
+	decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.PBES2_HS256_A128KW(), password))
+	if err != nil {
+		fmt.Printf("failed to decrypt payload: %s\n", err)
+		return
+	}
+	fmt.Printf("%s\n", decrypted)
+	// OUTPUT:
+	// Lorem ipsum
+}

--- a/jwe/encrypt.go
+++ b/jwe/encrypt.go
@@ -17,12 +17,13 @@ import (
 //
 //nolint:govet
 type encrypter struct {
-	apu    []byte
-	apv    []byte
-	ctalg  jwa.ContentEncryptionAlgorithm
-	keyalg jwa.KeyEncryptionAlgorithm
-	pubkey any
-	rawKey any
+	apu        []byte
+	apv        []byte
+	ctalg      jwa.ContentEncryptionAlgorithm
+	keyalg     jwa.KeyEncryptionAlgorithm
+	pubkey     any
+	rawKey     any
+	pbes2Count int
 }
 
 // newEncrypter creates a new Encrypter instance with all required parameters.
@@ -32,14 +33,15 @@ type encrypter struct {
 // *rsa.PublicKey, instead of jwk.Key)
 //
 // You should consider this object immutable once created.
-func newEncrypter(keyalg jwa.KeyEncryptionAlgorithm, ctalg jwa.ContentEncryptionAlgorithm, pubkey any, rawKey any, apu, apv []byte) *encrypter {
+func newEncrypter(keyalg jwa.KeyEncryptionAlgorithm, ctalg jwa.ContentEncryptionAlgorithm, pubkey any, rawKey any, apu, apv []byte, pbes2Count int) *encrypter {
 	return &encrypter{
-		apu:    apu,
-		apv:    apv,
-		ctalg:  ctalg,
-		keyalg: keyalg,
-		pubkey: pubkey,
-		rawKey: rawKey,
+		apu:        apu,
+		apv:        apv,
+		ctalg:      ctalg,
+		keyalg:     keyalg,
+		pubkey:     pubkey,
+		rawKey:     rawKey,
+		pbes2Count: pbes2Count,
 	}
 }
 
@@ -68,7 +70,7 @@ func (e *encrypter) EncryptKey(cek []byte) (keygen.ByteSource, error) {
 		if !ok {
 			return nil, fmt.Errorf("encrypt key: []byte is required as the password for %s (got %T)", keyalgStr, e.rawKey)
 		}
-		return jwebb.KeyEncryptPBES2(cek, keyalgStr, password)
+		return jwebb.KeyEncryptPBES2(cek, keyalgStr, password, e.pbes2Count)
 	}
 
 	if jwebb.IsAESGCMKW(keyalgStr) {

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -31,6 +31,7 @@ import (
 
 var maxPBES2Count atomic.Int64
 var minPBES2Count atomic.Int64
+var pbes2Count atomic.Int64
 var maxRecipients atomic.Int64
 var maxDecompressBufferSize atomic.Int64
 var maxParseInputSize atomic.Int64
@@ -38,6 +39,7 @@ var maxParseInputSize atomic.Int64
 func init() {
 	maxPBES2Count.Store(10000)
 	minPBES2Count.Store(1000)
+	pbes2Count.Store(int64(tokens.PBES2DefaultIterations))
 	maxRecipients.Store(100)
 	maxDecompressBufferSize.Store(10 * 1024 * 1024) // 10MB
 	maxParseInputSize.Store(10 * 1024 * 1024)       // 10MB
@@ -58,6 +60,15 @@ func Settings(options ...GlobalOption) {
 				panic(fmt.Sprintf("jwe.Settings: value for option WithMinPBES2Count must be an int: %s", err))
 			}
 			minPBES2Count.Store(int64(v))
+		case identPBES2Count{}:
+			var v int
+			if err := option.Value(&v); err != nil {
+				panic(fmt.Sprintf("jwe.Settings: value for option WithPBES2Count must be an int: %s", err))
+			}
+			if v <= 0 {
+				v = tokens.PBES2DefaultIterations
+			}
+			pbes2Count.Store(int64(v))
 		case identMaxRecipients{}:
 			var v int
 			if err := option.Value(&v); err != nil {
@@ -100,9 +111,10 @@ const (
 var registry = json.NewRegistry()
 
 type recipientBuilder struct {
-	alg     jwa.KeyEncryptionAlgorithm
-	key     any
-	headers Headers
+	alg        jwa.KeyEncryptionAlgorithm
+	key        any
+	headers    Headers
+	pbes2Count int
 }
 
 func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryptionAlgorithm, _ *content_crypt.Generic) ([]byte, error) {
@@ -147,7 +159,7 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 	}
 
 	// Create the encrypter using the new jwebb pattern
-	enc := newEncrypter(b.alg, calg, b.key, rawKey, apu, apv)
+	enc := newEncrypter(b.alg, calg, b.key, rawKey, apu, apv, b.pbes2Count)
 
 	_ = r.SetHeaders(hdr)
 
@@ -692,6 +704,7 @@ type encryptContext struct {
 	calg                jwa.ContentEncryptionAlgorithm
 	compression         jwa.CompressionAlgorithm
 	format              int
+	pbes2Count          int
 	builders            []*recipientBuilder
 	protected           Headers
 	legacyHeaderMerging bool
@@ -711,6 +724,7 @@ func freeEncryptContext(ec *encryptContext) *encryptContext {
 	ec.calg = jwa.A256GCM()
 	ec.compression = jwa.NoCompress()
 	ec.format = fmtCompact
+	ec.pbes2Count = 0
 	ec.builders = ec.builders[:0]
 	ec.protected = nil
 	return ec
@@ -718,6 +732,7 @@ func freeEncryptContext(ec *encryptContext) *encryptContext {
 
 func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
 	ec.legacyHeaderMerging = true
+	ec.pbes2Count = int(pbes2Count.Load())
 	var mergeProtected bool
 	var useRawCEK bool
 	for _, option := range options {
@@ -739,6 +754,14 @@ func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
 				key:     wk.key,
 				headers: wk.headers,
 			})
+		case identPBES2Count{}:
+			var v int
+			if err := option.Value(&v); err != nil {
+				return fmt.Errorf("jwe.encrypt: WithPBES2Count must be int: %w", err)
+			}
+			if v > 0 {
+				ec.pbes2Count = v
+			}
 		case identContentEncryptionAlgorithm{}:
 			var c jwa.ContentEncryptionAlgorithm
 			if err := option.Value(&c); err != nil {
@@ -908,6 +931,7 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 	defer recipientSlicePool.Put(recipients)
 
 	for i, builder := range ec.builders {
+		builder.pbes2Count = ec.pbes2Count
 		r := recipientPool.Get()
 		defer recipientPool.Put(r)
 

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -934,6 +934,66 @@ func TestPBES2CountPerCall(t *testing.T) {
 	})
 }
 
+func TestPBES2CountEncrypt(t *testing.T) {
+	password := []byte(`supersecret`)
+	key, err := jwk.Import(password)
+	require.NoError(t, err, `jwk.Import should succeed`)
+
+	payload := []byte(`hello world`)
+
+	t.Run("per-call WithPBES2Count reflected in p2c header and round-trips", func(t *testing.T) {
+		encrypted, err := jwe.Encrypt(payload,
+			jwe.WithKey(jwa.PBES2_HS256_A128KW(), key),
+			jwe.WithPBES2Count(2000),
+		)
+		require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+		msg, err := jwe.Parse(encrypted)
+		require.NoError(t, err, `jwe.Parse should succeed`)
+		var p2c float64
+		require.NoError(t, msg.ProtectedHeaders().Get("p2c", &p2c), `protected header should have p2c`)
+		require.Equal(t, float64(2000), p2c, `p2c should match WithPBES2Count value`)
+
+		decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+		require.NoError(t, err, `jwe.Decrypt should succeed`)
+		require.Equal(t, payload, decrypted, `decrypted payload should match`)
+	})
+
+	t.Run("per-call overrides Settings", func(t *testing.T) {
+		// NOTE: HAS GLOBAL EFFECT
+		jwe.Settings(jwe.WithPBES2Count(15000))
+		defer jwe.Settings(jwe.WithPBES2Count(10000))
+		// Decrypt with a raised max so both 15000 and 3000 round-trip.
+		jwe.Settings(jwe.WithMaxPBES2Count(20000))
+		defer jwe.Settings(jwe.WithMaxPBES2Count(10000))
+
+		// With only the global set, encrypt should use 15000.
+		encrypted, err := jwe.Encrypt(payload, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+		require.NoError(t, err, `jwe.Encrypt should succeed`)
+		msg, err := jwe.Parse(encrypted)
+		require.NoError(t, err)
+		var p2c float64
+		require.NoError(t, msg.ProtectedHeaders().Get("p2c", &p2c))
+		require.Equal(t, float64(15000), p2c, `p2c should match global setting`)
+
+		// Per-call option should win over global.
+		encrypted2, err := jwe.Encrypt(payload,
+			jwe.WithKey(jwa.PBES2_HS256_A128KW(), key),
+			jwe.WithPBES2Count(3000),
+		)
+		require.NoError(t, err)
+		msg2, err := jwe.Parse(encrypted2)
+		require.NoError(t, err)
+		var p2c2 float64
+		require.NoError(t, msg2.ProtectedHeaders().Get("p2c", &p2c2))
+		require.Equal(t, float64(3000), p2c2, `per-call WithPBES2Count should override global`)
+
+		decrypted, err := jwe.Decrypt(encrypted2, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+		require.NoError(t, err)
+		require.Equal(t, payload, decrypted)
+	})
+}
+
 func TestCBCBufferSize(t *testing.T) {
 	// NOTE: This has GLOBAL EFFECT
 	jwe.Settings(jwe.WithCBCBufferSize(1))

--- a/jwe/jwebb/decrypt_test.go
+++ b/jwe/jwebb/decrypt_test.go
@@ -41,7 +41,7 @@ func TestKeyDecryptPBES2(t *testing.T) {
 	cek := testCEK
 	password := testPassword
 
-	encrypted, err := jwebb.KeyEncryptPBES2(cek, tokens.PBES2_HS256_A128KW, password)
+	encrypted, err := jwebb.KeyEncryptPBES2(cek, tokens.PBES2_HS256_A128KW, password, tokens.PBES2DefaultIterations)
 	require.NoError(t, err)
 	require.NotNil(t, encrypted)
 

--- a/jwe/jwebb/jwebb_test.go
+++ b/jwe/jwebb/jwebb_test.go
@@ -208,7 +208,7 @@ func TestKeyEncryptPBES2(t *testing.T) {
 	cek := testCEK
 	password := testPassword
 
-	result, err := jwebb.KeyEncryptPBES2(cek, tokens.PBES2_HS256_A128KW, password)
+	result, err := jwebb.KeyEncryptPBES2(cek, tokens.PBES2_HS256_A128KW, password, tokens.PBES2DefaultIterations)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEqual(t, cek, result.Bytes())

--- a/jwe/jwebb/key_encrypt_symmetric.go
+++ b/jwe/jwebb/key_encrypt_symmetric.go
@@ -35,8 +35,11 @@ func KeyEncryptDirect(_ []byte, _ string, sharedkey []byte) (keygen.ByteSource, 
 	return keygen.ByteKey(sharedkey), nil
 }
 
-// KeyEncryptPBES2 encrypts the CEK using PBES2 password-based encryption
-func KeyEncryptPBES2(cek []byte, alg string, password []byte) (keygen.ByteSource, error) {
+// KeyEncryptPBES2 encrypts the CEK using PBES2 password-based encryption.
+// count is the PBKDF2 iteration count. If count <= 0, tokens.PBES2DefaultIterations
+// is used as a safety fallback; public callers go through jwe.Encrypt / jwe.Settings
+// and always provide a positive value via the WithPBES2Count option.
+func KeyEncryptPBES2(cek []byte, alg string, password []byte, count int) (keygen.ByteSource, error) {
 	var hashFunc func() hash.Hash
 	var keylen int
 
@@ -54,7 +57,9 @@ func KeyEncryptPBES2(cek []byte, alg string, password []byte) (keygen.ByteSource
 		return nil, fmt.Errorf(`unsupported PBES2 algorithm: %s`, alg)
 	}
 
-	count := tokens.PBES2DefaultIterations
+	if count <= 0 {
+		count = tokens.PBES2DefaultIterations
+	}
 	salt := make([]byte, keylen)
 	_, err := io.ReadFull(rand.Reader, salt)
 	if err != nil {

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -10,6 +10,12 @@ interfaces:
     methods:
       - globalOption
       - decryptOption
+  - name: GlobalEncryptOption
+    comment: |
+      GlobalEncryptOption describes options that changes global settings and for each call of the `jwe.Encrypt` function
+    methods:
+      - globalOption
+      - encryptOption
   - name: CompactOption
     comment: |
       CompactOption describes options that can be passed to `jwe.Compact`
@@ -167,6 +173,23 @@ options:
 
       This option can be used for `jwe.Settings()`, which changes the behavior
       globally, or for `jwe.Decrypt()`, which changes the behavior for that
+      specific call.
+  - ident: PBES2Count
+    interface: GlobalEncryptOption
+    argument_type: int
+    comment: |
+      WithPBES2Count specifies the number of PBKDF2 iterations to use when
+      encrypting a key with the PBES2 family of algorithms. If not specified,
+      the default value of 10,000 is used.
+
+      Modern guidance (OWASP 2023) recommends 600,000 or more for
+      PBKDF2-HMAC-SHA256. Callers handling long-lived or high-value tokens
+      should raise this value. Note that raising the encrypt-side count above
+      the decrypt-side WithMaxPBES2Count (default 10,000) will cause your own
+      messages to be rejected on decrypt until you also raise the max.
+
+      This option can be used for `jwe.Settings()`, which changes the behavior
+      globally, or for `jwe.Encrypt()`, which changes the behavior for that
       specific call.
   - ident: MaxRecipients
     interface: GlobalDecryptOption

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -180,13 +180,12 @@ options:
     comment: |
       WithPBES2Count specifies the number of PBKDF2 iterations to use when
       encrypting a key with the PBES2 family of algorithms. If not specified,
-      the default value of 10,000 is used.
+      the default value of 10,000 is used. Modern guidance (OWASP 2023)
+      recommends 600,000 or more for PBKDF2-HMAC-SHA256.
 
-      Modern guidance (OWASP 2023) recommends 600,000 or more for
-      PBKDF2-HMAC-SHA256. Callers handling long-lived or high-value tokens
-      should raise this value. Note that raising the encrypt-side count above
-      the decrypt-side WithMaxPBES2Count (default 10,000) will cause your own
-      messages to be rejected on decrypt until you also raise the max.
+      This option only affects encryption. Iteration counts on incoming
+      messages are validated separately on decrypt via WithMinPBES2Count
+      and WithMaxPBES2Count.
 
       This option can be used for `jwe.Settings()`, which changes the behavior
       globally, or for `jwe.Encrypt()`, which changes the behavior for that

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -78,6 +78,21 @@ func (*globalDecryptOption) globalOption() {}
 
 func (*globalDecryptOption) decryptOption() {}
 
+// GlobalEncryptOption describes options that changes global settings and for each call of the `jwe.Encrypt` function
+type GlobalEncryptOption interface {
+	Option
+	globalOption()
+	encryptOption()
+}
+
+type globalEncryptOption struct {
+	Option
+}
+
+func (*globalEncryptOption) globalOption() {}
+
+func (*globalEncryptOption) encryptOption() {}
+
 // GlobalOption describes options that changes global settings for this package
 type GlobalOption interface {
 	Option
@@ -172,6 +187,7 @@ type identMaxRecipients struct{}
 type identMergeProtectedHeaders struct{}
 type identMessage struct{}
 type identMinPBES2Count struct{}
+type identPBES2Count struct{}
 type identPerRecipientHeaders struct{}
 type identPretty struct{}
 type identProtectedHeaders struct{}
@@ -248,6 +264,10 @@ func (identMessage) String() string {
 
 func (identMinPBES2Count) String() string {
 	return "WithMinPBES2Count"
+}
+
+func (identPBES2Count) String() string {
+	return "WithPBES2Count"
 }
 
 func (identPerRecipientHeaders) String() string {
@@ -471,6 +491,23 @@ func WithMessage(v *Message) DecryptOption {
 // specific call.
 func WithMinPBES2Count(v int) GlobalDecryptOption {
 	return &globalDecryptOption{option.New(identMinPBES2Count{}, v)}
+}
+
+// WithPBES2Count specifies the number of PBKDF2 iterations to use when
+// encrypting a key with the PBES2 family of algorithms. If not specified,
+// the default value of 10,000 is used.
+//
+// Modern guidance (OWASP 2023) recommends 600,000 or more for
+// PBKDF2-HMAC-SHA256. Callers handling long-lived or high-value tokens
+// should raise this value. Note that raising the encrypt-side count above
+// the decrypt-side WithMaxPBES2Count (default 10,000) will cause your own
+// messages to be rejected on decrypt until you also raise the max.
+//
+// This option can be used for `jwe.Settings()`, which changes the behavior
+// globally, or for `jwe.Encrypt()`, which changes the behavior for that
+// specific call.
+func WithPBES2Count(v int) GlobalEncryptOption {
+	return &globalEncryptOption{option.New(identPBES2Count{}, v)}
 }
 
 // WithPretty specifies whether the JSON output should be formatted and

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -495,13 +495,12 @@ func WithMinPBES2Count(v int) GlobalDecryptOption {
 
 // WithPBES2Count specifies the number of PBKDF2 iterations to use when
 // encrypting a key with the PBES2 family of algorithms. If not specified,
-// the default value of 10,000 is used.
+// the default value of 10,000 is used. Modern guidance (OWASP 2023)
+// recommends 600,000 or more for PBKDF2-HMAC-SHA256.
 //
-// Modern guidance (OWASP 2023) recommends 600,000 or more for
-// PBKDF2-HMAC-SHA256. Callers handling long-lived or high-value tokens
-// should raise this value. Note that raising the encrypt-side count above
-// the decrypt-side WithMaxPBES2Count (default 10,000) will cause your own
-// messages to be rejected on decrypt until you also raise the max.
+// This option only affects encryption. Iteration counts on incoming
+// messages are validated separately on decrypt via WithMinPBES2Count
+// and WithMaxPBES2Count.
 //
 // This option can be used for `jwe.Settings()`, which changes the behavior
 // globally, or for `jwe.Encrypt()`, which changes the behavior for that

--- a/jwe/options_gen_test.go
+++ b/jwe/options_gen_test.go
@@ -27,6 +27,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithMergeProtectedHeaders", identMergeProtectedHeaders{}.String())
 	require.Equal(t, "WithMessage", identMessage{}.String())
 	require.Equal(t, "WithMinPBES2Count", identMinPBES2Count{}.String())
+	require.Equal(t, "WithPBES2Count", identPBES2Count{}.String())
 	require.Equal(t, "WithPerRecipientHeaders", identPerRecipientHeaders{}.String())
 	require.Equal(t, "WithPretty", identPretty{}.String())
 	require.Equal(t, "WithProtectedHeaders", identProtectedHeaders{}.String())


### PR DESCRIPTION
Adds a `WithPBES2Count(int)` option usable with both `jwe.Encrypt` and `jwe.Settings`, letting callers strengthen PBKDF2 iteration count on the encrypt side. Default stays at 10,000 so existing round-trips are unchanged. Addresses JWE-007.