### PR TITLE
cmd/jwx: reject alg=none in jws sign/verify

### DIFF
--- a/cmd/jwx/go.mod
+++ b/cmd/jwx/go.mod
@@ -4,17 +4,21 @@ go 1.26.0
 
 require (
 	github.com/lestrrat-go/jwx/v4 v4.0.0
+	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.26.0
 	golang.org/x/crypto v0.49.0
 )
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/lestrrat-go/dsig v1.3.0 // indirect
 	github.com/lestrrat-go/option/v3 v3.0.0-alpha1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/valyala/fastjson v1.6.10 // indirect
 	github.com/xrash/smetrics v0.0.0-20231213231151-1d8dd44e695e // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/lestrrat-go/jwx/v4 v4.0.0 => ../..

--- a/cmd/jwx/go.sum
+++ b/cmd/jwx/go.sum
@@ -20,5 +20,7 @@ github.com/xrash/smetrics v0.0.0-20231213231151-1d8dd44e695e h1:+SOyEddqYF09QP7v
 github.com/xrash/smetrics v0.0.0-20231213231151-1d8dd44e695e/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmd/jwx/jws.go
+++ b/cmd/jwx/jws.go
@@ -16,6 +16,22 @@ func init() {
 	topLevelCommands = append(topLevelCommands, makeJwsCmd())
 }
 
+// resolveSignatureAlgorithm looks up a JWS signature algorithm by name and
+// refuses "none". Accepting alg=none at a CLI boundary is the canonical JWT
+// footgun (RFC 7518 §3.6): sign would emit an unsigned blob, verify would
+// accept any unsigned token. There is no legitimate CLI use case, so we
+// reject unconditionally.
+func resolveSignatureAlgorithm(name string) (jwa.SignatureAlgorithm, error) {
+	alg, ok := jwa.LookupSignatureAlgorithm(name)
+	if !ok {
+		return jwa.SignatureAlgorithm{}, fmt.Errorf(`invalid algorithm %s`, name)
+	}
+	if alg == jwa.NoSignature() {
+		return jwa.SignatureAlgorithm{}, fmt.Errorf(`alg "none" is not permitted for jws sign/verify (RFC 7518 §3.6); refusing to produce or accept unsigned JWS`)
+	}
+	return alg, nil
+}
+
 func jwsAlgorithmFlag(use string) cli.Flag {
 	return &cli.StringFlag{
 		Name:    "alg",
@@ -165,13 +181,9 @@ func makeJwsVerifyCmd() *cli.Command {
 				return nil
 			}
 		} else {
-			var alg jwa.SignatureAlgorithm
-			{
-				v, ok := jwa.LookupSignatureAlgorithm(c.String("alg"))
-				if !ok {
-					return fmt.Errorf(`invalid algorithm %s`, c.String("alg"))
-				}
-				alg = v
+			alg, err := resolveSignatureAlgorithm(c.String("alg"))
+			if err != nil {
+				return err
 			}
 
 			for i := 0; i < keyset.Len(); i++ {
@@ -238,13 +250,9 @@ func makeJwsSignCmd() *cli.Command {
 			return fmt.Errorf(`failed to read data from source: %w`, err)
 		}
 
-		var alg jwa.SignatureAlgorithm
-		{
-			v, ok := jwa.LookupSignatureAlgorithm(c.String("alg"))
-			if !ok {
-				return fmt.Errorf(`invalid algorithm %s`, c.String("alg"))
-			}
-			alg = v
+		alg, err := resolveSignatureAlgorithm(c.String("alg"))
+		if err != nil {
+			return err
 		}
 
 		// headers must go to WithKeySuboptions

--- a/cmd/jwx/jws_test.go
+++ b/cmd/jwx/jws_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveSignatureAlgorithm(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		alg, err := resolveSignatureAlgorithm("RS256")
+		require.NoError(t, err)
+		require.Equal(t, jwa.RS256(), alg)
+	})
+	t.Run("unknown", func(t *testing.T) {
+		_, err := resolveSignatureAlgorithm("bogus")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid algorithm")
+	})
+	t.Run("none rejected", func(t *testing.T) {
+		_, err := resolveSignatureAlgorithm("none")
+		require.Error(t, err)
+		require.Contains(t, strings.ToLower(err.Error()), `"none"`)
+	})
+}


### PR DESCRIPTION
\`jws sign\`/\`verify\` resolved \`--alg\` via \`LookupSignatureAlgorithm\` and passed \`none\` straight through — sign emitted unsigned blobs, verify accepted any unsigned token (RFC 7518 §3.6 footgun). The CLI has no legitimate use for unsigned JWS, so reject unconditionally via a small \`resolveSignatureAlgorithm\` helper shared by both paths.

Tests cover valid/unknown/none.