### PR TITLE
fix jwk x509 decoder unregister index and race

### DIFF
--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -2734,10 +2734,8 @@ func TestX509DecoderConcurrent(t *testing.T) {
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
 
-	for i := 0; i < 8; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 8 {
+		wg.Go(func() {
 			for {
 				select {
 				case <-stop:
@@ -2749,10 +2747,10 @@ func TestX509DecoderConcurrent(t *testing.T) {
 				// the read path must not race on the decoder slice.
 				_, _ = jwk.ParseKey[jwk.Key](pemData, jwk.WithPEM(true))
 			}
-		}()
+		})
 	}
 
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		ident := fmt.Sprintf("test-concurrent-%d", i)
 		require.NoError(t, jwk.RegisterX509Decoder(ident, decoder))
 		jwk.UnregisterX509Decoder(ident)

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2610,6 +2611,155 @@ func TestUnregisterX509Decoder_NotRegistered(t *testing.T) {
 	require.NotPanics(t, func() {
 		jwk.UnregisterX509Decoder("non-existent-decoder")
 	})
+}
+
+// registerTrioDecoders registers three decoders that each recognize a
+// distinct PEM block type. Callers receive the idents and a function
+// that builds a PEM body for one of the types. Cleanup is registered
+// via t.Cleanup so leftover decoders never leak across tests.
+func registerTrioDecoders(t *testing.T) (identA, identB, identC string, pemFor func(string) []byte) {
+	t.Helper()
+	testKey, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err)
+
+	mk := func(wantType string) jwk.X509Decoder {
+		return jwk.X509DecodeFunc(func(block *pem.Block) (any, error) {
+			if block.Type == wantType {
+				return testKey, nil
+			}
+			return nil, fmt.Errorf("unsupported type")
+		})
+	}
+
+	identA = "test-trio-A"
+	identB = "test-trio-B"
+	identC = "test-trio-C"
+	require.NoError(t, jwk.RegisterX509Decoder(identA, mk("TRIO A")))
+	require.NoError(t, jwk.RegisterX509Decoder(identB, mk("TRIO B")))
+	require.NoError(t, jwk.RegisterX509Decoder(identC, mk("TRIO C")))
+
+	t.Cleanup(func() {
+		jwk.UnregisterX509Decoder(identA)
+		jwk.UnregisterX509Decoder(identB)
+		jwk.UnregisterX509Decoder(identC)
+	})
+
+	pemFor = func(typ string) []byte {
+		return []byte("-----BEGIN " + typ + "-----\ndGVzdCBkYXRh\n-----END " + typ + "-----")
+	}
+	return identA, identB, identC, pemFor
+}
+
+// TestUnregisterX509Decoder_StaleIndexMiddle exercises JWK-003: after
+// removing a decoder from the middle of the list, a subsequent
+// unregister of a later-registered ident must not panic and must
+// remove the correct decoder.
+func TestUnregisterX509Decoder_StaleIndexMiddle(t *testing.T) {
+	identA, identB, identC, pemFor := registerTrioDecoders(t)
+
+	// Remove the middle decoder. Prior to the fix, the surviving
+	// entry for identC kept its original index, which pointed past
+	// the end of the shrunken slice.
+	jwk.UnregisterX509Decoder(identB)
+
+	// B must no longer decode.
+	_, err := jwk.ParseKey[jwk.Key](pemFor("TRIO B"), jwk.WithPEM(true))
+	require.Error(t, err, "TRIO B should fail after unregister")
+
+	// A and C must still decode.
+	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO A"), jwk.WithPEM(true))
+	require.NoError(t, err, "TRIO A should still decode")
+	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
+	require.NoError(t, err, "TRIO C should still decode")
+
+	// Now unregister C by ident. Before the fix this would panic
+	// with an out-of-range slice index.
+	require.NotPanics(t, func() {
+		jwk.UnregisterX509Decoder(identC)
+	})
+
+	// C must no longer decode; A must still decode.
+	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
+	require.Error(t, err, "TRIO C should fail after second unregister")
+	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO A"), jwk.WithPEM(true))
+	require.NoError(t, err, "TRIO A must survive unrelated unregister")
+
+	// Keep identA alive until cleanup fires.
+	_ = identA
+}
+
+// TestUnregisterX509Decoder_StaleIndexFirst exercises the case where
+// the removed element is at index 0 of the user-registered portion of
+// the list. A later unregister for a surviving ident must still hit
+// the correct decoder.
+func TestUnregisterX509Decoder_StaleIndexFirst(t *testing.T) {
+	identA, identB, identC, pemFor := registerTrioDecoders(t)
+
+	jwk.UnregisterX509Decoder(identA)
+
+	_, err := jwk.ParseKey[jwk.Key](pemFor("TRIO A"), jwk.WithPEM(true))
+	require.Error(t, err)
+	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO B"), jwk.WithPEM(true))
+	require.NoError(t, err)
+	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		jwk.UnregisterX509Decoder(identC)
+	})
+
+	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
+	require.Error(t, err)
+	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO B"), jwk.WithPEM(true))
+	require.NoError(t, err, "TRIO B must survive unrelated unregister")
+
+	_ = identB
+}
+
+// TestX509DecoderConcurrent runs parsers and register/unregister
+// concurrently. Under -race this catches the in-place slice mutation
+// that was racing with snapshot-then-iterate readers in decodeX509.
+func TestX509DecoderConcurrent(t *testing.T) {
+	testKey, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err)
+
+	pemData := []byte("-----BEGIN TRIO CONCURRENT-----\ndGVzdCBkYXRh\n-----END TRIO CONCURRENT-----")
+	decoder := jwk.X509DecodeFunc(func(block *pem.Block) (any, error) {
+		if block.Type == "TRIO CONCURRENT" {
+			return testKey, nil
+		}
+		return nil, fmt.Errorf("unsupported type")
+	})
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// Best-effort parse; error is fine (decoder may be
+				// unregistered at this moment). The point is that
+				// the read path must not race on the decoder slice.
+				_, _ = jwk.ParseKey[jwk.Key](pemData, jwk.WithPEM(true))
+			}
+		}()
+	}
+
+	for i := 0; i < 200; i++ {
+		ident := fmt.Sprintf("test-concurrent-%d", i)
+		require.NoError(t, jwk.RegisterX509Decoder(ident, decoder))
+		jwk.UnregisterX509Decoder(ident)
+	}
+
+	close(stop)
+	wg.Wait()
 }
 
 func TestGH1529(t *testing.T) {

--- a/jwk/x509.go
+++ b/jwk/x509.go
@@ -151,8 +151,15 @@ func (f X509DecodeFunc) DecodeX509(block *pem.Block) (any, error) {
 	return f(block)
 }
 
+// x509Decoders holds every registered decoder keyed by its caller-supplied
+// ident. x509DecoderIdents keeps the registration order so decodeX509 tries
+// decoders in a stable, deterministic sequence. x509DecoderList is the
+// read-optimized snapshot handed out to readers; every mutation replaces it
+// with a freshly allocated slice so readers can iterate their captured
+// header without any further synchronization.
 var muX509Decoders sync.RWMutex
-var x509Decoders = map[any]int{}
+var x509Decoders = map[any]X509Decoder{}
+var x509DecoderIdents = []any{}
 var x509DecoderList = []X509Decoder{}
 
 type identDefaultX509Decoder struct{}
@@ -186,8 +193,14 @@ func RegisterX509Decoder(ident any, decoder X509Decoder) error {
 		return nil // already registered
 	}
 
-	x509Decoders[ident] = len(x509DecoderList)
-	x509DecoderList = append(x509DecoderList, decoder)
+	x509Decoders[ident] = decoder
+	x509DecoderIdents = append(x509DecoderIdents, ident)
+	// Publish a fresh slice so any reader that snapshotted the previous
+	// one keeps iterating its own immutable copy.
+	next := make([]X509Decoder, len(x509DecoderList)+1)
+	copy(next, x509DecoderList)
+	next[len(x509DecoderList)] = decoder
+	x509DecoderList = next
 	return nil
 }
 
@@ -198,26 +211,27 @@ func RegisterX509Decoder(ident any, decoder X509Decoder) error {
 func UnregisterX509Decoder(ident any) {
 	muX509Decoders.Lock()
 	defer muX509Decoders.Unlock()
-	idx, ok := x509Decoders[ident]
-	if !ok {
+	if _, ok := x509Decoders[ident]; !ok {
 		return // not registered
 	}
 
 	delete(x509Decoders, ident)
 
-	l := len(x509DecoderList)
-	switch idx {
-	case l - 1:
-		// if the last element, just truncate the slice
-		x509DecoderList = x509DecoderList[:l-1]
-	case 0:
-		// if the first element, just shift the slice
-		x509DecoderList = x509DecoderList[1:]
-	default:
-		// if the element is in the middle, remove it by slicing
-		// and appending the two slices together
-		x509DecoderList = append(x509DecoderList[:idx], x509DecoderList[idx+1:]...)
+	// Rebuild idents and the reader-facing slice as fresh allocations,
+	// preserving registration order and filtering the removed ident.
+	// Mutating the old slices in place would race with readers in
+	// decodeX509 that iterate a captured snapshot without holding RLock.
+	nextIdents := make([]any, 0, len(x509DecoderIdents)-1)
+	nextList := make([]X509Decoder, 0, len(x509DecoderList)-1)
+	for _, id := range x509DecoderIdents {
+		if id == ident {
+			continue
+		}
+		nextIdents = append(nextIdents, id)
+		nextList = append(nextList, x509Decoders[id])
 	}
+	x509DecoderIdents = nextIdents
+	x509DecoderList = nextList
 }
 
 // decodeX509 decodes a PEM encoded ASN.1 DER format and returns the raw key.


### PR DESCRIPTION
## Summary

- `UnregisterX509Decoder` no longer leaves stale indices — before this fix, removing a middle or first decoder and then unregistering any later ident would panic with `slice bounds out of range` or silently delete the wrong decoder
- `decodeX509`'s reader-side snapshot is no longer raced by in-place slice mutation in register/unregister (caught by `-race`)
- Register/Unregister publish a freshly allocated `x509DecoderList` on every change; registration order tracked via a parallel `x509DecoderIdents` slice

## Test plan

- [x] `go test ./jwk -run X509 -race -count=5`
- [x] `go test ./jwk -count=1` (full jwk suite)
