### PR TITLE
only populate WithCEK after content verification (JWE-021)

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -593,10 +593,6 @@ func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgo
 		return nil, fmt.Errorf(`jwe.Decrypt: failed to decrypt key: %w`, err)
 	}
 
-	if dc.cek != nil {
-		*dc.cek = cek
-	}
-
 	// Decrypt the payload
 	computedAadFull := computedAad
 	if aad != nil {
@@ -614,6 +610,13 @@ func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgo
 			return nil, fmt.Errorf(`jwe.Decrypt: failed to uncompress payload: %w`, err)
 		}
 		plaintext = buf
+	}
+
+	// Expose the CEK only after the content cipher has authenticated it.
+	// Writing earlier would hand the caller an unverified CEK on AEAD
+	// failure (JWE-021).
+	if dc.cek != nil {
+		*dc.cek = cek
 	}
 
 	return plaintext, nil

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -998,6 +998,57 @@ func TestPBES2CountEncrypt(t *testing.T) {
 	})
 }
 
+// TestCEKNotExposedOnFailure pins the invariant that jwe.WithCEK() only
+// writes to the caller's pointer after the content cipher has authenticated
+// the message. Regression test for JWE-021: earlier v4 code wrote the CEK
+// immediately after key unwrap, which leaked an unverified CEK on AEAD
+// failure even though Decrypt returned an error.
+func TestCEKNotExposedOnFailure(t *testing.T) {
+	rawKey, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err, `jwxtest.GenerateRsaKey should succeed`)
+
+	payload := []byte(`hello world`)
+	encrypted, err := jwe.Encrypt(payload, jwe.WithKey(jwa.RSA_OAEP(), rawKey.PublicKey))
+	require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+	t.Run("happy path writes CEK", func(t *testing.T) {
+		var cek []byte
+		decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.RSA_OAEP(), rawKey), jwe.WithCEK(&cek))
+		require.NoError(t, err, `jwe.Decrypt should succeed`)
+		require.Equal(t, payload, decrypted)
+		require.Len(t, cek, 32, `A256GCM CEK should be 32 bytes`)
+	})
+
+	t.Run("tampered tag must not populate CEK", func(t *testing.T) {
+		// Compact form: header.enckey.iv.ciphertext.tag
+		// Flip the last byte of the tag segment so that key unwrap still
+		// succeeds but the content AEAD verification fails. Work in raw
+		// base64url text — no need to base64-decode/re-encode.
+		segs := bytes.Split(encrypted, []byte{'.'})
+		require.Len(t, segs, 5, `compact JWE should have 5 segments`)
+		require.NotEmpty(t, segs[4], `tag segment should not be empty`)
+		tagged := make([]byte, len(segs[4]))
+		copy(tagged, segs[4])
+		// Flip the first base64url character of the tag. The first char
+		// encodes high bits of the first tag byte, so the change is
+		// guaranteed to alter the decoded tag (unlike the trailing char,
+		// whose low bits are padding and may be discarded).
+		if tagged[0] == 'A' {
+			tagged[0] = 'B'
+		} else {
+			tagged[0] = 'A'
+		}
+		segs[4] = tagged
+		tampered := bytes.Join(segs, []byte{'.'})
+		require.NotEqual(t, string(encrypted), string(tampered), `tampering should change the bytes`)
+
+		cek := []byte{0xAA, 0xBB, 0xCC} // sentinel — must NOT be overwritten
+		_, err := jwe.Decrypt(tampered, jwe.WithKey(jwa.RSA_OAEP(), rawKey), jwe.WithCEK(&cek))
+		require.Error(t, err, `jwe.Decrypt should fail on tampered tag`)
+		require.Equal(t, []byte{0xAA, 0xBB, 0xCC}, cek, `WithCEK pointer must not be written on decrypt failure (JWE-021)`)
+	})
+}
+
 func TestCBCBufferSize(t *testing.T) {
 	// NOTE: This has GLOBAL EFFECT
 	jwe.Settings(jwe.WithCBCBufferSize(1))


### PR DESCRIPTION
Move the `*dc.cek` write in `decryptContent` so it runs only after `contentCipher.Decrypt` (and DEFLATE uncompress, if applicable) succeed. Previously the CEK was written immediately after key unwrap, so a message whose unwrap succeeded but whose AEAD verification failed would populate the caller's `WithCEK` pointer even though `jwe.Decrypt` returned an error — violating the option's documented contract. v3 is already correct; this fix is v4-only. Regression test `TestCEKNotExposedOnFailure` flips a tag-segment byte and asserts the pointer is untouched on failure. Addresses JWE-021.