### PR TITLE
fix jwt.ParseRequest cookie branch dropping real errors

### DIFF
--- a/jwt/http.go
+++ b/jwt/http.go
@@ -143,10 +143,7 @@ func ParseRequest(req *http.Request, options ...ParseOption) (Token, error) {
 	for _, name := range cookiekeys {
 		tok, err := ParseCookie(req, name, parseOptions...)
 		if err != nil {
-			if err == http.ErrNoCookie {
-				// not fatal
-				mcookies[name] = err
-			}
+			mcookies[name] = err
 			continue
 		}
 		return tok, nil

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1026,6 +1026,24 @@ func TestParseRequest(t *testing.T) {
 		require.NoError(t, err, `jwt.ParseRequest should succeed`)
 		require.NotNil(t, dst, `cookie should be extracted`)
 	})
+
+	// Regression: cookie-branch used to drop every error except http.ErrNoCookie,
+	// so an expired/invalid JWT in the cookie was reported as "missing cookie".
+	t.Run("cookie with expired token surfaces real error", func(t *testing.T) {
+		expiredTok := jwt.New()
+		require.NoError(t, expiredTok.Set(jwt.IssuerKey, u))
+		require.NoError(t, expiredTok.Set(jwt.ExpirationKey, time.Now().Add(-time.Hour)))
+		expiredSigned, err := jwt.Sign(expiredTok, jwt.WithKey(jwa.ES256(), privkey))
+		require.NoError(t, err, `jwt.Sign should succeed`)
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, u, nil)
+		req.AddCookie(&http.Cookie{Name: "cookie", Value: string(expiredSigned)})
+
+		_, err = jwt.ParseRequest(req, jwt.WithCookieKey("cookie"), jwt.WithKey(jwa.ES256(), pubkey))
+		require.Error(t, err, `jwt.ParseRequest should fail`)
+		require.ErrorIs(t, err, jwt.TokenExpiredError{}, `error should report token expiration, not missing cookie`)
+		require.NotErrorIs(t, err, http.ErrNoCookie, `error must not masquerade as missing cookie`)
+	})
 }
 
 func TestGHIssue368(t *testing.T) {


### PR DESCRIPTION
## Summary
- cookie loop in `jwt.ParseRequest` now records every `ParseCookie` error, not just `http.ErrNoCookie` — expired/invalid/malformed JWTs in cookies were silently discarded, producing a misleading "missing cookie" summary
- mirrors the existing header and form branches in the same function
- regression test: expired signed JWT in a cookie now surfaces `jwt.TokenExpiredError{}` instead of `http.ErrNoCookie`