### PR TITLE
enforce max parse input size in jws.Parse and jwe.Parse

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -1107,11 +1107,25 @@ func Decrypt(buf []byte, options ...DecryptOption) ([]byte, error) {
 // Parse parses the JWE message into a Message object. The JWE message
 // can be either compact or full JSON format.
 //
-// Parse() currently does not process any options, but the API accepts
-// them so that callers like ParseReader can forward their option lists
-// without filtering. Options such as WithMaxParseInputSize are handled
-// by ParseReader before the data reaches this function.
-func Parse(buf []byte, _ ...ParseOption) (*Message, error) {
+// Parse enforces the `WithMaxParseInputSize` cap on the length of buf,
+// matching the behavior of ParseReader. Callers who pre-read bytes into
+// memory (e.g. HTTP middleware, database values) therefore get the same
+// hardening as the io.Reader path.
+func Parse(buf []byte, options ...ParseOption) (*Message, error) {
+	maxSize := maxParseInputSize.Load()
+	for _, option := range options {
+		if option.Ident() == (identMaxParseInputSize{}) {
+			if err := option.Value(&maxSize); err != nil {
+				return nil, makeParseError(`jwe.Parse`, `invalid WithMaxParseInputSize: %w`, err)
+			}
+			if maxSize <= 0 {
+				return nil, makeParseError(`jwe.Parse`, `WithMaxParseInputSize must be greater than zero`)
+			}
+		}
+	}
+	if maxSize > 0 && int64(len(buf)) > maxSize {
+		return nil, makeParseError(`jwe.Parse`, `input exceeded max size of %d bytes`, maxSize)
+	}
 	return parseJSONOrCompact(buf, false, int(maxRecipients.Load()))
 }
 

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1349,6 +1349,42 @@ func TestMaxParseInputSize(t *testing.T) {
 		require.Error(t, err)
 		require.NotContains(t, err.Error(), `exceeded max size`)
 	})
+	t.Run("Parse rejects oversized byte slice (global setting)", func(t *testing.T) {
+		jwe.Settings(jwe.WithMaxParseInputSize(50))
+		defer jwe.Settings(jwe.WithMaxParseInputSize(10 * 1024 * 1024))
+
+		_, err := jwe.Parse(make([]byte, 100))
+		require.Error(t, err, `jwe.Parse should reject oversized input`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("ParseString inherits the cap", func(t *testing.T) {
+		jwe.Settings(jwe.WithMaxParseInputSize(50))
+		defer jwe.Settings(jwe.WithMaxParseInputSize(10 * 1024 * 1024))
+
+		_, err := jwe.ParseString(strings.Repeat("a", 100))
+		require.Error(t, err, `jwe.ParseString should inherit the size cap`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("Parse honors per-call override", func(t *testing.T) {
+		_, err := jwe.Parse(make([]byte, 200), jwe.WithMaxParseInputSize(100))
+		require.Error(t, err, `jwe.Parse should reject input exceeding per-call cap`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("Parse per-call override can raise above global", func(t *testing.T) {
+		jwe.Settings(jwe.WithMaxParseInputSize(50))
+		defer jwe.Settings(jwe.WithMaxParseInputSize(10 * 1024 * 1024))
+
+		data := make([]byte, 100)
+		_, err := jwe.Parse(data, jwe.WithMaxParseInputSize(1024))
+		if err != nil {
+			require.NotContains(t, err.Error(), `exceeded max size`)
+		}
+	})
+	t.Run("Parse negative per-call value returns error", func(t *testing.T) {
+		_, err := jwe.Parse([]byte(`test`), jwe.WithMaxParseInputSize(-1))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `greater than zero`)
+	})
 }
 
 func TestMaxRecipients(t *testing.T) {

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -228,12 +228,14 @@ options:
     interface: GlobalParseOption
     argument_type: int64
     comment: |
-      WithMaxParseInputSize specifies the maximum number of bytes read from an
-      io.Reader in `jwe.ParseReader`. If the input exceeds this size,
-      `jwe.ParseReader` will return an error. The default value is 10MB.
+      WithMaxParseInputSize specifies the maximum byte length of input
+      accepted by every `jwe.Parse*` entry point (`jwe.Parse`,
+      `jwe.ParseString`, and `jwe.ParseReader`). Inputs exceeding this
+      size are rejected before decoding. The default value is 10MB.
 
       This option can be passed to `jwe.Settings()` to change the default
-      globally, or to `jwe.ReadFile()` for a per-call override.
+      globally, or to any `jwe.Parse*` call / `jwe.ReadFile()` for a
+      per-call override.
   - ident: CritValidation
     interface: DecryptOption
     argument_type: bool

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -446,12 +446,14 @@ func WithMaxPBES2Count(v int) GlobalDecryptOption {
 	return &globalDecryptOption{option.New(identMaxPBES2Count{}, v)}
 }
 
-// WithMaxParseInputSize specifies the maximum number of bytes read from an
-// io.Reader in `jwe.ParseReader`. If the input exceeds this size,
-// `jwe.ParseReader` will return an error. The default value is 10MB.
+// WithMaxParseInputSize specifies the maximum byte length of input
+// accepted by every `jwe.Parse*` entry point (`jwe.Parse`,
+// `jwe.ParseString`, and `jwe.ParseReader`). Inputs exceeding this
+// size are rejected before decoding. The default value is 10MB.
 //
 // This option can be passed to `jwe.Settings()` to change the default
-// globally, or to `jwe.ReadFile()` for a per-call override.
+// globally, or to any `jwe.Parse*` call / `jwe.ReadFile()` for a
+// per-call override.
 func WithMaxParseInputSize(v int64) GlobalParseOption {
 	return &globalParseOption{option.New(identMaxParseInputSize{}, v)}
 }

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -266,9 +266,15 @@ func getB64Value(hdr Headers) bool {
 // will attempt to autodetect the format. If one or the other is specified,
 // only the specified format will be attempted.
 //
+// Parse enforces the `WithMaxParseInputSize` cap on the length of src,
+// matching the behavior of ParseReader. Callers who pre-read bytes into
+// memory (e.g. HTTP middleware, database values) therefore get the same
+// hardening as the io.Reader path.
+//
 // On error, returns a jws.ParseError.
 func Parse(src []byte, options ...ParseOption) (*Message, error) {
 	maxSigs := int(maxSignatures.Load())
+	maxSize := maxParseInputSize.Load()
 
 	var formats int
 	for _, option := range options {
@@ -291,7 +297,18 @@ func Parse(src []byte, options ...ParseOption) (*Message, error) {
 			if maxSigs <= 0 {
 				return nil, makeParseError(`jws.Parse`, `WithMaxSignatures must be greater than zero`)
 			}
+		case identMaxParseInputSize{}:
+			if err := option.Value(&maxSize); err != nil {
+				return nil, makeParseError(`jws.Parse`, `invalid WithMaxParseInputSize: %w`, err)
+			}
+			if maxSize <= 0 {
+				return nil, makeParseError(`jws.Parse`, `WithMaxParseInputSize must be greater than zero`)
+			}
 		}
+	}
+
+	if maxSize > 0 && int64(len(src)) > maxSize {
+		return nil, makeParseError(`jws.Parse`, `input exceeded max size of %d bytes`, maxSize)
 	}
 
 	// if format is 0 or both JSON/Compact, auto detect

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1874,6 +1874,45 @@ func TestMaxParseInputSize(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), `greater than zero`)
 	})
+	t.Run("Parse rejects oversized byte slice (global setting)", func(t *testing.T) {
+		jws.Settings(jws.WithMaxParseInputSize(50))
+		defer jws.Settings(jws.WithMaxParseInputSize(10 * 1024 * 1024))
+
+		_, err := jws.Parse(make([]byte, 100))
+		require.Error(t, err, `jws.Parse should reject oversized input`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("ParseString inherits the cap", func(t *testing.T) {
+		jws.Settings(jws.WithMaxParseInputSize(50))
+		defer jws.Settings(jws.WithMaxParseInputSize(10 * 1024 * 1024))
+
+		_, err := jws.ParseString(strings.Repeat("a", 100))
+		require.Error(t, err, `jws.ParseString should inherit the size cap`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("Parse honors per-call override", func(t *testing.T) {
+		_, err := jws.Parse(make([]byte, 200), jws.WithMaxParseInputSize(100))
+		require.Error(t, err, `jws.Parse should reject input exceeding per-call cap`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("Parse per-call override can raise above global", func(t *testing.T) {
+		jws.Settings(jws.WithMaxParseInputSize(50))
+		defer jws.Settings(jws.WithMaxParseInputSize(10 * 1024 * 1024))
+
+		// Input exceeds the global cap but is within the per-call override;
+		// the size check must pass (payload is still invalid JWS, but the
+		// returned error must not be about the size cap).
+		data := make([]byte, 100)
+		_, err := jws.Parse(data, jws.WithMaxParseInputSize(1024))
+		if err != nil {
+			require.NotContains(t, err.Error(), `exceeded max size`)
+		}
+	})
+	t.Run("Parse negative per-call value returns error", func(t *testing.T) {
+		_, err := jws.Parse([]byte(`test`), jws.WithMaxParseInputSize(-1))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `greater than zero`)
+	})
 }
 
 func TestMaxSignatures(t *testing.T) {

--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -248,13 +248,14 @@ options:
     interface: GlobalParseOption
     argument_type: int64
     comment: |
-      WithMaxParseInputSize specifies the maximum number of bytes read from an
-      io.Reader in `jws.ParseReader`. If the input exceeds this size,
-      `jws.ParseReader` will return an error. The default value is 10MB.
+      WithMaxParseInputSize specifies the maximum byte length of input
+      accepted by every `jws.Parse*` entry point (`jws.Parse`,
+      `jws.ParseString`, and `jws.ParseReader`). Inputs exceeding this
+      size are rejected before decoding. The default value is 10MB.
 
       This option can be passed to `jws.Settings()` to change the default
-      globally, or to `jws.ParseReader()` / `jws.ReadFile()` for a per-call
-      override.
+      globally, or to any `jws.Parse*` call / `jws.ReadFile()` for a
+      per-call override.
   - ident: MaxSignatures
     interface: GlobalParseOption
     argument_type: int

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -435,13 +435,14 @@ func WithLegacySigners() GlobalOption {
 	return &globalOption{option.New(identLegacySigners{}, true)}
 }
 
-// WithMaxParseInputSize specifies the maximum number of bytes read from an
-// io.Reader in `jws.ParseReader`. If the input exceeds this size,
-// `jws.ParseReader` will return an error. The default value is 10MB.
+// WithMaxParseInputSize specifies the maximum byte length of input
+// accepted by every `jws.Parse*` entry point (`jws.Parse`,
+// `jws.ParseString`, and `jws.ParseReader`). Inputs exceeding this
+// size are rejected before decoding. The default value is 10MB.
 //
 // This option can be passed to `jws.Settings()` to change the default
-// globally, or to `jws.ParseReader()` / `jws.ReadFile()` for a per-call
-// override.
+// globally, or to any `jws.Parse*` call / `jws.ReadFile()` for a
+// per-call override.
 func WithMaxParseInputSize(v int64) GlobalParseOption {
 	return &globalParseOption{option.New(identMaxParseInputSize{}, v)}
 }


### PR DESCRIPTION
## Summary
- `jws.Parse` / `jwe.Parse` now enforce `WithMaxParseInputSize` on their `[]byte` input, matching `ParseReader`; previously the cap only applied to the `io.Reader` path so `jws.Verify`-style callers passing pre-read bytes bypassed the limit.
- Per-call `WithMaxParseInputSize` option is honored on `Parse` and `ParseString`.
- Option godoc updated to state the cap applies to every `Parse*` entry point.
