### PR TITLE
fix cert.Chain MarshalJSON and validate Add input

### DIFF
--- a/cert/chain.go
+++ b/cert/chain.go
@@ -26,9 +26,11 @@ func (cc Chain) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(tokens.Comma)
 		}
-		buf.WriteByte('"')
-		buf.Write(cert)
-		buf.WriteByte('"')
+		encoded, err := json.Marshal(string(cert))
+		if err != nil {
+			return nil, fmt.Errorf(`failed to encode certificate at index %d: %w`, i, err)
+		}
+		buf.Write(encoded)
 	}
 	buf.WriteByte(tokens.CloseSquareBracket)
 	return buf.Bytes(), nil
@@ -78,6 +80,24 @@ func (cc *Chain) Add(der []byte) error {
 		cc.certificates = append(cc.certificates, encoded)
 		return nil
 	}
-	cc.certificates = append(cc.certificates, der)
+	// Non-PEM input must be base64(DER). Strip any internal whitespace
+	// (callers commonly pass multi-line base64 literals) and validate.
+	normalized := stripASCIIWhitespace(der)
+	if _, err := base64.StdEncoding.DecodeString(string(normalized)); err != nil {
+		return fmt.Errorf(`cert.Chain.Add: input is not a PEM CERTIFICATE block or valid base64(DER): %w`, err)
+	}
+	cc.certificates = append(cc.certificates, normalized)
 	return nil
+}
+
+func stripASCIIWhitespace(src []byte) []byte {
+	dst := make([]byte, 0, len(src))
+	for _, b := range src {
+		switch b {
+		case ' ', '\t', '\r', '\n', '\v', '\f':
+			continue
+		}
+		dst = append(dst, b)
+	}
+	return dst
 }

--- a/cert/chain_test.go
+++ b/cert/chain_test.go
@@ -1,6 +1,8 @@
 package cert_test
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v3/cert"
@@ -65,5 +67,45 @@ func TestChain(t *testing.T) {
 	for _, i := range []int{-1, chain.Len()} {
 		_, ok := chain.Get(i)
 		require.False(t, ok, `out of bounds should properly error`)
+	}
+
+	t.Run(`MarshalJSON round-trip`, func(t *testing.T) {
+		// Regression for CERT-002: MarshalJSON must produce valid JSON
+		// even when Add was called with a multi-line base64 literal.
+		encoded, err := json.Marshal(&chain)
+		require.NoError(t, err, `json.Marshal(chain) should succeed`)
+
+		var back []string
+		require.NoError(t, json.Unmarshal(encoded, &back), `marshaled chain must be valid JSON`)
+		require.Equal(t, chain.Len(), len(back), `round-trip should preserve length`)
+
+		for i, s := range back {
+			der, err := base64.StdEncoding.DecodeString(s)
+			require.NoError(t, err, `entry %d must be valid base64`, i)
+			parsed, err := cert.Parse([]byte(s))
+			require.NoError(t, err, `entry %d must round-trip through cert.Parse`, i)
+			require.True(t, parsed.Equal(goldenCert), `entry %d must match golden cert`, i)
+			require.NotEmpty(t, der)
+		}
+	})
+}
+
+func TestChainAddRejectsInvalid(t *testing.T) {
+	// Regression for CERT-002: Add must reject input that would produce
+	// invalid JSON or enable JSON injection when later marshaled.
+	testcases := []struct {
+		Name string
+		Data []byte
+	}{
+		{Name: `quote injection`, Data: []byte(`abc","injected":"x`)},
+		{Name: `raw garbage`, Data: []byte(`not base64 at all !!!`)},
+		{Name: `control characters`, Data: []byte("ab\x00cd")},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var chain cert.Chain
+			require.Error(t, chain.Add(tc.Data), `Add should reject invalid input`)
+			require.Equal(t, 0, chain.Len(), `failed Add must not mutate chain`)
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- `MarshalJSON` routes each cert through `json.Marshal(string(cert))` instead of writing raw bytes between `"`, so whitespace/quotes in stored bytes can no longer produce invalid JSON or enable injection into enclosing `x5c` headers
- `Add` strips internal ASCII whitespace and validates the result as standard base64 on the non-PEM branch; non-base64 input now returns an error
- regression tests: `MarshalJSON` round-trip through `json.Unmarshal`+`cert.Parse`, and `TestChainAddRejectsInvalid` for quote injection / garbage / control characters