### PR TITLE
reject key-bearing options in jwt.ParseInsecure

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -162,29 +162,24 @@ func Parse(s []byte, options ...ParseOption) (Token, error) {
 // ParseInsecure is exactly the same as Parse(), but it disables
 // signature verification and token validation.
 //
-// You cannot override `jwt.WithVerify()` or `jwt.WithValidate()`
-// using this function. Providing these options would result in
-// an error.
-//
-// Key-related options (`jwt.WithKey`, `jwt.WithKeySet`,
-// `jwt.WithKeyProvider`, `jwt.WithVerifyAuto`) are silently ignored,
-// so callers may reuse an option slice across `Parse` and
-// `ParseInsecure` call sites without worrying about leaking a stray
-// verification step.
+// `jwt.WithVerify()` and `jwt.WithValidate()` may not be specified
+// because they would conflict with the function's purpose. Likewise,
+// the key-bearing options `jwt.WithKey()`, `jwt.WithKeySet()`,
+// `jwt.WithKeyProvider()`, and `jwt.WithVerifyAuto()` are rejected so
+// that typos like `jwt.ParseInsecure(data, jwt.WithKey(...))` cannot
+// silently skip verification. Use `jwt.Parse` when a key is available.
 func ParseInsecure(s []byte, options ...ParseOption) (Token, error) {
-	filtered := make([]ParseOption, 0, len(options)+2)
 	for _, option := range options {
 		switch option.Ident() {
 		case identVerify{}, identValidate{}:
 			return nil, jwterrs.ParseErrorf(`jwt.ParseInsecure`, `jwt.WithVerify() and jwt.WithValidate() may not be specified`)
 		case identKey{}, identKeySet{}, identKeyProvider{}, identVerifyAuto{}:
-			continue
+			return nil, jwterrs.ParseErrorf(`jwt.ParseInsecure`, `key-bearing options (jwt.WithKey, jwt.WithKeySet, jwt.WithKeyProvider, jwt.WithVerifyAuto) may not be specified; use jwt.Parse to verify with a key`)
 		}
-		filtered = append(filtered, option)
 	}
 
-	filtered = append(filtered, WithVerify(false), WithValidate(false))
-	tok, err := Parse(s, filtered...)
+	options = append(options, WithVerify(false), WithValidate(false))
+	tok, err := Parse(s, options...)
 	if err != nil {
 		return nil, jwterrs.ParseErrorf(`jwt.ParseInsecure`, `failed to parse token: %w`, err)
 	}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1649,22 +1649,25 @@ func TestGH1007(t *testing.T) {
 	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256(), key))
 	require.NoError(t, err, `jwt.Sign should succeed`)
 
-	// This was the intended usage (no WithKey). This worked from the beginning
+	// The intended usage of ParseInsecure is without any verification
+	// material. This worked from the beginning.
 	_, err = jwt.ParseInsecure(signed)
 	require.NoError(t, err, `jwt.ParseInsecure should succeed`)
 
-	// This is the problematic behavior reporded in #1007.
-	// The fact that we're specifying a wrong key caused Parse() to check for
-	// verification and yet fail :/
+	// #1007 originally asked for ParseInsecure to silently accept a stray
+	// WithKey. That was reversed: ParseInsecure now rejects key-bearing
+	// options outright so that typos like jwt.ParseInsecure(..., jwt.WithKey(...))
+	// cannot silently skip verification. Callers who want the key to be
+	// honored must use jwt.Parse.
 	wrongPubKey, err := jwxtest.GenerateRsaPublicJwk()
 	require.NoError(t, err, `jwxtest.GenerateRsaPublicJwk should succeed`)
-	require.NoError(t, err, `jwk.PublicKeyOf should succeed`)
 
 	_, err = jwt.ParseInsecure(signed, jwt.WithKey(jwa.RS256(), wrongPubKey))
-	require.NoError(t, err, `jwt.ParseInsecure with jwt.WithKey() should succeed`)
+	require.Error(t, err, `jwt.ParseInsecure with jwt.WithKey() should error`)
+	require.ErrorContains(t, err, `jwt.ParseInsecure`)
 }
 
-func TestParseInsecureStripsKeyOptions(t *testing.T) {
+func TestParseInsecureRejectsKeyOptions(t *testing.T) {
 	key, err := jwxtest.GenerateRsaJwk()
 	require.NoError(t, err, `jwxtest.GenerateRsaJwk should succeed`)
 
@@ -1677,36 +1680,28 @@ func TestParseInsecureStripsKeyOptions(t *testing.T) {
 	wrongKey, err := jwxtest.GenerateRsaJwk()
 	require.NoError(t, err, `jwxtest.GenerateRsaJwk should succeed`)
 
-	// WithKeySet: a set that contains no matching key must not cause a
-	// verification error, because ParseInsecure strips the option.
 	wrongSet := jwk.NewSet()
 	require.NoError(t, wrongSet.AddKey(wrongKey), `set.AddKey should succeed`)
 
-	got, err := jwt.ParseInsecure(signed, jwt.WithKeySet(wrongSet))
-	require.NoError(t, err, `jwt.ParseInsecure with jwt.WithKeySet() should succeed`)
-	iss, ok := got.Issuer()
-	require.True(t, ok)
-	require.Equal(t, `me`, iss)
-
-	// WithKeyProvider: a provider that always errors must not be invoked.
-	failProvider := jws.KeyProviderFunc(func(_ context.Context, _ jws.KeySink, _ *jws.Signature, _ *jws.Message) error {
-		return fmt.Errorf(`should not be called`)
+	noopProvider := jws.KeyProviderFunc(func(_ context.Context, _ jws.KeySink, _ *jws.Signature, _ *jws.Message) error {
+		return nil
 	})
-	got, err = jwt.ParseInsecure(signed, jwt.WithKeyProvider(failProvider))
-	require.NoError(t, err, `jwt.ParseInsecure with jwt.WithKeyProvider() should succeed`)
-	iss, ok = got.Issuer()
-	require.True(t, ok)
-	require.Equal(t, `me`, iss)
 
-	// WithVerifyAuto: a fetcher that always fails must not be invoked.
-	failFetcher := jwk.FetchFunc(func(_ context.Context, _ string, _ ...jwk.FetchOption) (jwk.Set, error) {
-		return nil, fmt.Errorf(`should not be called`)
-	})
-	got, err = jwt.ParseInsecure(signed, jwt.WithVerifyAuto(failFetcher))
-	require.NoError(t, err, `jwt.ParseInsecure with jwt.WithVerifyAuto() should succeed`)
-	iss, ok = got.Issuer()
-	require.True(t, ok)
-	require.Equal(t, `me`, iss)
+	for _, tc := range []struct {
+		name string
+		opt  jwt.ParseOption
+	}{
+		{`WithKey`, jwt.WithKey(jwa.RS256(), wrongKey)},
+		{`WithKeySet`, jwt.WithKeySet(wrongSet)},
+		{`WithKeyProvider`, jwt.WithKeyProvider(noopProvider)},
+		{`WithVerifyAuto`, jwt.WithVerifyAuto(nil)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := jwt.ParseInsecure(signed, tc.opt)
+			require.Error(t, err, `jwt.ParseInsecure with jwt.%s() should error`, tc.name)
+			require.ErrorContains(t, err, `jwt.ParseInsecure`)
+		})
+	}
 }
 
 func TestParseJSON(t *testing.T) {


### PR DESCRIPTION
## Summary
- `jwt.ParseInsecure` now errors on `WithKey`, `WithKeySet`, `WithKeyProvider`, `WithVerifyAuto` — typos like `jwt.ParseInsecure(data, jwt.WithKey(...))` no longer silently skip verification
- Behavior change: reverses the silent-accept stance from #1008 and the silent-strip from #1802
- `TestGH1007` assertion flipped to match the new contract; `TestParseInsecureStripsKeyOptions` replaced with a table-driven `TestParseInsecureRejectsKeyOptions`