### PR TITLE
fix jwe aescbc open opaque errors

### DIFF
--- a/jwe/internal/aescbc/aescbc.go
+++ b/jwe/internal/aescbc/aescbc.go
@@ -23,6 +23,12 @@ const defaultBufSize int64 = 256 * 1024 * 1024
 
 var maxBufSize atomic.Int64
 
+// errInvalidCiphertext is the single opaque error returned by Hmac.Open for
+// every failure mode (pre-MAC structural checks and post-MAC tag mismatch).
+// Keeping one value across all paths prevents a structural-vs-cryptographic
+// oracle on remote decrypt endpoints.
+var errInvalidCiphertext = errors.New("invalid ciphertext")
+
 func init() {
 	SetMaxBufferSize(defaultBufSize)
 }
@@ -242,20 +248,22 @@ func (c Hmac) Open(dst, nonce, ciphertext, data []byte) ([]byte, error) {
 	// invariants we don't currently enforce). Removing either layer would
 	// mean relying on the other — this way a regression in one is still
 	// caught by the other. See JWE-005 in the v4 security review.
+	// All pre-MAC structural failures return the exact same error value
+	// as the post-MAC failure below. Distinguishing "malformed nonce",
+	// "ciphertext too short", "ciphertext length not block-aligned", and
+	// "MAC mismatch" at the caller would leak whether an attacker probe
+	// is block-aligned vs cryptographically invalid — a structural-vs-MAC
+	// oracle that composes with other leaks. Keep all four paths opaque.
 	if len(nonce) != c.blockCipher.BlockSize() {
-		return nil, fmt.Errorf(`invalid nonce (length %d, expected %d)`, len(nonce), c.blockCipher.BlockSize())
+		return nil, errInvalidCiphertext
 	}
 	if len(ciphertext) < c.tlen {
-		return nil, fmt.Errorf(`invalid ciphertext (too short)`)
+		return nil, errInvalidCiphertext
 	}
 
 	tagOffset := len(ciphertext) - c.tlen
 	if tagOffset%c.blockCipher.BlockSize() != 0 {
-		return nil, fmt.Errorf(
-			"invalid ciphertext (invalid length: %d %% %d != 0)",
-			tagOffset,
-			c.blockCipher.BlockSize(),
-		)
+		return nil, errInvalidCiphertext
 	}
 	tag := ciphertext[tagOffset:]
 	ciphertext = ciphertext[:tagOffset]
@@ -274,7 +282,7 @@ func (c Hmac) Open(dst, nonce, ciphertext, data []byte) ([]byte, error) {
 	toRemove, good := extractPadding(buf)
 	cmp := subtle.ConstantTimeCompare(expectedTag, tag) & int(good)
 	if cmp != 1 {
-		return nil, errors.New(`invalid ciphertext`)
+		return nil, errInvalidCiphertext
 	}
 
 	plaintext := buf[:len(buf)-toRemove]

--- a/jwe/internal/aescbc/aescbc_test.go
+++ b/jwe/internal/aescbc/aescbc_test.go
@@ -47,6 +47,48 @@ func TestVectorsAESCBC128(t *testing.T) {
 	require.Equal(t, plaintext, out, "Open should get us original text")
 }
 
+// TestOpenOpaqueErrors locks in the guarantee that Hmac.Open returns a
+// single opaque error value for every failure mode: malformed nonce,
+// ciphertext shorter than the tag, ciphertext whose tag offset is not
+// block-aligned, and post-MAC tag mismatch. Distinguishable error
+// strings on these paths would create a structural-vs-cryptographic
+// oracle on any decrypt endpoint that forwards the error text.
+// Regression guard for JWE-20260415151950-016.
+func TestOpenOpaqueErrors(t *testing.T) {
+	key := make([]byte, 32) // A128CBC-HS256 uses 32-byte key (16 mac + 16 enc)
+	enc, err := New(key, aes.NewCipher)
+	require.NoError(t, err, "aescbc.New")
+
+	aad := []byte("aad")
+	plaintext := []byte("hello world")
+	nonce := make([]byte, enc.blockCipher.BlockSize())
+	sealed := enc.Seal(nil, nonce, plaintext, aad)
+
+	t.Run("nonce wrong length", func(t *testing.T) {
+		_, err := enc.Open(nil, make([]byte, enc.blockCipher.BlockSize()-1), sealed, aad)
+		require.EqualError(t, err, "invalid ciphertext")
+	})
+
+	t.Run("ciphertext shorter than tag", func(t *testing.T) {
+		_, err := enc.Open(nil, nonce, make([]byte, enc.keysize-1), aad)
+		require.EqualError(t, err, "invalid ciphertext")
+	})
+
+	t.Run("ciphertext length not block-aligned", func(t *testing.T) {
+		bad := make([]byte, enc.keysize+7)
+		_, err := enc.Open(nil, nonce, bad, aad)
+		require.EqualError(t, err, "invalid ciphertext")
+	})
+
+	t.Run("mac mismatch", func(t *testing.T) {
+		tampered := make([]byte, len(sealed))
+		copy(tampered, sealed)
+		tampered[len(tampered)-1] ^= 0xFF
+		_, err := enc.Open(nil, nonce, tampered, aad)
+		require.EqualError(t, err, "invalid ciphertext")
+	})
+}
+
 func TestPad(t *testing.T) {
 	for i := range 256 {
 		buf := make([]byte, i)


### PR DESCRIPTION
Collapse all `Hmac.Open` failure paths — malformed nonce, ciphertext too short, tag offset not block-aligned, and post-MAC tag mismatch — onto a single `errInvalidCiphertext` sentinel. Distinguishable error strings across these paths leak whether an attacker probe is block-aligned vs cryptographically invalid, a structural-vs-MAC oracle that composes with other leaks on decrypt endpoints that forward error text.

Outer `jwe.Decrypt` `errors.Join` is left alone: collapsing it would hide legitimate multi-recipient diagnostics, and the root-cause fix lives at the aescbc layer.

Regression test `TestOpenOpaqueErrors` locks all four failure modes to the exact string `invalid ciphertext`.

Addresses JWE-20260415151950-016 from the v4 adversarial review. v3 fix: #TBD.