### PR TITLE
fix jwe ecdh-es invalid-curve attack surface

### DIFF
--- a/jwe/jwebb/ecdh_es_ext.go
+++ b/jwe/jwebb/ecdh_es_ext.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/lestrrat-go/jwx/v4/internal/ecutil"
 	"github.com/lestrrat-go/jwx/v4/internal/keyconv"
 	"github.com/lestrrat-go/jwx/v4/internal/tokens"
 	"github.com/lestrrat-go/jwx/v4/jwe/internal/concatkdf"
@@ -143,16 +142,35 @@ func NewECDHESKeyGenerator(key any) (ECDHESKeyGenerator, error) {
 	case ecdh.PrivateKey:
 		return &ecdhGenerator{key: k.PublicKey()}, nil
 	case *ecdsa.PublicKey:
-		return &ecdsaGenerator{key: k}, nil
+		return ecdhGeneratorFromECDSAPublic(k)
 	case ecdsa.PublicKey:
-		return &ecdsaGenerator{key: &k}, nil
+		return ecdhGeneratorFromECDSAPublic(&k)
 	case *ecdsa.PrivateKey:
-		return &ecdsaGenerator{key: &k.PublicKey}, nil
+		return ecdhGeneratorFromECDSAPublic(&k.PublicKey)
 	case ecdsa.PrivateKey:
-		return &ecdsaGenerator{key: &k.PublicKey}, nil
+		return ecdhGeneratorFromECDSAPublic(&k.PublicKey)
 	default:
 		return nil, fmt.Errorf(`unsupported key type for ECDH-ES key generation: %T`, key)
 	}
+}
+
+// ecdhGeneratorFromECDSAPublic converts an *ecdsa.PublicKey into an
+// *ecdh.PublicKey via stdlib (*ecdsa.PublicKey).ECDH() and wraps it in
+// ecdhGenerator. This routes every ecdsa-input ECDH-ES path through
+// crypto/ecdh, which uses identity matching on named NIST curves and
+// refuses anything else — including the generic elliptic.CurveParams
+// big-int path. That closes the invalid-curve attack surface that a
+// caller-controlled ecdsa.PublicKey.Curve field would otherwise expose
+// via the deprecated crypto/elliptic.Curve.ScalarMult.
+func ecdhGeneratorFromECDSAPublic(pub *ecdsa.PublicKey) (ECDHESKeyGenerator, error) {
+	if pub == nil || pub.X == nil || pub.Y == nil {
+		return nil, fmt.Errorf(`invalid ecdsa public key: nil X or Y`)
+	}
+	ecdhPub, err := pub.ECDH()
+	if err != nil {
+		return nil, fmt.Errorf(`failed to convert ecdsa public key to *ecdh.PublicKey: %w`, err)
+	}
+	return &ecdhGenerator{key: ecdhPub}, nil
 }
 
 // NewECDHESKeyDeriver normalizes a raw key into an ECDHESKeyDeriver.
@@ -197,33 +215,6 @@ func (g *ecdhGenerator) GenerateECDHES(alg string, keysize int, apu, apv []byte)
 	}
 
 	return derived, priv.PublicKey(), nil
-}
-
-// ecdsaGenerator wraps *ecdsa.PublicKey to implement ECDHESKeyGenerator.
-type ecdsaGenerator struct {
-	key *ecdsa.PublicKey
-}
-
-func (g *ecdsaGenerator) GenerateECDHES(alg string, keysize int, apu, apv []byte) ([]byte, any, error) {
-	priv, err := ecdsa.GenerateKey(g.key.Curve, rand.Reader)
-	if err != nil {
-		return nil, nil, fmt.Errorf(`failed to generate ephemeral key: %w`, err)
-	}
-
-	if !priv.PublicKey.Curve.IsOnCurve(g.key.X, g.key.Y) {
-		return nil, nil, fmt.Errorf(`public key used does not contain a point (X,Y) on the curve`)
-	}
-
-	z, _ := priv.PublicKey.Curve.ScalarMult(g.key.X, g.key.Y, priv.D.Bytes())
-	zBytes := ecutil.AllocECPointBuffer(z, priv.PublicKey.Curve)
-	defer ecutil.ReleaseECPointBuffer(zBytes)
-
-	derived, err := DeriveECDHESRaw(alg, zBytes, apu, apv, keysize)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return derived, &priv.PublicKey, nil
 }
 
 // ecdhDeriver wraps *ecdh.PrivateKey to implement ECDHESKeyDeriver.

--- a/jwe/jwebb/ecdh_es_ext_test.go
+++ b/jwe/jwebb/ecdh_es_ext_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"math/big"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v4/jwe/jwebb"
@@ -206,5 +207,68 @@ func TestECDHESGenerateAndDerive(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, derivedEnc, derivedDec)
+	})
+}
+
+// unsafeCurve is a minimal elliptic.Curve stub used to prove that an
+// attacker-controlled curve on an *ecdsa.PublicKey is rejected at
+// conversion time and cannot reach a big-int ScalarMult computation.
+type unsafeCurve struct{}
+
+func (unsafeCurve) Params() *elliptic.CurveParams {
+	return &elliptic.CurveParams{Name: "unsafe"}
+}
+func (unsafeCurve) IsOnCurve(_, _ *big.Int) bool { return true }
+func (unsafeCurve) Add(_, _, _, _ *big.Int) (*big.Int, *big.Int) {
+	return big.NewInt(0), big.NewInt(0)
+}
+func (unsafeCurve) Double(_, _ *big.Int) (*big.Int, *big.Int) {
+	return big.NewInt(0), big.NewInt(0)
+}
+func (unsafeCurve) ScalarMult(_, _ *big.Int, _ []byte) (*big.Int, *big.Int) {
+	return big.NewInt(0), big.NewInt(0)
+}
+func (unsafeCurve) ScalarBaseMult(_ []byte) (*big.Int, *big.Int) {
+	return big.NewInt(0), big.NewInt(0)
+}
+
+func TestNewECDHESKeyGeneratorRejectsUnsafeECDSACurves(t *testing.T) {
+	t.Run("tampered curve", func(t *testing.T) {
+		pub := &ecdsa.PublicKey{
+			Curve: unsafeCurve{},
+			X:     big.NewInt(1),
+			Y:     big.NewInt(1),
+		}
+		_, err := jwebb.NewECDHESKeyGenerator(pub)
+		require.Error(t, err, "attacker-controlled curve must not be accepted")
+	})
+
+	t.Run("generic CurveParams path", func(t *testing.T) {
+		// A valid P-256 point with Curve set to the generic big-int
+		// implementation. crypto/ecdh uses identity matching on named
+		// curves, so the slow generic path is rejected even though the
+		// point is mathematically on P-256.
+		valid, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		pub := &ecdsa.PublicKey{
+			Curve: elliptic.P256().Params(),
+			X:     valid.X,
+			Y:     valid.Y,
+		}
+		_, err = jwebb.NewECDHESKeyGenerator(pub)
+		require.Error(t, err, "generic CurveParams path must not be accepted")
+	})
+
+	t.Run("unsupported stdlib curve P-224", func(t *testing.T) {
+		priv, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+		require.NoError(t, err)
+		_, err = jwebb.NewECDHESKeyGenerator(&priv.PublicKey)
+		require.Error(t, err, "P-224 is not a valid JOSE ECDH-ES curve")
+	})
+
+	t.Run("nil X and Y", func(t *testing.T) {
+		pub := &ecdsa.PublicKey{Curve: elliptic.P256()}
+		_, err := jwebb.NewECDHESKeyGenerator(pub)
+		require.Error(t, err, "nil X/Y must not be accepted")
 	})
 }


### PR DESCRIPTION
## Summary

- Route every ecdsa-keyed ECDH-ES encrypt through `crypto/ecdh` via stdlib `(*ecdsa.PublicKey).ECDH()`; delete the `ecdsaGenerator` path that called the deprecated `crypto/elliptic.Curve.ScalarMult` against a caller-controlled `Curve` field.
- Reject tampered curves, `elliptic.P256().Params()` generic big-int path, P-224, and nil X/Y up front.
- Regression tests in `jwe/jwebb/ecdh_es_ext_test.go` cover all four rejection paths.