### PR TITLE
fix nil-aware ok return in jws header accessors

### DIFF
--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -117,13 +117,13 @@ func (h *stdHeaders) ContentType() (string, bool) {
 func (h *stdHeaders) Critical() ([]string, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	return h.critical, true
+	return h.critical, h.critical != nil
 }
 
 func (h *stdHeaders) JWK() (jwk.Key, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	return h.jwk, true
+	return h.jwk, h.jwk != nil
 }
 
 func (h *stdHeaders) JWKSetURL() (string, bool) {
@@ -156,7 +156,7 @@ func (h *stdHeaders) Type() (string, bool) {
 func (h *stdHeaders) X509CertChain() (*cert.Chain, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	return h.x509CertChain, true
+	return h.x509CertChain, h.x509CertChain != nil
 }
 
 func (h *stdHeaders) X509CertThumbprint() (string, bool) {

--- a/jws/headers_nil_test.go
+++ b/jws/headers_nil_test.go
@@ -1,0 +1,66 @@
+package jws_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/jws"
+	"github.com/stretchr/testify/require"
+)
+
+// A freshly constructed Headers must report ok=false on every typed
+// accessor for a field that has never been set. This is a regression
+// guard for the genjws generator where slice/interface accessors used
+// to unconditionally return ok=true.
+func TestHeaders_NilAccessorsReportNotPresent(t *testing.T) {
+	t.Parallel()
+
+	h := jws.NewHeaders()
+
+	t.Run("Algorithm", func(t *testing.T) {
+		_, ok := h.Algorithm()
+		require.False(t, ok)
+	})
+	t.Run("ContentType", func(t *testing.T) {
+		_, ok := h.ContentType()
+		require.False(t, ok)
+	})
+	t.Run("Critical", func(t *testing.T) {
+		v, ok := h.Critical()
+		require.False(t, ok)
+		require.Nil(t, v)
+	})
+	t.Run("JWK", func(t *testing.T) {
+		v, ok := h.JWK()
+		require.False(t, ok)
+		require.Nil(t, v)
+	})
+	t.Run("JWKSetURL", func(t *testing.T) {
+		_, ok := h.JWKSetURL()
+		require.False(t, ok)
+	})
+	t.Run("KeyID", func(t *testing.T) {
+		_, ok := h.KeyID()
+		require.False(t, ok)
+	})
+	t.Run("Type", func(t *testing.T) {
+		_, ok := h.Type()
+		require.False(t, ok)
+	})
+	t.Run("X509CertChain", func(t *testing.T) {
+		v, ok := h.X509CertChain()
+		require.False(t, ok)
+		require.Nil(t, v)
+	})
+	t.Run("X509CertThumbprint", func(t *testing.T) {
+		_, ok := h.X509CertThumbprint()
+		require.False(t, ok)
+	})
+	t.Run("X509CertThumbprintS256", func(t *testing.T) {
+		_, ok := h.X509CertThumbprintS256()
+		require.False(t, ok)
+	})
+	t.Run("X509URL", func(t *testing.T) {
+		_, ok := h.X509URL()
+		require.False(t, ok)
+	})
+}

--- a/jws/headers_nil_test.go
+++ b/jws/headers_nil_test.go
@@ -14,53 +14,28 @@ import (
 func TestHeaders_NilAccessorsReportNotPresent(t *testing.T) {
 	t.Parallel()
 
-	h := jws.NewHeaders()
+	testcases := []struct {
+		name string
+		get  func(jws.Headers) (any, bool)
+	}{
+		{"Algorithm", func(h jws.Headers) (any, bool) { v, ok := h.Algorithm(); return v, ok }},
+		{"ContentType", func(h jws.Headers) (any, bool) { v, ok := h.ContentType(); return v, ok }},
+		{"Critical", func(h jws.Headers) (any, bool) { v, ok := h.Critical(); return v, ok }},
+		{"JWK", func(h jws.Headers) (any, bool) { v, ok := h.JWK(); return v, ok }},
+		{"JWKSetURL", func(h jws.Headers) (any, bool) { v, ok := h.JWKSetURL(); return v, ok }},
+		{"KeyID", func(h jws.Headers) (any, bool) { v, ok := h.KeyID(); return v, ok }},
+		{"Type", func(h jws.Headers) (any, bool) { v, ok := h.Type(); return v, ok }},
+		{"X509CertChain", func(h jws.Headers) (any, bool) { v, ok := h.X509CertChain(); return v, ok }},
+		{"X509CertThumbprint", func(h jws.Headers) (any, bool) { v, ok := h.X509CertThumbprint(); return v, ok }},
+		{"X509CertThumbprintS256", func(h jws.Headers) (any, bool) { v, ok := h.X509CertThumbprintS256(); return v, ok }},
+		{"X509URL", func(h jws.Headers) (any, bool) { v, ok := h.X509URL(); return v, ok }},
+	}
 
-	t.Run("Algorithm", func(t *testing.T) {
-		_, ok := h.Algorithm()
-		require.False(t, ok)
-	})
-	t.Run("ContentType", func(t *testing.T) {
-		_, ok := h.ContentType()
-		require.False(t, ok)
-	})
-	t.Run("Critical", func(t *testing.T) {
-		v, ok := h.Critical()
-		require.False(t, ok)
-		require.Nil(t, v)
-	})
-	t.Run("JWK", func(t *testing.T) {
-		v, ok := h.JWK()
-		require.False(t, ok)
-		require.Nil(t, v)
-	})
-	t.Run("JWKSetURL", func(t *testing.T) {
-		_, ok := h.JWKSetURL()
-		require.False(t, ok)
-	})
-	t.Run("KeyID", func(t *testing.T) {
-		_, ok := h.KeyID()
-		require.False(t, ok)
-	})
-	t.Run("Type", func(t *testing.T) {
-		_, ok := h.Type()
-		require.False(t, ok)
-	})
-	t.Run("X509CertChain", func(t *testing.T) {
-		v, ok := h.X509CertChain()
-		require.False(t, ok)
-		require.Nil(t, v)
-	})
-	t.Run("X509CertThumbprint", func(t *testing.T) {
-		_, ok := h.X509CertThumbprint()
-		require.False(t, ok)
-	})
-	t.Run("X509CertThumbprintS256", func(t *testing.T) {
-		_, ok := h.X509CertThumbprintS256()
-		require.False(t, ok)
-	})
-	t.Run("X509URL", func(t *testing.T) {
-		_, ok := h.X509URL()
-		require.False(t, ok)
-	})
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, ok := tc.get(jws.NewHeaders())
+			require.False(t, ok)
+		})
+	}
 }

--- a/tools/cmd/genjws/main.go
+++ b/tools/cmd/genjws/main.go
@@ -165,7 +165,7 @@ func generateHeaders(obj *codegen.Object) error {
 			o.L("}")
 			o.L("return *(h.%s), true", f.Name(false))
 		} else {
-			o.L("return h.%s, true", f.Name(false))
+			o.L("return h.%[1]s, h.%[1]s != nil", f.Name(false))
 		}
 		o.L("}") // func (h *stdHeaders) %s() %s
 	}


### PR DESCRIPTION
## Summary

- `jws.(*stdHeaders).Critical()`, `JWK()`, and `X509CertChain()` unconditionally returned `ok=true`, so callers using `if v, ok := hdrs.Critical(); ok` entered the branch even when the field was never set.
- Root cause: `tools/cmd/genjws/main.go:168` emitted `return h.X, true` for nilable storage types. Matches the same fix already in v3 `genjwe` and v4's PR #1738.
- Generator now emits `return h.X, h.X != nil`; `jws/headers_gen.go` regenerated; new `jws/headers_nil_test.go` asserts `ok=false` on a fresh `NewHeaders()` for every typed accessor.
