### PR TITLE
add .golangci.yml companion template

### DIFF
--- a/.companions/templates.yaml
+++ b/.companions/templates.yaml
@@ -14,6 +14,9 @@ templates:
   lint.yml:
     dest: .github/workflows/lint.yml
     skip: [benchmarks]
+  golangci.yml:
+    dest: .golangci.yml
+    skip: [benchmarks, examples]
   ci.yml:
     dest: .github/workflows/ci.yml
     skip: [benchmarks]

--- a/.companions/templates/golangci.yml
+++ b/.companions/templates/golangci.yml
@@ -1,0 +1,107 @@
+version: "2"
+linters:
+  default: all
+  disable:
+    - cyclop
+    - depguard
+    - dupl
+    - err113
+    - errorlint
+    - exhaustive
+    - funcorder
+    - funlen
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - gocritic
+    - gocyclo
+    - godot
+    - godox
+    - gosec
+    - gosmopolitan
+    - govet
+    - inamedparam
+    - ireturn
+    - lll
+    - maintidx
+    - makezero
+    - mnd
+    - nakedret
+    - nestif
+    - nlreturn
+    - noinlineerr
+    - nonamedreturns
+    - paralleltest
+    - perfsprint
+    - staticcheck
+    - recvcheck
+    - tagliatelle
+    - testifylint
+    - testpackage
+    - thelper
+    - varnamelen
+    - wrapcheck
+    - wsl
+    - wsl_v5
+  settings:
+    govet:
+      disable:
+        - shadow
+        - fieldalignment
+      enable-all: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        path: /*.go
+        text: 'ST1003: should not use underscores in package names'
+      - linters:
+          - revive
+        path: /*.go
+        text: don't use an underscore in package name
+      - linters:
+          - staticcheck
+        text: SA1019
+      - linters:
+          - contextcheck
+          - exhaustruct
+        path: /*.go
+      - linters:
+          - errcheck
+        path: /main.go
+      - linters:
+          - errcheck
+          - errchkjson
+          - forcetypeassert
+        path: /*_test.go
+      - linters:
+          - forbidigo
+        path: /*_example_test.go
+      - linters:
+          - revive
+        path: /*_test.go
+        text: 'var-naming: '
+      - linters:
+          - godoclint
+        path: (^|/)internal/
+    paths:
+      - third_party$
+      - builtin$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$


### PR DESCRIPTION
Adds a canonical `.golangci.yml` template under `.companions/templates/` so every companion repo carries the same lint config at its root as the main jwx repo.

## Why

Running `golangci-lint` inside `.companions/repo/<name>/` walks up the directory tree looking for `.golangci.yml` and finds the main jwx repo's config several levels above. Under that config, local lint passes. Under CI (which runs with no project config and therefore picks up golangci-lint's defaults), lint fires on issues the main jwx config suppresses. We hit this on jwkfetch's lint PR — a `defer res.Body.Close()` errcheck finding that was invisible locally and only surfaced on CI.

## What

- `.companions/templates/golangci.yml` — verbatim copy of the main jwx repo's `.golangci.yml`. Companions that adopt this template get the same linter set and the same exclusion rules jwx uses, eliminating local-vs-CI drift.
- `.companions/templates.yaml` — registers the template with `dest: .golangci.yml` and `skip: [benchmarks, examples]`:
  - `benchmarks` already skips the `lint.yml` workflow, so no config is needed.
  - `examples` has its own richer hand-tuned `.golangci.yml` that shouldn't be clobbered.

## Verification

```
python3 scripts/companion-render-template.py --dest .companions/templates/golangci.yml ed448
# → .golangci.yml

python3 scripts/companion-render-template.py .companions/templates/golangci.yml examples
# → SKIP: template 'golangci.yml' skipped for 'examples'
```

## Follow-up

Companion repos pick this up via `/jwx-companion-bulk` sync in a separate pass — this PR only adds the source template.