### PR TITLE
fix cmd jwe decrypt alg selection

### DIFF
--- a/cmd/jwx/jwe.go
+++ b/cmd/jwx/jwe.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"io"
 
@@ -134,10 +133,20 @@ func makeJweDecryptCmd() *cli.Command {
 	var cmd cli.Command
 	cmd.Name = "decrypt"
 	cmd.Aliases = []string{"dec"}
+	cmd.UsageText = `jwx jwe decrypt [command options] FILE
+
+   Decrypts the JWE message in FILE using the specified key and
+   key encryption algorithm.
+   Use "-" as FILE to read from STDIN.
+
+   The user must explicitly provide "--key-encryption". This command
+   refuses to trust the recipient-header "alg" value to choose the
+   decryption primitive.
+`
 	cmd.Flags = []cli.Flag{
 		keyFlag("decrypt"),
 		keyFormatFlag(),
-		keyEncryptionFlag(false),
+		keyEncryptionFlag(true),
 		outputFlag(),
 	}
 	cmd.Action = func(c *cli.Context) error {
@@ -161,39 +170,19 @@ func makeJweDecryptCmd() *cli.Command {
 		}
 		key, _ := keyset.Key(0)
 
-		var decrypted []byte
-
-		if keyencalg := c.String("key-encryption"); keyencalg != "" {
-			var keyenc jwa.KeyEncryptionAlgorithm
-			{
-				v, ok := jwa.LookupKeyEncryptionAlgorithm(keyencalg)
-				if !ok {
-					return fmt.Errorf(`invalid key encryption algorithm %q`, keyencalg)
-				}
-				keyenc = v
-
+		keyencalg := c.String("key-encryption")
+		var keyenc jwa.KeyEncryptionAlgorithm
+		{
+			v, ok := jwa.LookupKeyEncryptionAlgorithm(keyencalg)
+			if !ok {
+				return fmt.Errorf(`invalid key encryption algorithm %q`, keyencalg)
 			}
+			keyenc = v
+		}
 
-			// if we have an explicit key encryption algorithm, we don't have to
-			// guess it.
-			v, err := jwe.Decrypt(buf, jwe.WithKey(keyenc, key))
-			if err != nil {
-				return fmt.Errorf(`failed to decrypt message: %w`, err)
-			}
-			decrypted = v
-		} else {
-			v, err := jwe.Decrypt(buf, jwe.WithKeyProvider(jwe.KeyProviderFunc(func(_ context.Context, sink jwe.KeySink, r jwe.Recipient, _ *jwe.Message) error {
-				alg, ok := r.Headers().Algorithm()
-				if !ok {
-					return fmt.Errorf(`failed to determine key encryption algorithm`)
-				}
-				sink.Key(alg, key)
-				return nil
-			})))
-			if err != nil {
-				return fmt.Errorf(`failed to decrypt message: %w`, err)
-			}
-			decrypted = v
+		decrypted, err := jwe.Decrypt(buf, jwe.WithKey(keyenc, key))
+		if err != nil {
+			return fmt.Errorf(`failed to decrypt message: %w`, err)
 		}
 
 		output, err := getOutput(c.String("output"))

--- a/cmd/jwx/jwe_test.go
+++ b/cmd/jwx/jwe_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/internal/jwxtest"
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwe"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestJweDecryptRequiresExplicitKeyEncryption(t *testing.T) {
+	key, err := jwxtest.GenerateRsaJwk()
+	require.NoError(t, err)
+
+	keyFile := writeSingleKeyJWK(t, key)
+	jweFile := writeEncryptedJWE(t, key, jwa.RSA_OAEP(), []byte("payload"))
+
+	app := &cli.App{
+		Commands: []*cli.Command{makeJweCmd()},
+	}
+
+	err = app.Run([]string{
+		"jwx",
+		"jwe",
+		"decrypt",
+		"--key", keyFile,
+		jweFile,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Required flag")
+	require.Contains(t, err.Error(), "key-encryption")
+}
+
+func TestJweDecryptWithExplicitKeyEncryption(t *testing.T) {
+	key, err := jwxtest.GenerateRsaJwk()
+	require.NoError(t, err)
+
+	keyFile := writeSingleKeyJWK(t, key)
+	payload := []byte("payload")
+	jweFile := writeEncryptedJWE(t, key, jwa.RSA_OAEP(), payload)
+	outputFile := filepath.Join(t.TempDir(), "out.txt")
+
+	app := &cli.App{
+		Commands: []*cli.Command{makeJweCmd()},
+	}
+
+	err = app.Run([]string{
+		"jwx",
+		"jwe",
+		"decrypt",
+		"--key", keyFile,
+		"--key-encryption", jwa.RSA_OAEP().String(),
+		"--output", outputFile,
+		jweFile,
+	})
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+func writeSingleKeyJWK(t *testing.T, key jwk.Key) string {
+	t.Helper()
+
+	buf, err := json.Marshal(key)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "key.jwk")
+	require.NoError(t, os.WriteFile(path, buf, 0600))
+	return path
+}
+
+func writeEncryptedJWE(t *testing.T, key jwk.Key, alg jwa.KeyEncryptionAlgorithm, payload []byte) string {
+	t.Helper()
+
+	pubkey, err := jwk.PublicKeyOf(key)
+	require.NoError(t, err)
+
+	encrypted, err := jwe.Encrypt(payload, jwe.WithKey(alg, pubkey), jwe.WithContentEncryption(jwa.A256GCM()))
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "payload.jwe")
+	require.NoError(t, os.WriteFile(path, encrypted, 0600))
+	return path
+}


### PR DESCRIPTION
- require explicit --key-encryption for `jwx jwe decrypt`
- remove recipient-header alg fallback from the CLI decrypt path
- add command tests for missing flag rejection and explicit decrypt success
- verification: `GOEXPERIMENT=jsonv2 go test ./...` in `cmd/jwx`
