### PR TITLE
wrap underlying error in jwk set single-key fallback

### DIFF
--- a/jwk/set.go
+++ b/jwk/set.go
@@ -279,7 +279,7 @@ func (s *set) UnmarshalJSON(data []byte) error {
 	if !sawKeysField {
 		key, err := doParseKey(data, options...)
 		if err != nil {
-			return fmt.Errorf(`failed to parse sole key in key set`)
+			return fmt.Errorf(`failed to parse sole key in key set: %w`, err)
 		}
 		s.keys = append(s.keys, key)
 	}


### PR DESCRIPTION
The single-key fallback in `set.UnmarshalJSON` dropped the underlying parse error, leaving callers with "failed to parse sole key in key set" and no cause.