### PR TITLE
fix jwa Unregister* guard against builtin removal

### DIFF
--- a/internal/jwxcodegen/cmd/jwxcodegen/genjwa.go
+++ b/internal/jwxcodegen/cmd/jwxcodegen/genjwa.go
@@ -185,6 +185,9 @@ func generateAlgInit(o *codegen.Output, t Algorithm) {
 	o.LL("if err := Register%s(algorithms...); err != nil {", t.Name)
 	o.L("panic(fmt.Sprintf(%q, err))", fmt.Sprintf("jwa: failed to register builtin %s: %%s", t.Name))
 	o.L("}")
+	o.L("for _, alg := range algorithms {")
+	o.L("builtin%s[alg.String()] = struct{}{}", t.Name)
+	o.L("}")
 	o.L("}") // end init
 }
 

--- a/jwa/compression_gen.go
+++ b/jwa/compression_gen.go
@@ -27,6 +27,9 @@ func init() {
 	if err := RegisterCompressionAlgorithm(algorithms...); err != nil {
 		panic(fmt.Sprintf("jwa: failed to register builtin CompressionAlgorithm: %s", err))
 	}
+	for _, alg := range algorithms {
+		builtinCompressionAlgorithm[alg.String()] = struct{}{}
+	}
 }
 
 // Deflate returns an object representing the "DEF" content compression algorithm value. Using this value specifies that the content should be compressed using DEFLATE (RFC 1951).

--- a/jwa/content_encryption_gen.go
+++ b/jwa/content_encryption_gen.go
@@ -32,6 +32,9 @@ func init() {
 	if err := RegisterContentEncryptionAlgorithm(algorithms...); err != nil {
 		panic(fmt.Sprintf("jwa: failed to register builtin ContentEncryptionAlgorithm: %s", err))
 	}
+	for _, alg := range algorithms {
+		builtinContentEncryptionAlgorithm[alg.String()] = struct{}{}
+	}
 }
 
 // A128CBC_HS256 returns an object representing A128CBC-HS256. Using this value specifies that the content should be encrypted using AES-CBC + HMAC-SHA256 (128).

--- a/jwa/elliptic_gen.go
+++ b/jwa/elliptic_gen.go
@@ -31,6 +31,9 @@ func init() {
 	if err := RegisterEllipticCurveAlgorithm(algorithms...); err != nil {
 		panic(fmt.Sprintf("jwa: failed to register builtin EllipticCurveAlgorithm: %s", err))
 	}
+	for _, alg := range algorithms {
+		builtinEllipticCurveAlgorithm[alg.String()] = struct{}{}
+	}
 }
 
 // Ed25519 returns an object representing Ed25519 algorithm for EdDSA operations.

--- a/jwa/key_encryption_gen.go
+++ b/jwa/key_encryption_gen.go
@@ -51,6 +51,9 @@ func init() {
 	if err := RegisterKeyEncryptionAlgorithm(algorithms...); err != nil {
 		panic(fmt.Sprintf("jwa: failed to register builtin KeyEncryptionAlgorithm: %s", err))
 	}
+	for _, alg := range algorithms {
+		builtinKeyEncryptionAlgorithm[alg.String()] = struct{}{}
+	}
 }
 
 // A128GCMKW returns an object representing AES-GCM key wrap (128) key encryption algorithm.

--- a/jwa/key_type_gen.go
+++ b/jwa/key_type_gen.go
@@ -30,6 +30,9 @@ func init() {
 	if err := RegisterKeyType(algorithms...); err != nil {
 		panic(fmt.Sprintf("jwa: failed to register builtin KeyType: %s", err))
 	}
+	for _, alg := range algorithms {
+		builtinKeyType[alg.String()] = struct{}{}
+	}
 }
 
 // AKP returns an object representing AKP. Algorithm Key Pair (post-quantum KEM/signature keys)

--- a/jwa/signature_gen.go
+++ b/jwa/signature_gen.go
@@ -40,6 +40,9 @@ func init() {
 	if err := RegisterSignatureAlgorithm(algorithms...); err != nil {
 		panic(fmt.Sprintf("jwa: failed to register builtin SignatureAlgorithm: %s", err))
 	}
+	for _, alg := range algorithms {
+		builtinSignatureAlgorithm[alg.String()] = struct{}{}
+	}
 }
 
 // ES256 returns an object representing ECDSA signature algorithm using P-256 curve and SHA-256.

--- a/jwa/unregister_builtin_test.go
+++ b/jwa/unregister_builtin_test.go
@@ -1,0 +1,45 @@
+package jwa_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUnregisterBuiltinIgnored asserts that the Unregister* family refuses to
+// remove built-in algorithms, as documented on each Unregister* function.
+// Regression test for a bug where the builtin guard map was declared but never
+// populated by the generator, so Unregister would silently delete built-ins.
+func TestUnregisterBuiltinIgnored(t *testing.T) {
+	t.Run("SignatureAlgorithm", func(t *testing.T) {
+		jwa.UnregisterSignatureAlgorithm(jwa.RS256())
+		_, ok := jwa.LookupSignatureAlgorithm("RS256")
+		require.True(t, ok, "RS256 must survive Unregister")
+	})
+	t.Run("KeyEncryptionAlgorithm", func(t *testing.T) {
+		jwa.UnregisterKeyEncryptionAlgorithm(jwa.RSA_OAEP())
+		_, ok := jwa.LookupKeyEncryptionAlgorithm("RSA-OAEP")
+		require.True(t, ok, "RSA-OAEP must survive Unregister")
+	})
+	t.Run("ContentEncryptionAlgorithm", func(t *testing.T) {
+		jwa.UnregisterContentEncryptionAlgorithm(jwa.A128GCM())
+		_, ok := jwa.LookupContentEncryptionAlgorithm("A128GCM")
+		require.True(t, ok, "A128GCM must survive Unregister")
+	})
+	t.Run("EllipticCurveAlgorithm", func(t *testing.T) {
+		jwa.UnregisterEllipticCurveAlgorithm(jwa.P256())
+		_, ok := jwa.LookupEllipticCurveAlgorithm("P-256")
+		require.True(t, ok, "P-256 must survive Unregister")
+	})
+	t.Run("KeyType", func(t *testing.T) {
+		jwa.UnregisterKeyType(jwa.RSA())
+		_, ok := jwa.LookupKeyType("RSA")
+		require.True(t, ok, "RSA must survive Unregister")
+	})
+	t.Run("CompressionAlgorithm", func(t *testing.T) {
+		jwa.UnregisterCompressionAlgorithm(jwa.Deflate())
+		_, ok := jwa.LookupCompressionAlgorithm("DEF")
+		require.True(t, ok, "DEF must survive Unregister")
+	})
+}


### PR DESCRIPTION
## Summary
- `genjwa.go` now populates the per-type `builtin*` guard map in `init()`; previously the map was declared but never written, so `Unregister*` silently deleted built-ins despite godoc promising otherwise.
- Regenerated all six `jwa/*_gen.go` files.
- Added `jwa/unregister_builtin_test.go` round-tripping `Unregister(builtin); Lookup(name)` for every algorithm type.