### PR TITLE
fix jwk akp thumbprint to include alg per rfc 9802

### DIFF
--- a/jwk/akp.go
+++ b/jwk/akp.go
@@ -60,11 +60,14 @@ func (k *akpPrivateKey) PublicKey() (Key, error) {
 	return makeAKPPublicKey(k)
 }
 
-func akpThumbprint(hash crypto.Hash, pub string) []byte {
+// akpThumbprint hashes the canonical JSON form defined by RFC 7638 §3.2
+// for AKP keys: the required members {alg, kty, pub} in lexicographic order.
+// RFC 9802 makes alg a required thumbprint input for AKP because pub is
+// algorithm-scoped — omitting alg would break cross-implementation kid
+// lookup.
+func akpThumbprint(hash crypto.Hash, alg, pub string) []byte {
 	h := hash.New()
-	fmt.Fprint(h, `{"kty":"AKP","pub":"`)
-	fmt.Fprint(h, pub)
-	fmt.Fprint(h, `"}`)
+	fmt.Fprintf(h, `{"alg":%q,"kty":"AKP","pub":%q}`, alg, pub)
 	return h.Sum(nil)
 }
 
@@ -75,7 +78,10 @@ func (k *akpPublicKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	if k.pub == nil {
 		return nil, fmt.Errorf(`missing "pub" field`)
 	}
-	return akpThumbprint(hash, base64.EncodeToString(k.pub)), nil
+	if k.algorithm == nil {
+		return nil, fmt.Errorf(`missing "alg" field (required for AKP thumbprint)`)
+	}
+	return akpThumbprint(hash, (*k.algorithm).String(), base64.EncodeToString(k.pub)), nil
 }
 
 func (k *akpPrivateKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
@@ -85,7 +91,10 @@ func (k *akpPrivateKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	if k.pub == nil {
 		return nil, fmt.Errorf(`missing "pub" field`)
 	}
-	return akpThumbprint(hash, base64.EncodeToString(k.pub)), nil
+	if k.algorithm == nil {
+		return nil, fmt.Errorf(`missing "alg" field (required for AKP thumbprint)`)
+	}
+	return akpThumbprint(hash, (*k.algorithm).String(), base64.EncodeToString(k.pub)), nil
 }
 
 func (k *akpPublicKey) Validate() error {

--- a/jwk/akp_test.go
+++ b/jwk/akp_test.go
@@ -1,0 +1,66 @@
+package jwk
+
+import (
+	"crypto"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/internal/base64"
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAKPThumbprintIncludesAlg locks in the RFC 7638 / RFC 9802 contract that
+// AKP thumbprints hash the canonical JSON of {alg, kty, pub} in lexicographic
+// order. A real PQ algorithm string (e.g. ML-DSA-44) lives in the ML-DSA
+// extension module, so this test uses jwa.RS256() as a stand-in registered
+// algorithm — the byte value of alg is irrelevant; what matters is that it
+// appears in the hash input.
+func TestAKPThumbprintIncludesAlg(t *testing.T) {
+	pub := []byte("pub-bytes-for-thumbprint")
+	b64Pub := base64.EncodeToString(pub)
+	alg := jwa.RS256()
+
+	expected := sha256.Sum256([]byte(fmt.Sprintf(`{"alg":%q,"kty":"AKP","pub":%q}`, alg.String(), b64Pub)))
+
+	t.Run("public key", func(t *testing.T) {
+		k := newAKPPublicKey()
+		require.NoError(t, k.Set(AKPPubKey, pub))
+		require.NoError(t, k.Set(AlgorithmKey, alg))
+
+		got, err := k.Thumbprint(crypto.SHA256)
+		require.NoError(t, err)
+		require.Equal(t, expected[:], got)
+	})
+
+	t.Run("private key", func(t *testing.T) {
+		k := newAKPPrivateKey()
+		require.NoError(t, k.Set(AKPPubKey, pub))
+		require.NoError(t, k.Set(AKPPrivKey, []byte("priv-bytes")))
+		require.NoError(t, k.Set(AlgorithmKey, alg))
+
+		got, err := k.Thumbprint(crypto.SHA256)
+		require.NoError(t, err)
+		require.Equal(t, expected[:], got)
+	})
+}
+
+func TestAKPThumbprintRequiresAlg(t *testing.T) {
+	pub := []byte("pub-bytes")
+
+	t.Run("public key without alg", func(t *testing.T) {
+		k := newAKPPublicKey()
+		require.NoError(t, k.Set(AKPPubKey, pub))
+		_, err := k.Thumbprint(crypto.SHA256)
+		require.Error(t, err)
+	})
+
+	t.Run("private key without alg", func(t *testing.T) {
+		k := newAKPPrivateKey()
+		require.NoError(t, k.Set(AKPPubKey, pub))
+		require.NoError(t, k.Set(AKPPrivKey, []byte("priv-bytes")))
+		_, err := k.Thumbprint(crypto.SHA256)
+		require.Error(t, err)
+	})
+}

--- a/jwk/akp_test.go
+++ b/jwk/akp_test.go
@@ -22,7 +22,7 @@ func TestAKPThumbprintIncludesAlg(t *testing.T) {
 	b64Pub := base64.EncodeToString(pub)
 	alg := jwa.RS256()
 
-	expected := sha256.Sum256([]byte(fmt.Sprintf(`{"alg":%q,"kty":"AKP","pub":%q}`, alg.String(), b64Pub)))
+	expected := sha256.Sum256(fmt.Appendf(nil, `{"alg":%q,"kty":"AKP","pub":%q}`, alg.String(), b64Pub))
 
 	t.Run("public key", func(t *testing.T) {
 		k := newAKPPublicKey()


### PR DESCRIPTION
AKP thumbprints previously hashed only `{kty, pub}`, so jwx-generated `kid` values did not match thumbprints computed by any other RFC 9802 implementation. RFC 7638 §3.2 requires all registry-listed members in lex order; RFC 9802 lists `alg` as required for AKP because `pub` is algorithm-scoped.

Fix: canonical input is now `{"alg":…,"kty":"AKP","pub":…}`, and `Thumbprint` errors if `alg` is unset instead of silently dropping it.