### PR TITLE
fix jwt/jws fast path alg name json injection

### DIFF
--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -11,6 +11,20 @@ const (
 	Period             = '.'
 )
 
+// IsJSONSafeASCII reports whether s can be concatenated into a
+// hand-built JSON string literal without escaping. Any byte that
+// would require a JSON escape (control bytes, `"`, `\`) or any
+// non-ASCII byte disqualifies the value.
+func IsJSONSafeASCII(s string) bool {
+	for i := range len(s) {
+		c := s[i]
+		if c < 0x20 || c >= 0x7f || c == '"' || c == '\\' {
+			return false
+		}
+	}
+	return true
+}
+
 // Cryptographic key sizes
 const (
 	KeySize16 = 16

--- a/jws/options.go
+++ b/jws/options.go
@@ -71,6 +71,7 @@ type withKey struct {
 	protected       Headers
 	public          Headers
 	cachedHdrJSON   []byte // precomputed header JSON when no custom headers and no kid
+	cachedHdrErr    error  // deferred precompute error, surfaced at Sign() time
 	keyPrevalidated bool   // true if algorithm-key validation was done at construction time
 }
 
@@ -84,6 +85,7 @@ func (w *withKey) Protected(v Headers) Headers {
 		// Invalidate the precomputed header JSON because the caller
 		// will likely modify the headers (e.g., jwt sets "typ").
 		w.cachedHdrJSON = nil
+		w.cachedHdrErr = nil
 	}
 	return w.protected
 }
@@ -174,7 +176,11 @@ func WithKey(alg jwa.KeyAlgorithm, key any, options ...WithKeySuboption) SignVer
 				}
 			}
 			if !needsKid {
-				wk.cachedHdrJSON = buildAlgHeaderJSON(salg.String())
+				// WithKey cannot return an error, so defer any validation
+				// failure (unsafe alg characters) to Sign() time via
+				// cachedHdrErr. The sign path checks this before using
+				// the cached bytes.
+				wk.cachedHdrJSON, wk.cachedHdrErr = buildAlgHeaderJSON(salg.String())
 			}
 		}
 	}

--- a/jws/sign_context.go
+++ b/jws/sign_context.go
@@ -79,6 +79,13 @@ func (sc *signContext) ProcessOptions(options []SignOption) error {
 				}
 			}
 
+			// Surface any deferred error captured while precomputing the
+			// fast-path header JSON (e.g. an algorithm name that would
+			// require JSON escaping).
+			if data.cachedHdrErr != nil {
+				return makeSignError(`%w`, data.cachedHdrErr)
+			}
+
 			sb := signatureBuilderPool.Get()
 			sb.alg = alg
 			sb.protected = data.protected

--- a/jws/signature_builder.go
+++ b/jws/signature_builder.go
@@ -14,13 +14,22 @@ import (
 
 // buildAlgHeaderJSON constructs the JSON for a protected header containing
 // only the "alg" field. This is used by the precomputed header fast path.
-func buildAlgHeaderJSON(alg string) []byte {
+//
+// The fast path hand-builds the JSON rather than calling json.Marshal,
+// so any algorithm name that would require escaping (control bytes, `"`,
+// `\`, or non-ASCII) must be rejected up front. Callers that hit this
+// error cannot silently fall back to the slow path because the same
+// unsafe name would still appear in the emitted header.
+func buildAlgHeaderJSON(alg string) ([]byte, error) {
+	if !tokens.IsJSONSafeASCII(alg) {
+		return nil, fmt.Errorf(`jws: algorithm name %q contains characters that would require JSON escaping`, alg)
+	}
 	// Construct {"alg":"<alg>"} without going through json.Marshal
 	buf := make([]byte, 0, 9+len(alg))
 	buf = append(buf, `{"alg":"`...)
 	buf = append(buf, alg...)
 	buf = append(buf, `"}`...)
-	return buf
+	return buf, nil
 }
 
 var signatureBuilderPool = pool.New[*signatureBuilder](allocSignatureBuilder, freeSignatureBuilder)

--- a/jws/signature_builder_test.go
+++ b/jws/signature_builder_test.go
@@ -1,0 +1,78 @@
+package jws_test
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/internal/jwxtest"
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/lestrrat-go/jwx/v4/jws"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFastPathSigner is a no-op Signer used to exercise the precomputed
+// {"alg":"..."} header fast path with an arbitrary algorithm name.
+type fakeFastPathSigner struct{}
+
+func (fakeFastPathSigner) Sign(_ any, payload []byte) ([]byte, error) {
+	h := sha256.Sum256(payload)
+	return h[:], nil
+}
+
+// A caller that registers a SignatureAlgorithm whose name contains
+// JSON-special bytes must not be able to inject fields into the
+// precomputed protected header. jws.WithKey caches a hand-built
+// {"alg":"..."} literal; validation is deferred to jws.Sign so the
+// option constructor stays error-free.
+//
+// Not parallel: each subtest mutates global state via
+// jws.RegisterSigner / jwa.RegisterSignatureAlgorithm.
+func TestSign_UnsafeAlgNameRejectedFastPath(t *testing.T) {
+	testcases := []struct {
+		name string
+		alg  string
+	}{
+		{name: "injection via quote", alg: `ES256","x":"y`},
+		{name: "backslash", alg: `RS\256`},
+		{name: "control byte", alg: "RS\x01256"},
+		{name: "non-ascii", alg: "RSβ256"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			badAlg := jwa.NewSignatureAlgorithm(tc.alg)
+			require.NoError(t, jws.RegisterSigner(badAlg, fakeFastPathSigner{}))
+			t.Cleanup(func() {
+				jws.UnregisterSigner(badAlg)
+				jwa.UnregisterSignatureAlgorithm(badAlg)
+			})
+
+			_, err := jws.Sign([]byte("payload"), jws.WithKey(badAlg, nil))
+			require.Error(t, err, "sign with unsafe alg name must fail")
+			require.Contains(t, err.Error(), "alg")
+		})
+	}
+}
+
+// Sanity check: the happy path with a well-formed algorithm name
+// still produces a valid JWS through the cached-header fast path.
+func TestSign_SafeAlgNameFastPath(t *testing.T) {
+	t.Parallel()
+
+	priv, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err)
+	key, err := jwk.Import[jwk.Key](priv)
+	require.NoError(t, err)
+
+	signed, err := jws.Sign([]byte("payload"), jws.WithKey(jwa.RS256(), key))
+	require.NoError(t, err)
+
+	msg, err := jws.Parse(signed)
+	require.NoError(t, err)
+	sigs := msg.Signatures()
+	require.Len(t, sigs, 1)
+	gotAlg, ok := sigs[0].ProtectedHeaders().Algorithm()
+	require.True(t, ok)
+	require.Equal(t, jwa.RS256().String(), gotAlg.String())
+}

--- a/jwt/fastpath.go
+++ b/jwt/fastpath.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lestrrat-go/jwx/v4/internal/base64"
 	"github.com/lestrrat-go/jwx/v4/internal/json"
 	"github.com/lestrrat-go/jwx/v4/internal/pool"
+	"github.com/lestrrat-go/jwx/v4/internal/tokens"
 	"github.com/lestrrat-go/jwx/v4/jwa"
 	"github.com/lestrrat-go/jwx/v4/jwk"
 	"github.com/lestrrat-go/jwx/v4/jws"
@@ -13,24 +14,24 @@ import (
 )
 
 // fastPathKidSafe reports whether kid can be concatenated into a
-// hand-built JSON header literal without escaping. Any byte that would
-// require a JSON escape (control bytes, `"`, `\`) or any non-ASCII
-// byte disqualifies the fast path; such kids fall through to the
-// regular jws.Sign path where encoding/json handles escaping.
+// hand-built JSON header literal without escaping. Callers that
+// receive false fall through to jws.Sign where encoding/json handles
+// the escaping.
 func fastPathKidSafe(kid string) bool {
-	for i := range len(kid) {
-		c := kid[i]
-		if c < 0x20 || c >= 0x7f || c == '"' || c == '\\' {
-			return false
-		}
-	}
-	return true
+	return tokens.IsJSONSafeASCII(kid)
 }
 
 // signFast reinvents the wheel a bit to avoid the overhead of
 // going through the entire jws.Sign() machinery.
 func signFast(t Token, alg jwa.SignatureAlgorithm, key any) ([]byte, error) {
 	algstr := alg.String()
+	// Unlike kid, an unsafe alg name cannot silently fall back to
+	// jws.Sign: a caller that registered an algorithm with a name
+	// containing JSON-special bytes is misconfigured, and slow-path
+	// encoding would still produce output under that rogue alg.
+	if !tokens.IsJSONSafeASCII(algstr) {
+		return nil, fmt.Errorf(`jwt.signFast: algorithm name %q contains characters that would require JSON escaping`, algstr)
+	}
 
 	var kid string
 	if jwkKey, ok := key.(jwk.Key); ok {

--- a/jwt/fastpath_test.go
+++ b/jwt/fastpath_test.go
@@ -1,6 +1,7 @@
 package jwt_test
 
 import (
+	"crypto/sha256"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v4/internal/jwxtest"
@@ -10,6 +11,16 @@ import (
 	"github.com/lestrrat-go/jwx/v4/jwt"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeSigner is a no-op Signer used by tests that need to exercise the
+// fast-path header construction with an arbitrary algorithm name. It
+// ignores the key entirely so tests can pass nil.
+type fakeSigner struct{}
+
+func (fakeSigner) Sign(_ any, payload []byte) ([]byte, error) {
+	h := sha256.Sum256(payload)
+	return h[:], nil
+}
 
 // Regression for REV-JWT-001: a kid containing JSON-special bytes must
 // not be concatenated raw into the protected header. The fast path
@@ -81,4 +92,64 @@ func TestSign_SafeKidFastPath(t *testing.T) {
 	gotKid, ok := sigs[0].ProtectedHeaders().KeyID()
 	require.True(t, ok)
 	require.Equal(t, "safe-kid-123", gotKid)
+}
+
+// A caller that registers a SignatureAlgorithm whose name contains
+// JSON-special bytes must not be able to inject fields into the
+// protected header through the fast path. Unlike the kid case, the
+// fast path fails fast here rather than silently falling back,
+// because a caller who deliberately registers such a name is
+// almost certainly misconfigured.
+//
+// Not parallel: each subtest mutates global state via
+// jws.RegisterSigner / jwa.RegisterSignatureAlgorithm.
+func TestSign_UnsafeAlgNameIsRejected(t *testing.T) {
+	testcases := []struct {
+		name string
+		alg  string
+	}{
+		{name: "injection via quote", alg: `ES256","x":"y`},
+		{name: "backslash", alg: `RS\256`},
+		{name: "control byte", alg: "RS\x01256"},
+		{name: "non-ascii", alg: "RSβ256"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			badAlg := jwa.NewSignatureAlgorithm(tc.alg)
+			// Register a real signer so jws.signFast reaches the header
+			// construction step instead of bailing out in jwsbb.Sign.
+			require.NoError(t, jws.RegisterSigner(badAlg, fakeSigner{}))
+			t.Cleanup(func() {
+				jws.UnregisterSigner(badAlg)
+				jwa.UnregisterSignatureAlgorithm(badAlg)
+			})
+
+			tok := jwt.New()
+			_, err := jwt.Sign(tok, jwt.WithKey(badAlg, nil))
+			require.Error(t, err, "sign with unsafe alg name must fail")
+			require.Contains(t, err.Error(), "alg")
+		})
+	}
+}
+
+// Sanity check: a valid alg with JSON-safe characters still signs.
+func TestSign_SafeAlgNameFastPath(t *testing.T) {
+	t.Parallel()
+
+	priv, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err)
+	key, err := jwk.Import[jwk.Key](priv)
+	require.NoError(t, err)
+
+	signed, err := jwt.Sign(jwt.New(), jwt.WithKey(jwa.RS256(), key))
+	require.NoError(t, err)
+
+	msg, err := jws.Parse(signed)
+	require.NoError(t, err)
+	sigs := msg.Signatures()
+	require.Len(t, sigs, 1)
+	gotAlg, ok := sigs[0].ProtectedHeaders().Algorithm()
+	require.True(t, ok)
+	require.Equal(t, jwa.RS256().String(), gotAlg.String())
 }


### PR DESCRIPTION
## Summary
- `jwt.signFast` and `jws.buildAlgHeaderJSON` (precomputed cache in `jws.WithKey`) concatenated `alg.String()` raw into the JSON protected header — same class as the kid fix in 75c261ff
- A `jwa.SignatureAlgorithm` registered with a name containing `"`, `\`, control bytes, or non-ASCII would smuggle fields into the header
- New `internal/tokens.IsJSONSafeASCII` gates both sites; unsafe alg returns an error rather than falling back (unlike kid: kid is wire-adjacent, alg is a caller-registered constant, so unsafe alg is a bug or attack)
- `jws.buildAlgHeaderJSON` now returns `([]byte, error)`; `withKey.cachedHdrErr` defers the validation error to sign time since `jws.WithKey` cannot return errors

## Test plan
- [x] `go test ./jwt/... ./jws/...` — all green
- [x] Injection regression tests in `jwt/fastpath_test.go` + new `jws/signature_builder_test.go` (quote, backslash, `\x01`, non-ASCII) + clean controls
- [x] `golangci-lint run ./...` — 0 issues