### PR TITLE
enforce jws signatures cap before decoding entries

### DIFF
--- a/jws/interface.go
+++ b/jws/interface.go
@@ -71,10 +71,11 @@ type DecodeCtx interface {
 //
 // To sign and verify, use the appropriate `Sign()` and `Verify()` functions.
 type Message struct {
-	dc         DecodeCtx
-	payload    []byte
-	signatures []*Signature
-	b64        bool // true if payload should be base64 encoded
+	dc            DecodeCtx
+	payload       []byte
+	signatures    []*Signature
+	b64           bool // true if payload should be base64 encoded
+	maxSignatures int  // scratch cap enforced during UnmarshalJSON; 0 means use global default
 }
 
 type Signature struct {

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -320,15 +320,10 @@ func Parse(src []byte, options ...ParseOption) (*Message, error) {
 		}
 		return msg, nil
 	} else if formats&fmtJSON == fmtJSON {
-		msg, err := parseJSON(src)
+		msg, err := parseJSON(src, maxSigs)
 		if err != nil {
 			return nil, makeParseError(`jws.Parse`, `failed to parse JSON format: %w`, err)
 		}
-
-		if maxSigs > 0 && len(msg.signatures) > maxSigs {
-			return nil, makeParseError(`jws.Parse`, `too many signatures in JWS message (%d > %d)`, len(msg.signatures), maxSigs)
-		}
-
 		return msg, nil
 	}
 
@@ -389,8 +384,9 @@ func ParseReader(src io.Reader, options ...ParseOption) (*Message, error) {
 	return Parse(buf, options...)
 }
 
-func parseJSON(data []byte) (result *Message, err error) {
+func parseJSON(data []byte, maxSigs int) (result *Message, err error) {
 	var m Message
+	m.maxSignatures = maxSigs
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, fmt.Errorf(`failed to unmarshal jws message: %w`, err)
 	}

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1957,6 +1957,23 @@ func TestMaxSignatures(t *testing.T) {
 		require.NoError(t, err, `jws.Parse should succeed with per-call limit of 10`)
 	})
 
+	t.Run("rejects before decoding entries", func(t *testing.T) {
+		// Build a payload with many tiny signature stubs. If the cap were
+		// enforced only after Message.UnmarshalJSON finished decoding every
+		// entry, this would allocate hundreds of thousands of Headers before
+		// rejection.
+		const n = 200000
+		parts := make([]string, n)
+		for i := range parts {
+			parts[i] = `{"protected":"","signature":""}`
+		}
+		body := []byte(`{"payload":"","signatures":[` + strings.Join(parts, ",") + `]}`)
+
+		_, err := jws.Parse(body, jws.WithMaxSignatures(16))
+		require.Error(t, err, `jws.Parse should reject oversized signatures array`)
+		require.Contains(t, err.Error(), `too many signatures`)
+	})
+
 	t.Run("verify inherits limit", func(t *testing.T) {
 		jws.Settings(jws.WithMaxSignatures(5))
 		defer jws.Settings(jws.WithMaxSignatures(100))

--- a/jws/message.go
+++ b/jws/message.go
@@ -291,6 +291,19 @@ func (m *Message) UnmarshalJSON(buf []byte) error {
 		return fmt.Errorf(`failed to unmarshal into temporary structure: %w`, err)
 	}
 
+	// Enforce the signature cap before we decode any signature entry.
+	// The probe above leaves mup.Signatures as []json.RawMessage, so no
+	// headers/base64 work has happened yet. Doing the check here prevents
+	// a large signatures array from allocating O(input) work before Parse
+	// gets a chance to reject it.
+	maxSigs := m.maxSignatures
+	if maxSigs == 0 {
+		maxSigs = int(maxSignatures.Load())
+	}
+	if maxSigs > 0 && len(mup.Signatures) > maxSigs {
+		return fmt.Errorf(`too many signatures in JWS message (%d > %d)`, len(mup.Signatures), maxSigs)
+	}
+
 	b64 := true
 	if mup.Signature == nil { // flattened signature is NOT present
 		if len(mup.Signatures) == 0 {


### PR DESCRIPTION
## Summary
- reject oversized `signatures` arrays in `Message.UnmarshalJSON` right after the probe unmarshal, before any header/base64 work
- plumb `maxSigs` from `jws.Parse` through `parseJSON` via a scratch field on `Message`; `UnmarshalJSON` falls back to the global default when the field is unset
- add `TestMaxSignatures/rejects_before_decoding_entries` covering a 200k-stub payload rejected under a cap of 16

Previously `Parse` only checked `len(msg.signatures)` after `json.Unmarshal` had already allocated a `Headers` map and base64-decoded protected headers for every entry, so the cap did not bound worst-case work.
