### PR TITLE
cap SplitCompactReader non-finite reads at 10 MiB

### DIFF
--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -610,6 +610,25 @@ func TestEncode(t *testing.T) {
 			})
 		}
 	})
+	t.Run("SplitCompactReaderNonFiniteSizeCap", func(t *testing.T) {
+		t.Parallel()
+		_, _, _, err := jwsbb.SplitCompactReader(&endlessReader{b: 'X'})
+		require.Error(t, err, "SplitCompactReader should fail on oversized non-finite input")
+		require.ErrorIs(t, err, jwsbb.InputTooLargeError(), "error should be InputTooLargeError")
+	})
+}
+
+// endlessReader is a non-finite io.Reader that fills buf with b indefinitely
+// and never returns EOF. It is intentionally not a
+// *bytes.Reader/*bytes.Buffer/*strings.Reader so that
+// jwxio.ReadAllFromFiniteSource classifies it as non-finite.
+type endlessReader struct{ b byte }
+
+func (r *endlessReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = r.b
+	}
+	return len(p), nil
 }
 
 func TestReadFile(t *testing.T) {

--- a/jws/jwsbb/format.go
+++ b/jws/jwsbb/format.go
@@ -109,6 +109,20 @@ func InvalidNumberOfSegmentsError() error {
 	return errInvalidNumberOfSegments
 }
 
+// maxSplitCompactReaderSize caps the number of bytes SplitCompactReader will
+// consume from a non-finite io.Reader. It matches the default
+// jws.maxParseInputSize (10 MiB). Callers that need a different limit should
+// wrap their reader with io.LimitReader before calling SplitCompactReader.
+const maxSplitCompactReaderSize = 10 * 1024 * 1024
+
+var errInputTooLarge = errors.New(`jwsbb: input exceeds maximum size`)
+
+// InputTooLargeError returns the sentinel error used when SplitCompactReader
+// reads more than its internal size cap from a non-finite source.
+func InputTooLargeError() error {
+	return errInputTooLarge
+}
+
 // SplitCompact parses a compact JWS serialization into its three components.
 // This function validates that the input has exactly 3 segments separated by periods
 // and returns the base64-encoded components without decoding them.
@@ -176,15 +190,24 @@ func SplitCompactReader(rdr io.Reader) (protected, payload, signature []byte, er
 		return nil, nil, nil, err
 	}
 
+	// Cap total bytes read from a non-finite source. Read one extra byte so
+	// we can distinguish "exactly at the limit" from "over".
+	limited := io.LimitReader(rdr, maxSplitCompactReaderSize+1)
+
 	var periods int
 	var state int
+	var total int64
 
 	buf := make([]byte, 4096)
 	var sofar []byte
 
 	for {
 		// read next bytes
-		n, err := rdr.Read(buf)
+		n, err := limited.Read(buf)
+		total += int64(n)
+		if total > maxSplitCompactReaderSize {
+			return nil, nil, nil, InputTooLargeError()
+		}
 		// return on unexpected read error
 		if err != nil && err != io.EOF {
 			return nil, nil, nil, io.ErrUnexpectedEOF


### PR DESCRIPTION
`jwsbb.SplitCompactReader`'s fallback streaming path appended every chunk
from a non-finite reader into an unbounded buffer. A reader that never
produces a period delimiter (e.g. a chunked HTTP body) could grow the
backing slice until OOM.

Cap the non-finite read at 10 MiB (matching the default
`jws.maxParseInputSize`) via `io.LimitReader` and return a new
`InputTooLargeError` sentinel once the cap is exceeded. Callers needing
a different limit should wrap the reader themselves.
