### PR TITLE
make MissingRequiredClaimError.Is type-only

### DIFF
--- a/jwt/errors.go
+++ b/jwt/errors.go
@@ -271,15 +271,8 @@ type MissingRequiredClaimError struct {
 }
 
 func (err *MissingRequiredClaimError) Is(target error) bool {
-	err1, ok := target.(*MissingRequiredClaimError)
-	if !ok {
-		return false
-	}
-	// Zero-value Claim matches any MissingRequiredClaimError.
-	if err1.Claim == "" {
-		return true
-	}
-	return err1.Claim == err.Claim
+	_, ok := target.(*MissingRequiredClaimError)
+	return ok
 }
 
 func missingRequiredClaimErrorf(name string) error {


### PR DESCRIPTION
All other structured jwt error types match on type alone. Aligning `MissingRequiredClaimError` removes a surprising divergence where `errors.Is(err, &jwt.MissingRequiredClaimError{Claim: "aud"})` would behave differently from every sibling. Callers that need the missing claim name can still use `errors.AsType[*MissingRequiredClaimError]`.

Refs JWT-20260415151950-038.