### PR TITLE
make MissingRequiredClaimError.Is type-only

### DIFF
--- a/jwt/internal/errors/errors.go
+++ b/jwt/internal/errors/errors.go
@@ -173,11 +173,8 @@ type MissingRequiredClaimError struct {
 }
 
 func (err *MissingRequiredClaimError) Is(target error) bool {
-	err1, ok := target.(*MissingRequiredClaimError)
-	if !ok {
-		return false
-	}
-	return err1 == ErrMissingRequiredClaimDefault || err1.claim == err.claim
+	_, ok := target.(*MissingRequiredClaimError)
+	return ok
 }
 
 func MissingRequiredClaimErrorf(name string) error {


### PR DESCRIPTION
All other structured jwt error types match on type alone. Aligning `MissingRequiredClaimError` removes a surprising divergence in `errors.Is` behavior depending on whether the target's claim field was set.

Refs JWT-20260415151950-038. Companion fix to the v4 PR.