### PR TITLE
document WithUseNumber concurrency contract as startup-only

### DIFF
--- a/docs/20-global-settings.md
+++ b/docs/20-global-settings.md
@@ -14,6 +14,14 @@ func init() {
 Do be aware that this has *global* effect. All code that calls in to `encoding/json`
 within `jwx` *will* use your settings.
 
+**Apply this once at program startup** — from `func init()` or early in `main()`,
+before any goroutine begins parsing JWx payloads. The underlying flag is
+read atomically, so toggling it at runtime will not race, but any decoders
+already running (or started after the flip) will produce a mix of `float64`
+and `json.Number` values in concurrently-decoded custom fields, and callers
+that type-assert on those values will break non-deterministically. There is
+no per-call override.
+
 ## Decode private fields to objects
 
 Packages within `github.com/lestrrat-go/jwx/v4` parses known fields into pre-defined types,

--- a/jwx.go
+++ b/jwx.go
@@ -28,6 +28,12 @@ import (
 )
 
 // Settings configures global settings for the jwx package.
+//
+// All options accepted here have process-global effect and are intended
+// to be applied exactly once at program startup, before any goroutine
+// begins parsing JWx payloads. See the godoc on individual GlobalOption
+// constructors (e.g. [WithUseNumber]) for the concurrency contract of
+// each setting.
 func Settings(options ...GlobalOption) {
 	for _, opt := range options {
 		switch opt.Ident() {

--- a/options.go
+++ b/options.go
@@ -22,6 +22,15 @@ type identUseNumber struct{}
 // JSON numbers in private/custom fields as json.Number instead of
 // float64. This preserves numeric precision for large integers.
 //
+// This setting has process-global effect and must be applied once
+// at program startup (typically from func init() or early in main())
+// before any goroutine begins parsing JWx payloads. The underlying
+// flag is read atomically, so toggling it at runtime is race-free,
+// but any in-flight or subsequent decoders will observe a mix of
+// float64 and json.Number values in concurrently-decoded custom
+// fields — callers that type-assert on those values will break
+// non-deterministically. There is no per-call override.
+//
 // Default is false.
 func WithUseNumber(v bool) GlobalOption {
 	return &globalOption{option.New(identUseNumber{}, v)}


### PR DESCRIPTION
Closes review finding INTERNAL-20260415151950-041.

Godoc + `docs/20-global-settings.md` now state that `jwx.WithUseNumber` must be applied once at program startup, before any goroutine begins parsing. The flag is atomic so toggling at runtime won't race, but concurrent decoders will emit a mix of `float64` and `json.Number` in custom fields — callers that type-assert will break non-deterministically. No behavior change.