### PR TITLE
fix jwt fast path json injection via unescaped kid

### DIFF
--- a/jwt/fastpath.go
+++ b/jwt/fastpath.go
@@ -18,7 +18,7 @@ import (
 // byte disqualifies the fast path; such kids fall through to the
 // regular jws.Sign path where encoding/json handles escaping.
 func fastPathKidSafe(kid string) bool {
-	for i := 0; i < len(kid); i++ {
+	for i := range len(kid) {
 		c := kid[i]
 		if c < 0x20 || c >= 0x7f || c == '"' || c == '\\' {
 			return false

--- a/jwt/fastpath.go
+++ b/jwt/fastpath.go
@@ -12,6 +12,21 @@ import (
 	"github.com/lestrrat-go/jwx/v3/jws/jwsbb"
 )
 
+// fastPathKidSafe reports whether kid can be concatenated into a
+// hand-built JSON header literal without escaping. Any byte that would
+// require a JSON escape (control bytes, `"`, `\`) or any non-ASCII
+// byte disqualifies the fast path; such kids fall through to the
+// regular jws.Sign path where encoding/json handles escaping.
+func fastPathKidSafe(kid string) bool {
+	for i := 0; i < len(kid); i++ {
+		c := kid[i]
+		if c < 0x20 || c >= 0x7f || c == '"' || c == '\\' {
+			return false
+		}
+	}
+	return true
+}
+
 // signFast reinvents the wheel a bit to avoid the overhead of
 // going through the entire jws.Sign() machinery.
 func signFast(t Token, alg jwa.SignatureAlgorithm, key any) ([]byte, error) {

--- a/jwt/fastpath_test.go
+++ b/jwt/fastpath_test.go
@@ -1,0 +1,83 @@
+package jwt_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/internal/jwxtest"
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/lestrrat-go/jwx/v3/jws"
+	"github.com/lestrrat-go/jwx/v3/jwt"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for REV-JWT-001: a kid containing JSON-special bytes must
+// not be concatenated raw into the protected header. The fast path
+// should fall back to jws.Sign so encoding/json escapes the value.
+func TestSign_UnsafeKidFallsBackToSlowPath(t *testing.T) {
+	t.Parallel()
+
+	priv, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err)
+
+	testcases := []struct {
+		name string
+		kid  string
+	}{
+		{name: "injection via quote+crit", kid: `a","crit":["x"],"x`},
+		{name: "backslash", kid: `back\slash`},
+		{name: "control byte", kid: "ctrl\x01byte"},
+		{name: "non-ascii", kid: "naïve"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			key, err := jwk.Import(priv)
+			require.NoError(t, err)
+			require.NoError(t, key.Set(jwk.KeyIDKey, tc.kid))
+
+			tok := jwt.New()
+			signed, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256(), key))
+			require.NoError(t, err)
+
+			msg, err := jws.Parse(signed)
+			require.NoError(t, err)
+
+			sigs := msg.Signatures()
+			require.Len(t, sigs, 1)
+			hdrs := sigs[0].ProtectedHeaders()
+
+			gotKid, ok := hdrs.KeyID()
+			require.True(t, ok, "kid should be present")
+			require.Equal(t, tc.kid, gotKid, "kid must round-trip exactly")
+
+			// Ensure no injected crit field from a hand-crafted kid.
+			crit, _ := hdrs.Critical()
+			require.Empty(t, crit, "crit must not be injected")
+		})
+	}
+}
+
+// Sanity check: ascii-safe kid still produces a valid token with the
+// expected kid in the header (exercises the fast path itself).
+func TestSign_SafeKidFastPath(t *testing.T) {
+	t.Parallel()
+
+	priv, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err)
+
+	key, err := jwk.Import(priv)
+	require.NoError(t, err)
+	require.NoError(t, key.Set(jwk.KeyIDKey, "safe-kid-123"))
+
+	signed, err := jwt.Sign(jwt.New(), jwt.WithKey(jwa.RS256(), key))
+	require.NoError(t, err)
+
+	msg, err := jws.Parse(signed)
+	require.NoError(t, err)
+	sigs := msg.Signatures()
+	require.Len(t, sigs, 1)
+	gotKid, ok := sigs[0].ProtectedHeaders().KeyID()
+	require.True(t, ok)
+	require.Equal(t, "safe-kid-123", gotKid)
+}

--- a/jwt/fastpath_test.go
+++ b/jwt/fastpath_test.go
@@ -32,6 +32,7 @@ func TestSign_UnsafeKidFallsBackToSlowPath(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			key, err := jwk.Import(priv)
 			require.NoError(t, err)
 			require.NoError(t, key.Set(jwk.KeyIDKey, tc.kid))

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lestrrat-go/jwx/v3"
 	"github.com/lestrrat-go/jwx/v3/internal/json"
 	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/lestrrat-go/jwx/v3/jws"
 	jwterrs "github.com/lestrrat-go/jwx/v3/jwt/internal/errors"
 	"github.com/lestrrat-go/jwx/v3/jwt/internal/types"
@@ -512,8 +513,19 @@ func Sign(t Token, options ...SignOption) ([]byte, error) {
 
 			// Check if option contains anything other than alg/key
 			if len(wk.options) == 0 {
-				// yay, we have something we can put in the FAST PATH!
-				return signFast(t, alg, wk.key)
+				// If the key carries a kid that would require JSON escaping,
+				// skip the fast path (which concatenates kid raw into the
+				// protected header) and fall through to jws.Sign.
+				fastSafe := true
+				if jwkKey, ok := wk.key.(jwk.Key); ok {
+					if v, ok := jwkKey.KeyID(); ok && !fastPathKidSafe(v) {
+						fastSafe = false
+					}
+				}
+				if fastSafe {
+					// yay, we have something we can put in the FAST PATH!
+					return signFast(t, alg, wk.key)
+				}
 			}
 			// fallthrough
 		}


### PR DESCRIPTION
## Summary

- `jwt.Sign` fast path hand-concatenated `jwk.Key.KeyID()` raw into the protected header; a `kid` containing `"`, `\`, control bytes, or non-ASCII could inject header fields (e.g. `crit`) or produce invalid JSON.
- Gate the fast path on an ASCII-safe `kid` check; unsafe values fall through to `jws.Sign` where `encoding/json` escapes properly.
- Regression test covers quote+crit injection, backslash, control byte, non-ASCII, plus a safe-kid sanity check.
