### PR TITLE
fix jwe keyset selecting keys without alg field

### DIFF
--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -233,7 +233,6 @@ func TestParse_RSAES_OAEP_AES_GCM(t *testing.T) {
 			t.Run("WithKeySet", func(t *testing.T) {
 				pkJwk, err := jwk.Import[jwk.Key](rawkey)
 				require.NoError(t, err, `jwk.New should succeed`)
-				// Keys are not going to be selected without an algorithm
 				require.NoError(t, pkJwk.Set(jwe.AlgorithmKey, jwa.RSA_OAEP()), `jwk.Set should succeed`)
 				set := jwk.NewSet()
 				set.AddKey(pkJwk)
@@ -241,6 +240,24 @@ func TestParse_RSAES_OAEP_AES_GCM(t *testing.T) {
 				var used any
 				plaintext, err = jwe.Decrypt(encrypted, jwe.WithKeySet(set, jwe.WithRequireKid(false)), jwe.WithKeyUsed(&used))
 				require.NoError(t, err)
+				require.Equal(t, payload, string(plaintext), "jwe.Decrypt should produce the same plaintext")
+				require.Equal(t, pkJwk, used)
+			})
+			t.Run("WithKeySet (JWK without alg)", func(t *testing.T) {
+				// Regression for JWE-20260415151950-033: keys from JWK Sets
+				// that omit "alg" (common for IdP-published encryption keys)
+				// must still be selectable when the recipient's header
+				// declares the algorithm.
+				pkJwk, err := jwk.Import[jwk.Key](rawkey)
+				require.NoError(t, err, `jwk.Import should succeed`)
+				_, hasAlg := pkJwk.Algorithm()
+				require.False(t, hasAlg, `imported JWK should have no "alg" field`)
+				set := jwk.NewSet()
+				require.NoError(t, set.AddKey(pkJwk))
+
+				var used any
+				plaintext, err = jwe.Decrypt(encrypted, jwe.WithKeySet(set, jwe.WithRequireKid(false)), jwe.WithKeyUsed(&used))
+				require.NoError(t, err, `jwe.Decrypt with alg-less JWK should succeed`)
 				require.Equal(t, payload, string(plaintext), "jwe.Decrypt should produce the same plaintext")
 				require.Equal(t, pkJwk, used)
 			})

--- a/jwe/key_provider.go
+++ b/jwe/key_provider.go
@@ -106,7 +106,7 @@ type keySetProvider struct {
 	requireKid bool
 }
 
-func (kp *keySetProvider) selectKey(sink KeySink, key jwk.Key, _ Recipient, _ *Message) error {
+func (kp *keySetProvider) selectKey(sink KeySink, key jwk.Key, r Recipient, msg *Message) error {
 	if usage, ok := key.KeyUsage(); ok {
 		if usage != "" && usage != jwk.ForEncryption.String() {
 			return nil
@@ -123,7 +123,30 @@ func (kp *keySetProvider) selectKey(sink KeySink, key jwk.Key, _ Recipient, _ *M
 		return nil
 	}
 
-	return nil
+	// The JWK has no "alg" — common for IdP-published encryption keys.
+	// Fall back to the recipient's declared "alg" (per-recipient header,
+	// then protected header), matching the preference order used when
+	// jwe.Decrypt verifies the chosen key's algorithm against the message.
+	// jwe.Decrypt re-checks agreement before use, so trusting the header
+	// alg here does not widen the attack surface.
+	for _, hdr := range []Headers{r.Headers(), msg.ProtectedHeaders()} {
+		if hdr == nil {
+			continue
+		}
+		v, ok := hdr.Algorithm()
+		if !ok {
+			continue
+		}
+		kalg, ok := jwa.LookupKeyEncryptionAlgorithm(v.String())
+		if !ok {
+			continue
+		}
+		sink.Key(kalg, key)
+		return nil
+	}
+
+	kid, _ := key.KeyID()
+	return fmt.Errorf(`key %q in set has no "alg" field and the JWE message has no recoverable "alg" header; declare "alg" on the JWK or use jwe.WithKey(alg, key) directly`, kid)
 }
 
 func (kp *keySetProvider) FetchKeys(_ context.Context, sink KeySink, r Recipient, msg *Message) error {


### PR DESCRIPTION
## Summary
- `keySetProvider.selectKey` now falls back to the recipient/protected header `alg` when the JWK has no `alg` field, so `jwe.WithKeySet` works with IdP JWK Sets that don't publish `alg`.
- Clearer error when no `alg` can be resolved from either the key or the message headers.
- `jwe.Decrypt` still re-checks key/header alg agreement (`jwe.go:562-578`), so the fallback does not widen the attack surface.

## Test plan
- [x] new `WithKeySet (JWK without alg)` subtest in `jwe/jwe_test.go`
- [x] `make test`
- [x] `make lint`