### PR TITLE
add interface adapters for jwk and jwe extension points

### DIFF
--- a/jwe/interface.go
+++ b/jwe/interface.go
@@ -23,6 +23,21 @@ type KeyEncrypter interface {
 	EncryptKey([]byte) ([]byte, error)
 }
 
+// KeyEncryptFunc is a function adapter for KeyEncrypter. Because a
+// KeyEncrypter must report its Algorithm in addition to doing the
+// encryption, KeyEncryptFunc carries the algorithm alongside a plain
+// encrypt function.
+//
+// This API is experimental and may change without notice, even
+// in minor releases.
+type KeyEncryptFunc struct {
+	Alg     jwa.KeyEncryptionAlgorithm
+	Encrypt func([]byte) ([]byte, error)
+}
+
+func (f KeyEncryptFunc) Algorithm() jwa.KeyEncryptionAlgorithm { return f.Alg }
+func (f KeyEncryptFunc) EncryptKey(cek []byte) ([]byte, error) { return f.Encrypt(cek) }
+
 // KeyIDer is an interface for things that can return a key ID.
 //
 // As of this writing, this is solely used to identify KeyEncrypter
@@ -56,6 +71,17 @@ type KeyDecrypter interface {
 	// When checking a header value, you can decide to use either one, or both, but you
 	// must be aware that there are multiple places to look for.
 	DecryptKey(alg jwa.KeyEncryptionAlgorithm, encryptedKey []byte, recipient Recipient, message *Message) ([]byte, error)
+}
+
+// KeyDecryptFunc is a function adapter that implements KeyDecrypter for
+// a plain function with the same signature as DecryptKey.
+//
+// This API is experimental and may change without notice, even
+// in minor releases.
+type KeyDecryptFunc func(alg jwa.KeyEncryptionAlgorithm, encryptedKey []byte, recipient Recipient, message *Message) ([]byte, error)
+
+func (f KeyDecryptFunc) DecryptKey(alg jwa.KeyEncryptionAlgorithm, encryptedKey []byte, recipient Recipient, message *Message) ([]byte, error) {
+	return f(alg, encryptedKey, recipient, message)
 }
 
 // Recipient holds the encrypted key and hints to decrypt the key

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -790,6 +790,36 @@ func TestGH924(t *testing.T) {
 	require.Equal(t, payload, decrypted, `decrypt messages match`)
 }
 
+func TestKeyEncrypterFuncAdapter(t *testing.T) {
+	// KeyEncryptFunc / KeyDecryptFunc should round-trip a JWE using a
+	// plain function on both sides, verifying that the adapters satisfy
+	// the KeyEncrypter / KeyDecrypter interfaces end-to-end.
+	sharedKey := []byte("abra-kadabra")
+
+	enc := jwe.KeyEncryptFunc{
+		Alg: jwa.A128GCMKW(),
+		Encrypt: func(cek []byte) ([]byte, error) {
+			return append(cek, sharedKey...), nil
+		},
+	}
+	dec := jwe.KeyDecryptFunc(func(_ jwa.KeyEncryptionAlgorithm, cek []byte, _ jwe.Recipient, _ *jwe.Message) ([]byte, error) {
+		return bytes.TrimSuffix(cek, sharedKey), nil
+	})
+
+	payload := []byte("Lorem Ipsum")
+	encrypted, err := jwe.Encrypt(
+		payload,
+		jwe.WithJSON(),
+		jwe.WithKey(jwa.A128GCMKW(), enc),
+		jwe.WithContentEncryption(jwa.A128GCM()),
+	)
+	require.NoError(t, err)
+
+	decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.A128GCMKW(), dec))
+	require.NoError(t, err)
+	require.Equal(t, payload, decrypted)
+}
+
 func TestGH1001(t *testing.T) {
 	rawKey, err := jwxtest.GenerateRsaKey()
 	require.NoError(t, err, `jwxtest.GenerateRsaKey should succeed`)

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -2202,6 +2203,44 @@ func TestExportEmbeddedKey(t *testing.T) {
 		require.NoError(t, err, "jwk.Export should succeed with double indirect embed")
 		_ = rawKeyV
 	})
+}
+
+func TestPEMDecodeFunc(t *testing.T) {
+	// PEMDecodeFunc should adapt a plain function to PEMDecoder and
+	// forward the call verbatim.
+	wantRaw := []byte("raw")
+	wantRest := []byte("rest")
+	wantErr := errors.New("boom")
+	var got []byte
+	var dec jwk.PEMDecoder = jwk.PEMDecodeFunc(func(src []byte) (any, []byte, error) {
+		got = src
+		return wantRaw, wantRest, wantErr
+	})
+
+	raw, rest, err := dec.Decode([]byte("src"))
+	require.Equal(t, []byte("src"), got, "adapter should forward the input")
+	require.Equal(t, any(wantRaw), raw)
+	require.Equal(t, wantRest, rest)
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestOKPRawKeyImporterFunc(t *testing.T) {
+	// OKPRawKeyImporterFunc should adapt a plain function to the
+	// OKPRawKeyImporter interface and forward the call verbatim.
+	wantX := []byte{0x01}
+	wantD := []byte{0x02}
+	var got any
+	var imp jwk.OKPRawKeyImporter = jwk.OKPRawKeyImporterFunc(func(key any) (jwa.EllipticCurveAlgorithm, []byte, []byte, bool) {
+		got = key
+		return jwa.Ed25519(), wantX, wantD, true
+	})
+
+	crv, x, d, ok := imp.ImportOKPRawKey("sentinel")
+	require.True(t, ok)
+	require.Equal(t, "sentinel", got)
+	require.Equal(t, jwa.Ed25519(), crv)
+	require.Equal(t, wantX, x)
+	require.Equal(t, wantD, d)
 }
 
 func TestWithPEMDecoder(t *testing.T) {

--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -77,8 +77,8 @@ func (k *okpPublicKey) Import(rawKeyIf any) error {
 	default:
 		muOKPRawKeyImporters.RLock()
 		defer muOKPRawKeyImporters.RUnlock()
-		for _, fn := range okpRawKeyImporters {
-			c, x, _, ok := fn(rawKeyIf)
+		for _, imp := range okpRawKeyImporters {
+			c, x, _, ok := imp.ImportOKPRawKey(rawKeyIf)
 			if ok {
 				k.x = x
 				crv = c
@@ -112,8 +112,8 @@ func (k *okpPrivateKey) Import(rawKeyIf any) error {
 	default:
 		muOKPRawKeyImporters.RLock()
 		defer muOKPRawKeyImporters.RUnlock()
-		for _, fn := range okpRawKeyImporters {
-			c, x, d, ok := fn(rawKeyIf)
+		for _, imp := range okpRawKeyImporters {
+			c, x, d, ok := imp.ImportOKPRawKey(rawKeyIf)
 			if ok {
 				k.x = x
 				k.d = d
@@ -128,23 +128,44 @@ func (k *okpPrivateKey) Import(rawKeyIf any) error {
 	return nil
 }
 
-// OKPRawKeyImporter tries to import a raw key as an OKP key.
-// Returns the curve, x, d (nil for public), and true if handled.
-type OKPRawKeyImporter func(key any) (crv jwa.EllipticCurveAlgorithm, x, d []byte, ok bool)
+// OKPRawKeyImporter is an extension point for importing raw keys as OKP
+// JWK fields. Extension modules (for example ed448, x448) register an
+// implementation via RegisterOKPRawKeyImporter; the default OKP import
+// path consults every registered importer when it encounters an unknown
+// raw key type.
+//
+// ImportOKPRawKey inspects key and, if it recognises the concrete type,
+// returns the corresponding curve, the x component, the d component
+// (nil for public keys), and ok=true. Implementations must return
+// ok=false for unrecognised types so the next importer can be tried.
+type OKPRawKeyImporter interface {
+	ImportOKPRawKey(key any) (crv jwa.EllipticCurveAlgorithm, x, d []byte, ok bool)
+}
+
+// OKPRawKeyImporterFunc is a function adapter for OKPRawKeyImporter,
+// letting callers register a plain function without defining a
+// dedicated type.
+type OKPRawKeyImporterFunc func(key any) (crv jwa.EllipticCurveAlgorithm, x, d []byte, ok bool)
+
+func (f OKPRawKeyImporterFunc) ImportOKPRawKey(key any) (jwa.EllipticCurveAlgorithm, []byte, []byte, bool) {
+	return f(key)
+}
 
 var muOKPRawKeyImporters sync.RWMutex
 var okpRawKeyImporters []OKPRawKeyImporter
 
-// RegisterOKPRawKeyImporter registers a function that can import raw keys as OKP keys.
+// RegisterOKPRawKeyImporter registers an OKPRawKeyImporter consulted by
+// the OKP import path for unknown raw key types. To register a plain
+// function, wrap it with OKPRawKeyImporterFunc.
 //
 // The error return is reserved for future validation. The current
 // implementation always returns nil, but callers — especially extension
 // modules calling this from init() — must check the return value and panic
 // on failure to stay forward-compatible.
-func RegisterOKPRawKeyImporter(fn OKPRawKeyImporter) error {
+func RegisterOKPRawKeyImporter(imp OKPRawKeyImporter) error {
 	muOKPRawKeyImporters.Lock()
 	defer muOKPRawKeyImporters.Unlock()
-	okpRawKeyImporters = append(okpRawKeyImporters, fn)
+	okpRawKeyImporters = append(okpRawKeyImporters, imp)
 	return nil
 }
 

--- a/jwk/x509.go
+++ b/jwk/x509.go
@@ -22,6 +22,14 @@ type PEMDecoder interface {
 	Decode([]byte) (any, []byte, error)
 }
 
+// PEMDecodeFunc is a function adapter that implements PEMDecoder,
+// mirroring PEMEncodeFunc for symmetry.
+type PEMDecodeFunc func([]byte) (any, []byte, error)
+
+func (f PEMDecodeFunc) Decode(src []byte) (any, []byte, error) {
+	return f(src)
+}
+
 // PEMEncoder is an interface to describe an object that can encode
 // a key into PEM encoded ASN.1 DER format.
 //


### PR DESCRIPTION
## Summary
- Convert `jwk.OKPRawKeyImporter` from a raw `func` type to an interface with `OKPRawKeyImporterFunc` adapter (addresses adversarial review JWK-036).
- Add `jwk.PEMDecodeFunc` adapter for the existing `PEMDecoder` interface, mirroring `PEMEncodeFunc` (JWK-062).
- Add `jwe.KeyEncryptFunc` / `jwe.KeyDecryptFunc` adapters for the existing `KeyEncrypter` / `KeyDecrypter` interfaces (JWE-060).

## Breaking change
`RegisterOKPRawKeyImporter` now takes an interface. Callers passing a bare function must wrap with `jwk.OKPRawKeyImporterFunc(...)`. Coordinated updates required in `jwx-go/ed448` and `jwx-go/x448` (separate PRs).