### PR TITLE
fix jwt fast path json injection via unescaped alg

### DIFF
--- a/jwt/fastpath.go
+++ b/jwt/fastpath.go
@@ -27,6 +27,21 @@ func fastPathKidSafe(kid string) bool {
 	return true
 }
 
+// fastPathAlgSafe reports whether alg can be concatenated into a
+// hand-built JSON header literal without escaping. The byte set
+// mirrors fastPathKidSafe: any control byte, `"`, `\`, or non-ASCII
+// byte disqualifies the value. Unlike kid, an unsafe alg is rejected
+// outright by jwt.Sign rather than silently falling through.
+func fastPathAlgSafe(alg string) bool {
+	for i := range len(alg) {
+		c := alg[i]
+		if c < 0x20 || c >= 0x7f || c == '"' || c == '\\' {
+			return false
+		}
+	}
+	return true
+}
+
 // signFast reinvents the wheel a bit to avoid the overhead of
 // going through the entire jws.Sign() machinery.
 func signFast(t Token, alg jwa.SignatureAlgorithm, key any) ([]byte, error) {

--- a/jwt/fastpath_test.go
+++ b/jwt/fastpath_test.go
@@ -82,3 +82,60 @@ func TestSign_SafeKidFastPath(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "safe-kid-123", gotKid)
 }
+
+// Regression: a SignatureAlgorithm whose name contains JSON-special
+// bytes must not be concatenated raw into the protected header via
+// the fast path. jwt.Sign should fail fast with a descriptive error
+// instead of emitting an injectable header.
+func TestSign_UnsafeAlgRejected(t *testing.T) {
+	t.Parallel()
+
+	priv, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err)
+
+	testcases := []struct {
+		name    string
+		algName string
+	}{
+		{name: "injection via quote+crit", algName: `ES256","x":"y`},
+		{name: "backslash", algName: `back\slash`},
+		{name: "control byte", algName: "ctrl\x01byte"},
+		{name: "non-ascii", algName: "RS256é"},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			key, err := jwk.Import(priv)
+			require.NoError(t, err)
+
+			alg := jwa.NewSignatureAlgorithm(tc.algName)
+			_, err = jwt.Sign(jwt.New(), jwt.WithKey(alg, key))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "jwt.Sign")
+			require.Contains(t, err.Error(), "algorithm")
+		})
+	}
+}
+
+// Sanity check: a built-in alg still signs via the fast path.
+func TestSign_SafeAlgFastPath(t *testing.T) {
+	t.Parallel()
+
+	priv, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err)
+
+	key, err := jwk.Import(priv)
+	require.NoError(t, err)
+
+	signed, err := jwt.Sign(jwt.New(), jwt.WithKey(jwa.RS256(), key))
+	require.NoError(t, err)
+
+	msg, err := jws.Parse(signed)
+	require.NoError(t, err)
+	sigs := msg.Signatures()
+	require.Len(t, sigs, 1)
+	gotAlg, ok := sigs[0].ProtectedHeaders().Algorithm()
+	require.True(t, ok)
+	require.Equal(t, jwa.RS256(), gotAlg)
+}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -532,6 +532,15 @@ func Sign(t Token, options ...SignOption) ([]byte, error) {
 				return nil, fmt.Errorf(`jwt.Sign: invalid algorithm type %T. jwa.SignatureAlgorithm is required`, wk.alg)
 			}
 
+			// Reject algorithm names that would require JSON escaping
+			// in the protected header. Unlike kid (which may be attacker-
+			// influenced and silently falls through to jws.Sign), an
+			// unsafe alg is almost certainly a caller bug or an injection
+			// attempt, so we fail fast rather than emit any signature.
+			if !fastPathAlgSafe(alg.String()) {
+				return nil, fmt.Errorf(`jwt.Sign: algorithm %q contains bytes that require JSON escaping`, alg.String())
+			}
+
 			// Check if option contains anything other than alg/key
 			if len(wk.options) == 0 {
 				// If the key carries a kid that would require JSON escaping,


### PR DESCRIPTION
## Summary
- Backport of the alg-name hardening; jwt fast path only (v3 has no jws fast path)
- Same class as #1817 (kid). A `jwa.SignatureAlgorithm` registered with a name containing `"`, `\`, control bytes, or non-ASCII was concatenated raw into the JWS protected header via `jwt.signFast`
- New sibling `fastPathAlgSafe` in `jwt/fastpath.go`; `jwt.Sign` fails fast on unsafe alg (kid's silent fallback is preserved)

## Test plan
- [x] `go test ./jwt/...` — all green, including 4 injection subtests + clean control
- [x] `go test ./... -short -race` — no regressions