### PR TITLE
return typed errors from jwt.Get

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -34,7 +34,8 @@ Only `jwt.UnknownPayloadTypeError()` remains a sentinel function (no struct type
 | `ValidationError` | *(wraps inner)* | Blanket validation failure |
 | `ParseError` | *(wraps inner)* | Parse failed |
 | `MissingRequiredClaimError` | `Claim` | Required claim missing |
-| `ClaimNotFoundError` | `Name` | Claim not present |
+| `ClaimNotFoundError` | `Name` | Claim not present (`jwt.Get` miss) |
+| `ClaimTypeMismatchError` | `Name`, `Got`, `Want` | Claim present but wrong type (`jwt.Get` type assertion failed) |
 | `ClaimAssignmentFailedError` | `Err` | Claim value assignment failed |
 
 ## Sentinel Function Registry

--- a/jwt/accessors.go
+++ b/jwt/accessors.go
@@ -6,6 +6,14 @@ import "fmt"
 // It returns the value and an error if the claim does not exist or cannot be
 // converted to type T.
 //
+// The returned error can be inspected with errors.Is / errors.AsType:
+//
+//   - ClaimNotFoundError is returned when the claim is absent.
+//   - ClaimTypeMismatchError is returned when the claim is present
+//     but its stored value is not assignable to T.
+//
+// Both errors are wrapped with a "jwt.Get:" prefix.
+//
 // Usage:
 //
 //	issuer, err := jwt.Get[string](token, jwt.IssuerKey)
@@ -14,11 +22,11 @@ func Get[T any](token Token, key string) (T, error) {
 	var zero T
 	v, ok := token.Field(key)
 	if !ok {
-		return zero, fmt.Errorf(`jwt.Get: field %q not found`, key)
+		return zero, fmt.Errorf(`jwt.Get: %w`, ClaimNotFoundError{Name: key})
 	}
 	result, ok := v.(T)
 	if !ok {
-		return zero, fmt.Errorf(`jwt.Get: field %q is %T, not %T`, key, v, zero)
+		return zero, fmt.Errorf(`jwt.Get: %w`, ClaimTypeMismatchError{Name: key, Got: v, Want: zero})
 	}
 	return result, nil
 }

--- a/jwt/errors.go
+++ b/jwt/errors.go
@@ -38,6 +38,37 @@ func (e ClaimNotFoundError) Is(target error) bool {
 }
 
 //-------------------------------------------------------------------
+// ClaimTypeMismatchError
+//-------------------------------------------------------------------
+
+// ClaimTypeMismatchError is returned when jwt.Get finds the requested
+// claim but the stored value cannot be converted to the requested type.
+//
+// Callers that need to distinguish "claim missing" from "claim present
+// but wrong type" should use errors.Is with ClaimNotFoundError{} /
+// ClaimTypeMismatchError{}, or errors.AsType to recover the Name, Got,
+// and Want fields.
+type ClaimTypeMismatchError struct {
+	// Name is the name of the claim whose value could not be converted.
+	Name string
+	// Got is the value currently stored under the claim. Use %T to
+	// inspect its concrete type.
+	Got any
+	// Want is a zero value of the requested type T. Use %T to inspect
+	// its concrete type.
+	Want any
+}
+
+func (e ClaimTypeMismatchError) Error() string {
+	return fmt.Sprintf(`field "%s" is %T, not %T`, e.Name, e.Got, e.Want)
+}
+
+func (e ClaimTypeMismatchError) Is(target error) bool {
+	_, ok := target.(ClaimTypeMismatchError)
+	return ok
+}
+
+//-------------------------------------------------------------------
 // ClaimAssignmentFailedError
 //-------------------------------------------------------------------
 

--- a/jwt/structured_errors_test.go
+++ b/jwt/structured_errors_test.go
@@ -258,4 +258,40 @@ func TestCollectErrors(t *testing.T) {
 		)
 		require.NoError(t, err)
 	})
+
+	t.Run("Get returns ClaimNotFoundError when claim is missing", func(t *testing.T) {
+		t.Parallel()
+
+		tok, err := jwt.NewBuilder().Issuer("me").Build()
+		require.NoError(t, err)
+
+		_, err = jwt.Get[string](tok, "absent")
+		require.Error(t, err)
+		require.ErrorContains(t, err, `jwt.Get`)
+		require.ErrorIs(t, err, jwt.ClaimNotFoundError{})
+		require.False(t, errors.Is(err, jwt.ClaimTypeMismatchError{}))
+
+		notFound, ok := errors.AsType[jwt.ClaimNotFoundError](err)
+		require.True(t, ok, `errors.AsType should find ClaimNotFoundError`)
+		require.Equal(t, `absent`, notFound.Name)
+	})
+
+	t.Run("Get returns ClaimTypeMismatchError when claim is wrong type", func(t *testing.T) {
+		t.Parallel()
+
+		tok, err := jwt.NewBuilder().Issuer("me").Build()
+		require.NoError(t, err)
+
+		_, err = jwt.Get[int](tok, jwt.IssuerKey)
+		require.Error(t, err)
+		require.ErrorContains(t, err, `jwt.Get`)
+		require.ErrorIs(t, err, jwt.ClaimTypeMismatchError{})
+		require.False(t, errors.Is(err, jwt.ClaimNotFoundError{}))
+
+		mismatch, ok := errors.AsType[jwt.ClaimTypeMismatchError](err)
+		require.True(t, ok, `errors.AsType should find ClaimTypeMismatchError`)
+		require.Equal(t, jwt.IssuerKey, mismatch.Name)
+		require.IsType(t, "", mismatch.Got, `Got should carry the stored string value`)
+		require.IsType(t, 0, mismatch.Want, `Want should carry a zero int`)
+	})
 }


### PR DESCRIPTION
## Summary
- `jwt.Get[T]` now returns `ClaimNotFoundError` when the claim is absent and the new `ClaimTypeMismatchError` (`Name`/`Got`/`Want`) when the stored value is not assignable to `T`; both wrapped with a `jwt.Get:` prefix so `errors.Is` / `errors.AsType` work
- Callers can finally distinguish "missing" from "wrong type" without substring matching
- `.claude/docs/error-formatting.md` updated to list the new type