### PR TITLE
fix jwe ecdh-es invalid-curve attack surface

### DIFF
--- a/jwe/internal/keygen/keygen.go
+++ b/jwe/internal/keygen/keygen.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/lestrrat-go/jwx/v3/internal/ecutil"
 	"github.com/lestrrat-go/jwx/v3/internal/tokens"
 	"github.com/lestrrat-go/jwx/v3/jwe/internal/concatkdf"
 	"github.com/lestrrat-go/jwx/v3/jwk"
@@ -28,9 +27,27 @@ func Random(n int) (ByteSource, error) {
 	return ByteKey(buf), nil
 }
 
-// Ecdhes generates a new key using ECDH-ES
+// Ecdhes generates a new key using ECDH-ES.
+//
+// The recipient pubkey is converted to *ecdh.PublicKey via stdlib
+// (*ecdsa.PublicKey).ECDH() before any cryptographic operation. That
+// conversion uses identity matching against the named NIST curves
+// (elliptic.P256/P384/P521) and rejects anything else — including a
+// caller-controlled or tampered elliptic.Curve and the generic big-int
+// CurveParams path. This closes the invalid-curve attack surface that
+// the previous deprecated crypto/elliptic.Curve.ScalarMult code path
+// exposed when the recipient's *ecdsa.PublicKey.Curve field was
+// attacker-influenced.
 func Ecdhes(alg string, enc string, keysize int, pubkey *ecdsa.PublicKey, apu, apv []byte) (ByteSource, error) {
-	priv, err := ecdsa.GenerateKey(pubkey.Curve, rand.Reader)
+	if pubkey == nil || pubkey.X == nil || pubkey.Y == nil {
+		return nil, fmt.Errorf(`invalid ECDH-ES public key: nil X or Y`)
+	}
+	ecdhPub, err := pubkey.ECDH()
+	if err != nil {
+		return nil, fmt.Errorf(`failed to convert ECDH-ES public key to *ecdh.PublicKey: %w`, err)
+	}
+
+	priv, err := ecdhPub.Curve().GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf(`failed to generate key for ECDH-ES: %w`, err)
 	}
@@ -45,12 +62,11 @@ func Ecdhes(alg string, enc string, keysize int, pubkey *ecdsa.PublicKey, apu, a
 	pubinfo := make([]byte, 4)
 	binary.BigEndian.PutUint32(pubinfo, uint32(keysize)*8)
 
-	if !priv.PublicKey.Curve.IsOnCurve(pubkey.X, pubkey.Y) {
-		return nil, fmt.Errorf(`public key used does not contain a point (X,Y) on the curve`)
+	zBytes, err := priv.ECDH(ecdhPub)
+	if err != nil {
+		return nil, fmt.Errorf(`failed to compute Z: %w`, err)
 	}
-	z, _ := priv.PublicKey.Curve.ScalarMult(pubkey.X, pubkey.Y, priv.D.Bytes())
-	zBytes := ecutil.AllocECPointBuffer(z, priv.PublicKey.Curve)
-	defer ecutil.ReleaseECPointBuffer(zBytes)
+
 	kdf := concatkdf.New(crypto.SHA256, []byte(algorithm), zBytes, apu, apv, pubinfo, []byte{})
 	kek := make([]byte, keysize)
 	if _, err := kdf.Read(kek); err != nil {
@@ -58,7 +74,7 @@ func Ecdhes(alg string, enc string, keysize int, pubkey *ecdsa.PublicKey, apu, a
 	}
 
 	return ByteWithECPublicKey{
-		PublicKey: &priv.PublicKey,
+		PublicKey: priv.PublicKey(),
 		ByteKey:   ByteKey(kek),
 	}, nil
 }

--- a/jwe/internal/keygen/keygen_test.go
+++ b/jwe/internal/keygen/keygen_test.go
@@ -1,0 +1,84 @@
+package keygen_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/jwe/internal/keygen"
+	"github.com/stretchr/testify/require"
+)
+
+// unsafeCurve is a minimal elliptic.Curve stub used to prove that an
+// attacker-controlled curve on an *ecdsa.PublicKey is rejected at
+// conversion time and cannot reach a big-int ScalarMult computation.
+type unsafeCurve struct{}
+
+func (unsafeCurve) Params() *elliptic.CurveParams {
+	return &elliptic.CurveParams{Name: "unsafe"}
+}
+func (unsafeCurve) IsOnCurve(_, _ *big.Int) bool { return true }
+func (unsafeCurve) Add(_, _, _, _ *big.Int) (*big.Int, *big.Int) {
+	return big.NewInt(0), big.NewInt(0)
+}
+func (unsafeCurve) Double(_, _ *big.Int) (*big.Int, *big.Int) {
+	return big.NewInt(0), big.NewInt(0)
+}
+func (unsafeCurve) ScalarMult(_, _ *big.Int, _ []byte) (*big.Int, *big.Int) {
+	return big.NewInt(0), big.NewInt(0)
+}
+func (unsafeCurve) ScalarBaseMult(_ []byte) (*big.Int, *big.Int) {
+	return big.NewInt(0), big.NewInt(0)
+}
+
+func TestEcdhesRejectsUnsafeCurves(t *testing.T) {
+	t.Run("tampered curve", func(t *testing.T) {
+		pub := &ecdsa.PublicKey{
+			Curve: unsafeCurve{},
+			X:     big.NewInt(1),
+			Y:     big.NewInt(1),
+		}
+		_, err := keygen.Ecdhes("ECDH-ES", "A128GCM", 16, pub, nil, nil)
+		require.Error(t, err, "attacker-controlled curve must not be accepted")
+	})
+
+	t.Run("generic CurveParams path", func(t *testing.T) {
+		valid, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		pub := &ecdsa.PublicKey{
+			Curve: elliptic.P256().Params(),
+			X:     valid.X,
+			Y:     valid.Y,
+		}
+		_, err = keygen.Ecdhes("ECDH-ES", "A128GCM", 16, pub, nil, nil)
+		require.Error(t, err, "generic CurveParams path must not be accepted")
+	})
+
+	t.Run("unsupported stdlib curve P-224", func(t *testing.T) {
+		priv, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+		require.NoError(t, err)
+		_, err = keygen.Ecdhes("ECDH-ES", "A128GCM", 16, &priv.PublicKey, nil, nil)
+		require.Error(t, err, "P-224 is not a valid JOSE ECDH-ES curve")
+	})
+
+	t.Run("nil X and Y", func(t *testing.T) {
+		pub := &ecdsa.PublicKey{Curve: elliptic.P256()}
+		_, err := keygen.Ecdhes("ECDH-ES", "A128GCM", 16, pub, nil, nil)
+		require.Error(t, err, "nil X/Y must not be accepted")
+	})
+}
+
+func TestEcdhesPositive(t *testing.T) {
+	// Sanity: ensure P-256/P-384/P-521 still produce outputs.
+	for _, curve := range []elliptic.Curve{elliptic.P256(), elliptic.P384(), elliptic.P521()} {
+		t.Run(curve.Params().Name, func(t *testing.T) {
+			priv, err := ecdsa.GenerateKey(curve, rand.Reader)
+			require.NoError(t, err)
+			src, err := keygen.Ecdhes("ECDH-ES", "A128GCM", 16, &priv.PublicKey, nil, nil)
+			require.NoError(t, err)
+			require.Len(t, src.Bytes(), 16)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Rewrite `keygen.Ecdhes` to convert the recipient `*ecdsa.PublicKey` to `*ecdh.PublicKey` via stdlib `(*ecdsa.PublicKey).ECDH()` and run the shared-secret computation through `crypto/ecdh`. Removes the deprecated `crypto/elliptic.Curve.ScalarMult` call against a caller-controlled `Curve` field.
- Reject tampered curves, `elliptic.P256().Params()` generic big-int path, P-224, and nil X/Y up front. Closes a panic on the unfixed code path as well.
- New regression suite in `jwe/internal/keygen/keygen_test.go`: four negative cases plus P-256/P-384/P-521 smoke tests.

Companion v4 PR: #1846