### PR TITLE
document default InsecureWhitelist on jwk.Fetch (JWK-001)

### DIFF
--- a/docs/04-jwk.md
+++ b/docs/04-jwk.md
@@ -17,6 +17,7 @@ In this document we describe how to work with JWK using `github.com/lestrrat-go/
 * [Fetching JWK Sets](#fetching-jwk-sets)
   * [Parse a key from a remote resource](#parse-a-key-from-a-remote-resource)
   * [Auto-refreshing remote keys](#auto-refreshing-remote-keys)
+  * [Default Fetch Security Behavior](#default-fetch-security-behavior)
   * [Using Whitelists](#using-whitelists)
 * [Working with jwk.Key](#working-with-jwkkey)
   * [Working with key-specific methods](#working-with-key-specific-methods)
@@ -756,6 +757,25 @@ func Example_jwk_cached_set() {
 ```
 source: [examples/jwk_cached_set_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jwk_cached_set_example_test.go)
 <!-- END INCLUDE -->
+
+## Default Fetch Security Behavior
+
+`jwk.Fetch()` does not apply a URL whitelist by default — it uses
+`jwk.InsecureWhitelist{}`, which allows every URL. This keeps the
+zero-config path short for the common case where the URL is a constant
+in your own code or a value loaded from trusted configuration.
+
+**If the URL comes from an untrusted source** — most commonly the `jku`
+header of a JWS handed to you by a peer — you **must** pass a
+`jwk.WithFetchWhitelist()` option that restricts which destinations the
+library will contact. See [Using Whitelists](#using-whitelists) below for
+the concrete whitelist types and an example.
+
+Note that even with a whitelist, the default HTTP client will follow
+redirects and does not inspect the resolved destination IP. For defense
+against redirect-to-private-IP and DNS-rebinding attacks, combine the
+whitelist with a custom `http.Client` (via `jwk.WithHTTPClient`) whose
+`Transport.DialContext` validates addresses.
 
 ## Using Whitelists
 

--- a/jwk/cache.go
+++ b/jwk/cache.go
@@ -130,7 +130,12 @@ func NewCache(ctx context.Context, client *httprc.Client) (*Cache, error) {
 // Register registers a URL to be managed by the cache. URLs must
 // be registered before issuing `Get`
 //
-// The `Register` method is a thin wrapper around `(httprc.Controller).Add`
+// The `Register` method is a thin wrapper around `(httprc.Controller).Add`.
+//
+// As with `jwk.Fetch`, the default whitelist is `jwk.InsecureWhitelist{}`
+// — every URL is allowed. Supply `jwk.WithFetchWhitelist()` when the URL
+// originates from untrusted input. See `jwk.Fetch` for the full security
+// rationale.
 func (c *Cache) Register(ctx context.Context, u string, options ...RegisterOption) error {
 	var parseOptions []ParseOption
 	var resourceOptions []httprc.NewResourceOption

--- a/jwk/fetch.go
+++ b/jwk/fetch.go
@@ -168,6 +168,22 @@ func (f *CachedFetcher) Fetch(ctx context.Context, u string, _ ...FetchOption) (
 // contents of the object with the data at the remote resource,
 // consider using `jwk.Cache`, which automatically refreshes
 // jwk.Set objects asynchronously.
+//
+// # Security
+//
+// By default, jwk.Fetch does not restrict which URLs may be contacted: the
+// URL you pass is fetched as-is, with only the default HTTP client's
+// HTTPS-to-HTTP redirect block applied. This is the right default when the
+// URL is hard-coded or comes from configuration you control.
+//
+// It is NOT safe when the URL is attacker-controllable — most commonly a
+// `jku` header copied out of an untrusted JWS. In that case you MUST pass
+// a jwk.WithFetchWhitelist() option that restricts the reachable URLs via
+// jwk.MapWhitelist, jwk.RegexpWhitelist, or a custom Whitelist.
+//
+// For defense against redirect-to-private-IP and DNS-rebinding attacks,
+// combine WithFetchWhitelist with a custom http.Client (see WithHTTPClient)
+// whose Transport.DialContext validates resolved addresses.
 func Fetch(ctx context.Context, u string, options ...FetchOption) (Set, error) {
 	var parseOptions []ParseOption
 	//nolint:revive // I want to keep the type of `wl` as `Whitelist` instead of `InsecureWhitelist`

--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -125,9 +125,25 @@ options:
     interface: FetchOption
     argument_type: Whitelist
     comment: |
-      WithFetchWhitelist specifies the Whitelist object to use when
-      fetching JWKs from a remote source. This option can be passed
-      to both `jwk.Fetch()`
+      WithFetchWhitelist specifies the Whitelist applied to the URL passed
+      to `jwk.Fetch()` (and `(*jwk.Cache).Register()`).
+
+      The default when this option is not supplied is `jwk.InsecureWhitelist{}`,
+      which allows every URL. That is the right default for URLs that are
+      hard-coded in your program or loaded from trusted configuration, and
+      keeps first-time usage free of boilerplate.
+
+      It is NOT safe when the URL comes from an untrusted source — most
+      commonly the `jku` header of a JWS handed to you by a peer. For those
+      call sites you MUST supply a restrictive Whitelist: use
+      `jwk.NewMapWhitelist()` for a fixed allow-list, `jwk.RegexpWhitelist`
+      for pattern-based allow-lists, or implement the `jwk.Whitelist`
+      interface yourself.
+
+      Note that a whitelist only constrains the initial URL. For defense
+      against redirect-to-private-IP and DNS-rebinding attacks, also supply
+      a custom `http.Client` via `jwk.WithHTTPClient` whose
+      `Transport.DialContext` validates resolved addresses.
   - ident: IgnoreParseError
     interface: ParseOption
     argument_type: bool

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -232,9 +232,25 @@ func WithFS(v fs.FS) ReadFileOption {
 	return &readFileOption{option.New(identFS{}, v)}
 }
 
-// WithFetchWhitelist specifies the Whitelist object to use when
-// fetching JWKs from a remote source. This option can be passed
-// to both `jwk.Fetch()`
+// WithFetchWhitelist specifies the Whitelist applied to the URL passed
+// to `jwk.Fetch()` (and `(*jwk.Cache).Register()`).
+//
+// The default when this option is not supplied is `jwk.InsecureWhitelist{}`,
+// which allows every URL. That is the right default for URLs that are
+// hard-coded in your program or loaded from trusted configuration, and
+// keeps first-time usage free of boilerplate.
+//
+// It is NOT safe when the URL comes from an untrusted source — most
+// commonly the `jku` header of a JWS handed to you by a peer. For those
+// call sites you MUST supply a restrictive Whitelist: use
+// `jwk.NewMapWhitelist()` for a fixed allow-list, `jwk.RegexpWhitelist`
+// for pattern-based allow-lists, or implement the `jwk.Whitelist`
+// interface yourself.
+//
+// Note that a whitelist only constrains the initial URL. For defense
+// against redirect-to-private-IP and DNS-rebinding attacks, also supply
+// a custom `http.Client` via `jwk.WithHTTPClient` whose
+// `Transport.DialContext` validates resolved addresses.
 func WithFetchWhitelist(v Whitelist) FetchOption {
 	return &fetchOption{option.New(identFetchWhitelist{}, v)}
 }

--- a/jwk/whitelist.go
+++ b/jwk/whitelist.go
@@ -5,8 +5,16 @@ import "github.com/lestrrat-go/httprc/v3"
 type Whitelist = httprc.Whitelist
 type WhitelistFunc = httprc.WhitelistFunc
 
-// InsecureWhitelist is an alias to httprc.InsecureWhitelist. Use
-// functions in the `httprc` package to interact with this type.
+// InsecureWhitelist is a Whitelist implementation (aliased to
+// httprc.InsecureWhitelist) that allows every URL jwk.Fetch() is asked to
+// retrieve. It is the library's default, which keeps first-time usage
+// simple: callers with a hard-coded JWKS URL do not have to configure
+// anything.
+//
+// Do NOT use InsecureWhitelist in any code path where the URL originates
+// from untrusted input (for example, the `jku` header of a JWS). For
+// those paths, construct a MapWhitelist, RegexpWhitelist, or custom
+// Whitelist and pass it via jwk.WithFetchWhitelist().
 type InsecureWhitelist = httprc.InsecureWhitelist
 
 func NewInsecureWhitelist() InsecureWhitelist {


### PR DESCRIPTION
Doc-only. Spell out that `jwk.Fetch` uses `InsecureWhitelist{}` by default, which is fine for hard-coded/trusted URLs but requires `WithFetchWhitelist` when the URL comes from untrusted input (e.g. a JWS `jku` header). Touches `Fetch` godoc, `WithFetchWhitelist` option comment, `InsecureWhitelist` type godoc, `Cache.Register` godoc, and `docs/04-jwk.md`. No behavior change — fail-closed default was considered and rejected as unfriendly for the common case.