### PR TITLE
bound jws keyset verification fan-out by header alg

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -549,6 +549,7 @@ type curver interface {
 // Helpers for signature verification
 var muAlgorithmMaps sync.RWMutex
 var keyTypeToAlgorithms = make(map[jwa.KeyType][]jwa.SignatureAlgorithm)
+var algorithmToKeyTypes = make(map[jwa.SignatureAlgorithm][]jwa.KeyType)
 var curveToAlgorithms = make(map[jwa.EllipticCurveAlgorithm][]jwa.SignatureAlgorithm)
 
 func init() {
@@ -572,6 +573,9 @@ func RegisterAlgorithmForKeyType(kty jwa.KeyType, alg jwa.SignatureAlgorithm) {
 	muAlgorithmMaps.Lock()
 	defer muAlgorithmMaps.Unlock()
 	keyTypeToAlgorithms[kty] = append(keyTypeToAlgorithms[kty], alg)
+	if !slices.Contains(algorithmToKeyTypes[alg], kty) {
+		algorithmToKeyTypes[alg] = append(algorithmToKeyTypes[alg], kty)
+	}
 }
 
 // RegisterAlgorithmForCurve registers an algorithm as valid for the given

--- a/jws/key_provider.go
+++ b/jws/key_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 	"sync"
 
 	"github.com/lestrrat-go/jwx/v3/jwa"
@@ -223,17 +224,52 @@ func (kp *keySetProvider) fetchKeysByKid(sink KeySink, sig *Signature, msg *Mess
 }
 
 // fetchAllKeys iterates all keys in the set and adds suitable ones to the sink.
+//
+// When the protected header advertises an `alg`, keys whose type cannot
+// produce that algorithm are skipped before reaching selectKey. This
+// bounds verification fan-out to N_keys_of_matching_type instead of
+// N_keys when `WithRequireKid(false)` is used against a heterogeneous
+// JWKS. The skip is semantics-preserving: validateAlgorithmForKey in
+// verify_context would reject the incompatible (alg, key) pair before
+// running any verifier anyway.
+//
+// The allowed-KeyType set is looked up once per FetchKeys call via the
+// precomputed algorithmToKeyTypes inverse map, so the per-key check is
+// a cheap KeyType equality over a tiny slice (typically 1 element).
+// When allowedKtys is nil (no header alg, or alg has no registered
+// key type), the filter is skipped.
 func (kp *keySetProvider) fetchAllKeys(sink KeySink, sig *Signature, msg *Message) error {
+	var allowedKtys []jwa.KeyType
+	if hdrAlg, ok := sig.ProtectedHeaders().Algorithm(); ok {
+		allowedKtys = keyTypesForAlgorithm(hdrAlg)
+	}
 	for i := range kp.set.Len() {
 		key, ok := kp.set.Key(i)
 		if !ok {
 			return fmt.Errorf(`failed to get key at index %d`, i)
+		}
+		if allowedKtys != nil && !slices.Contains(allowedKtys, key.KeyType()) {
+			continue
 		}
 		if _, err := kp.selectKey(sink, key, sig, msg); err != nil {
 			continue
 		}
 	}
 	return nil
+}
+
+// keyTypesForAlgorithm returns the registered key types that can
+// produce the given signature algorithm. The inverse map is maintained
+// at registration time so this is an O(1) lookup. Returns nil if no
+// key type is registered for alg, which signals callers to skip the
+// prefilter.
+func keyTypesForAlgorithm(alg jwa.SignatureAlgorithm) []jwa.KeyType {
+	muAlgorithmMaps.RLock()
+	defer muAlgorithmMaps.RUnlock()
+	// Copy so the caller can safely iterate without holding the
+	// lock; RegisterAlgorithmForKeyType may append concurrently
+	// after we return. Typical length is 1.
+	return slices.Clone(algorithmToKeyTypes[alg])
 }
 
 type jkuProvider struct {

--- a/jws/key_provider_test.go
+++ b/jws/key_provider_test.go
@@ -1,0 +1,91 @@
+package jws
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+// countingKeySink records every (alg, key) pair sunk by a KeyProvider
+// so tests can assert on fan-out precisely.
+type countingKeySink struct {
+	pairs []algKeyPair
+}
+
+func (s *countingKeySink) Key(alg jwa.SignatureAlgorithm, key any) {
+	s.pairs = append(s.pairs, algKeyPair{alg: alg, key: key})
+}
+
+// TestKeySetProviderFetchAllKeysAlgPrefilter asserts that when
+// WithRequireKid(false) is used against a heterogeneous JWKS and the
+// JWS protected header advertises an alg, keys whose type cannot
+// produce that alg are skipped before reaching selectKey. This bounds
+// verification fan-out and guards against CPU amplification on large
+// multi-type JWKS.
+func TestKeySetProviderFetchAllKeysAlgPrefilter(t *testing.T) {
+	t.Parallel()
+
+	rsaRaw, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	rsaKey, err := jwk.Import(rsaRaw)
+	require.NoError(t, err)
+
+	ecRaw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	ecKey, err := jwk.Import(ecRaw)
+	require.NoError(t, err)
+
+	set := jwk.NewSet()
+	require.NoError(t, set.AddKey(rsaKey))
+	require.NoError(t, set.AddKey(ecKey))
+
+	kp := &keySetProvider{
+		set:            set,
+		requireKid:     false,
+		inferAlgorithm: true,
+	}
+
+	t.Run("alg=ES256 skips RSA key", func(t *testing.T) {
+		sig := NewSignature()
+		hdr := NewHeaders()
+		require.NoError(t, hdr.Set(AlgorithmKey, jwa.ES256()))
+		sig.SetProtectedHeaders(hdr)
+
+		sink := &countingKeySink{}
+		require.NoError(t, kp.FetchKeys(context.Background(), sink, sig, &Message{}))
+		require.Len(t, sink.pairs, 1, "only the EC key should be sunk")
+		require.Equal(t, jwa.ES256(), sink.pairs[0].alg)
+	})
+
+	t.Run("alg=RS256 skips EC key", func(t *testing.T) {
+		sig := NewSignature()
+		hdr := NewHeaders()
+		require.NoError(t, hdr.Set(AlgorithmKey, jwa.RS256()))
+		sig.SetProtectedHeaders(hdr)
+
+		sink := &countingKeySink{}
+		require.NoError(t, kp.FetchKeys(context.Background(), sink, sig, &Message{}))
+		require.Len(t, sink.pairs, 1, "only the RSA key should be sunk")
+		require.Equal(t, jwa.RS256(), sink.pairs[0].alg)
+	})
+
+	t.Run("no alg header still tries every key", func(t *testing.T) {
+		// Pre-existing opt-in behavior: without an alg in the header,
+		// inferAlgorithm=true sinks every compatible alg for every key.
+		// This test pins the documented fan-out so a future change is
+		// an intentional decision.
+		sig := NewSignature()
+		sig.SetProtectedHeaders(NewHeaders())
+
+		sink := &countingKeySink{}
+		require.NoError(t, kp.FetchKeys(context.Background(), sink, sig, &Message{}))
+		require.GreaterOrEqual(t, len(sink.pairs), 2, "both keys should be sunk when header has no alg")
+	})
+}

--- a/jws/key_provider_test.go
+++ b/jws/key_provider_test.go
@@ -53,6 +53,7 @@ func TestKeySetProviderFetchAllKeysAlgPrefilter(t *testing.T) {
 	}
 
 	t.Run("alg=ES256 skips RSA key", func(t *testing.T) {
+		t.Parallel()
 		sig := NewSignature()
 		hdr := NewHeaders()
 		require.NoError(t, hdr.Set(AlgorithmKey, jwa.ES256()))
@@ -65,6 +66,7 @@ func TestKeySetProviderFetchAllKeysAlgPrefilter(t *testing.T) {
 	})
 
 	t.Run("alg=RS256 skips EC key", func(t *testing.T) {
+		t.Parallel()
 		sig := NewSignature()
 		hdr := NewHeaders()
 		require.NoError(t, hdr.Set(AlgorithmKey, jwa.RS256()))
@@ -77,6 +79,7 @@ func TestKeySetProviderFetchAllKeysAlgPrefilter(t *testing.T) {
 	})
 
 	t.Run("no alg header still tries every key", func(t *testing.T) {
+		t.Parallel()
 		// Pre-existing opt-in behavior: without an alg in the header,
 		// inferAlgorithm=true sinks every compatible alg for every key.
 		// This test pins the documented fan-out so a future change is

--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -181,6 +181,17 @@ options:
       It is highly recommended that you fix your key to contain a proper `alg`
       header field instead of resorting to using this option, but sometimes
       it just needs to happen.
+
+      Fan-out and DoS considerations: when combined with `WithRequireKid(false)`
+      against a large JWKS, verification attempts scale with the number of
+      keys in the set. If the JWS protected header advertises an `alg` (as
+      required by RFC 7515 §4.1.1), only keys whose type is compatible with
+      that algorithm are tried, so the cost is bounded by the number of
+      type-compatible keys. If the header has no `alg`, every inferred
+      algorithm is tried against every candidate key, and the cost becomes
+      `N_keys × N_algs_per_keytype`. Operators exposing verification to
+      untrusted input should pair this option with `WithMaxSignatures` and
+      keep their JWKS bounded.
   - ident: UseDefault
     interface: WithKeySetSuboption
     argument_type: bool

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -408,6 +408,17 @@ func WithFS(v fs.FS) ReadFileOption {
 // It is highly recommended that you fix your key to contain a proper `alg`
 // header field instead of resorting to using this option, but sometimes
 // it just needs to happen.
+//
+// Fan-out and DoS considerations: when combined with `WithRequireKid(false)`
+// against a large JWKS, verification attempts scale with the number of
+// keys in the set. If the JWS protected header advertises an `alg` (as
+// required by RFC 7515 §4.1.1), only keys whose type is compatible with
+// that algorithm are tried, so the cost is bounded by the number of
+// type-compatible keys. If the header has no `alg`, every inferred
+// algorithm is tried against every candidate key, and the cost becomes
+// `N_keys × N_algs_per_keytype`. Operators exposing verification to
+// untrusted input should pair this option with `WithMaxSignatures` and
+// keep their JWKS bounded.
 func WithInferAlgorithmFromKey(v bool) WithKeySetSuboption {
 	return &withKeySetSuboption{option.New(identInferAlgorithmFromKey{}, v)}
 }


### PR DESCRIPTION
## Summary

- `jws.WithKeySet(set, WithRequireKid(false), WithInferAlgorithmFromKey(true))` let `fetchAllKeys` feed every key in the set to `selectKey` regardless of the header `alg`. Against a heterogeneous JWKS this amplified verifier work to `N_keys` (or `N_keys × N_algs_per_keytype` when the header had no `alg`) per inbound JWS — cheap per call but DoS-friendly on large sets.
- Precompute the allowed key types for the header `alg` once via a new `algorithmToKeyTypes` inverse map (maintained append-only at registration time) and skip type-incompatible keys before reaching `selectKey`. Per-key cost is now a single `KeyType` equality over a typically-1-element slice.
- Document the residual fan-out on `WithInferAlgorithmFromKey` and recommend pairing with `WithMaxSignatures`.

## Test plan

- [x] `go test ./jws/...`
- [x] New `TestKeySetProviderFetchAllKeysAlgPrefilter` asserts that mixed RSA+EC JWKS + `alg=ES256` / `alg=RS256` header reaches only the compatible key, and pins the "no alg ⇒ try all" behavior.