### PR TITLE
reject crit-bearing messages in jws.VerifyCompactFast

### DIFF
--- a/jws/errors.go
+++ b/jws/errors.go
@@ -1,8 +1,25 @@
 package jws
 
 import (
+	"errors"
 	"fmt"
 )
+
+// errCritPresent is returned by VerifyCompactFast when the protected
+// header carries a "crit" list. The fast path cannot enforce RFC 7515
+// §4.1.11 (it has no WithCritExtension allowlist), so it refuses rather
+// than silently accepting. Callers that wrap VerifyCompactFast and want
+// the full validateCritical rule set applied should detect this via
+// errors.Is(err, jws.ErrCritPresent()) and retry through jws.Verify.
+var errCritPresent = errors.New("VerifyCompactFast: protected header contains \"crit\"; use jws.Verify")
+
+// ErrCritPresent returns the sentinel error returned by VerifyCompactFast
+// when the protected header contains a "crit" list. Callers that front
+// VerifyCompactFast with an auto-fallback to jws.Verify can detect it
+// via errors.Is.
+func ErrCritPresent() error {
+	return errCritPresent
+}
 
 type signError struct {
 	error

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -750,19 +750,21 @@ func Settings(options ...GlobalOption) {
 // Since this function avoids doing many checks that jws.Verify would perform,
 // you must ensure to perform the necessary checks including ensuring that algorithm is safe to use for your payload yourself.
 //
-// In particular, VerifyCompactFast does NOT enforce the RFC 7515 Section
-// 4.1.11 "crit" (Critical) header validation. If your application processes
-// messages that may carry a "crit" header, use jws.Verify() with
-// jws.WithCritValidation(true) and jws.WithCritExtension(...) instead.
+// VerifyCompactFast refuses messages whose protected header carries a
+// "crit" list. RFC 7515 §4.1.11 requires every critical extension to be
+// understood by the recipient, and the fast path has no WithCritExtension
+// allowlist to consult. On crit-present input it returns a sentinel error
+// that callers can detect with errors.Is(err, jws.ErrCritPresent()) and
+// retry through jws.Verify, which enforces the full validateCritical rule
+// set. Applications that may legitimately receive "crit" headers should
+// call jws.Verify directly.
 //
 // VerifyCompactFast also assumes the JWS uses the default "b64":true
-// (base64url-encoded) payload encoding. JWSs that declare "b64":false
-// (RFC 7797), carry a detached payload, or otherwise rely on "crit"
-// semantics must be verified with jws.Verify() instead — jws.Verify()
-// handles all RFC 7797 and "crit" cases, including auto-allowlisting
-// "b64" in "crit" when jws.WithDetachedPayload is used. A conforming
-// b64:false JWS is required by RFC 7797 Section 5 to list "b64" in
-// "crit", so it is already outside VerifyCompactFast's contract.
+// (base64url-encoded) payload encoding. A conforming RFC 7797 b64:false
+// JWS is required to list "b64" in "crit", so it is automatically routed
+// away from the fast path by the crit refusal above. Detached-payload
+// callers must use jws.Verify with jws.WithDetachedPayload regardless,
+// since VerifyCompactFast has no way to accept a detached payload.
 func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]byte, error) {
 	if err := validateAlgorithmForKey(alg, key); err != nil {
 		return nil, makeVerifyError(`%w`, err)
@@ -774,6 +776,14 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	hdr, payload, encodedSig, err := jwsbb.SplitCompact(compact)
 	if err != nil {
 		return nil, makeVerifyError("failed to split compact: %w", err)
+	}
+
+	// Refuse crit-bearing messages: the fast path has no WithCritExtension
+	// allowlist, so accepting them would silently violate RFC 7515 §4.1.11.
+	// Callers that wrap VerifyCompactFast can detect this via
+	// errors.Is(err, jws.ErrCritPresent()) and fall through to jws.Verify.
+	if jwsbb.HeaderHas(jwsbb.HeaderParseCompact(hdr), CriticalKey) {
+		return nil, errCritPresent
 	}
 
 	signature, err := base64.Decode(encodedSig)

--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -313,9 +313,12 @@ func TestCritInBandB64RequiresExplicit(t *testing.T) {
 	require.NoError(t, err, `explicit WithCritExtension("b64") should make in-band b64=false succeed`)
 }
 
-// TestVerifyCompactFastIgnoresCrit documents that the fast path performs
-// no crit validation regardless of message contents.
-func TestVerifyCompactFastIgnoresCrit(t *testing.T) {
+// TestVerifyCompactFastRefusesCrit documents that the fast path refuses
+// crit-bearing messages with the jws.ErrCritPresent() sentinel. The fast
+// path has no WithCritExtension allowlist, so it cannot enforce RFC 7515
+// §4.1.11; silently accepting would violate the RFC. Callers that want
+// full crit handling must use jws.Verify.
+func TestVerifyCompactFastRefusesCrit(t *testing.T) {
 	payload := []byte(`hello world`)
 	key, err := jwxtest.GenerateSymmetricJwk()
 	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
@@ -351,7 +354,8 @@ func TestVerifyCompactFastIgnoresCrit(t *testing.T) {
 			signed := signWith(t, key, payload, hdrs)
 
 			_, err := jws.VerifyCompactFast(key, signed, jwa.HS256())
-			require.NoError(t, err, `VerifyCompactFast does not enforce crit; should succeed`)
+			require.Error(t, err, `VerifyCompactFast must refuse crit-bearing messages`)
+			require.ErrorIs(t, err, jws.ErrCritPresent(), `error should match jws.ErrCritPresent sentinel`)
 		})
 	}
 }

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -6,6 +6,7 @@ package jwt
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -337,10 +338,20 @@ func verifyJWS(ctx *parseCtx, payload []byte) ([]byte, int, error) {
 		alg, ok := wk.alg.(jwa.SignatureAlgorithm)
 		if ok && len(wk.options) == 0 {
 			verified, err := jws.VerifyCompactFast(wk.key, payload, alg)
-			if err != nil {
-				return nil, _JwsVerifyDone, err
+			if err == nil {
+				return verified, _JwsVerifyDone, nil
 			}
-			return verified, _JwsVerifyDone, nil
+			// VerifyCompactFast refuses crit-bearing messages. In v3
+			// jws.Verify defaults critValidation=false, so the generic
+			// fall-through path would still silently accept "crit".
+			// Force the strict path here: jwt.Parse must not be laxer
+			// than jws.Verify + WithCritValidation.
+			if errors.Is(err, jws.ErrCritPresent()) {
+				verifyOpts := append(ctx.verifyOpts, jws.WithCompact(), jws.WithCritValidation(true))
+				verified, err := jws.Verify(payload, verifyOpts...)
+				return verified, _JwsVerifyDone, err
+			}
+			return nil, _JwsVerifyDone, err
 		}
 	}
 

--- a/jwt/jwt_crit_test.go
+++ b/jwt/jwt_crit_test.go
@@ -1,0 +1,105 @@
+package jwt_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/internal/jwxtest"
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jws"
+	"github.com/lestrrat-go/jwx/v3/jwt"
+	"github.com/stretchr/testify/require"
+)
+
+// signJWTWithCrit builds a JWT compact serialization whose JWS protected
+// header contains the supplied extras (typically a "crit" list). Used to
+// exercise the jwt-layer verifyJWS single-key short-circuit that previously
+// routed through jws.VerifyCompactFast and silently bypassed RFC 7515
+// §4.1.11 crit checks.
+func signJWTWithCrit(t *testing.T, key any, hdrExtras map[string]any) []byte {
+	t.Helper()
+
+	tok, err := jwt.NewBuilder().
+		Issuer("https://example.com").
+		Subject("crit-test").
+		Build()
+	require.NoError(t, err, `jwt.NewBuilder should succeed`)
+
+	payload, err := json.Marshal(tok)
+	require.NoError(t, err, `json.Marshal(tok) should succeed`)
+
+	hdrs := jws.NewHeaders()
+	for k, v := range hdrExtras {
+		require.NoError(t, hdrs.Set(k, v), `jws.Headers.Set(%q)`, k)
+	}
+
+	signed, err := jws.Sign(payload, jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)))
+	require.NoError(t, err, `jws.Sign should succeed`)
+	return signed
+}
+
+// TestParse_CritRejected_FastPath covers the canonical jwt.Parse call
+// shape (single WithKey) which takes the verifyJWS single-key short-circuit
+// and routes to jws.VerifyCompactFast. RFC 7515 §4.1.11 requires rejection
+// of any unrecognized critical extension, and jwt.Parse must not be laxer
+// than jws.Verify.
+func TestParse_CritRejected_FastPath(t *testing.T) {
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+
+	signed := signJWTWithCrit(t, key, map[string]any{
+		"x-evil":        "pwned",
+		jws.CriticalKey: []string{"x-evil"},
+	})
+
+	_, err = jwt.Parse(signed, jwt.WithKey(jwa.HS256(), key))
+	require.Error(t, err, `jwt.Parse must reject unknown crit extension on the fast path`)
+	require.ErrorContains(t, err, `x-evil`)
+}
+
+// TestParse_NoCrit_FastPathUnchanged is a regression sanity check: an
+// ordinary HS256 token without "crit" continues to parse successfully.
+func TestParse_NoCrit_FastPathUnchanged(t *testing.T) {
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+
+	tok, err := jwt.NewBuilder().Issuer("https://example.com").Build()
+	require.NoError(t, err)
+
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.HS256(), key))
+	require.NoError(t, err, `jwt.Sign should succeed`)
+
+	got, err := jwt.Parse(signed, jwt.WithKey(jwa.HS256(), key))
+	require.NoError(t, err, `jwt.Parse without crit must still succeed on the fast path`)
+	require.True(t, jwt.Equal(tok, got), `parsed token equals original`)
+}
+
+// TestParse_EmptyCritArray verifies that "crit":[] is rejected via the
+// fall-through to jws.Verify, inheriting validateCritical's empty-list rule.
+func TestParse_EmptyCritArray(t *testing.T) {
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+
+	signed := signJWTWithCrit(t, key, map[string]any{
+		jws.CriticalKey: []string{},
+	})
+
+	_, err = jwt.Parse(signed, jwt.WithKey(jwa.HS256(), key))
+	require.Error(t, err, `jwt.Parse must reject empty crit array`)
+	require.ErrorContains(t, err, `must not be empty`)
+}
+
+// TestParse_CritWithStandardName verifies that "crit":["alg"] is rejected
+// via the fall-through, inheriting validateCritical's standard-name rule.
+func TestParse_CritWithStandardName(t *testing.T) {
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+
+	signed := signJWTWithCrit(t, key, map[string]any{
+		jws.CriticalKey: []string{"alg"},
+	})
+
+	_, err = jwt.Parse(signed, jwt.WithKey(jwa.HS256(), key))
+	require.Error(t, err, `jwt.Parse must reject standard header name in crit`)
+	require.ErrorContains(t, err, `standard header parameter`)
+}


### PR DESCRIPTION
`jwt.Parse(data, jwt.WithKey(alg, key))` silently accepted JWTs carrying an unknown "crit" extension, because the `verifyJWS` single-key short-circuit routed through `jws.VerifyCompactFast`, which was documented as skipping RFC 7515 §4.1.11. jwt.Parse must not be laxer than `jws.Verify` with `WithCritValidation`.

`VerifyCompactFast` now detects "crit" in the protected header (via `jwsbb.HeaderParseCompact` + `HeaderHas`, reusing its existing `SplitCompact`) and refuses with a new `jws.ErrCritPresent()` sentinel. `jwt.verifyJWS` detects the sentinel and falls through to `jws.Verify` with `jws.WithCritValidation(true)` injected — necessary in v3, where `jws.Verify` defaults `critValidation=false`. The full `validateCritical` rule set then applies with the default-strict (empty) `WithCritExtension` allowlist. Legitimate (no-crit) callers of `VerifyCompactFast` pay only one `HeaderParseCompact`/`HeaderHas` after the existing split.

The pre-existing `TestVerifyCompactFastIgnoresCrit` test (which asserted the old lax contract) is renamed to `TestVerifyCompactFastRefusesCrit` and flipped to assert refusal via `require.ErrorIs(err, jws.ErrCritPresent())`. New `jwt/jwt_crit_test.go` covers the fast-path site, empty-crit-array, standard-name-in-crit, and a no-crit regression sanity check.

Companion to #1792 on develop/v4.
