### PR TITLE
strip key options in jwt.ParseInsecure

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -148,17 +148,27 @@ func Parse(s []byte, options ...ParseOption) (Token, error) {
 //
 // You cannot override `jwt.WithVerify()` or `jwt.WithValidate()`
 // using this function. Providing these options would result in
-// an error
+// an error.
+//
+// Key-related options (`jwt.WithKey`, `jwt.WithKeySet`,
+// `jwt.WithKeyProvider`, `jwt.WithVerifyAuto`) are silently ignored,
+// so callers may reuse an option slice across `Parse` and
+// `ParseInsecure` call sites without worrying about leaking a stray
+// verification step.
 func ParseInsecure(s []byte, options ...ParseOption) (Token, error) {
+	filtered := make([]ParseOption, 0, len(options)+2)
 	for _, opt := range options {
 		switch opt.Ident() {
 		case identVerify{}, identValidate{}:
 			return nil, parseErrorf(`jwt.ParseInsecure`, `jwt.WithVerify() and jwt.WithValidate() may not be specified`)
+		case identKey{}, identKeySet{}, identKeyProvider{}, identVerifyAuto{}:
+			continue
 		}
+		filtered = append(filtered, opt)
 	}
 
-	options = append(options, WithVerify(false), WithValidate(false))
-	tok, err := Parse(s, options...)
+	filtered = append(filtered, WithVerify(false), WithValidate(false))
+	tok, err := Parse(s, filtered...)
 	if err != nil {
 		return nil, parseErrorf(`jwt.ParseInsecure`, `failed to parse token: %w`, err)
 	}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1676,6 +1676,51 @@ func TestGH1007(t *testing.T) {
 	require.NoError(t, err, `jwt.ParseInsecure with jwt.WithKey() should succeed`)
 }
 
+func TestParseInsecureStripsKeyOptions(t *testing.T) {
+	key, err := jwxtest.GenerateRsaJwk()
+	require.NoError(t, err, `jwxtest.GenerateRsaJwk should succeed`)
+
+	tok, err := jwt.NewBuilder().Issuer(`me`).Build()
+	require.NoError(t, err, `jwt.NewBuilder should succeed`)
+
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256(), key))
+	require.NoError(t, err, `jwt.Sign should succeed`)
+
+	wrongKey, err := jwxtest.GenerateRsaJwk()
+	require.NoError(t, err, `jwxtest.GenerateRsaJwk should succeed`)
+
+	// WithKeySet: even a set that contains no matching key must not cause
+	// a verification error, because ParseInsecure strips the option.
+	wrongSet := jwk.NewSet()
+	require.NoError(t, wrongSet.AddKey(wrongKey), `set.AddKey should succeed`)
+
+	got, err := jwt.ParseInsecure(signed, jwt.WithKeySet(wrongSet))
+	require.NoError(t, err, `jwt.ParseInsecure with jwt.WithKeySet() should succeed`)
+	iss, ok := got.Issuer()
+	require.True(t, ok)
+	require.Equal(t, `me`, iss)
+
+	// WithKeyProvider: a provider that always errors must not be invoked.
+	failProvider := jws.KeyProviderFunc(func(_ context.Context, _ jws.KeySink, _ *jws.Signature, _ *jws.Message) error {
+		return fmt.Errorf(`should not be called`)
+	})
+	got, err = jwt.ParseInsecure(signed, jwt.WithKeyProvider(failProvider))
+	require.NoError(t, err, `jwt.ParseInsecure with jwt.WithKeyProvider() should succeed`)
+	iss, ok = got.Issuer()
+	require.True(t, ok)
+	require.Equal(t, `me`, iss)
+
+	// WithVerifyAuto: a fetcher that always fails must not be invoked.
+	failFetcher := jwk.FetchFunc(func(_ context.Context, _ string, _ ...jwk.FetchOption) (jwk.Set, error) {
+		return nil, fmt.Errorf(`should not be called`)
+	})
+	got, err = jwt.ParseInsecure(signed, jwt.WithVerifyAuto(failFetcher))
+	require.NoError(t, err, `jwt.ParseInsecure with jwt.WithVerifyAuto() should succeed`)
+	iss, ok = got.Issuer()
+	require.True(t, ok)
+	require.Equal(t, `me`, iss)
+}
+
 func TestParseJSON(t *testing.T) {
 	// NOTE: Unlike in v2, there is no setting for CompactOnly
 	privKey, err := jwxtest.GenerateRsaJwk()


### PR DESCRIPTION
## Summary
- `jwt.ParseInsecure` now filters out `WithKey`, `WithKeySet`, `WithKeyProvider`, `WithVerifyAuto` before delegating to `Parse`, making the documented "no verification" contract self-enforcing
- Today's safety is incidental (`tryFastPath` option-count/unknown-ident guards plus `ctx.skipVerification`); this removes the latent fragility if fast-path or parse-loop logic changes later
- Adds `TestParseInsecureStripsKeyOptions` covering `WithKeySet`, `WithKeyProvider`, `WithVerifyAuto` with failing stubs that must never be invoked
