### PR TITLE
fix cmd/jwx output file mode and truncation

### DIFF
--- a/cmd/jwx/jwx.go
+++ b/cmd/jwx/jwx.go
@@ -98,7 +98,11 @@ func getOutput(filename string) (io.WriteCloser, error) {
 	case "":
 		return nil, fmt.Errorf(`output must be a file name, or "-" for STDOUT`)
 	default:
-		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
+		// Output may be private key material (jwk generate), decrypted
+		// plaintext (jwe decrypt), or an extracted JWS payload (jws verify).
+		// Use 0600 and always truncate so a shorter re-run cannot leak
+		// tail bytes left over from a previous invocation.
+		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 		if err != nil {
 			return nil, fmt.Errorf(`failed to create file %s: %w`, filename, err)
 		}

--- a/cmd/jwx/jwx_test.go
+++ b/cmd/jwx/jwx_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetOutput(t *testing.T) {
+	t.Run("truncates existing file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "out")
+		stale := bytes.Repeat([]byte{0xFF}, 100)
+		require.NoError(t, os.WriteFile(path, stale, 0600))
+
+		w, err := getOutput(path)
+		require.NoError(t, err)
+		_, err = w.Write([]byte("abc"))
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+
+		got, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, []byte("abc"), got, "tail bytes from the previous write must not survive")
+	})
+
+	t.Run("creates file with 0600 mode", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("windows file modes only honor the write bit")
+		}
+		path := filepath.Join(t.TempDir(), "fresh")
+		w, err := getOutput(path)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	})
+}


### PR DESCRIPTION
## Summary
- `cmd/jwx/jwx.go` `getOutput` now opens with `O_TRUNC` and creates files at mode `0600`
- Prevents stale tail bytes on shorter re-runs (potential key material / plaintext leak across `jwk generate`, `jwe decrypt`, `jws verify`, etc.) and stops defaulting key-material output to world-readable
- Adds `cmd/jwx/jwx_test.go` covering truncation and the fresh-create mode (skips mode check on Windows)

## Test plan
- [x] `go test -race ./cmd/jwx` (GOEXPERIMENT=jsonv2)
- [x] Manual: pre-seed `stale.json` with 101 bytes, run `jwx jwk generate -t oct -s 16 -o stale.json`, verify file shrinks to 51 bytes with no tail garbage
- [x] Manual: fresh `jwx jwk generate -o newkey.json` → `stat` shows `0600`