### PR TITLE
fix jwk.Set.AddKey panic on nil or struct keys

### DIFF
--- a/jwk/set.go
+++ b/jwk/set.go
@@ -89,8 +89,15 @@ func (s *set) AddKey(key Key) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if reflect.ValueOf(key).IsNil() {
-		panic("nil key")
+	rv := reflect.ValueOf(key)
+	if !rv.IsValid() {
+		return fmt.Errorf(`(jwk.Set).AddKey: nil key`)
+	}
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func, reflect.Map, reflect.Slice:
+		if rv.IsNil() {
+			return fmt.Errorf(`(jwk.Set).AddKey: nil key`)
+		}
 	}
 
 	if i := s.indexNL(key); i > -1 {

--- a/jwk/set_test.go
+++ b/jwk/set_test.go
@@ -52,6 +52,30 @@ func TestSet(t *testing.T) {
 	require.Equal(t, set.Len(), 0, `set.Len should be 0`)
 }
 
+// fakeStructKey embeds jwk.Key to satisfy the interface without implementing
+// any methods. AddKey never calls methods on its argument, so a nil-embedded
+// stub is enough to exercise the reflect-guard code path for struct-valued
+// Key implementations.
+type fakeStructKey struct {
+	jwk.Key
+}
+
+func TestSetAddKeyNil(t *testing.T) {
+	t.Run("typed-nil interface", func(t *testing.T) {
+		var k jwk.Key
+		require.Error(t, jwk.NewSet().AddKey(k), `AddKey should return an error for nil Key, not panic`)
+	})
+	t.Run("nil concrete pointer", func(t *testing.T) {
+		var k *fakeStructKey
+		require.Error(t, jwk.NewSet().AddKey(k), `AddKey should return an error for nil pointer Key, not panic`)
+	})
+	t.Run("struct-value Key", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			_ = jwk.NewSet().AddKey(fakeStructKey{})
+		}, `AddKey must not panic when Key's dynamic type is a struct`)
+	})
+}
+
 func TestSetKeys(t *testing.T) {
 	set := jwk.NewSet()
 	require.NoError(t, set.Set("a", "foo"), `Set should succeed`)


### PR DESCRIPTION
## Summary
- `AddKey` panicked on typed-nil `jwk.Key`, nil concrete pointer, and struct-valued `Key` (via `reflect.Value.IsNil` on zero/struct values)
- return `(jwk.Set).AddKey: nil key` error instead; guard `IsNil` behind a `Kind()` switch
- add `TestSetAddKeyNil` covering all three cases

## Test plan
- [x] `go test ./jwk/... -count=1`
- [x] `go vet ./jwk/...`