### PR TITLE
reject key-bearing options in jwt.ParseInsecure

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -147,14 +147,19 @@ func Parse(s []byte, options ...ParseOption) (Token, error) {
 // ParseInsecure is exactly the same as Parse(), but it disables
 // signature verification and token validation.
 //
-// You cannot override `jwt.WithVerify()` or `jwt.WithValidate()`
-// using this function. Providing these options would result in
-// an error
+// `jwt.WithVerify()` and `jwt.WithValidate()` may not be specified
+// because they would conflict with the function's purpose. Likewise,
+// the key-bearing options `jwt.WithKey()`, `jwt.WithKeySet()`,
+// `jwt.WithKeyProvider()`, and `jwt.WithVerifyAuto()` are rejected so
+// that typos like `jwt.ParseInsecure(data, jwt.WithKey(...))` cannot
+// silently skip verification. Use `jwt.Parse` when a key is available.
 func ParseInsecure(s []byte, options ...ParseOption) (Token, error) {
 	for _, opt := range options {
 		switch opt.Ident() {
 		case identVerify{}, identValidate{}:
 			return nil, parseErrorf(`jwt.ParseInsecure`, `jwt.WithVerify() and jwt.WithValidate() may not be specified`)
+		case identKey{}, identKeySet{}, identKeyProvider{}, identVerifyAuto{}:
+			return nil, parseErrorf(`jwt.ParseInsecure`, `key-bearing options (jwt.WithKey, jwt.WithKeySet, jwt.WithKeyProvider, jwt.WithVerifyAuto) may not be specified; use jwt.Parse to verify with a key`)
 		}
 	}
 

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -37,14 +37,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// failFetcher is a jwk.Fetcher that always errors; used in ParseInsecure
-// tests to assert that the verify path is short-circuited.
-type failFetcher struct{}
-
-func (failFetcher) Fetch(_ context.Context, _ string) (jwk.Set, error) {
-	return nil, fmt.Errorf(`should not be called`)
-}
-
 /* This is commented out, because it is intended to cause compilation errors */
 /*
 func TestOption(t *testing.T) {
@@ -1791,22 +1783,25 @@ func TestGH1007(t *testing.T) {
 	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256(), key))
 	require.NoError(t, err, `jwt.Sign should succeed`)
 
-	// This was the intended usage (no WithKey). This worked from the beginning
+	// The intended usage of ParseInsecure is without any verification
+	// material. This worked from the beginning.
 	_, err = jwt.ParseInsecure(signed)
 	require.NoError(t, err, `jwt.ParseInsecure should succeed`)
 
-	// This is the problematic behavior reporded in #1007.
-	// The fact that we're specifying a wrong key caused Parse() to check for
-	// verification and yet fail :/
+	// #1007 originally asked for ParseInsecure to silently accept a stray
+	// WithKey. That was reversed: ParseInsecure now rejects key-bearing
+	// options outright so that typos like jwt.ParseInsecure(..., jwt.WithKey(...))
+	// cannot silently skip verification. Callers who want the key to be
+	// honored must use jwt.Parse.
 	wrongPubKey, err := jwxtest.GenerateRsaPublicJwk()
 	require.NoError(t, err, `jwxtest.GenerateRsaPublicJwk should succeed`)
-	require.NoError(t, err, `jwk.PublicKeyOf should succeed`)
 
 	_, err = jwt.ParseInsecure(signed, jwt.WithKey(jwa.RS256(), wrongPubKey))
-	require.NoError(t, err, `jwt.ParseInsecure with jwt.WithKey() should succeed`)
+	require.Error(t, err, `jwt.ParseInsecure with jwt.WithKey() should error`)
+	require.ErrorContains(t, err, `jwt.ParseInsecure`)
 }
 
-func TestParseInsecureStripsKeyOptions(t *testing.T) {
+func TestParseInsecureRejectsKeyOptions(t *testing.T) {
 	key, err := jwxtest.GenerateRsaJwk()
 	require.NoError(t, err, `jwxtest.GenerateRsaJwk should succeed`)
 
@@ -1819,33 +1814,28 @@ func TestParseInsecureStripsKeyOptions(t *testing.T) {
 	wrongKey, err := jwxtest.GenerateRsaJwk()
 	require.NoError(t, err, `jwxtest.GenerateRsaJwk should succeed`)
 
-	// WithKeySet: even a set that contains no matching key must not cause
-	// a verification error, because ParseInsecure strips the option.
 	wrongSet := jwk.NewSet()
 	require.NoError(t, wrongSet.AddKey(wrongKey), `set.AddKey should succeed`)
 
-	got, err := jwt.ParseInsecure(signed, jwt.WithKeySet(wrongSet))
-	require.NoError(t, err, `jwt.ParseInsecure with jwt.WithKeySet() should succeed`)
-	iss, ok := got.Issuer()
-	require.True(t, ok)
-	require.Equal(t, `me`, iss)
-
-	// WithKeyProvider: a provider that always errors must not be invoked.
-	failProvider := jws.KeyProviderFunc(func(_ context.Context, _ jws.KeySink, _ *jws.Signature, _ *jws.Message) error {
-		return fmt.Errorf(`should not be called`)
+	noopProvider := jws.KeyProviderFunc(func(_ context.Context, _ jws.KeySink, _ *jws.Signature, _ *jws.Message) error {
+		return nil
 	})
-	got, err = jwt.ParseInsecure(signed, jwt.WithKeyProvider(failProvider))
-	require.NoError(t, err, `jwt.ParseInsecure with jwt.WithKeyProvider() should succeed`)
-	iss, ok = got.Issuer()
-	require.True(t, ok)
-	require.Equal(t, `me`, iss)
 
-	// WithVerifyAuto: a fetcher that always fails must not be invoked.
-	got, err = jwt.ParseInsecure(signed, jwt.WithVerifyAuto(failFetcher{}))
-	require.NoError(t, err, `jwt.ParseInsecure with jwt.WithVerifyAuto() should succeed`)
-	iss, ok = got.Issuer()
-	require.True(t, ok)
-	require.Equal(t, `me`, iss)
+	for _, tc := range []struct {
+		name string
+		opt  jwt.ParseOption
+	}{
+		{`WithKey`, jwt.WithKey(jwa.RS256(), wrongKey)},
+		{`WithKeySet`, jwt.WithKeySet(wrongSet)},
+		{`WithKeyProvider`, jwt.WithKeyProvider(noopProvider)},
+		{`WithVerifyAuto`, jwt.WithVerifyAuto(nil)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := jwt.ParseInsecure(signed, tc.opt)
+			require.Error(t, err, `jwt.ParseInsecure with jwt.%s() should error`, tc.name)
+			require.ErrorContains(t, err, `jwt.ParseInsecure`)
+		})
+	}
 }
 
 func TestParseJSON(t *testing.T) {


### PR DESCRIPTION
## Summary
- `jwt.ParseInsecure` now errors on `WithKey`, `WithKeySet`, `WithKeyProvider`, `WithVerifyAuto` — typos like `jwt.ParseInsecure(data, jwt.WithKey(...))` no longer silently skip verification
- Supersedes the silent-strip approach from #1801, which was accidentally reverted when #1816 (kid-injection fix) merged from a branch cut before #1801
- `TestGH1007` assertion flipped to match the new contract; `TestParseInsecureStripsKeyOptions` replaced with a table-driven `TestParseInsecureRejectsKeyOptions`