### PR TITLE
fix jws jku kid-miss silent nil

### DIFF
--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1269,6 +1269,27 @@ func TestJKU(t *testing.T) {
 			})
 		}
 	})
+	t.Run("KidNotInJWKS", func(t *testing.T) {
+		// Sign with a key whose kid is NOT present in the remote JWKS.
+		// The fetched set only contains a key with a different kid.
+		// jkuProvider used to return nil in this case, collapsing the
+		// failure into a generic "could not verify" error and hiding
+		// the root cause from operators. It must now surface an
+		// explicit kid-not-found error.
+		signerKey, err := jwxtest.GenerateRsaJwk()
+		require.NoError(t, err, `jwxtest.GenerateRsaJwk should succeed`)
+		require.NoError(t, signerKey.Set(jwk.KeyIDKey, `signer-kid`), `Set kid should succeed`)
+
+		hdr := jws.NewHeaders()
+		require.NoError(t, hdr.Set(jws.JWKSetURLKey, srv.URL), `Set jku should succeed`)
+		signed, err := jws.Sign(payload, jws.WithKey(jwa.RS256(), signerKey, jws.WithProtectedHeaders(hdr)))
+		require.NoError(t, err, `jws.Sign should succeed`)
+
+		_, err = jws.Verify(signed, jws.WithVerifyAuto(&jwxtest.JKUFetcher{Client: srv.Client()}))
+		require.Error(t, err, `jws.Verify should fail when jku JWKS has no matching kid`)
+		require.Contains(t, err.Error(), `signer-kid`, `error should name the missing kid`)
+		require.Contains(t, err.Error(), `not found`, `error should say the kid was not found`)
+	})
 }
 
 func TestAlgorithmsForKey(t *testing.T) {

--- a/jws/key_provider.go
+++ b/jws/key_provider.go
@@ -293,8 +293,7 @@ func (kp jkuProvider) FetchKeys(ctx context.Context, sink KeySink, sig *Signatur
 
 	key, ok := set.LookupKeyID(kid)
 	if !ok {
-		// It is not an error if the key with the kid doesn't exist
-		return nil
+		return fmt.Errorf(`jku: key with "kid" %q not found in JWKS fetched from %q`, kid, u)
 	}
 
 	algs, err := AlgorithmsForKey(key)

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -186,7 +186,8 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 		for i, kp := range vc.keyProviders {
 			var sink algKeySink
 			if err := kp.FetchKeys(vc.ctx, &sink, sig, msg); err != nil {
-				return nil, makeVerifyError(`key provider %d failed: %w`, i, err)
+				errs = append(errs, makeVerifyError(`signature #%d: key provider %d failed: %w`, idx+1, i, err))
+				continue
 			}
 
 			for _, pair := range sink.list {


### PR DESCRIPTION
`jkuProvider.FetchKeys` returned `nil` when the fetched JWKS had no key matching the signature's `kid`, collapsing the failure into the generic `could not be verified with any of the keys` error and leaving operators unable to tell a kid mismatch from a real verify failure. It now returns an explicit error naming the missing kid and the `jku` URL.

`VerifyMessage` now appends per-provider `FetchKeys` errors to the joined error slice and continues to the next provider/signature instead of hard-failing, so a multi-signature JWS where one signature's kid is missing from the JWKS can still verify through another signature. Regression-locked by `TestJKU/KidNotInJWKS`.

v3 counterpart: #1888. Finding: `JWS-20260415151950-058`.