### PR TITLE
copy recipientKey in KeyDecryptAESGCMKW to avoid caller aliasing (JWE-002)

### DIFF
--- a/jwe/jwebb/decrypt_test.go
+++ b/jwe/jwebb/decrypt_test.go
@@ -69,6 +69,33 @@ func TestKeyDecryptAESGCMKW(t *testing.T) {
 	require.Equal(t, cek, decrypted)
 }
 
+func TestKeyDecryptAESGCMKW_DoesNotMutateRecipientKey(t *testing.T) {
+	cek := testCEK
+	sharedkey := testSharedKey16
+
+	encrypted, err := jwebb.KeyEncryptAESGCMKW(cek, tokens.A128GCMKW, sharedkey)
+	require.NoError(t, err)
+	encryptedWithIVTag, ok := encrypted.(keygen.ByteWithIVAndTag)
+	require.True(t, ok, "encrypted result should have IV and tag")
+
+	// Put the encrypted key in a backing array with spare capacity and
+	// fill the tail with a sentinel pattern. The buggy
+	// append(recipientKey[:], tag...) would overwrite the tail.
+	src := encryptedWithIVTag.Bytes()
+	backing := make([]byte, len(src)+len(encryptedWithIVTag.Tag)+16)
+	copy(backing, src)
+	for i := len(src); i < len(backing); i++ {
+		backing[i] = 0xAB
+	}
+	recipientKey := backing[:len(src):len(backing)]
+	snapshot := append([]byte(nil), backing...)
+
+	decrypted, err := jwebb.KeyDecryptAESGCMKW(recipientKey, recipientKey, tokens.A128GCMKW, sharedkey, encryptedWithIVTag.IV, encryptedWithIVTag.Tag)
+	require.NoError(t, err)
+	require.Equal(t, cek, decrypted)
+	require.Equal(t, snapshot, backing, "recipientKey backing array must not be mutated")
+}
+
 func TestKeyDecryptRSA15(t *testing.T) {
 	cek := testCEK
 

--- a/jwe/jwebb/key_decrypt_symmetric.go
+++ b/jwe/jwebb/key_decrypt_symmetric.go
@@ -78,8 +78,11 @@ func KeyDecryptAESGCMKW(recipientKey, _ []byte, _ string, sharedkey []byte, iv [
 		return nil, fmt.Errorf(`failed to create new GCM wrap: %w`, err)
 	}
 
-	// Combine recipient key and tag for GCM decryption
-	ciphertext := recipientKey[:]
+	// Combine recipient key and tag for GCM decryption. Allocate a fresh
+	// buffer so we never alias into recipientKey's backing array, which
+	// is owned by the parsed message.
+	ciphertext := make([]byte, 0, len(recipientKey)+len(tag))
+	ciphertext = append(ciphertext, recipientKey...)
 	ciphertext = append(ciphertext, tag...)
 
 	jek, err := aesgcm.Open(nil, iv, ciphertext, nil)


### PR DESCRIPTION
Fix JWE-002. `KeyDecryptAESGCMKW` built its GCM ciphertext with
`ciphertext := recipientKey[:]; append(ciphertext, tag...)`, which mutates the
backing array of `recipientKey` whenever there's spare capacity. Since
`recipientKey` is the parsed Message's owned encrypted-key slice, this
corrupts message state on multi-recipient JWEs or any re-decrypt. Allocate
a fresh buffer instead.

Regression test in `jwe/jwebb/decrypt_test.go` constructs a backing array
with sentinel tail bytes and asserts they're untouched; it fails on the
prior code and passes after the fix.

v3 counterpart: #TBD
