### PR TITLE
document default InsecureWhitelist on jwk.Fetch (JWK-001)

### DIFF
--- a/docs/04-jwk.md
+++ b/docs/04-jwk.md
@@ -17,6 +17,7 @@ In this document we describe how to work with JWK using `github.com/lestrrat-go/
 * [Fetching JWK Sets](#fetching-jwk-sets)
   * [Parse a key from a remote resource](#parse-a-key-from-a-remote-resource)
   * [Auto-refreshing remote keys](#auto-refreshing-remote-keys)
+  * [Default Fetch Security Behavior](#default-fetch-security-behavior)
   * [Using Whitelists](#using-whitelists)
 * [Working with jwk.Key](#working-with-jwkkey)
   * [Working with key-specific methods](#working-with-key-specific-methods)
@@ -754,6 +755,25 @@ func Example_jwk_cached_set() {
 ```
 source: [examples/jwk_cached_set_example_test.go](https://github.com/jwx-go/examples/blob/v4/jwk_cached_set_example_test.go)
 <!-- END INCLUDE -->
+
+## Default Fetch Security Behavior
+
+`jwk.Fetch()` does not apply a URL whitelist by default — it uses
+`jwk.InsecureWhitelist{}`, which allows every URL. This keeps the
+zero-config path short for the common case where the URL is a constant
+in your own code or a value loaded from trusted configuration.
+
+**If the URL comes from an untrusted source** — most commonly the `jku`
+header of a JWS handed to you by a peer — you **must** pass a
+`jwk.WithFetchWhitelist()` option that restricts which destinations the
+library will contact. See [Using Whitelists](#using-whitelists) below for
+the concrete whitelist types and an example.
+
+Note that even with a whitelist, the default HTTP client will follow
+redirects and does not inspect the resolved destination IP. For defense
+against redirect-to-private-IP and DNS-rebinding attacks, combine the
+whitelist with a custom `http.Client` (via `jwk.WithHTTPClient`) whose
+`Transport.DialContext` validates addresses.
 
 ## Using Whitelists
 

--- a/jwk/fetch.go
+++ b/jwk/fetch.go
@@ -144,10 +144,26 @@ func (ff FetchFunc) Fetch(ctx context.Context, u string, options ...FetchOption)
 // mechanism to fetch the JWKS.
 //
 // If you are using the same `jwk.Set` for long periods of time during
-// the lifecycle of your program, and would like to periodically refresh the
-// contents of the object with the data at the remote resource,
-// consider using `jwk.Cache`, which automatically refreshes
-// jwk.Set objects asynchronously.
+// the lifecycle of your program, and would like to periodically refresh
+// the contents of the object with the data at the remote resource,
+// consider using the `github.com/jwx-go/jwkcache/v4` extension module,
+// which automatically refreshes jwk.Set objects asynchronously.
+//
+// # Security
+//
+// By default, jwk.Fetch does not restrict which URLs may be contacted: the
+// URL you pass is fetched as-is, with only the default HTTP client's
+// HTTPS-to-HTTP redirect block applied. This is the right default when the
+// URL is hard-coded or comes from configuration you control.
+//
+// It is NOT safe when the URL is attacker-controllable — most commonly a
+// `jku` header copied out of an untrusted JWS. In that case you MUST pass
+// a jwk.WithFetchWhitelist() option that restricts the reachable URLs via
+// jwk.MapWhitelist, jwk.RegexpWhitelist, or a custom Whitelist.
+//
+// For defense against redirect-to-private-IP and DNS-rebinding attacks,
+// combine WithFetchWhitelist with a custom http.Client (see WithHTTPClient)
+// whose Transport.DialContext validates resolved addresses.
 func Fetch(ctx context.Context, u string, options ...FetchOption) (Set, error) {
 	var parseOptions []ParseOption
 	var wl Whitelist = InsecureWhitelist{}

--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -94,9 +94,25 @@ options:
     interface: FetchOption
     argument_type: Whitelist
     comment: |
-      WithFetchWhitelist specifies the Whitelist object to use when
-      fetching JWKs from a remote source. This option can be passed
-      to both `jwk.Fetch()`
+      WithFetchWhitelist specifies the Whitelist applied to the URL passed
+      to `jwk.Fetch()`.
+
+      The default when this option is not supplied is `jwk.InsecureWhitelist{}`,
+      which allows every URL. That is the right default for URLs that are
+      hard-coded in your program or loaded from trusted configuration, and
+      keeps first-time usage free of boilerplate.
+
+      It is NOT safe when the URL comes from an untrusted source — most
+      commonly the `jku` header of a JWS handed to you by a peer. For those
+      call sites you MUST supply a restrictive Whitelist: use
+      `jwk.NewMapWhitelist()` for a fixed allow-list, `jwk.RegexpWhitelist`
+      for pattern-based allow-lists, or implement the `jwk.Whitelist`
+      interface yourself.
+
+      Note that a whitelist only constrains the initial URL. For defense
+      against redirect-to-private-IP and DNS-rebinding attacks, also supply
+      a custom `http.Client` via `jwk.WithHTTPClient` whose
+      `Transport.DialContext` validates resolved addresses.
   - ident: IgnoreParseError
     interface: ParseOption
     argument_type: bool

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -132,9 +132,25 @@ func (identX509) String() string {
 	return "WithX509"
 }
 
-// WithFetchWhitelist specifies the Whitelist object to use when
-// fetching JWKs from a remote source. This option can be passed
-// to both `jwk.Fetch()`
+// WithFetchWhitelist specifies the Whitelist applied to the URL passed
+// to `jwk.Fetch()`.
+//
+// The default when this option is not supplied is `jwk.InsecureWhitelist{}`,
+// which allows every URL. That is the right default for URLs that are
+// hard-coded in your program or loaded from trusted configuration, and
+// keeps first-time usage free of boilerplate.
+//
+// It is NOT safe when the URL comes from an untrusted source — most
+// commonly the `jku` header of a JWS handed to you by a peer. For those
+// call sites you MUST supply a restrictive Whitelist: use
+// `jwk.NewMapWhitelist()` for a fixed allow-list, `jwk.RegexpWhitelist`
+// for pattern-based allow-lists, or implement the `jwk.Whitelist`
+// interface yourself.
+//
+// Note that a whitelist only constrains the initial URL. For defense
+// against redirect-to-private-IP and DNS-rebinding attacks, also supply
+// a custom `http.Client` via `jwk.WithHTTPClient` whose
+// `Transport.DialContext` validates resolved addresses.
 func WithFetchWhitelist(v Whitelist) FetchOption {
 	return &fetchOption{option.New(identFetchWhitelist{}, v)}
 }

--- a/jwk/whitelist.go
+++ b/jwk/whitelist.go
@@ -15,8 +15,15 @@ func (f WhitelistFunc) IsAllowed(u string) bool {
 	return f(u)
 }
 
-// InsecureWhitelist is a whitelist that allows all URLs.
-// Use this only in development/testing.
+// InsecureWhitelist is a Whitelist implementation that allows every URL
+// jwk.Fetch() is asked to retrieve. It is the library's default, which
+// keeps first-time usage simple: callers with a hard-coded JWKS URL do
+// not have to configure anything.
+//
+// Do NOT use InsecureWhitelist in any code path where the URL originates
+// from untrusted input (for example, the `jku` header of a JWS). For
+// those paths, construct a MapWhitelist, RegexpWhitelist, or custom
+// Whitelist and pass it via jwk.WithFetchWhitelist().
 type InsecureWhitelist struct{}
 
 func (InsecureWhitelist) IsAllowed(string) bool { return true }


### PR DESCRIPTION
v4 counterpart of #1790. Doc-only. Spell out that `jwk.Fetch` uses `InsecureWhitelist{}` by default — fine for hard-coded/trusted URLs, but `WithFetchWhitelist` is required when the URL is attacker-controllable (e.g. JWS `jku` header). Touches `Fetch` godoc, `WithFetchWhitelist` option comment, `InsecureWhitelist` type godoc, and `docs/04-jwk.md`. Also fixes a stale reference on `Fetch` that still pointed at `jwk.Cache` instead of the `github.com/jwx-go/jwkcache/v4` extension. No behavior change.