### PR TITLE
jwe: pass *Message to KeyDecrypter

### DIFF
--- a/jwe/decrypt.go
+++ b/jwe/decrypt.go
@@ -23,12 +23,12 @@ type decryptCEKContext struct {
 // decryptCEK dispatches key decryption to the appropriate per-family
 // function based on the algorithm. Each function extracts its own
 // algorithm-specific parameters from the merged headers.
-func decryptCEK(alg jwa.KeyEncryptionAlgorithm, key any, recipient Recipient, headers Headers, ctx *decryptCEKContext) ([]byte, error) {
+func decryptCEK(alg jwa.KeyEncryptionAlgorithm, key any, msg *Message, recipient Recipient, headers Headers, ctx *decryptCEKContext) ([]byte, error) {
 	algStr := alg.String()
 	recipientKey := recipient.EncryptedKey()
 
 	if kd, ok := key.(KeyDecrypter); ok {
-		return kd.DecryptKey(alg, recipientKey, recipient, nil)
+		return kd.DecryptKey(alg, recipientKey, recipient, msg)
 	}
 
 	switch {

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -610,7 +610,7 @@ func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgo
 		ctalg:         ce,
 		contentCipher: contentCipher,
 	}
-	cek, err := decryptCEK(alg, key, recipient, h2, cekCtx)
+	cek, err := decryptCEK(alg, key, msg, recipient, h2, cekCtx)
 	if err != nil {
 		return nil, fmt.Errorf(`jwe.Decrypt: failed to decrypt key: %w`, err)
 	}

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -837,6 +837,52 @@ func TestKeyEncrypterFuncAdapter(t *testing.T) {
 	require.Equal(t, payload, decrypted)
 }
 
+// recordingKeyDecrypter captures the *Message passed by decryptCEK so
+// tests can assert that HSM-style callers get access to protected headers.
+type recordingKeyDecrypter struct {
+	alg jwa.KeyEncryptionAlgorithm
+	cek []byte
+	got *jwe.Message
+}
+
+func (r *recordingKeyDecrypter) Algorithm() jwa.KeyEncryptionAlgorithm { return r.alg }
+func (r *recordingKeyDecrypter) EncryptKey(_ []byte) ([]byte, error)   { return r.cek, nil }
+func (r *recordingKeyDecrypter) DecryptKey(_ jwa.KeyEncryptionAlgorithm, _ []byte, _ jwe.Recipient, msg *jwe.Message) ([]byte, error) {
+	r.got = msg
+	return r.cek, nil
+}
+
+func TestKeyDecrypterReceivesMessage(t *testing.T) {
+	// Regression: decryptCEK must thread the *Message through to
+	// user-supplied KeyDecrypter implementations so HSM callers can see
+	// protected-header fields (typ, cty, etc.) they were promised by the
+	// interface doc.
+	cek := make([]byte, 16)
+	_, err := rand.Read(cek)
+	require.NoError(t, err, `rand.Read should succeed`)
+
+	kd := &recordingKeyDecrypter{alg: jwa.DIRECT(), cek: cek}
+
+	hdrs := jwe.NewHeaders()
+	require.NoError(t, hdrs.Set(jwe.TypeKey, "example+jwt"))
+
+	encrypted, err := jwe.Encrypt(
+		[]byte("Lorem Ipsum"),
+		jwe.WithKey(jwa.DIRECT(), cek),
+		jwe.WithContentEncryption(jwa.A128GCM()),
+		jwe.WithProtectedHeaders(hdrs),
+	)
+	require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+	_, err = jwe.Decrypt(encrypted, jwe.WithKey(jwa.DIRECT(), kd))
+	require.NoError(t, err, `jwe.Decrypt should succeed`)
+
+	require.NotNil(t, kd.got, `KeyDecrypter should receive a non-nil *Message`)
+	typ, ok := kd.got.ProtectedHeaders().Type()
+	require.True(t, ok, `protected 'typ' header should be visible`)
+	require.Equal(t, "example+jwt", typ)
+}
+
 func TestGH1001(t *testing.T) {
 	rawKey, err := jwxtest.GenerateRsaKey()
 	require.NoError(t, err, `jwxtest.GenerateRsaKey should succeed`)


### PR DESCRIPTION
HSM-backed `KeyDecrypter` implementations need access to protected-header fields (`typ`, `cty`, etc.) to enforce per-message policy. `decryptCEK` was passing `nil`, forcing callbacks to either re-parse the ciphertext (creating a TOCTOU window) or run blind.

Threads the already-available `*Message` from `decryptContent` through `decryptCEK` into `kd.DecryptKey`. No public API change — `KeyDecrypter.DecryptKey` already takes `*Message`; this fix honors the contract documented at `jwe/interface.go:59`.

Adds `TestKeyDecrypterReceivesMessage` asserting a `recordingKeyDecrypter` sees the protected `typ` header end-to-end.