### PR TITLE
snapshot now once per jwt.Validate call

### DIFF
--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -117,6 +117,11 @@ func Validate(t Token, options ...ValidateOption) error {
 	ctx = SetValidationCtxSkew(ctx, skew)
 	ctx = SetValidationCtxClock(ctx, clock)
 	ctx = SetValidationCtxTruncation(ctx, trunc)
+	// Snapshot "now" once so all default validators observe the same
+	// instant — matches the fast path in validateDefault and avoids
+	// second-boundary inconsistency when a custom Clock is stepped
+	// between validator calls.
+	ctx = setValidationCtxNow(ctx, clock.Now().Truncate(trunc))
 
 	var validators []Validator
 	if !resetValidators {
@@ -252,6 +257,22 @@ func (vf ValidatorFunc) Validate(ctx context.Context, tok Token) error {
 type identValidationCtxClock struct{}
 type identValidationCtxSkew struct{}
 type identValidationCtxTruncation struct{}
+type identValidationCtxNow struct{}
+
+func setValidationCtxNow(ctx context.Context, now time.Time) context.Context {
+	return context.WithValue(ctx, identValidationCtxNow{}, now)
+}
+
+// validationCtxNow returns the "now" snapshotted by [Validate] for this
+// validation run. If the context was not initialized by [Validate]
+// (e.g. a custom validator invoked with a bare context), it falls back
+// to sampling the supplied clock.
+func validationCtxNow(ctx context.Context, clock Clock, trunc time.Duration) time.Time {
+	if v, ok := ctx.Value(identValidationCtxNow{}).(time.Time); ok {
+		return v
+	}
+	return clock.Now().Truncate(trunc)
+}
 
 func SetValidationCtxClock(ctx context.Context, cl Clock) context.Context {
 	return context.WithValue(ctx, identValidationCtxClock{}, cl)
@@ -319,7 +340,7 @@ func isExpirationValid(ctx context.Context, t Token) error {
 	skew := ValidationCtxSkew(ctx)        // MUST be populated
 	trunc := ValidationCtxTruncation(ctx) // MUST be populated
 
-	now := clock.Now().Truncate(trunc)
+	now := validationCtxNow(ctx, clock, trunc)
 	ttv := tv.Truncate(trunc)
 
 	// expiration date must be after NOW
@@ -350,7 +371,7 @@ func isIssuedAtValid(ctx context.Context, t Token) error {
 	skew := ValidationCtxSkew(ctx)        // MUST be populated
 	trunc := ValidationCtxTruncation(ctx) // MUST be populated
 
-	now := clock.Now().Truncate(trunc)
+	now := validationCtxNow(ctx, clock, trunc)
 	ttv := tv.Truncate(trunc)
 
 	if now.Before(ttv.Add(-1 * skew)) {
@@ -382,7 +403,7 @@ func isNbfValid(ctx context.Context, t Token) error {
 
 	// Truncation always happens even for trunc = 0 because
 	// we also use this to strip monotonic clocks
-	now := clock.Now().Truncate(trunc)
+	now := validationCtxNow(ctx, clock, trunc)
 	ttv := tv.Truncate(trunc)
 
 	// "now" cannot be before t - skew, so we check for now > t - skew

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -852,3 +852,48 @@ func TestClaimValidator(t *testing.T) {
 		})
 	}
 }
+
+// countingClock returns successive samples from a fixed sequence and
+// records how many times Now was called. Used to lock in the invariant
+// that jwt.Validate samples the clock exactly once per call, so that
+// every default validator observes the same "now".
+type countingClock struct {
+	samples []time.Time
+	Count   int
+}
+
+func (c *countingClock) Now() time.Time {
+	t := c.samples[c.Count]
+	if c.Count < len(c.samples)-1 {
+		c.Count++
+	}
+	return t
+}
+
+func TestValidateClockSnapshottedOnce(t *testing.T) {
+	t.Parallel()
+
+	// iat/nbf == t0 and exp == t0+1s makes the token valid at exactly
+	// t0. The stepped clock's second sample is deliberately past exp
+	// so that any validator re-sampling the clock would observe an
+	// expired token and fail.
+	t0 := time.Unix(1_700_000_000, 0)
+	clock := &countingClock{
+		samples: []time.Time{t0, t0.Add(2 * time.Second), t0.Add(4 * time.Second)},
+	}
+
+	tok, err := jwt.NewBuilder().
+		IssuedAt(t0).
+		NotBefore(t0).
+		Expiration(t0.Add(time.Second)).
+		Build()
+	require.NoError(t, err, `jwt.NewBuilder should succeed`)
+
+	require.NoError(t,
+		jwt.Validate(tok, jwt.WithClock(clock)),
+		`jwt.Validate should pass when clock.Now() is sampled once`,
+	)
+	require.Equal(t, 1, clock.Count,
+		`jwt.Validate should call clock.Now() exactly once per call`,
+	)
+}


### PR DESCRIPTION
## Summary
- `jwt.Validate` slow path now samples `clock.Now()` once and stashes it in ctx; `isExpirationValid`/`isIssuedAtValid`/`isNbfValid` read the snapshot instead of re-sampling
- Fixes inconsistency with the `validateDefault` fast path — stepped/fake clocks and second-boundary crossings no longer flip validator outcomes
- No public API change (helpers are unexported)

## Test plan
- [x] `go test ./jwt/...`
- [x] New `TestValidateClockSnapshottedOnce` fails pre-fix, passes post-fix