### PR TITLE
fix jwk exporter case-insensitive dispatch

### DIFF
--- a/jwk/convert.go
+++ b/jwk/convert.go
@@ -456,7 +456,7 @@ func doExport(key Key, hint any) (any, error) {
 // hold muKeyExporters.RLock.
 func findExporters(key Key) []KeyExporter {
 	if ki, ok := key.(KeyKinder); ok {
-		ident := ki.KeyKind()
+		ident := ki.KeyKind().normalize()
 		if exporters, ok := keyExporters[ident]; ok {
 			return exporters
 		}

--- a/jwk/convert_test.go
+++ b/jwk/convert_test.go
@@ -1,0 +1,42 @@
+package jwk_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+// keyKinderMock is a minimal jwk.Key that only implements KeyType() and
+// KeyKind(). The embedded jwk.Key interface is nil at runtime; only
+// findExporters dispatches on this mock, and the sentinel exporter
+// registered in the test never touches the other Key methods.
+type keyKinderMock struct {
+	jwk.Key
+	kty  jwa.KeyType
+	kind jwk.KeyKind
+}
+
+func (m keyKinderMock) KeyType() jwa.KeyType { return m.kty }
+func (m keyKinderMock) KeyKind() jwk.KeyKind { return m.kind }
+
+func TestFindExportersCaseInsensitiveKeyKind(t *testing.T) {
+	const (
+		registeredIdent = jwk.KeyKind("TESTKIND:FindExporters")
+		mockIdent       = jwk.KeyKind("testkind:findexporters")
+	)
+	mockKty := jwa.NewKeyType("Test-FindExporters")
+
+	type sentinelType struct{ name string }
+	sentinel := sentinelType{name: "sentinel"}
+	require.NoError(t,
+		jwk.RegisterKeyExporter(registeredIdent, jwk.KeyExportFunc(func(_ jwk.Key, _ any) (any, error) {
+			return sentinel, nil
+		})),
+		"RegisterKeyExporter should succeed")
+
+	got, err := jwk.Export[any](keyKinderMock{kty: mockKty, kind: mockIdent})
+	require.NoError(t, err, "Export should dispatch via case-insensitive KeyKind")
+	require.Equal(t, sentinel, got, "Export should return sentinel from registered exporter")
+}

--- a/jwk/convert_test.go
+++ b/jwk/convert_test.go
@@ -14,6 +14,7 @@ import (
 // registered in the test never touches the other Key methods.
 type keyKinderMock struct {
 	jwk.Key
+
 	kty  jwa.KeyType
 	kind jwk.KeyKind
 }


### PR DESCRIPTION
findExporters looked up exporters with the KeyKinder-returned ident verbatim, while RegisterKeyExporter stores under .normalize() (uppercase) and the KeyKind / RegisterKeyExporter docs advertise case-insensitive lookup. External KeyKinder implementations returning mixed-case values silently fell through to the generic key-type fallback — potentially dispatching to a handler that doesn't understand the specific curve.

Normalizes the lookup ident in findExporters to match. Regression test exercises the case-mismatch path with a mock KeyKinder + a unique jwa.NewKeyType, so it fails before the fix and passes after.

Built-in keys aren't affected (okpKeyKind / akpKeyKind already normalize their returns). v3 is intentionally untouched — it has no case-insensitive contract and both register/lookup sides are case-sensitive by design.