### PR TITLE
fix cmd/jwx output file mode and truncation

### DIFF
--- a/cmd/jwx/jwx.go
+++ b/cmd/jwx/jwx.go
@@ -97,7 +97,11 @@ func getOutput(filename string) (io.WriteCloser, error) {
 	case "":
 		return nil, fmt.Errorf(`output must be a file name, or "-" for STDOUT`)
 	default:
-		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0644)
+		// Output may be private key material (jwk generate), decrypted
+		// plaintext (jwe decrypt), or an extracted JWS payload (jws verify).
+		// Use 0600 and always truncate so a shorter re-run cannot leak
+		// tail bytes left over from a previous invocation.
+		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 		if err != nil {
 			return nil, fmt.Errorf(`failed to create file %s: %w`, filename, err)
 		}


### PR DESCRIPTION
## Summary
- Backport of #1857 to v3
- `cmd/jwx/jwx.go` `getOutput` now opens with `O_TRUNC` and creates files at mode `0600`
- Prevents stale tail bytes on shorter re-runs (potential key material / plaintext leak across `jwk generate`, `jwe decrypt`, `jws verify`, etc.) and stops defaulting key-material output to world-readable

## Test plan
- [x] `go build ./cmd/jwx`
- [x] Manual: pre-seed `stale.json` with 96 bytes, run `jwx jwk generate -t oct -s 16 -o stale.json`, verify file shrinks to 51 bytes with no tail garbage
- [x] Manual: fresh `jwx jwk generate -o newkey.json` → `stat` shows `0600`