### PR TITLE
validate ECDSA point on curve (JWK-003)

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -41,7 +41,7 @@ JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 - Extension: `RegisterCustomField[T]()`, `RegisterCustomDecoder[T]()`, `RegisterKeyParser()`, `RegisterKeyImporter()`, `RegisterKeyExporter()`
 - Error sentinels: `ImportError()`, `ParseError()`, `WhitelistError()`, `ContinueError()`
 - Files: `jwk.go`, `set.go`, `parser.go`, `convert.go`, `fetch.go`, `interface.go`, `errors.go`, `x509.go`, `filter.go`, `rsa.go`, `ecdsa.go`, `okp.go`, `symmetric.go`, `akp.go`, `accessors.go`, `io.go`
-- Sub-packages: `jwk/ecdsa` — elliptic curve registration (`RegisterCurve`, `CurveFromAlgorithm`, `AlgorithmFromCurve`); `jwk/jwkbb` — X.509/PEM encoding building blocks (`EncodeX509`, `DecodeX509`); `jwk/jwkunsafe` — low-level key constructors (`NewKey`, `NewPublicKey`) for extension modules
+- Sub-packages: `jwk/ecdsa` — elliptic curve registration (`RegisterCurve(alg, curve, PointValidator)`, `CurveFromAlgorithm`, `AlgorithmFromCurve`, `ValidatorFromCurve`, `PointValidator` interface, `PointValidatorFunc` adapter); `jwk/jwkbb` — X.509/PEM encoding building blocks (`EncodeX509`, `DecodeX509`); `jwk/jwkunsafe` — low-level key constructors (`NewKey`, `NewPublicKey`) for extension modules
 - Imports: jwa, cert, transform, internal/{base64,json,ecutil}
 
 ## jws/

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -16,11 +16,38 @@ import (
 )
 
 func init() {
-	panicOnRegistrationError(ourecdsa.RegisterCurve(jwa.P256(), elliptic.P256()))
-	panicOnRegistrationError(ourecdsa.RegisterCurve(jwa.P384(), elliptic.P384()))
-	panicOnRegistrationError(ourecdsa.RegisterCurve(jwa.P521(), elliptic.P521()))
+	panicOnRegistrationError(ourecdsa.RegisterCurve(jwa.P256(), elliptic.P256(), ecdhPointValidator(ecdh.P256(), 32)))
+	panicOnRegistrationError(ourecdsa.RegisterCurve(jwa.P384(), elliptic.P384(), ecdhPointValidator(ecdh.P384(), 48)))
+	panicOnRegistrationError(ourecdsa.RegisterCurve(jwa.P521(), elliptic.P521(), ecdhPointValidator(ecdh.P521(), 66)))
 
 	panicOnRegistrationError(RegisterKeyExporter(KeyKind(jwa.EC().String()), KeyExportFunc(ecdsaJWKToRaw)))
+}
+
+// ecdhPointValidator returns a PointValidator for a stdlib NIST curve
+// that routes validation through crypto/ecdh. Go 1.21 deprecated the
+// generic crypto/elliptic.Curve methods in favor of crypto/ecdh for
+// exactly this use case: ecdh.Curve.NewPublicKey parses the SEC1
+// uncompressed encoding (0x04 || X || Y), enforces point-on-curve
+// membership, and rejects the identity point as a side effect. Routing
+// the stdlib curves through ecdh means jwk never touches any
+// deprecated crypto/elliptic method for the curves the Go team
+// explicitly wanted callers to migrate.
+//
+// size is the fixed byte length of each coordinate on the curve
+// (32 for P-256, 48 for P-384, 66 for P-521). It is supplied literally
+// rather than computed from crv.Params().BitSize so that a mismatched
+// registration is caught at code-review time, not at runtime.
+func ecdhPointValidator(crv ecdh.Curve, size int) ourecdsa.PointValidator {
+	return ourecdsa.PointValidatorFunc(func(x, y *big.Int) error {
+		buf := make([]byte, 1+2*size)
+		buf[0] = 0x04
+		x.FillBytes(buf[1 : 1+size])
+		y.FillBytes(buf[1+size:])
+		if _, err := crv.NewPublicKey(buf); err != nil {
+			return fmt.Errorf(`invalid ECDSA public key: %w`, err)
+		}
+		return nil
+	})
 }
 
 func (k *ecdsaPublicKey) Import(rawKey *ecdsa.PublicKey) error {
@@ -33,6 +60,10 @@ func (k *ecdsaPublicKey) Import(rawKey *ecdsa.PublicKey) error {
 
 	if rawKey.Y == nil {
 		return fmt.Errorf(`invalid ecdsa.PublicKey`)
+	}
+
+	if err := validateECDSAPoint(rawKey.Curve, rawKey.X, rawKey.Y); err != nil {
+		return fmt.Errorf(`jwk: %w`, err)
 	}
 
 	xbuf := ecutil.AllocECPointBuffer(rawKey.X, rawKey.Curve)
@@ -68,6 +99,10 @@ func (k *ecdsaPrivateKey) Import(rawKey *ecdsa.PrivateKey) error {
 		return fmt.Errorf(`invalid ecdsa.PrivateKey`)
 	}
 
+	if err := validateECDSAPoint(rawKey.Curve, rawKey.PublicKey.X, rawKey.PublicKey.Y); err != nil {
+		return fmt.Errorf(`jwk: %w`, err)
+	}
+
 	xbuf := ecutil.AllocECPointBuffer(rawKey.PublicKey.X, rawKey.Curve)
 	ybuf := ecutil.AllocECPointBuffer(rawKey.PublicKey.Y, rawKey.Curve)
 	dbuf := ecutil.AllocECPointBuffer(rawKey.D, rawKey.Curve)
@@ -101,7 +136,52 @@ func buildECDSAPublicKey(alg jwa.EllipticCurveAlgorithm, xbuf, ybuf []byte) (*ec
 	x.SetBytes(xbuf)
 	y.SetBytes(ybuf)
 
+	if err := validateECDSAPoint(crv, &x, &y); err != nil {
+		return nil, fmt.Errorf(`jwk: %w`, err)
+	}
+
 	return &ecdsa.PublicKey{Curve: crv, X: &x, Y: &y}, nil
+}
+
+// validateECDSAPoint rejects ECDSA public key coordinates that are not
+// safe to use: the identity point (0, 0) and any point that does not lie
+// on the named curve. Without these checks, attacker-supplied JWKs can
+// smuggle off-curve or small-subgroup points into downstream ECDSA/ECDH
+// operations (invalid-curve attacks). See JWK-003.
+//
+// The identity-point check is done inline here so every caller gets it
+// unconditionally. The on-curve check is delegated to the PointValidator
+// that was registered alongside the curve via jwk/ecdsa.RegisterCurve:
+// the stdlib NIST P-curves register an ecdh-backed validator from this
+// package's init(); extension modules such as jwx-go/es256k register
+// their own curve-library-backed validators.
+//
+// Delegating via a registered validator keeps jwk completely free of
+// calls to the crypto/elliptic.Curve methods that Go 1.21 deprecated.
+// Each curve's validator lives next to the code that knows how to
+// validate it correctly — ecdh.Curve.NewPublicKey for stdlib curves,
+// the third-party library's own point check for custom curves — and
+// jwk never has to fall back to an IsOnCurve call on the deprecated
+// interface.
+//
+// A curve with no registered validator is treated as an error: it is
+// the extension module author's responsibility to supply one, and
+// failing closed is preferable to silently accepting unvalidated
+// points.
+func validateECDSAPoint(crv elliptic.Curve, x, y *big.Int) error {
+	if x.Sign() == 0 && y.Sign() == 0 {
+		return fmt.Errorf(`invalid ECDSA public key: identity point is not a valid public key`)
+	}
+
+	alg, err := ourecdsa.AlgorithmFromCurve(crv)
+	if err != nil {
+		return fmt.Errorf(`invalid ECDSA public key: %w`, err)
+	}
+	validator, err := ourecdsa.ValidatorFromCurve(alg)
+	if err != nil {
+		return fmt.Errorf(`invalid ECDSA public key: %w`, err)
+	}
+	return validator.ValidatePoint(x, y)
 }
 
 func buildECDHPublicKey(alg jwa.EllipticCurveAlgorithm, xbuf, ybuf []byte) (*ecdh.PublicKey, error) {
@@ -389,12 +469,21 @@ func ecdsaValidateKey(k interface {
 	}
 
 	keySize := ecutil.CalculateKeySize(crv)
-	if x, ok := k.X(); !ok || len(x) != keySize {
-		return fmt.Errorf(`invalid "x" length (%d) for curve %q`, len(x), crv.Params().Name)
+	xbuf, ok := k.X()
+	if !ok || len(xbuf) != keySize {
+		return fmt.Errorf(`invalid "x" length (%d) for curve %q`, len(xbuf), crv.Params().Name)
 	}
 
-	if y, ok := k.Y(); !ok || len(y) != keySize {
-		return fmt.Errorf(`invalid "y" length (%d) for curve %q`, len(y), crv.Params().Name)
+	ybuf, ok := k.Y()
+	if !ok || len(ybuf) != keySize {
+		return fmt.Errorf(`invalid "y" length (%d) for curve %q`, len(ybuf), crv.Params().Name)
+	}
+
+	var x, y big.Int
+	x.SetBytes(xbuf)
+	y.SetBytes(ybuf)
+	if err := validateECDSAPoint(crv, &x, &y); err != nil {
+		return err
 	}
 
 	if checkPrivate {

--- a/jwk/ecdsa/ecdsa.go
+++ b/jwk/ecdsa/ecdsa.go
@@ -3,39 +3,122 @@ package ecdsa
 import (
 	"crypto/elliptic"
 	"fmt"
+	"math/big"
 	"sync"
 
 	"github.com/lestrrat-go/jwx/v4/jwa"
 )
 
+// PointValidator validates whether (x, y) represents a safe-to-use
+// public key point on the associated elliptic curve. Implementations
+// MUST reject:
+//
+//   - the identity point (0, 0)
+//   - any point that is not on the curve
+//   - any other coordinate pair that would lead to an unsafe key
+//     (for example, small-subgroup points where applicable)
+//
+// ValidatePoint returns nil iff the point is safe to use. jwk consults
+// the registered PointValidator on every parse, import, and Validate()
+// call that touches an ECDSA key, so it is the choke point that
+// protects downstream crypto/ecdsa and crypto/ecdh consumers from
+// invalid-curve attacks.
+//
+// Extension modules that register a non-stdlib curve (for example
+// secp256k1 via jwx-go/es256k) MUST provide a correct PointValidator;
+// it is the mechanism that replaces the deprecated
+// crypto/elliptic.Curve.IsOnCurve fallback jwk previously used. A
+// typical implementation calls the curve library's own point-on-curve
+// check after rejecting the identity point explicitly.
+//
+// For implementations that are naturally a plain function, wrap them
+// in PointValidatorFunc instead of defining a new named type.
+type PointValidator interface {
+	ValidatePoint(x, y *big.Int) error
+}
+
+// PointValidatorFunc is a function adapter that lets a plain function
+// satisfy the PointValidator interface, analogous to http.HandlerFunc
+// for http.Handler.
+type PointValidatorFunc func(x, y *big.Int) error
+
+// ValidatePoint calls f(x, y).
+func (f PointValidatorFunc) ValidatePoint(x, y *big.Int) error {
+	return f(x, y)
+}
+
+type curveInfo struct {
+	curve     elliptic.Curve
+	validator PointValidator
+}
+
 var muCurves sync.RWMutex
-var algToCurveMap map[jwa.EllipticCurveAlgorithm]elliptic.Curve
+var algToCurveMap map[jwa.EllipticCurveAlgorithm]curveInfo
 var curveToAlgMap map[elliptic.Curve]jwa.EllipticCurveAlgorithm
 var algList []jwa.EllipticCurveAlgorithm
 
 func init() {
 	muCurves.Lock()
-	algToCurveMap = make(map[jwa.EllipticCurveAlgorithm]elliptic.Curve)
+	algToCurveMap = make(map[jwa.EllipticCurveAlgorithm]curveInfo)
 	curveToAlgMap = make(map[elliptic.Curve]jwa.EllipticCurveAlgorithm)
 	muCurves.Unlock()
 }
 
-// RegisterCurve registers a jwa.EllipticCurveAlgorithm constant and its
-// corresponding elliptic.Curve object. Users do not need to call this unless
-// they are registering a new ECDSA key type.
+// RegisterCurve registers a jwa.EllipticCurveAlgorithm constant, its
+// corresponding elliptic.Curve object, and a PointValidator that checks
+// public-key coordinates on that curve. Users do not need to call this
+// unless they are registering a new ECDSA key type from an extension
+// module.
 //
-// The error return is reserved for future validation. The current
-// implementation always returns nil, but callers — especially extension
-// modules calling this from init() — must check the return value and panic
-// on failure to stay forward-compatible.
-func RegisterCurve(alg jwa.EllipticCurveAlgorithm, crv elliptic.Curve) error {
+// The validator must not be nil. jwk uses the registered validator in
+// place of calling crypto/elliptic.Curve.IsOnCurve (deprecated in
+// Go 1.21) so that custom curves can plug in their own, non-deprecated
+// point-membership check. Passing a nil validator returns an error and
+// does not register the curve.
+//
+// RegisterCurve refuses to re-register an alg or curve that is already
+// in the registry. This is a deliberate defense-in-depth measure: the
+// stdlib NIST P-curves are registered from jwk's init() with
+// ecdh-backed validators, and silently allowing a later init() in a
+// compromised dependency to overwrite that entry with a weaker or
+// no-op validator would disable JWK-003 point validation without any
+// observable symptom. Callers that genuinely need to replace an entry
+// must unregister it first; this package does not expose an
+// unregister API, which keeps the built-in NIST entries effectively
+// sealed once jwk is imported.
+func RegisterCurve(alg jwa.EllipticCurveAlgorithm, crv elliptic.Curve, validator PointValidator) error {
+	if validator == nil {
+		return fmt.Errorf(`jwk/ecdsa: RegisterCurve: validator must not be nil`)
+	}
+
 	muCurves.Lock()
 	defer muCurves.Unlock()
 
-	algToCurveMap[alg] = crv
+	if _, exists := algToCurveMap[alg]; exists {
+		return fmt.Errorf(`jwk/ecdsa: RegisterCurve: algorithm %q is already registered`, alg)
+	}
+	if _, exists := curveToAlgMap[crv]; exists {
+		return fmt.Errorf(`jwk/ecdsa: RegisterCurve: curve %q is already registered`, crv.Params().Name)
+	}
+
+	algToCurveMap[alg] = curveInfo{curve: crv, validator: validator}
 	curveToAlgMap[crv] = alg
 	rebuildCurves()
 	return nil
+}
+
+// ValidatorFromCurve returns the PointValidator that was registered
+// alongside the given curve via RegisterCurve. It returns an error if
+// no curve is registered for the given alg.
+func ValidatorFromCurve(alg jwa.EllipticCurveAlgorithm) (PointValidator, error) {
+	muCurves.RLock()
+	defer muCurves.RUnlock()
+
+	info, ok := algToCurveMap[alg]
+	if !ok {
+		return nil, fmt.Errorf(`unknown elliptic curve algorithm: %q`, alg)
+	}
+	return info.validator, nil
 }
 
 func rebuildCurves() {
@@ -75,11 +158,11 @@ func CurveFromAlgorithm(alg jwa.EllipticCurveAlgorithm) (elliptic.Curve, error) 
 	muCurves.RLock()
 	defer muCurves.RUnlock()
 
-	crv, ok := algToCurveMap[alg]
+	info, ok := algToCurveMap[alg]
 	if !ok {
 		return nil, fmt.Errorf(`unknown elliptic curve algorithm: %q`, alg)
 	}
-	return crv, nil
+	return info.curve, nil
 }
 
 func IsCurveAvailable(alg jwa.EllipticCurveAlgorithm) bool {

--- a/jwk/ecdsa/ecdsa_test.go
+++ b/jwk/ecdsa/ecdsa_test.go
@@ -3,11 +3,24 @@ package ecdsa
 import (
 	"crypto/elliptic"
 	"fmt"
+	"math/big"
 	"sync"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v4/jwa"
 )
+
+var noopValidator = PointValidatorFunc(func(_, _ *big.Int) error { return nil })
+
+// uniqueTestCurve wraps an elliptic.Curve to give each instance a
+// distinct pointer identity. RegisterCurve now rejects duplicate
+// registrations of the same curve value, so tests that exercise the
+// writer path need fresh curve identities per iteration. The embedded
+// Curve provides all the interface methods unchanged, so behavior is
+// identical to the underlying stdlib curve.
+type uniqueTestCurve struct {
+	elliptic.Curve
+}
 
 // TestConcurrentRegisterAndLookup is a race-detector test. It runs many
 // goroutines that call the read-side lookup functions while a writer
@@ -15,10 +28,11 @@ import (
 // `go test -race` flags the concurrent map access; with RLock, the test
 // passes cleanly.
 //
-// The writer reuses elliptic.P256() as the curve value and registers a
-// sequence of synthetic algorithm names, so the standard-curve entries
-// (P256/P384/P521) installed in init() are preserved for any subsequent
-// tests in the same process.
+// Each writer iteration wraps elliptic.P256() in a fresh uniqueTestCurve
+// pointer so it gets a distinct interface identity and passes the
+// duplicate-registration guard. The stdlib P256/P384/P521 entries
+// installed in init() are preserved for any subsequent tests in the
+// same process.
 func TestConcurrentRegisterAndLookup(_ *testing.T) {
 	const (
 		numReaders    = 8
@@ -44,10 +58,54 @@ func TestConcurrentRegisterAndLookup(_ *testing.T) {
 	}
 
 	for i := range writerEntries {
-		alg := jwa.NewEllipticCurveAlgorithm(fmt.Sprintf("xcut006-test-%d", i))
-		RegisterCurve(alg, elliptic.P256())
+		alg := jwa.NewEllipticCurveAlgorithm(fmt.Sprintf("concurrent-register-test-%d", i))
+		_ = RegisterCurve(alg, &uniqueTestCurve{Curve: elliptic.P256()}, noopValidator)
 	}
 
 	close(done)
 	wg.Wait()
+}
+
+// TestRegisterCurveRejectsDuplicates asserts that RegisterCurve refuses
+// to overwrite an existing entry keyed by either the alg or the curve.
+// This is the defense-in-depth guard that prevents a late init() from
+// silently replacing a built-in NIST validator with a weaker one.
+//
+// The test is in the internal ecdsa package, so the parent jwk package's
+// init() does not run and the NIST entries are not pre-populated. The
+// test establishes its own baseline by registering a fresh (alg, curve)
+// pair and then asserts the second registration errors.
+func TestRegisterCurveRejectsDuplicates(t *testing.T) {
+	baselineAlg := jwa.NewEllipticCurveAlgorithm("dupe-test-baseline")
+	baselineCurve := &uniqueTestCurve{Curve: elliptic.P256()}
+	if err := RegisterCurve(baselineAlg, baselineCurve, noopValidator); err != nil {
+		t.Fatalf(`baseline RegisterCurve must succeed: %v`, err)
+	}
+
+	t.Run("duplicate alg", func(t *testing.T) {
+		// Re-registering baselineAlg, even with a fresh curve identity,
+		// must error.
+		err := RegisterCurve(baselineAlg, &uniqueTestCurve{Curve: elliptic.P256()}, noopValidator)
+		if err == nil {
+			t.Fatal(`RegisterCurve must refuse to re-register an existing algorithm`)
+		}
+	})
+
+	t.Run("duplicate curve", func(t *testing.T) {
+		// Registering baselineCurve under a brand-new alg must error
+		// because the curve identity already has an owner.
+		alg := jwa.NewEllipticCurveAlgorithm("dupe-test-other-alg")
+		err := RegisterCurve(alg, baselineCurve, noopValidator)
+		if err == nil {
+			t.Fatal(`RegisterCurve must refuse to re-register an existing curve`)
+		}
+	})
+
+	t.Run("nil validator", func(t *testing.T) {
+		alg := jwa.NewEllipticCurveAlgorithm("dupe-test-nil-validator")
+		err := RegisterCurve(alg, &uniqueTestCurve{Curve: elliptic.P256()}, nil)
+		if err == nil {
+			t.Fatal(`RegisterCurve must refuse a nil validator`)
+		}
+	})
 }

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -1,0 +1,96 @@
+package jwk_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"math/big"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/internal/base64"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+// ecdsaPointJWK builds a JWK JSON body with the given curve name and raw
+// x/y coordinates. It zero-pads each coordinate to the curve byte size so
+// length validation in ecdsaValidateKey does not reject the input before
+// the point-on-curve check runs.
+func ecdsaPointJWK(t *testing.T, crv elliptic.Curve, crvName string, x, y *big.Int) []byte {
+	t.Helper()
+	size := (crv.Params().BitSize + 7) / 8
+	xb := make([]byte, size)
+	yb := make([]byte, size)
+	x.FillBytes(xb)
+	y.FillBytes(yb)
+	body := `{"kty":"EC","crv":"` + crvName + `","x":"` + base64.EncodeToString(xb) + `","y":"` + base64.EncodeToString(yb) + `"}`
+	return []byte(body)
+}
+
+// TestECDSAInvalidPointsRejectedOnUse covers JWK-003: ParseKey stores raw
+// x/y bytes without curve checks, but any downstream use of the key —
+// Export/Raw (which constructs a *ecdsa.PublicKey) or an explicit
+// Validate() — must refuse points that are not on the declared curve and
+// the identity point (0, 0). Without validation, these feed invalid-curve
+// attacks to downstream ECDSA/ECDH consumers.
+func TestECDSAInvalidPointsRejectedOnUse(t *testing.T) {
+	cases := []struct {
+		name string
+		x, y *big.Int
+	}{
+		{"identity point", big.NewInt(0), big.NewInt(0)},
+		// (1, 1) is overwhelmingly unlikely to be on P-256.
+		{"off-curve point", big.NewInt(1), big.NewInt(1)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := ecdsaPointJWK(t, elliptic.P256(), "P-256", tc.x, tc.y)
+			key, err := jwk.ParseKey[jwk.Key](body)
+			require.NoError(t, err, `ParseKey stores raw bytes; it does not run curve checks yet`)
+
+			require.Error(t, key.Validate(), `Validate must reject invalid ECDSA point`)
+
+			_, err = jwk.Export[*ecdsa.PublicKey](key)
+			require.Error(t, err, `Export to *ecdsa.PublicKey must reject invalid ECDSA point`)
+		})
+	}
+
+	t.Run("valid point round-trips", func(t *testing.T) {
+		body := []byte(`{
+			"kty": "EC",
+			"crv": "P-256",
+			"x": "AYwhwiE1hXWdfwu-HlBSsY5Chxycu-LyE6WsZ_w2DO4",
+			"y": "zumemGclMFkimMsKMXlLdKYWtLle58e4N9hDPcN7lig"
+		}`)
+		key, err := jwk.ParseKey[jwk.Key](body)
+		require.NoError(t, err, `ParseKey on a valid P-256 key should succeed`)
+		require.NoError(t, key.Validate(), `Validate on a valid P-256 key should succeed`)
+		_, err = jwk.Export[*ecdsa.PublicKey](key)
+		require.NoError(t, err, `Export on a valid P-256 key should succeed`)
+	})
+}
+
+// TestECDSAImportRejectsInvalidPoints covers the Import(*ecdsa.PublicKey)
+// entry point, which previously accepted any non-nil X/Y without curve
+// membership checks.
+func TestECDSAImportRejectsInvalidPoints(t *testing.T) {
+	t.Run("off-curve public key", func(t *testing.T) {
+		bad := &ecdsa.PublicKey{
+			Curve: elliptic.P256(),
+			X:     big.NewInt(1),
+			Y:     big.NewInt(1),
+		}
+		_, err := jwk.Import[jwk.Key](bad)
+		require.Error(t, err, `jwk.Import must reject an off-curve ecdsa.PublicKey`)
+	})
+
+	t.Run("identity public key", func(t *testing.T) {
+		bad := &ecdsa.PublicKey{
+			Curve: elliptic.P256(),
+			X:     big.NewInt(0),
+			Y:     big.NewInt(0),
+		}
+		_, err := jwk.Import[jwk.Key](bad)
+		require.Error(t, err, `jwk.Import must reject the identity point`)
+	})
+}


### PR DESCRIPTION
## Summary
- Reject ECDSA points that are not on the declared curve and the identity point (0, 0) on Import, Parse, and Validate paths
- **Breaking**: `jwk/ecdsa.RegisterCurve` now takes a `PointValidator` (interface with `PointValidatorFunc` adapter). Nil validator is rejected. Custom-curve extension modules must supply a validator backed by the curve library's own non-deprecated point parser
- Stdlib NIST curves register `ecdh.Curve.NewPublicKey`-backed validators from jwk init(). No `crypto/elliptic.Curve.IsOnCurve` calls remain anywhere in the jwk tree
- Adds regression tests covering off-curve and identity inputs for ParseKey/Validate/Export/Import

Closes JWK-003. Companion updates for `jwx-go/es256k` and `jwx-go/examples` required.
