### PR TITLE
reject sub-minimum input in RFC 3394 keywrap primitives

### DIFF
--- a/jwe/jwebb/keywrap.go
+++ b/jwe/jwebb/keywrap.go
@@ -13,6 +13,9 @@ import (
 var keywrapDefaultIV = []byte{0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6}
 
 func Wrap(kek cipher.Block, cek []byte) ([]byte, error) {
+	if len(cek) < tokens.KeywrapChunkLen {
+		return nil, fmt.Errorf(`keywrap input must be at least %d bytes`, tokens.KeywrapChunkLen)
+	}
 	if len(cek)%tokens.KeywrapBlockSize != 0 {
 		return nil, fmt.Errorf(`keywrap input must be %d byte blocks`, tokens.KeywrapBlockSize)
 	}
@@ -55,6 +58,9 @@ func Wrap(kek cipher.Block, cek []byte) ([]byte, error) {
 }
 
 func Unwrap(block cipher.Block, ciphertxt []byte) ([]byte, error) {
+	if len(ciphertxt) < 2*tokens.KeywrapChunkLen {
+		return nil, fmt.Errorf(`keyunwrap input must be at least %d bytes`, 2*tokens.KeywrapChunkLen)
+	}
 	if len(ciphertxt)%tokens.KeywrapChunkLen != 0 {
 		return nil, fmt.Errorf(`keyunwrap input must be %d byte blocks`, tokens.KeywrapChunkLen)
 	}

--- a/jwe/jwebb/keywrap_test.go
+++ b/jwe/jwebb/keywrap_test.go
@@ -63,6 +63,59 @@ func TestRFC3394_Wrap(t *testing.T) {
 	}
 }
 
+// TestWrapRejectsShortInput pins RFC 3394 §2.2.1 — the plaintext must be
+// at least one 64-bit data block. Without this guard Wrap silently returns
+// an 8-byte buffer containing only the default IV for a zero-length CEK.
+func TestWrapRejectsShortInput(t *testing.T) {
+	kek := mustHexDecode("000102030405060708090A0B0C0D0E0F")
+	block, err := aes.NewCipher(kek)
+	require.NoError(t, err, "NewCipher should succeed")
+
+	testcases := []struct {
+		name string
+		cek  []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+		{"seven bytes", make([]byte, 7)},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := jwebb.Wrap(block, tc.cek)
+			require.Error(t, err, `jwebb.Wrap must reject sub-minimum input`)
+		})
+	}
+}
+
+// TestUnwrapRejectsShortInput pins RFC 3394 §2.2.2 — ciphertext is IV plus
+// at least one 64-bit data block (≥ 16 bytes). Without this guard Unwrap
+// panics on empty input (negative make length) and silently returns []byte{}
+// when given the 8-byte default IV alone, because the decrypt loop is
+// skipped and the IV check trivially passes.
+func TestUnwrapRejectsShortInput(t *testing.T) {
+	kek := mustHexDecode("000102030405060708090A0B0C0D0E0F")
+	block, err := aes.NewCipher(kek)
+	require.NoError(t, err, "NewCipher should succeed")
+
+	testcases := []struct {
+		name string
+		ct   []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+		{"default IV alone", []byte{0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6, 0xa6}},
+		{"fifteen bytes", make([]byte, 15)},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, err := jwebb.Unwrap(block, tc.ct)
+				require.Error(t, err, `jwebb.Unwrap must reject sub-minimum input`)
+			})
+		})
+	}
+}
+
 func TestKeyWrap(t *testing.T) {
 	// Test vectors from: http://csrc.nist.gov/groups/ST/toolkit/documents/kms/key-wrap.pdf
 	for i, v := range rfc3394Vectors {


### PR DESCRIPTION
## Summary
- `jwebb.Wrap` now rejects `len(cek) < 8`; previously a zero-length CEK silently produced an 8-byte buffer containing only the default IV
- `jwebb.Unwrap` now rejects `len(ciphertxt) < 16`; previously empty input panicked (negative makeslice length) and the bare 8-byte default IV returned `[]byte{}` as a valid unwrap
- regression tests in `jwe/jwebb/keywrap_test.go` pin all three cases (nil/empty/short + the default-IV-alone trivial-match)