### PR TITLE
tighten HeaderGetStringBytes lifetime doc

### DIFF
--- a/jws/jwsbb/header.go
+++ b/jws/jwsbb/header.go
@@ -171,12 +171,16 @@ func HeaderGetInt64(h Header, key string) (int64, error) {
 	return v.Int64()
 }
 
-// HeaderGetStringBytes returns the byte slice value for the given key from the JWS header.
-// An error is returned if the JSON was not valid, if the key does not exist,
-// or if the value is not a byte slice.
+// HeaderGetStringBytes returns the JSON string bytes for the given key
+// from the JWS header, without copying. An error is returned if the JSON
+// was not valid, if the key does not exist, or if the value is not a
+// JSON string.
 //
-// Because of limitations of the underlying library, you cannot use the return value
-// of this function after the parser is garbage collected.
+// WARNING: the returned slice aliases memory owned by h. It becomes
+// invalid as soon as h is reused, re-parsed, or goes out of scope and is
+// garbage collected. Do not retain the slice, share it across
+// goroutines, or use it after any further call on h. If you need a value
+// that outlives h, use [HeaderGetString], which returns a string copy.
 //
 // This function is experimental and may change or be removed in the future.
 func HeaderGetStringBytes(h Header, key string) ([]byte, error) {


### PR DESCRIPTION
## Summary
- Doc-only tightening of `jwsbb.HeaderGetStringBytes`: reference `h` (the `Header` the caller holds) instead of "the parser", explicitly ban retention / cross-goroutine use, point at `HeaderGetString` as the copy alternative.
- Implementation unchanged; the function stays zero-copy by design.