### PR TITLE
copy rawKey in symmetricKey.Import to avoid caller aliasing

### DIFF
--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1251,6 +1251,7 @@ func TestECDSA(t *testing.T) {
 }
 
 func TestSymmetric(t *testing.T) {
+	t.Parallel()
 	t.Run("Key", func(t *testing.T) {
 		VerifyKey(t, map[string]keyDef{
 			jwk.KeyTypeKey: {

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1263,6 +1263,22 @@ func TestSymmetric(t *testing.T) {
 			}),
 		})
 	})
+	t.Run("ImportCopiesCallerSlice", func(t *testing.T) {
+		t.Parallel()
+		buf := []byte("super-secret-hmac-key")
+		want := append([]byte(nil), buf...)
+
+		key, err := jwk.Import[jwk.SymmetricKey](buf)
+		require.NoError(t, err)
+
+		for i := range buf {
+			buf[i] = 0
+		}
+
+		got, ok := key.Octets()
+		require.True(t, ok)
+		require.Equal(t, want, got, "JWK octets must not alias caller slice")
+	})
 }
 
 func TestOKP(t *testing.T) {

--- a/jwk/symmetric.go
+++ b/jwk/symmetric.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/lestrrat-go/jwx/v4/internal/base64"
 	"github.com/lestrrat-go/jwx/v4/jwa"
@@ -21,7 +22,7 @@ func (k *symmetricKey) Import(rawKey []byte) error {
 		return fmt.Errorf(`non-empty []byte key required`)
 	}
 
-	k.octets = rawKey
+	k.octets = slices.Clone(rawKey)
 
 	return nil
 }


### PR DESCRIPTION
`symmetricKey.Import` retained the caller's `[]byte` instead of copying it. A caller that later zeroized or mutated the buffer (common after handing an HMAC key to a store) would silently corrupt the JWK, with an added data race against the key's mutex. Every other Import path and the generated `Set("k", ...)` already copy; this brings Import in line using `slices.Clone`.

Regression test added under `TestSymmetric/ImportCopiesCallerSlice`.
