### PR TITLE
jwe: stop aliasing AAD backing slices when concatenating external aad

### DIFF
--- a/jwe/decrypt.go
+++ b/jwe/decrypt.go
@@ -3,7 +3,6 @@ package jwe
 import (
 	"fmt"
 
-	"github.com/lestrrat-go/jwx/v3/internal/tokens"
 	"github.com/lestrrat-go/jwx/v3/jwa"
 	"github.com/lestrrat-go/jwx/v3/jwe/internal/content_crypt"
 	"github.com/lestrrat-go/jwx/v3/jwe/jwebb"
@@ -140,10 +139,11 @@ func (d *decrypter) Decrypt(recipient Recipient, ciphertext []byte, msg *Message
 		return
 	}
 
-	computedAad := d.computedAad
-	if d.aad != nil {
-		computedAad = append(append(computedAad, tokens.Period), d.aad...)
-	}
+	// When an external aad is present we must NOT append into
+	// d.computedAad's backing array: it aliases msg.rawProtectedHeaders
+	// in the caller, and appending would mutate bytes past its length
+	// in storage still referenced by the Message.
+	computedAad := concatAAD(d.computedAad, d.aad)
 
 	plaintext, err = cipher.Decrypt(cek, d.iv, ciphertext, d.tag, computedAad)
 	if err != nil {

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -431,6 +431,24 @@ func validateCritical(protected Headers, allowedExtensions []string) error {
 	return nil
 }
 
+// concatAAD returns the AAD value used to seal or open a JWE payload:
+// the protected-header segment, optionally followed by ASCII '.' and
+// the caller-supplied external aad (RFC 7516 §5.1 step 14 / §5.2
+// step 14). A fresh slice is always allocated so the caller's computed
+// and aad slices are never appended into, which matters because
+// computedAad often aliases a Message field whose backing array is
+// still referenced elsewhere.
+func concatAAD(computed, aad []byte) []byte {
+	if len(aad) == 0 {
+		return computed
+	}
+	out := make([]byte, len(computed)+1+len(aad))
+	n := copy(out, computed)
+	out[n] = tokens.Period
+	copy(out[n+1:], aad)
+	return out
+}
+
 func (dc *decryptContext) DecryptMessage(buf []byte) ([]byte, error) {
 	msg, err := parseJSONOrCompact(buf, true, dc.maxRecipients)
 	if err != nil {

--- a/jwe/jwe_aad_internal_test.go
+++ b/jwe/jwe_aad_internal_test.go
@@ -1,0 +1,65 @@
+package jwe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcatAADDoesNotAlias is a regression test for an AAD aliasing
+// bug where the decrypt path used
+// `append(append(computedAad, '.'), aad...)` and computedAad aliased
+// msg.rawProtectedHeaders, silently mutating its backing storage when
+// spare capacity was available.
+func TestConcatAADDoesNotAlias(t *testing.T) {
+	t.Run("no external aad returns input as-is", func(t *testing.T) {
+		computed := []byte("protected")
+		require.Equal(t, computed, concatAAD(computed, nil))
+		require.Equal(t, computed, concatAAD(computed, []byte{}))
+	})
+
+	t.Run("computed's backing array past len is untouched", func(t *testing.T) {
+		const head = "AAAAAAAAAA" // 10 bytes
+		const sentinel = byte('Z')
+		backing := make([]byte, 64)
+		copy(backing, head)
+		for i := len(head); i < len(backing); i++ {
+			backing[i] = sentinel
+		}
+		computed := backing[:len(head)]
+		require.Equal(t, 64, cap(computed))
+
+		out := concatAAD(computed, []byte("external"))
+		require.Equal(t, []byte("AAAAAAAAAA.external"), out)
+
+		// computed's visible content unchanged.
+		require.Equal(t, []byte(head), computed)
+		// Bytes past len in the shared backing array unchanged — this
+		// is the actual aliasing regression we're guarding against.
+		tail := computed[:cap(computed)][len(head):]
+		for i, b := range tail {
+			require.Equal(t, sentinel, b, `backing[%d] past computed's length must be unchanged`, len(head)+i)
+		}
+	})
+
+	t.Run("aad's backing array past len is untouched", func(t *testing.T) {
+		const body = "AAD!?" // 5 bytes
+		const sentinel = byte('Y')
+		backing := make([]byte, 32)
+		copy(backing, body)
+		for i := len(body); i < len(backing); i++ {
+			backing[i] = sentinel
+		}
+		aad := backing[:len(body)]
+		require.Equal(t, 32, cap(aad))
+
+		out := concatAAD([]byte("protected"), aad)
+		require.Equal(t, []byte("protected.AAD!?"), out)
+
+		require.Equal(t, []byte(body), aad)
+		tail := aad[:cap(aad)][len(body):]
+		for i, b := range tail {
+			require.Equal(t, sentinel, b, `aad backing[%d] past len must be unchanged`, len(body)+i)
+		}
+	})
+}

--- a/jwe/message.go
+++ b/jwe/message.go
@@ -248,8 +248,7 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 	if aad := m.AuthenticatedData(); len(aad) > 0 {
 		aad = base64.Encode(aad)
 		if encodedProtectedHeaders != nil {
-			tmp := append(encodedProtectedHeaders, tokens.Period)
-			aad = append(tmp, aad...)
+			aad = concatAAD(encodedProtectedHeaders, aad)
 		}
 
 		buf.Reset()


### PR DESCRIPTION
Backport of #1794 to v3.

The decrypt path (`jwe/decrypt.go`) and `Message.MarshalJSON` (`jwe/message.go`) both used `append(append(x, '.'), aad...)` to concatenate the protected-header segment with an external aad. In the decrypt case the base slice aliases `msg.rawProtectedHeaders`; when the backing array has spare capacity the append silently writes past its length into storage still referenced by the Message. Same shape in `MarshalJSON` against the freshly-encoded protected headers.

Add a `concatAAD` helper in `jwe/jwe.go` that allocates a fresh slice with exact size via `make` + `copy`, and use it at both sites. Internal regression test verifies neither input slice's backing array is touched past its length, using sentinel bytes in the spare capacity.
