### PR TITLE
fix: jwk.PublicSetOf rejects symmetric keys by default

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -33,7 +33,7 @@ JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 - **Fetch(ctx, url, ...FetchOption) (Set, error)** — HTTP fetch with optional whitelist, body size limit (default 10 MB via `WithMaxFetchBodySize`)
 - **DefaultHTTPClient() \*http.Client** — returns a new http.Client with library defaults (30s timeout, redirect policy)
 - **Import[T Key](raw any) (T, error)** / **Export[T any](key Key) (T, error)** — convert between Go crypto types and JWK (generic)
-- **PublicKeyOf(v any) (Key, error)** / **PublicSetOf(v Set) (Set, error)** — extract public keys
+- **PublicKeyOf(v any) (Key, error)** / **PublicSetOf(v Set, ...PublicSetOption) (Set, error)** — extract public keys. `PublicSetOf` rejects sets containing symmetric (oct) keys by default; pass `WithAllowSymmetric(true)` for legacy pass-through.
 - **AssignKeyID(key Key, ...AssignKeyIDOption) error** — compute and set kid via thumbprint
 - **Pem(v any) ([]byte, error)** — PEM encode
 - JWKS caching moved to `github.com/jwx-go/jwkcache` — see [Extension Modules](../../docs/10-extensions.md)

--- a/Changes-v4.md
+++ b/Changes-v4.md
@@ -66,6 +66,18 @@ For a step-by-step migration guide with before/after code examples, see [MIGRATI
 
 ## JWK
 
+* `jwk.PublicSetOf` now returns an error if the input set contains a
+  symmetric (`oct`) key, because the "public" form of a symmetric key
+  would be the secret itself — publishing the result (e.g. as
+  `/.well-known/jwks.json`) would leak the HMAC secret. Callers who
+  genuinely want the legacy pass-through can opt in with
+  `jwk.PublicSetOf(set, jwk.WithAllowSymmetric(true))`. The signature
+  is now variadic (`PublicSetOf(v Set, options ...PublicSetOption)`),
+  so existing call sites compile unchanged.
+
+  `jwk.PublicKeyOf` on a single symmetric key is unchanged — it still
+  returns the key as-is, matching its documented behavior.
+
 * `jwk.Import()` is now generic: `jwk.Import[T Key](raw any) (T, error)`.
   This replaces the previous `jwk.Import()` which returned an untyped `jwk.Key`.
 

--- a/cmd/jwx/jws.go
+++ b/cmd/jwx/jws.go
@@ -136,7 +136,7 @@ func makeJwsVerifyCmd() *cli.Command {
 			return err
 		}
 
-		keyset, err = jwk.PublicSetOf(keyset)
+		keyset, err = jwk.PublicSetOf(keyset, jwk.WithAllowSymmetric(true))
 		if err != nil {
 			return fmt.Errorf(`failed to retrieve public key: %w`, err)
 		}

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -135,9 +135,25 @@ func doImport(raw any) (Key, error) {
 // you want to generate the corresponding public versions for the
 // users to verify with.
 //
-// Be aware that all fields will be copied onto the new public key. It is the caller's
-// responsibility to remove any fields, if necessary.
-func PublicSetOf(v Set) (Set, error) {
+// By default, if the input set contains a symmetric (oct) key, this
+// function returns an error: a symmetric key has no public form, and
+// its "public" representation would be the secret itself. Publishing
+// such a set (e.g. as `/.well-known/jwks.json`) would leak secret
+// material. Callers who explicitly want the legacy pass-through
+// behavior can opt in with `jwk.WithAllowSymmetric(true)`.
+//
+// Be aware that for asymmetric private keys, all fields will be
+// copied onto the new public key. It is the caller's responsibility
+// to remove any fields, if necessary.
+func PublicSetOf(v Set, options ...PublicSetOption) (Set, error) {
+	var allowSymmetric bool
+	for _, opt := range options {
+		switch opt.Ident() {
+		case identAllowSymmetric{}:
+			allowSymmetric = option.MustGet[bool](opt)
+		}
+	}
+
 	newSet := NewSet()
 
 	n := v.Len()
@@ -145,6 +161,10 @@ func PublicSetOf(v Set) (Set, error) {
 		k, ok := v.Key(i)
 		if !ok {
 			return nil, fmt.Errorf(`key not found`)
+		}
+		if _, isSymmetric := k.(SymmetricKey); isSymmetric && !allowSymmetric {
+			kid, _ := k.KeyID()
+			return nil, fmt.Errorf(`jwk.PublicSetOf: input set contains a symmetric key (kid=%q, index=%d); symmetric keys have no public form and would leak secret material if published. Remove symmetric keys from the set before calling PublicSetOf, or pass jwk.WithAllowSymmetric(true) to opt into legacy pass-through behavior`, kid, i)
 		}
 		pubKey, err := PublicKeyOf(k)
 		if err != nil {

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -987,6 +987,83 @@ func TestPublicKeyOf(t *testing.T) {
 	})
 }
 
+func TestPublicSetOfSymmetricRejection(t *testing.T) {
+	t.Parallel()
+
+	makeRSA := func(t *testing.T, kid string) jwk.Key {
+		t.Helper()
+		rawRSA, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err, `rsa.GenerateKey should succeed`)
+		k, err := jwk.Import[jwk.Key](rawRSA)
+		require.NoError(t, err, `jwk.Import RSA should succeed`)
+		require.NoError(t, k.Set(jwk.KeyIDKey, kid), `Set kid should succeed`)
+		return k
+	}
+	makeHMAC := func(t *testing.T, kid string) jwk.Key {
+		t.Helper()
+		k, err := jwk.Import[jwk.Key]([]byte("top-secret-hmac-material"))
+		require.NoError(t, err, `jwk.Import symmetric should succeed`)
+		require.NoError(t, k.Set(jwk.KeyIDKey, kid), `Set kid should succeed`)
+		return k
+	}
+
+	t.Run("mixed set rejects symmetric by default", func(t *testing.T) {
+		t.Parallel()
+		set := jwk.NewSet()
+		require.NoError(t, set.AddKey(makeRSA(t, "rsa-1")))
+		require.NoError(t, set.AddKey(makeHMAC(t, "hmac-1")))
+
+		_, err := jwk.PublicSetOf(set)
+		require.Error(t, err, `PublicSetOf should reject a set containing a symmetric key`)
+		require.ErrorContains(t, err, "symmetric")
+		require.ErrorContains(t, err, `"hmac-1"`)
+	})
+
+	t.Run("mixed set passes through with WithAllowSymmetric(true)", func(t *testing.T) {
+		t.Parallel()
+		set := jwk.NewSet()
+		require.NoError(t, set.AddKey(makeRSA(t, "rsa-1")))
+		require.NoError(t, set.AddKey(makeHMAC(t, "hmac-1")))
+
+		pub, err := jwk.PublicSetOf(set, jwk.WithAllowSymmetric(true))
+		require.NoError(t, err, `PublicSetOf with WithAllowSymmetric(true) should succeed`)
+		require.Equal(t, 2, pub.Len(), `resulting set should still contain both keys`)
+
+		buf, err := json.Marshal(pub)
+		require.NoError(t, err, `json.Marshal should succeed`)
+		// Pin the dangerous opt-in behavior: secret material is still present.
+		require.Contains(t, string(buf), `"k":`, `opt-in pass-through keeps the secret in the output`)
+	})
+
+	t.Run("pure symmetric set rejected by default", func(t *testing.T) {
+		t.Parallel()
+		set := jwk.NewSet()
+		require.NoError(t, set.AddKey(makeHMAC(t, "hmac-only")))
+
+		_, err := jwk.PublicSetOf(set)
+		require.Error(t, err, `PublicSetOf should reject a purely symmetric set`)
+		require.ErrorContains(t, err, `"hmac-only"`)
+	})
+
+	t.Run("empty set succeeds", func(t *testing.T) {
+		t.Parallel()
+		pub, err := jwk.PublicSetOf(jwk.NewSet())
+		require.NoError(t, err, `PublicSetOf on empty set should succeed`)
+		require.Equal(t, 0, pub.Len(), `result should be empty`)
+	})
+
+	t.Run("pure asymmetric set is unaffected", func(t *testing.T) {
+		t.Parallel()
+		set := jwk.NewSet()
+		require.NoError(t, set.AddKey(makeRSA(t, "rsa-a")))
+		require.NoError(t, set.AddKey(makeRSA(t, "rsa-b")))
+
+		pub, err := jwk.PublicSetOf(set)
+		require.NoError(t, err, `PublicSetOf on asymmetric-only set should succeed`)
+		require.Equal(t, 2, pub.Len())
+	})
+}
+
 func TestIssue207(t *testing.T) {
 	t.Parallel()
 	const src = `{"kty":"EC","alg":"ECMR","crv":"P-521","key_ops":["deriveKey"],"x":"AJwCS845x9VljR-fcrN2WMzIJHDYuLmFShhyu8ci14rmi2DMFp8txIvaxG8n7ZcODeKIs1EO4E_Bldm_pxxs8cUn","y":"ASjz754cIQHPJObihPV8D7vVNfjp_nuwP76PtbLwUkqTk9J1mzCDKM3VADEk-Z1tP-DHiwib6If8jxnb_FjNkiLJ"}`

--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -9,6 +9,9 @@ interfaces:
     comment: |
       GlobalOption is a type of Option that can be passed to the `jwk.Configure()` to
       change the global configuration of the jwk package.
+  - name: PublicSetOption
+    comment: |
+      PublicSetOption is a type of Option that can be passed to `jwk.PublicSetOf()`
 options:
   - ident: ThumbprintHash
     interface: AssignKeyIDOption
@@ -76,3 +79,19 @@ options:
       value. If this options is set to true, then the "use" field must
       be one of the registered values, and otherwise an error will be
       reported during parsing / assignment to `jwk.KeyUsageType`
+  - ident: AllowSymmetric
+    interface: PublicSetOption
+    argument_type: bool
+    comment: |
+      WithAllowSymmetric controls whether `jwk.PublicSetOf` tolerates
+      symmetric (oct) keys in the input set.
+
+      By default this option is false: a symmetric key in the input is
+      an error, because a symmetric key has no public form — its
+      "public" representation is the secret itself. Passing such a set
+      through `PublicSetOf` silently and then publishing the result
+      (e.g. as `/.well-known/jwks.json`) would leak HMAC secret material.
+
+      Pass `WithAllowSymmetric(true)` only if you are certain the
+      resulting set will not be published. When true, symmetric keys
+      are passed through unchanged, matching the legacy behavior.

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -47,6 +47,19 @@ type parseOption struct {
 
 func (*parseOption) parseOption() {}
 
+// PublicSetOption is a type of Option that can be passed to `jwk.PublicSetOf()`
+type PublicSetOption interface {
+	Option
+	publicSetOption()
+}
+
+type publicSetOption struct {
+	Option
+}
+
+func (*publicSetOption) publicSetOption() {}
+
+type identAllowSymmetric struct{}
 type identIgnoreParseError struct{}
 type identLocalRegistry struct{}
 type identPEM struct{}
@@ -54,6 +67,10 @@ type identPEMDecoder struct{}
 type identStrictKeyUsage struct{}
 type identThumbprintHash struct{}
 type identX509 struct{}
+
+func (identAllowSymmetric) String() string {
+	return "WithAllowSymmetric"
+}
 
 func (identIgnoreParseError) String() string {
 	return "WithIgnoreParseError"
@@ -81,6 +98,22 @@ func (identThumbprintHash) String() string {
 
 func (identX509) String() string {
 	return "WithX509"
+}
+
+// WithAllowSymmetric controls whether `jwk.PublicSetOf` tolerates
+// symmetric (oct) keys in the input set.
+//
+// By default this option is false: a symmetric key in the input is
+// an error, because a symmetric key has no public form — its
+// "public" representation is the secret itself. Passing such a set
+// through `PublicSetOf` silently and then publishing the result
+// (e.g. as `/.well-known/jwks.json`) would leak HMAC secret material.
+//
+// Pass `WithAllowSymmetric(true)` only if you are certain the
+// resulting set will not be published. When true, symmetric keys
+// are passed through unchanged, matching the legacy behavior.
+func WithAllowSymmetric(v bool) PublicSetOption {
+	return &publicSetOption{option.New(identAllowSymmetric{}, v)}
 }
 
 // WithIgnoreParseError is only applicable when used with `jwk.Parse()`

--- a/jwk/options_gen_test.go
+++ b/jwk/options_gen_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestOptionIdent(t *testing.T) {
+	require.Equal(t, "WithAllowSymmetric", identAllowSymmetric{}.String())
 	require.Equal(t, "WithIgnoreParseError", identIgnoreParseError{}.String())
 	require.Equal(t, "withLocalRegistry", identLocalRegistry{}.String())
 	require.Equal(t, "WithPEM", identPEM{}.String())


### PR DESCRIPTION
## Summary
- `jwk.PublicSetOf` now errors when the input set contains an `oct` key — previously the HMAC secret was silently copied into the returned "public" set, leaking through `/.well-known/jwks.json` publishing patterns.
- Opt-in `jwk.WithAllowSymmetric(true)` restores the legacy pass-through for callers who aren't publishing (e.g. `jwx jws verify`).
- `jwk.PublicKeyOf` on a single symmetric key is unchanged — documented contract, single-key caller intent is explicit.

## Test plan
- [x] `go test ./jwk/...` — new `TestPublicSetOfSymmetricRejection` (5 subtests) passes
- [x] `go test ./...` full main-module suite green
- [x] `cmd/jwx` builds; `jws verify` path updated to opt in