### PR TITLE
fix jwxio limited reader detection

### DIFF
--- a/internal/jwxio/jwxio.go
+++ b/internal/jwxio/jwxio.go
@@ -17,7 +17,7 @@ func NonFiniteSourceError() error {
 // finite source.
 func ReadAllFromFiniteSource(rdr io.Reader) ([]byte, error) {
 	switch rdr.(type) {
-	case *bytes.Reader, *bytes.Buffer, *strings.Reader:
+	case *bytes.Reader, *bytes.Buffer, *io.LimitedReader, *strings.Reader:
 		data, err := io.ReadAll(rdr)
 		if err != nil {
 			return nil, err

--- a/internal/jwxio/jwxio_test.go
+++ b/internal/jwxio/jwxio_test.go
@@ -1,0 +1,46 @@
+package jwxio_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/internal/jwxio"
+	"github.com/stretchr/testify/require"
+)
+
+type endlessReader struct{ b byte }
+
+func (r *endlessReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = r.b
+	}
+	return len(p), nil
+}
+
+func TestReadAllFromFiniteSource(t *testing.T) {
+	t.Parallel()
+
+	t.Run("limited reader from finite source", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := jwxio.ReadAllFromFiniteSource(io.LimitReader(strings.NewReader("hello"), 3))
+		require.NoError(t, err)
+		require.Equal(t, []byte("hel"), data)
+	})
+
+	t.Run("limited reader bounds endless source", func(t *testing.T) {
+		t.Parallel()
+
+		data, err := jwxio.ReadAllFromFiniteSource(io.LimitReader(&endlessReader{b: 'x'}, 4))
+		require.NoError(t, err)
+		require.Equal(t, []byte("xxxx"), data)
+	})
+
+	t.Run("endless source is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := jwxio.ReadAllFromFiniteSource(&endlessReader{b: 'x'})
+		require.ErrorIs(t, err, jwxio.NonFiniteSourceError())
+	})
+}


### PR DESCRIPTION
- accept *io.LimitedReader in jwxio finite-source reads
- add regression tests for bounded and non-finite readers
