### PR TITLE
add jwk.WithForceAssign to overwrite existing kid

### DIFF
--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -430,20 +430,30 @@ func ParseString(s string, options ...ParseOption) (Set, error) {
 
 // AssignKeyID is a convenience function to automatically assign the "kid"
 // section of the key, if it already doesn't have one. It uses Key.Thumbprint
-// method with crypto.SHA256 as the default hashing algorithm
+// method with crypto.SHA256 as the default hashing algorithm.
+//
+// By default, if the key already carries a `kid`, `AssignKeyID` leaves it
+// alone and returns nil. Pass `jwk.WithForceAssign(true)` to force
+// recomputation (for example, when upgrading to a stronger thumbprint hash
+// via `jwk.WithThumbprintHash`).
 func AssignKeyID(key Key, options ...AssignKeyIDOption) error {
-	if key.Has(KeyIDKey) {
-		return nil
-	}
-
 	hash := crypto.SHA256
+	var force bool
 	for _, option := range options {
 		switch option.Ident() {
 		case identThumbprintHash{}:
 			if err := option.Value(&hash); err != nil {
 				return fmt.Errorf(`failed to retrieve thumbprint hash option value: %w`, err)
 			}
+		case identForceAssign{}:
+			if err := option.Value(&force); err != nil {
+				return fmt.Errorf(`failed to retrieve force assign option value: %w`, err)
+			}
 		}
+	}
+
+	if !force && key.Has(KeyIDKey) {
+		return nil
 	}
 
 	h, err := key.Thumbprint(hash)

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -725,26 +725,68 @@ func TestAccept(t *testing.T) {
 
 func TestAssignKeyID(t *testing.T) {
 	t.Parallel()
-	generators := []func() (jwk.Key, error){
-		jwxtest.GenerateRsaJwk,
-		jwxtest.GenerateRsaPublicJwk,
-		jwxtest.GenerateEcdsaJwk,
-		jwxtest.GenerateEcdsaPublicJwk,
-		jwxtest.GenerateSymmetricJwk,
-		jwxtest.GenerateEd25519Jwk,
-	}
 
-	for _, generator := range generators {
-		k, err := generator()
+	t.Run("assigns kid when missing", func(t *testing.T) {
+		generators := []func() (jwk.Key, error){
+			jwxtest.GenerateRsaJwk,
+			jwxtest.GenerateRsaPublicJwk,
+			jwxtest.GenerateEcdsaJwk,
+			jwxtest.GenerateEcdsaPublicJwk,
+			jwxtest.GenerateSymmetricJwk,
+			jwxtest.GenerateEd25519Jwk,
+		}
+
+		for _, generator := range generators {
+			k, err := generator()
+			require.NoError(t, err, `jwk generation should be successful`)
+			kid, ok := k.KeyID()
+			require.False(t, ok, `k.KeyID should be empty`)
+			require.Empty(t, kid, `k.KeyID should be non-empty`)
+			require.NoError(t, jwk.AssignKeyID(k), `AssignKeyID shuld be successful`)
+			kid, ok = k.KeyID()
+			require.True(t, ok, `k.KeyID should be non-empty`)
+			require.NotEmpty(t, kid, `k.KeyID should be non-empty`)
+		}
+	})
+
+	t.Run("preserves existing kid without force", func(t *testing.T) {
+		k, err := jwxtest.GenerateRsaJwk()
 		require.NoError(t, err, `jwk generation should be successful`)
+		require.NoError(t, k.Set(jwk.KeyIDKey, "preset"), `pre-setting kid should succeed`)
+		require.NoError(t, jwk.AssignKeyID(k, jwk.WithThumbprintHash(crypto.SHA512)), `AssignKeyID should succeed`)
 		kid, ok := k.KeyID()
-		require.False(t, ok, `k.KeyID should be empty`)
-		require.Empty(t, kid, `k.KeyID should be non-empty`)
-		require.NoError(t, jwk.AssignKeyID(k), `AssignKeyID shuld be successful`)
-		kid, ok = k.KeyID()
-		require.True(t, ok, `k.KeyID should be non-empty`)
-		require.NotEmpty(t, kid, `k.KeyID should be non-empty`)
-	}
+		require.True(t, ok, `kid should still be set`)
+		require.Equal(t, "preset", kid, `kid should be preserved when not forced`)
+	})
+
+	t.Run("overwrites existing kid with force", func(t *testing.T) {
+		k, err := jwxtest.GenerateRsaJwk()
+		require.NoError(t, err, `jwk generation should be successful`)
+		require.NoError(t, k.Set(jwk.KeyIDKey, "preset"), `pre-setting kid should succeed`)
+		require.NoError(t, jwk.AssignKeyID(k, jwk.WithForceAssign(true)), `AssignKeyID with force should succeed`)
+		kid, ok := k.KeyID()
+		require.True(t, ok, `kid should be set`)
+		require.NotEqual(t, "preset", kid, `kid should be recomputed`)
+
+		tp, err := k.Thumbprint(crypto.SHA256)
+		require.NoError(t, err, `thumbprint should compute`)
+		require.Equal(t, base64.EncodeToString(tp), kid, `kid should equal base64(sha256 thumbprint)`)
+	})
+
+	t.Run("force honors WithThumbprintHash", func(t *testing.T) {
+		k, err := jwxtest.GenerateRsaJwk()
+		require.NoError(t, err, `jwk generation should be successful`)
+		require.NoError(t, k.Set(jwk.KeyIDKey, "preset"), `pre-setting kid should succeed`)
+		require.NoError(t,
+			jwk.AssignKeyID(k, jwk.WithForceAssign(true), jwk.WithThumbprintHash(crypto.SHA512)),
+			`AssignKeyID with force+sha512 should succeed`)
+		kid, ok := k.KeyID()
+		require.True(t, ok, `kid should be set`)
+
+		tp, err := k.Thumbprint(crypto.SHA512)
+		require.NoError(t, err, `thumbprint should compute`)
+		require.Equal(t, base64.EncodeToString(tp), kid, `kid should equal base64(sha512 thumbprint)`)
+	})
 }
 
 func TestPublicKeyOf(t *testing.T) {

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -727,6 +727,7 @@ func TestAssignKeyID(t *testing.T) {
 	t.Parallel()
 
 	t.Run("assigns kid when missing", func(t *testing.T) {
+		t.Parallel()
 		generators := []func() (jwk.Key, error){
 			jwxtest.GenerateRsaJwk,
 			jwxtest.GenerateRsaPublicJwk,
@@ -750,6 +751,7 @@ func TestAssignKeyID(t *testing.T) {
 	})
 
 	t.Run("preserves existing kid without force", func(t *testing.T) {
+		t.Parallel()
 		k, err := jwxtest.GenerateRsaJwk()
 		require.NoError(t, err, `jwk generation should be successful`)
 		require.NoError(t, k.Set(jwk.KeyIDKey, "preset"), `pre-setting kid should succeed`)
@@ -760,6 +762,7 @@ func TestAssignKeyID(t *testing.T) {
 	})
 
 	t.Run("overwrites existing kid with force", func(t *testing.T) {
+		t.Parallel()
 		k, err := jwxtest.GenerateRsaJwk()
 		require.NoError(t, err, `jwk generation should be successful`)
 		require.NoError(t, k.Set(jwk.KeyIDKey, "preset"), `pre-setting kid should succeed`)
@@ -774,6 +777,7 @@ func TestAssignKeyID(t *testing.T) {
 	})
 
 	t.Run("force honors WithThumbprintHash", func(t *testing.T) {
+		t.Parallel()
 		k, err := jwxtest.GenerateRsaJwk()
 		require.NoError(t, err, `jwk generation should be successful`)
 		require.NoError(t, k.Set(jwk.KeyIDKey, "preset"), `pre-setting kid should succeed`)

--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -97,6 +97,16 @@ options:
   - ident: ThumbprintHash
     interface: AssignKeyIDOption
     argument_type: crypto.Hash
+  - ident: ForceAssign
+    interface: AssignKeyIDOption
+    argument_type: bool
+    comment: |
+      WithForceAssign forces `jwk.AssignKeyID` to recompute and overwrite
+      the `kid` header even when the key already has one. The default
+      behavior preserves any existing `kid`; use this option to upgrade
+      the thumbprint hash (e.g. with `jwk.WithThumbprintHash`) or to
+      refresh a `kid` after mutating a key field that invalidates the
+      cached thumbprint.
   - ident: LocalRegistry
     option_name: withLocalRegistry
     interface: ParseOption

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -181,6 +181,7 @@ func (*resourceOption) resourceOption() {}
 type identAllowSymmetric struct{}
 type identFS struct{}
 type identFetchWhitelist struct{}
+type identForceAssign struct{}
 type identHTTPClient struct{}
 type identIgnoreParseError struct{}
 type identLocalRegistry struct{}
@@ -202,6 +203,10 @@ func (identFS) String() string {
 
 func (identFetchWhitelist) String() string {
 	return "WithFetchWhitelist"
+}
+
+func (identForceAssign) String() string {
+	return "WithForceAssign"
 }
 
 func (identHTTPClient) String() string {
@@ -286,6 +291,16 @@ func WithFS(v fs.FS) ReadFileOption {
 // `Transport.DialContext` validates resolved addresses.
 func WithFetchWhitelist(v Whitelist) FetchOption {
 	return &fetchOption{option.New(identFetchWhitelist{}, v)}
+}
+
+// WithForceAssign forces `jwk.AssignKeyID` to recompute and overwrite
+// the `kid` header even when the key already has one. The default
+// behavior preserves any existing `kid`; use this option to upgrade
+// the thumbprint hash (e.g. with `jwk.WithThumbprintHash`) or to
+// refresh a `kid` after mutating a key field that invalidates the
+// cached thumbprint.
+func WithForceAssign(v bool) AssignKeyIDOption {
+	return &assignKeyIDOption{option.New(identForceAssign{}, v)}
 }
 
 // WithHTTPClient allows users to specify the "net/http".Client object that

--- a/jwk/options_gen_test.go
+++ b/jwk/options_gen_test.go
@@ -12,6 +12,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithAllowSymmetric", identAllowSymmetric{}.String())
 	require.Equal(t, "WithFS", identFS{}.String())
 	require.Equal(t, "WithFetchWhitelist", identFetchWhitelist{}.String())
+	require.Equal(t, "WithForceAssign", identForceAssign{}.String())
 	require.Equal(t, "WithHTTPClient", identHTTPClient{}.String())
 	require.Equal(t, "WithIgnoreParseError", identIgnoreParseError{}.String())
 	require.Equal(t, "withLocalRegistry", identLocalRegistry{}.String())


### PR DESCRIPTION
## Summary
- `jwk.AssignKeyID` silently ignored `WithThumbprintHash` when the key already had a `kid`; new `WithForceAssign(true)` option opts in to recomputation (default preserves existing `kid`)
- tests cover: no-force preserves preset kid, force overwrites with sha256, force+WithThumbprintHash(sha512) overwrites with sha512
- v3 backport of #1873