### PR TITLE
fix jwt.ParseHeader bearer scheme per rfc 6750

### DIFF
--- a/jwt/http.go
+++ b/jwt/http.go
@@ -40,8 +40,10 @@ func ParseCookie(req *http.Request, name string, options ...ParseOption) (Token,
 
 // ParseHeader parses a JWT stored in a http.Header.
 //
-// For the header "Authorization", it will strip the prefix "Bearer " and will
-// treat the remaining value as a JWT.
+// For the header "Authorization", it will strip the "Bearer" scheme per
+// RFC 6750 §2.1 (case-insensitive scheme token; space or tab separator
+// required) and treat the remainder as a JWT. If the value does not begin
+// with a well-formed "Bearer <token>", the full value is parsed as-is.
 func ParseHeader(hdr http.Header, name string, options ...ParseOption) (Token, error) {
 	key := http.CanonicalHeaderKey(name)
 	v := strings.TrimSpace(hdr.Get(key))
@@ -50,9 +52,9 @@ func ParseHeader(hdr http.Header, name string, options ...ParseOption) (Token, e
 	}
 
 	if key == "Authorization" {
-		// Authorization header is an exception. We strip the "Bearer " from
-		// the prefix
-		v = strings.TrimSpace(strings.TrimPrefix(v, "Bearer"))
+		if len(v) >= 7 && strings.EqualFold(v[:6], "Bearer") && (v[6] == ' ' || v[6] == '\t') {
+			v = strings.TrimSpace(v[7:])
+		}
 	}
 
 	tok, err := ParseString(v, options...)

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -886,6 +886,88 @@ func TestParseRequest(t *testing.T) {
 			},
 		},
 		{
+			Name: "Authorization header: Bearer scheme is case-insensitive (lowercase)",
+			Request: func() *http.Request {
+				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, u, nil)
+				req.Header.Add("Authorization", "bearer "+string(signed))
+				return req
+			},
+			Parse: func(req *http.Request) (jwt.Token, error) {
+				return jwt.ParseRequest(req, jwt.WithKey(jwa.ES256(), pubkey))
+			},
+		},
+		{
+			Name: "Authorization header: Bearer scheme is case-insensitive (uppercase)",
+			Request: func() *http.Request {
+				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, u, nil)
+				req.Header.Add("Authorization", "BEARER "+string(signed))
+				return req
+			},
+			Parse: func(req *http.Request) (jwt.Token, error) {
+				return jwt.ParseRequest(req, jwt.WithKey(jwa.ES256(), pubkey))
+			},
+		},
+		{
+			Name: "Authorization header: Bearer scheme is case-insensitive (mixed case)",
+			Request: func() *http.Request {
+				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, u, nil)
+				req.Header.Add("Authorization", "BeArEr "+string(signed))
+				return req
+			},
+			Parse: func(req *http.Request) (jwt.Token, error) {
+				return jwt.ParseRequest(req, jwt.WithKey(jwa.ES256(), pubkey))
+			},
+		},
+		{
+			Name: "Authorization header: Bearer with tab separator",
+			Request: func() *http.Request {
+				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, u, nil)
+				req.Header.Add("Authorization", "Bearer\t"+string(signed))
+				return req
+			},
+			Parse: func(req *http.Request) (jwt.Token, error) {
+				return jwt.ParseRequest(req, jwt.WithKey(jwa.ES256(), pubkey))
+			},
+		},
+		{
+			Name: "Authorization header: Bearer with multiple spaces",
+			Request: func() *http.Request {
+				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, u, nil)
+				req.Header.Add("Authorization", "Bearer  "+string(signed))
+				return req
+			},
+			Parse: func(req *http.Request) (jwt.Token, error) {
+				return jwt.ParseRequest(req, jwt.WithKey(jwa.ES256(), pubkey))
+			},
+		},
+		{
+			// Regression: RFC 6750 ABNF requires 1*SP between scheme and
+			// credentials. Old code stripped "Bearer" without a separator and
+			// silently accepted concatenated forms like "Bearer<token>".
+			Name: "Authorization header: Bearer without separator is rejected",
+			Request: func() *http.Request {
+				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, u, nil)
+				req.Header.Add("Authorization", "Bearer"+string(signed))
+				return req
+			},
+			Parse: func(req *http.Request) (jwt.Token, error) {
+				return jwt.ParseRequest(req, jwt.WithKey(jwa.ES256(), pubkey))
+			},
+			Error: true,
+		},
+		{
+			Name: "Authorization header: non-Bearer scheme is rejected",
+			Request: func() *http.Request {
+				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, u, nil)
+				req.Header.Add("Authorization", "Basic "+string(signed))
+				return req
+			},
+			Parse: func(req *http.Request) (jwt.Token, error) {
+				return jwt.ParseRequest(req, jwt.WithKey(jwa.ES256(), pubkey))
+			},
+			Error: true,
+		},
+		{
 			Name: "Token in Authorization header (w/o extra options, using jwk.Set)",
 			Request: func() *http.Request {
 				req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, u, nil)


### PR DESCRIPTION
- RFC 6750 §2.1: scheme token is case-insensitive; `bearer …` now accepted instead of failing with an opaque parse error
- RFC 6750 ABNF: `1*SP` separator required; the old `TrimPrefix(v, "Bearer")` happily ate `Bearer<token>` — now rejected
- Added regression cases in `TestParseRequest` covering case variants, tab/multi-space separators, concatenated form, and non-Bearer schemes