### PR TITLE
fix jwk parser to validate keys after unmarshal

### DIFF
--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -745,7 +745,9 @@ func TestGH803(t *testing.T) {
 
 func TestGH840(t *testing.T) {
 	// Go 1.19+ panics if elliptic curve operations are called against
-	// a point that's _NOT_ on the curve
+	// a point that's _NOT_ on the curve. defaultParseKey calls Validate()
+	// on the imported key so an untrusted JWK with an off-curve point is
+	// rejected at the trust boundary — no bad key ever reaches jwe.Encrypt.
 	untrustedJWK := []byte(`{
 		"kty": "EC",
 		"crv": "P-256",
@@ -754,15 +756,8 @@ func TestGH840(t *testing.T) {
 		"d": "870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"
 	}`)
 
-	privkey, err := jwk.ParseKey[jwk.Key](untrustedJWK)
-	require.NoError(t, err, `jwk.ParseKey should succeed`)
-
-	pubkey, err := privkey.PublicKey()
-	require.NoError(t, err, `privkey.PublicKey should succeed`)
-
-	const payload = `Lorem ipsum`
-	_, err = jwe.Encrypt([]byte(payload), jwe.WithKey(jwa.ECDH_ES_A128KW(), pubkey))
-	require.Error(t, err, `jwe.Encrypt should fail (instead of panic)`)
+	_, err := jwk.ParseKey[jwk.Key](untrustedJWK)
+	require.Error(t, err, `jwk.ParseKey must reject an off-curve ECDSA JWK`)
 }
 
 type dummyKeyEncrypterDecrypter struct {

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -26,13 +26,13 @@ func ecdsaPointJWK(t *testing.T, crv elliptic.Curve, crvName string, x, y *big.I
 	return []byte(body)
 }
 
-// TestECDSAInvalidPointsRejectedOnUse covers JWK-003: ParseKey stores raw
-// x/y bytes without curve checks, but any downstream use of the key —
-// Export/Raw (which constructs a *ecdsa.PublicKey) or an explicit
-// Validate() — must refuse points that are not on the declared curve and
-// the identity point (0, 0). Without validation, these feed invalid-curve
-// attacks to downstream ECDSA/ECDH consumers.
-func TestECDSAInvalidPointsRejectedOnUse(t *testing.T) {
+// TestECDSAInvalidPointsRejectedOnParse asserts that ParseKey / Parse are
+// the trust boundary for externally supplied ECDSA JWKs: off-curve (x, y)
+// and the identity point (0, 0) are rejected at parse time, not deferred
+// to a later Validate() / Export call. The defaultParseKey path calls
+// key.Validate() after UnmarshalKey, so invalid points never escape as a
+// Key value.
+func TestECDSAInvalidPointsRejectedOnParse(t *testing.T) {
 	cases := []struct {
 		name string
 		x, y *big.Int
@@ -45,13 +45,17 @@ func TestECDSAInvalidPointsRejectedOnUse(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			body := ecdsaPointJWK(t, elliptic.P256(), "P-256", tc.x, tc.y)
-			key, err := jwk.ParseKey[jwk.Key](body)
-			require.NoError(t, err, `ParseKey stores raw bytes; it does not run curve checks yet`)
 
-			require.Error(t, key.Validate(), `Validate must reject invalid ECDSA point`)
+			_, err := jwk.ParseKey[jwk.Key](body)
+			require.Error(t, err, `ParseKey must reject invalid ECDSA point at parse time`)
+			require.True(t, jwk.IsKeyValidationError(err), `ParseKey error must unwrap to a key-validation error: %v`, err)
 
-			_, err = jwk.Export[*ecdsa.PublicKey](key)
-			require.Error(t, err, `Export to *ecdsa.PublicKey must reject invalid ECDSA point`)
+			// The Set-level entry point funnels individual keys through
+			// defaultParseKey too, so the same body wrapped in a JWKS must
+			// also be rejected.
+			setBody := []byte(`{"keys":[` + string(body) + `]}`)
+			_, err = jwk.Parse(setBody)
+			require.Error(t, err, `jwk.Parse must reject a JWKS containing an invalid ECDSA point`)
 		})
 	}
 

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -2008,12 +2008,14 @@ func TestECDSAPEM(t *testing.T) {
 }
 
 func TestGH947(t *testing.T) {
-	// AS OP described it. Below case will panic if the problem exists,
+	// GH947: parsing an OKP key with empty "x"/"d" strings used to panic
+	// inside the downstream Export path. The regression being guarded is
+	// that this input does not panic. Since defaultParseKey now calls
+	// Validate() on the freshly-unmarshaled key, the zero-length coordinate
+	// is rejected cleanly at parse time — no bad key is ever handed back.
 	raw := []byte(`{"crv":"Ed25519","d":"","x":"","kty":"OKP"}`)
-	k, err := jwk.ParseKey[jwk.Key](raw)
-	require.NoError(t, err, `jwk.ParseKey should succeed`)
-	_, err = jwk.Export[any](k)
-	require.Error(t, err, `(okpkey).Raw with 0-length OKP key should fail`)
+	_, err := jwk.ParseKey[jwk.Key](raw)
+	require.Error(t, err, `jwk.ParseKey must reject an OKP key with empty coordinates`)
 }
 
 func TestValidation(t *testing.T) {

--- a/jwk/parser.go
+++ b/jwk/parser.go
@@ -109,6 +109,15 @@ func defaultParseKey(probe *KeyProbe, unmarshaler KeyUnmarshaler, data []byte) (
 	if err := unmarshaler.UnmarshalKey(data, key); err != nil {
 		return nil, fmt.Errorf(`failed to unmarshal JSON into key (%T): %w`, key, err)
 	}
+	// Enforce the trust boundary: a key that fails its own Validate() must
+	// never escape Parse/ParseKey. All built-in key types implement this
+	// interface via NewKeyValidationError, so callers can still use
+	// jwk.IsKeyValidationError on the wrapped error.
+	if v, ok := key.(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return nil, fmt.Errorf(`jwk.Parse: key validation failed: %w`, err)
+		}
+	}
 	return key, nil
 }
 

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/lestrrat-go/jwx/v4/jwk"
 	"github.com/lestrrat-go/jwx/v4/jws"
 	"github.com/lestrrat-go/jwx/v4/jws/jwsbb"
-	"github.com/lestrrat-go/jwx/v4/jwt"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1450,7 +1449,10 @@ func TestGH681(t *testing.T) {
 
 func TestGH840(t *testing.T) {
 	// Go 1.19+ panics if elliptic curve operations are called against
-	// a point that's _NOT_ on the curve
+	// a point that's _NOT_ on the curve. defaultParseKey calls Validate()
+	// on the imported key so an untrusted JWK with an off-curve point is
+	// rejected at the trust boundary — no bad key ever reaches jws.Sign
+	// / jwt.Parse / jwk.PublicKeyOf.
 	untrustedJWK := []byte(`{
 		"kty": "EC",
 		"crv": "P-256",
@@ -1459,32 +1461,8 @@ func TestGH840(t *testing.T) {
 		"d": "870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"
 	}`)
 
-	// Parse, serialize, slice and dice JWKs!
-	privkey, err := jwk.ParseKey[jwk.Key](untrustedJWK)
-	require.NoError(t, err, `jwk.ParseKey should succeed`)
-
-	pubkey, err := jwk.PublicKeyOf(privkey)
-	require.NoError(t, err, `jwk.PublicKeyOf should succeed`)
-
-	tok, err := jwt.NewBuilder().
-		Issuer(`github.com/lestrrat-go/jwx`).
-		IssuedAt(time.Now()).
-		Build()
-	require.NoError(t, err, `jwt.NewBuilder should succeed`)
-
-	// As of go1.24.0, generating a signature with a private key that has
-	// X/Y that's not on the curve will fail, but all go < 1.24 will succeed.
-	// Instead of checking the version, we'll just check if the operation fails,
-	// and if it does we won't run the check for jwt.Parse
-	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256(), privkey))
-	if err != nil {
-		require.Error(t, err, `jwt.Sign should fail`)
-		return
-	}
-	require.NoError(t, err, `jwt.Sign should succeed`)
-
-	_, err = jwt.Parse(signed, jwt.WithKey(jwa.ES256(), pubkey))
-	require.Error(t, err, `jwt.Parse should FAIL`) // pubkey's X/Y is not on the curve
+	_, err := jwk.ParseKey[jwk.Key](untrustedJWK)
+	require.Error(t, err, `jwk.ParseKey must reject an off-curve ECDSA JWK`)
 }
 
 func TestGH888(t *testing.T) {


### PR DESCRIPTION
## Summary
- `defaultParseKey` now calls `key.Validate()` after `UnmarshalKey`, wrapping failures as `jwk.Parse: key validation failed: %w` — `jwk.IsKeyValidationError` still matches
- `jwk.Parse`/`ParseKey` is the trust boundary: off-curve ECDSA points, empty OKP coordinates, and other structural failures no longer escape as a valid `Key`
- regression fixtures `TestGH947` (empty OKP coords) and `TestGH840` (untrusted off-curve ECDSA JWK, in jwe/ and jws/) flipped to assert parse-time rejection