### PR TITLE
copy rawKey in symmetricKey.Import to avoid caller aliasing

### DIFF
--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1149,6 +1149,7 @@ func TestECDSA(t *testing.T) {
 }
 
 func TestSymmetric(t *testing.T) {
+	t.Parallel()
 	t.Run("Key", func(t *testing.T) {
 		VerifyKey(t, map[string]keyDef{
 			jwk.KeyTypeKey: {
@@ -1160,6 +1161,24 @@ func TestSymmetric(t *testing.T) {
 				Value:  "aGVsbG8K",
 			}),
 		})
+	})
+	t.Run("ImportCopiesCallerSlice", func(t *testing.T) {
+		t.Parallel()
+		buf := []byte("super-secret-hmac-key")
+		want := append([]byte(nil), buf...)
+
+		key, err := jwk.Import(buf)
+		require.NoError(t, err)
+
+		for i := range buf {
+			buf[i] = 0
+		}
+
+		sym, ok := key.(jwk.SymmetricKey)
+		require.True(t, ok)
+		got, ok := sym.Octets()
+		require.True(t, ok)
+		require.Equal(t, want, got, "JWK octets must not alias caller slice")
 	})
 }
 

--- a/jwk/symmetric.go
+++ b/jwk/symmetric.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/lestrrat-go/jwx/v3/internal/base64"
 	"github.com/lestrrat-go/jwx/v3/jwa"
@@ -21,7 +22,7 @@ func (k *symmetricKey) Import(rawKey []byte) error {
 		return fmt.Errorf(`non-empty []byte key required`)
 	}
 
-	k.octets = rawKey
+	k.octets = slices.Clone(rawKey)
 
 	return nil
 }


### PR DESCRIPTION
`symmetricKey.Import` retained the caller's `[]byte` instead of copying it. A caller that later zeroized or mutated the buffer (common after handing an HMAC key to a store) would silently corrupt the JWK, with an added data race against the key's mutex. Every other Import path and the generated `Set("k", ...)` already copy; this brings Import in line using `slices.Clone`.

Regression test added under `TestSymmetric/ImportCopiesCallerSlice`.
