### PR TITLE
add jwe.WithPBES2Count encrypt option

### DIFF
--- a/jwe/encrypt.go
+++ b/jwe/encrypt.go
@@ -13,7 +13,7 @@ import (
 
 // encryptKey dispatches key encryption to the appropriate algorithm-specific
 // function. This is a standalone function to avoid allocating an encrypter struct.
-func encryptKey(cek []byte, keyalg jwa.KeyEncryptionAlgorithm, ctalg jwa.ContentEncryptionAlgorithm, key any, apu, apv []byte) (keygen.ByteSource, error) {
+func encryptKey(cek []byte, keyalg jwa.KeyEncryptionAlgorithm, ctalg jwa.ContentEncryptionAlgorithm, key any, apu, apv []byte, pbes2Count int) (keygen.ByteSource, error) {
 	algStr := keyalg.String()
 	ctalgStr := ctalg.String()
 
@@ -29,7 +29,7 @@ func encryptKey(cek []byte, keyalg jwa.KeyEncryptionAlgorithm, ctalg jwa.Content
 		if err != nil {
 			return nil, err
 		}
-		return jwebb.KeyEncryptPBES2(cek, algStr, password)
+		return jwebb.KeyEncryptPBES2(cek, algStr, password, pbes2Count)
 	case jwebb.IsAESGCMKW(algStr):
 		sharedkey, err := requireByteKey(key, algStr)
 		if err != nil {

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -31,6 +31,7 @@ import (
 
 var maxPBES2Count atomic.Int64
 var minPBES2Count atomic.Int64
+var pbes2Count atomic.Int64
 var maxRecipients atomic.Int64
 var maxDecompressBufferSize atomic.Int64
 var maxParseInputSize atomic.Int64
@@ -38,6 +39,7 @@ var maxParseInputSize atomic.Int64
 func init() {
 	maxPBES2Count.Store(10000)
 	minPBES2Count.Store(1000)
+	pbes2Count.Store(int64(tokens.PBES2DefaultIterations))
 	maxRecipients.Store(100)
 	maxDecompressBufferSize.Store(10 * 1024 * 1024) // 10MB
 	maxParseInputSize.Store(10 * 1024 * 1024)       // 10MB
@@ -50,6 +52,12 @@ func Settings(options ...GlobalOption) {
 			maxPBES2Count.Store(int64(option.MustGet[int](opt)))
 		case identMinPBES2Count{}:
 			minPBES2Count.Store(int64(option.MustGet[int](opt)))
+		case identPBES2Count{}:
+			v := option.MustGet[int](opt)
+			if v <= 0 {
+				v = tokens.PBES2DefaultIterations
+			}
+			pbes2Count.Store(int64(v))
 		case identMaxRecipients{}:
 			maxRecipients.Store(int64(option.MustGet[int](opt)))
 		case identMaxDecompressBufferSize{}:
@@ -77,9 +85,10 @@ const (
 var registry = json.NewRegistry()
 
 type recipientBuilder struct {
-	alg     jwa.KeyEncryptionAlgorithm
-	key     any
-	headers Headers
+	alg        jwa.KeyEncryptionAlgorithm
+	key        any
+	headers    Headers
+	pbes2Count int
 }
 
 func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryptionAlgorithm) ([]byte, error) {
@@ -178,7 +187,7 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 
 	// Handle the encrypted key
 	var rawCEK []byte
-	enckey, err := encryptKey(cek, b.alg, calg, resolvedKey, apu, apv)
+	enckey, err := encryptKey(cek, b.alg, calg, resolvedKey, apu, apv, b.pbes2Count)
 	if err != nil {
 		return nil, fmt.Errorf(`failed to encrypt key: %w`, err)
 	}
@@ -615,6 +624,7 @@ type encryptContext struct {
 	calg        jwa.ContentEncryptionAlgorithm
 	compression jwa.CompressionAlgorithm
 	format      int
+	pbes2Count  int
 	builders    []*recipientBuilder
 	protected   Headers
 	builderBuf  [1]recipientBuilder // inline storage for common single-recipient case
@@ -634,6 +644,7 @@ func freeEncryptContext(ec *encryptContext) *encryptContext {
 	ec.calg = jwa.A256GCM()
 	ec.compression = jwa.NoCompress()
 	ec.format = fmtCompact
+	ec.pbes2Count = 0
 	ec.builders = ec.builders[:0]
 	ec.protected = nil
 	ec.builderBuf[0] = recipientBuilder{}
@@ -641,10 +652,16 @@ func freeEncryptContext(ec *encryptContext) *encryptContext {
 }
 
 func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
+	ec.pbes2Count = int(pbes2Count.Load())
 	var mergeProtected bool
 	var useRawCEK bool
 	for _, opt := range options {
 		switch opt.Ident() {
+		case identPBES2Count{}:
+			v := option.MustGet[int](opt)
+			if v > 0 {
+				ec.pbes2Count = v
+			}
 		case identKey{}:
 			wk := option.MustGet[*withKey](opt)
 			v, ok := wk.alg.(jwa.KeyEncryptionAlgorithm)
@@ -814,6 +831,7 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 	defer recipientSlicePool.Put(recipients)
 
 	for i, builder := range ec.builders {
+		builder.pbes2Count = ec.pbes2Count
 		r := recipientPool.Get()
 		defer recipientPool.Put(r)
 

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -941,6 +941,63 @@ func TestPBES2CountPerCall(t *testing.T) {
 	})
 }
 
+func TestPBES2CountEncrypt(t *testing.T) {
+	password := []byte(`supersecret`)
+	key, err := jwk.Import[jwk.Key](password)
+	require.NoError(t, err, `jwk.Import should succeed`)
+
+	payload := []byte(`hello world`)
+
+	t.Run("per-call WithPBES2Count reflected in p2c header and round-trips", func(t *testing.T) {
+		encrypted, err := jwe.Encrypt(payload,
+			jwe.WithKey(jwa.PBES2_HS256_A128KW(), key),
+			jwe.WithPBES2Count(2000),
+		)
+		require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+		msg, err := jwe.Parse(encrypted)
+		require.NoError(t, err, `jwe.Parse should succeed`)
+		p2cV, ok := msg.ProtectedHeaders().Field(jwe.CountKey)
+		require.True(t, ok, `protected header should have p2c`)
+		require.EqualValues(t, 2000, p2cV, `p2c should match WithPBES2Count value`)
+
+		decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+		require.NoError(t, err, `jwe.Decrypt should succeed`)
+		require.Equal(t, payload, decrypted, `decrypted payload should match`)
+	})
+
+	t.Run("per-call overrides Settings", func(t *testing.T) {
+		// NOTE: HAS GLOBAL EFFECT
+		jwe.Settings(jwe.WithPBES2Count(15000))
+		defer jwe.Settings(jwe.WithPBES2Count(10000))
+		jwe.Settings(jwe.WithMaxPBES2Count(20000))
+		defer jwe.Settings(jwe.WithMaxPBES2Count(10000))
+
+		encrypted, err := jwe.Encrypt(payload, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+		require.NoError(t, err, `jwe.Encrypt should succeed`)
+		msg, err := jwe.Parse(encrypted)
+		require.NoError(t, err)
+		p2cV, ok := msg.ProtectedHeaders().Field(jwe.CountKey)
+		require.True(t, ok)
+		require.EqualValues(t, 15000, p2cV, `p2c should match global setting`)
+
+		encrypted2, err := jwe.Encrypt(payload,
+			jwe.WithKey(jwa.PBES2_HS256_A128KW(), key),
+			jwe.WithPBES2Count(3000),
+		)
+		require.NoError(t, err)
+		msg2, err := jwe.Parse(encrypted2)
+		require.NoError(t, err)
+		p2c2V, ok := msg2.ProtectedHeaders().Field(jwe.CountKey)
+		require.True(t, ok)
+		require.EqualValues(t, 3000, p2c2V, `per-call WithPBES2Count should override global`)
+
+		decrypted, err := jwe.Decrypt(encrypted2, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+		require.NoError(t, err)
+		require.Equal(t, payload, decrypted)
+	})
+}
+
 func TestCBCBufferSize(t *testing.T) {
 	// NOTE: This has GLOBAL EFFECT
 	jwe.Settings(jwe.WithCBCBufferSize(1))

--- a/jwe/jwebb/decrypt_test.go
+++ b/jwe/jwebb/decrypt_test.go
@@ -41,7 +41,7 @@ func TestKeyDecryptPBES2(t *testing.T) {
 	cek := testCEK
 	password := testPassword
 
-	encrypted, err := jwebb.KeyEncryptPBES2(cek, tokens.PBES2_HS256_A128KW, password)
+	encrypted, err := jwebb.KeyEncryptPBES2(cek, tokens.PBES2_HS256_A128KW, password, tokens.PBES2DefaultIterations)
 	require.NoError(t, err)
 	require.NotNil(t, encrypted)
 

--- a/jwe/jwebb/jwebb_test.go
+++ b/jwe/jwebb/jwebb_test.go
@@ -208,7 +208,7 @@ func TestKeyEncryptPBES2(t *testing.T) {
 	cek := testCEK
 	password := testPassword
 
-	result, err := jwebb.KeyEncryptPBES2(cek, tokens.PBES2_HS256_A128KW, password)
+	result, err := jwebb.KeyEncryptPBES2(cek, tokens.PBES2_HS256_A128KW, password, tokens.PBES2DefaultIterations)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEqual(t, cek, result.Bytes())

--- a/jwe/jwebb/key_encrypt_symmetric.go
+++ b/jwe/jwebb/key_encrypt_symmetric.go
@@ -35,8 +35,11 @@ func KeyEncryptDirect(_ []byte, _ string, sharedkey []byte) (keygen.ByteSource, 
 	return keygen.ByteKey(sharedkey), nil
 }
 
-// KeyEncryptPBES2 encrypts the CEK using PBES2 password-based encryption
-func KeyEncryptPBES2(cek []byte, alg string, password []byte) (keygen.ByteSource, error) {
+// KeyEncryptPBES2 encrypts the CEK using PBES2 password-based encryption.
+// count is the PBKDF2 iteration count. If count <= 0, tokens.PBES2DefaultIterations
+// is used as a safety fallback; public callers go through jwe.Encrypt / jwe.Settings
+// and always provide a positive value via the WithPBES2Count option.
+func KeyEncryptPBES2(cek []byte, alg string, password []byte, count int) (keygen.ByteSource, error) {
 	var hashFunc func() hash.Hash
 	var keylen int
 
@@ -54,7 +57,9 @@ func KeyEncryptPBES2(cek []byte, alg string, password []byte) (keygen.ByteSource
 		return nil, fmt.Errorf(`unsupported PBES2 algorithm: %s`, alg)
 	}
 
-	count := tokens.PBES2DefaultIterations
+	if count <= 0 {
+		count = tokens.PBES2DefaultIterations
+	}
 	salt := make([]byte, keylen)
 	_, err := io.ReadFull(rand.Reader, salt)
 	if err != nil {

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -10,6 +10,12 @@ interfaces:
     methods:
       - globalOption
       - decryptOption
+  - name: GlobalEncryptOption
+    comment: |
+      GlobalEncryptOption describes options that changes global settings and for each call of the `jwe.Encrypt` function
+    methods:
+      - globalOption
+      - encryptOption
   - name: CompactOption
     comment: |
       CompactOption describes options that can be passed to `jwe.Compact`
@@ -156,6 +162,23 @@ options:
 
       This option can be used for `jwe.Settings()`, which changes the behavior
       globally, or for `jwe.Decrypt()`, which changes the behavior for that
+      specific call.
+  - ident: PBES2Count
+    interface: GlobalEncryptOption
+    argument_type: int
+    comment: |
+      WithPBES2Count specifies the number of PBKDF2 iterations to use when
+      encrypting a key with the PBES2 family of algorithms. If not specified,
+      the default value of 10,000 is used.
+
+      Modern guidance (OWASP 2023) recommends 600,000 or more for
+      PBKDF2-HMAC-SHA256. Callers handling long-lived or high-value tokens
+      should raise this value. Note that raising the encrypt-side count above
+      the decrypt-side WithMaxPBES2Count (default 10,000) will cause your own
+      messages to be rejected on decrypt until you also raise the max.
+
+      This option can be used for `jwe.Settings()`, which changes the behavior
+      globally, or for `jwe.Encrypt()`, which changes the behavior for that
       specific call.
   - ident: MaxRecipients
     interface: GlobalDecryptOption

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -169,13 +169,12 @@ options:
     comment: |
       WithPBES2Count specifies the number of PBKDF2 iterations to use when
       encrypting a key with the PBES2 family of algorithms. If not specified,
-      the default value of 10,000 is used.
+      the default value of 10,000 is used. Modern guidance (OWASP 2023)
+      recommends 600,000 or more for PBKDF2-HMAC-SHA256.
 
-      Modern guidance (OWASP 2023) recommends 600,000 or more for
-      PBKDF2-HMAC-SHA256. Callers handling long-lived or high-value tokens
-      should raise this value. Note that raising the encrypt-side count above
-      the decrypt-side WithMaxPBES2Count (default 10,000) will cause your own
-      messages to be rejected on decrypt until you also raise the max.
+      This option only affects encryption. Iteration counts on incoming
+      messages are validated separately on decrypt via WithMinPBES2Count
+      and WithMaxPBES2Count.
 
       This option can be used for `jwe.Settings()`, which changes the behavior
       globally, or for `jwe.Encrypt()`, which changes the behavior for that

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -427,13 +427,12 @@ func WithMinPBES2Count(v int) GlobalDecryptOption {
 
 // WithPBES2Count specifies the number of PBKDF2 iterations to use when
 // encrypting a key with the PBES2 family of algorithms. If not specified,
-// the default value of 10,000 is used.
+// the default value of 10,000 is used. Modern guidance (OWASP 2023)
+// recommends 600,000 or more for PBKDF2-HMAC-SHA256.
 //
-// Modern guidance (OWASP 2023) recommends 600,000 or more for
-// PBKDF2-HMAC-SHA256. Callers handling long-lived or high-value tokens
-// should raise this value. Note that raising the encrypt-side count above
-// the decrypt-side WithMaxPBES2Count (default 10,000) will cause your own
-// messages to be rejected on decrypt until you also raise the max.
+// This option only affects encryption. Iteration counts on incoming
+// messages are validated separately on decrypt via WithMinPBES2Count
+// and WithMaxPBES2Count.
 //
 // This option can be used for `jwe.Settings()`, which changes the behavior
 // globally, or for `jwe.Encrypt()`, which changes the behavior for that

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -77,6 +77,21 @@ func (*globalDecryptOption) globalOption() {}
 
 func (*globalDecryptOption) decryptOption() {}
 
+// GlobalEncryptOption describes options that changes global settings and for each call of the `jwe.Encrypt` function
+type GlobalEncryptOption interface {
+	Option
+	globalOption()
+	encryptOption()
+}
+
+type globalEncryptOption struct {
+	Option
+}
+
+func (*globalEncryptOption) globalOption() {}
+
+func (*globalEncryptOption) encryptOption() {}
+
 // GlobalOption describes options that changes global settings for this package
 type GlobalOption interface {
 	Option
@@ -157,6 +172,7 @@ type identMaxRecipients struct{}
 type identMergeProtectedHeaders struct{}
 type identMessage struct{}
 type identMinPBES2Count struct{}
+type identPBES2Count struct{}
 type identPerRecipientHeaders struct{}
 type identPretty struct{}
 type identProtectedHeaders struct{}
@@ -225,6 +241,10 @@ func (identMessage) String() string {
 
 func (identMinPBES2Count) String() string {
 	return "WithMinPBES2Count"
+}
+
+func (identPBES2Count) String() string {
+	return "WithPBES2Count"
 }
 
 func (identPerRecipientHeaders) String() string {
@@ -403,6 +423,23 @@ func WithMessage(v *Message) DecryptOption {
 // specific call.
 func WithMinPBES2Count(v int) GlobalDecryptOption {
 	return &globalDecryptOption{option.New(identMinPBES2Count{}, v)}
+}
+
+// WithPBES2Count specifies the number of PBKDF2 iterations to use when
+// encrypting a key with the PBES2 family of algorithms. If not specified,
+// the default value of 10,000 is used.
+//
+// Modern guidance (OWASP 2023) recommends 600,000 or more for
+// PBKDF2-HMAC-SHA256. Callers handling long-lived or high-value tokens
+// should raise this value. Note that raising the encrypt-side count above
+// the decrypt-side WithMaxPBES2Count (default 10,000) will cause your own
+// messages to be rejected on decrypt until you also raise the max.
+//
+// This option can be used for `jwe.Settings()`, which changes the behavior
+// globally, or for `jwe.Encrypt()`, which changes the behavior for that
+// specific call.
+func WithPBES2Count(v int) GlobalEncryptOption {
+	return &globalEncryptOption{option.New(identPBES2Count{}, v)}
 }
 
 // WithPretty specifies whether the JSON output should be formatted and

--- a/jwe/options_gen_test.go
+++ b/jwe/options_gen_test.go
@@ -25,6 +25,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithMergeProtectedHeaders", identMergeProtectedHeaders{}.String())
 	require.Equal(t, "WithMessage", identMessage{}.String())
 	require.Equal(t, "WithMinPBES2Count", identMinPBES2Count{}.String())
+	require.Equal(t, "WithPBES2Count", identPBES2Count{}.String())
 	require.Equal(t, "WithPerRecipientHeaders", identPerRecipientHeaders{}.String())
 	require.Equal(t, "WithPretty", identPretty{}.String())
 	require.Equal(t, "WithProtectedHeaders", identProtectedHeaders{}.String())


### PR DESCRIPTION
v4 counterpart of #1782. Adds a `WithPBES2Count(int)` option usable with both `jwe.Encrypt` and `jwe.Settings`, letting callers strengthen PBKDF2 iteration count on the encrypt side. Default stays at 10,000 so existing round-trips are unchanged. Addresses JWE-007.