### PR TITLE
fix jwk rsa exponent truncation and thumbprint collision

### DIFF
--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
+	"math/bits"
 	"reflect"
 
 	"github.com/lestrrat-go/jwx/v4/internal/base64"
@@ -102,9 +103,18 @@ func (k *rsaPublicKey) Import(rawKey *rsa.PublicKey) error {
 	return nil
 }
 
-func buildRSAPublicKey(key *rsa.PublicKey, n, e []byte) {
+func buildRSAPublicKey(key *rsa.PublicKey, n, e []byte) error {
+	bigE := new(big.Int).SetBytes(e)
+	// rsa.PublicKey.E is a Go int. Reject exponents that do not fit on the
+	// current platform (e.g. GOARCH=386). Without this guard, Int64()/int()
+	// silently truncates, causing the materialized key to disagree with the
+	// JSON bytes and breaking RFC 7638 thumbprint uniqueness.
+	if bigE.BitLen() >= bits.UintSize {
+		return fmt.Errorf(`rsa public exponent too large for this platform: %d bits (max %d)`, bigE.BitLen(), bits.UintSize-1)
+	}
 	key.N = new(big.Int).SetBytes(n)
-	key.E = int(new(big.Int).SetBytes(e).Int64())
+	key.E = int(bigE.Int64())
+	return nil
 }
 
 var rsaConvertibleKeys = []reflect.Type{
@@ -207,7 +217,9 @@ func rsaJWKToRaw(keyif Key, _ any) (any, error) {
 		}
 
 		var privkey rsa.PrivateKey
-		buildRSAPublicKey(&privkey.PublicKey, on, oe)
+		if err := buildRSAPublicKey(&privkey.PublicKey, on, oe); err != nil {
+			return nil, fmt.Errorf(`failed to build rsa.PublicKey: %w`, err)
+		}
 		privkey.D = &d
 		privkey.Primes = []*big.Int{&p, &q}
 
@@ -250,7 +262,9 @@ func rsaJWKToRaw(keyif Key, _ any) (any, error) {
 		}
 
 		var pubkey rsa.PublicKey
-		buildRSAPublicKey(&pubkey, n, e)
+		if err := buildRSAPublicKey(&pubkey, n, e); err != nil {
+			return nil, fmt.Errorf(`failed to build rsa.PublicKey: %w`, err)
+		}
 
 		return &pubkey, nil
 
@@ -295,32 +309,42 @@ func (k *rsaPrivateKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	k.mu.RLock()
 	defer k.mu.RUnlock()
 
-	key, err := Export[*rsa.PrivateKey](k)
-	if err != nil {
-		return nil, fmt.Errorf(`failed to export RSA private key: %w`, err)
-	}
-	return rsaThumbprint(hash, &key.PublicKey)
+	return rsaThumbprint(hash, k.n, k.e)
 }
 
 func (k *rsaPublicKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	k.mu.RLock()
 	defer k.mu.RUnlock()
 
-	key, err := Export[*rsa.PublicKey](k)
-	if err != nil {
-		return nil, fmt.Errorf(`failed to export RSA public key: %w`, err)
-	}
-	return rsaThumbprint(hash, key)
+	return rsaThumbprint(hash, k.n, k.e)
 }
 
-func rsaThumbprint(hash crypto.Hash, key *rsa.PublicKey) ([]byte, error) {
+// trimLeadingZeroBytes strips leading zero bytes. RFC 7638 requires the
+// minimal big-endian representation of n/e for canonical JSON.
+func trimLeadingZeroBytes(b []byte) []byte {
+	for len(b) > 0 && b[0] == 0 {
+		b = b[1:]
+	}
+	return b
+}
+
+func rsaThumbprint(hash crypto.Hash, n, e []byte) ([]byte, error) {
+	n = trimLeadingZeroBytes(n)
+	e = trimLeadingZeroBytes(e)
+	if len(n) == 0 {
+		return nil, fmt.Errorf(`failed to compute rsa thumbprint: missing "n" value`)
+	}
+	if len(e) == 0 {
+		return nil, fmt.Errorf(`failed to compute rsa thumbprint: missing "e" value`)
+	}
+
 	buf := pool.BytesBuffer().Get()
 	defer pool.BytesBuffer().Put(buf)
 
 	buf.WriteString(`{"e":"`)
-	buf.WriteString(base64.EncodeUint64ToString(uint64(key.E)))
+	buf.WriteString(base64.EncodeToString(e))
 	buf.WriteString(`","kty":"RSA","n":"`)
-	buf.WriteString(base64.EncodeToString(key.N.Bytes()))
+	buf.WriteString(base64.EncodeToString(n))
 	buf.WriteString(`"}`)
 
 	h := hash.New()

--- a/jwk/rsa_thumbprint_test.go
+++ b/jwk/rsa_thumbprint_test.go
@@ -1,0 +1,111 @@
+package jwk_test
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"encoding/hex"
+	"encoding/json"
+	"math/bits"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+// RFC 7638 Section 3.1 canonical example.
+const rfc7638RSAJWK = `{
+  "kty": "RSA",
+  "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+  "e": "AQAB"
+}`
+
+// Expected SHA-256 thumbprint from RFC 7638 Section 3.1:
+//
+//	NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs
+//
+// decoded to hex.
+const rfc7638ExpectedThumbprintHex = "3736cbb1787cb8309c77ee8c3705c5e16ffb9e859715901f1e4c59b11182f57b"
+
+func TestRSA_Thumbprint_RFC7638Vector(t *testing.T) {
+	k, err := jwk.ParseKey[jwk.Key]([]byte(rfc7638RSAJWK))
+	require.NoError(t, err)
+
+	got, err := k.Thumbprint(crypto.SHA256)
+	require.NoError(t, err)
+
+	require.Equal(t, rfc7638ExpectedThumbprintHex, hex.EncodeToString(got))
+}
+
+// TestRSA_ExponentTruncation_Rejected verifies that an RSA public exponent
+// whose bit length does not fit in a Go `int` on this platform is rejected
+// at export time, rather than being silently truncated.
+//
+// Regression for JWK-20260415151950-008.
+func TestRSA_ExponentTruncation_Rejected(t *testing.T) {
+	// e = 0x01_00_00_00_00_00_00_01 (65 bits) — fits neither 32-bit nor 64-bit int.
+	payload := `{"kty":"RSA","n":"AQAB","e":"AQAAAAAAAAAB"}`
+
+	k, err := jwk.ParseKey[jwk.Key]([]byte(payload))
+	require.NoError(t, err, "parse should accept the raw bytes")
+
+	_, err = jwk.Export[*rsa.PublicKey](k)
+	require.Error(t, err, "export must reject oversized exponent")
+	require.Contains(t, err.Error(), "rsa public exponent too large")
+}
+
+// TestRSA_Thumbprint_UsesStoredBytes verifies that Thumbprint hashes the
+// stored e/n bytes rather than round-tripping through rsa.PublicKey.E (int).
+// Two JWKs whose e values differ only in leading zero bytes must produce
+// identical thumbprints (leading zeros are stripped per RFC 7638 minimal
+// representation). Two JWKs whose e values actually differ must produce
+// different thumbprints.
+//
+// Regression for JWK-20260415151950-008.
+func TestRSA_Thumbprint_UsesStoredBytes(t *testing.T) {
+	// Standard F4 = 0x10001
+	jwkF4 := `{"kty":"RSA","n":"AQAB","e":"AQAB"}`
+	// Same exponent with an added leading zero byte: e = 0x00_01_00_01
+	jwkF4PaddedE := `{"kty":"RSA","n":"AQAB","e":"AAEAAQ"}`
+	// Different exponent entirely: e = 3
+	jwkE3 := `{"kty":"RSA","n":"AQAB","e":"Aw"}`
+
+	thumb := func(payload string) []byte {
+		k, err := jwk.ParseKey[jwk.Key]([]byte(payload))
+		require.NoError(t, err)
+		tp, err := k.Thumbprint(crypto.SHA256)
+		require.NoError(t, err)
+		return tp
+	}
+
+	f4 := thumb(jwkF4)
+	f4Padded := thumb(jwkF4PaddedE)
+	e3 := thumb(jwkE3)
+
+	require.Equal(t, f4, f4Padded, "leading-zero-padded e must produce the same RFC 7638 thumbprint")
+	require.NotEqual(t, f4, e3, "distinct e values must produce distinct thumbprints")
+}
+
+// sanity: the check should be per-platform (only triggers on 32-bit builds
+// for values between 2^31 and 2^63 — but the pure-Go guard is the same).
+func TestRSA_BitsUintSize(t *testing.T) {
+	require.True(t, bits.UintSize == 32 || bits.UintSize == 64)
+}
+
+// ensure the tests don't drift from Parse/Export behavior. Marshal the
+// RFC 7638 JWK back out and confirm it round-trips.
+func TestRSA_RFC7638_RoundTrip(t *testing.T) {
+	k, err := jwk.ParseKey[jwk.Key]([]byte(rfc7638RSAJWK))
+	require.NoError(t, err)
+
+	buf, err := json.Marshal(k)
+	require.NoError(t, err)
+
+	k2, err := jwk.ParseKey[jwk.Key](buf)
+	require.NoError(t, err)
+
+	tp1, err := k.Thumbprint(crypto.SHA256)
+	require.NoError(t, err)
+	tp2, err := k2.Thumbprint(crypto.SHA256)
+	require.NoError(t, err)
+	require.Equal(t, tp1, tp2)
+}


### PR DESCRIPTION
## Summary
- reject RSA \`e\` whose bit length does not fit in \`int\` on the current platform (previously silently truncated via \`Int64()\`/\`int()\`)
- compute RFC 7638 thumbprint from stored \`n\`/\`e\` bytes (minimal representation) instead of round-tripping through \`rsa.PublicKey.E\`, which masked collisions