### PR TITLE
fix jws VerifyCompactFast header alg cross-check

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -811,6 +811,12 @@ func Settings(options ...GlobalOption) {
 // Since this function avoids doing many checks that jws.Verify would perform,
 // you must ensure to perform the necessary checks including ensuring that algorithm is safe to use for your payload yourself.
 //
+// VerifyCompactFast cross-checks the protected header's "alg" against
+// the caller-supplied alg: if the header omits "alg" (required by
+// RFC 7515 §4.1.1) or advertises a different value, it returns a
+// verification error. This prevents silently verifying a message
+// under a different discipline than the one its header advertises.
+//
 // VerifyCompactFast refuses messages whose protected header carries a
 // "crit" list. RFC 7515 §4.1.11 requires every critical extension to be
 // understood by the recipient, and the fast path has no WithCritExtension
@@ -839,12 +845,28 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 		return nil, makeVerifyError("failed to split compact: %w", err)
 	}
 
+	parsedHdr := jwsbb.HeaderParseCompact(hdr)
+
 	// Refuse crit-bearing messages: the fast path has no WithCritExtension
 	// allowlist, so accepting them would silently violate RFC 7515 §4.1.11.
 	// Callers that wrap VerifyCompactFast can detect this via
 	// errors.Is(err, jws.ErrCritPresent()) and fall through to jws.Verify.
-	if jwsbb.HeaderHas(jwsbb.HeaderParseCompact(hdr), CriticalKey) {
+	if jwsbb.HeaderHas(parsedHdr, CriticalKey) {
 		return nil, errCritPresent
+	}
+
+	// Cross-check the protected header "alg" against the caller-supplied
+	// alg. RFC 7515 §4.1.1 makes "alg" mandatory in the protected header
+	// for compact serialization, and a mismatch between what the message
+	// advertises and the discipline under which we verify is the sort of
+	// silent divergence that downstream code (e.g. JWT consumers) should
+	// not be asked to re-discover on its own.
+	hdrAlg, err := jwsbb.HeaderGetString(parsedHdr, AlgorithmKey)
+	if err != nil {
+		return nil, verifyError{verificationError{fmt.Errorf(`jws.Verify: failed to extract %q from protected header: %w`, AlgorithmKey, err)}}
+	}
+	if hdrAlg != algstr {
+		return nil, verifyError{verificationError{fmt.Errorf(`jws.Verify: protected header %q %q does not match caller-supplied algorithm %q`, AlgorithmKey, hdrAlg, algstr)}}
 	}
 
 	signature, err := base64.Decode(encodedSig)

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -2172,3 +2172,46 @@ func TestVerifyWithNonSignatureAlgorithm(t *testing.T) {
 	require.True(t, errors.Is(err, jws.VerifyError()))
 	require.Contains(t, err.Error(), "SignatureAlgorithm")
 }
+
+func TestVerifyCompactFastHeaderAlgCrossCheck(t *testing.T) {
+	hmacKey := jwxtest.GenerateSymmetricKey()
+
+	t.Run("Match", func(t *testing.T) {
+		signed, err := jws.Sign([]byte("payload"), jws.WithKey(jwa.HS256(), hmacKey))
+		require.NoError(t, err)
+
+		payload, err := jws.VerifyCompactFast(hmacKey, signed, jwa.HS256())
+		require.NoError(t, err)
+		require.Equal(t, []byte("payload"), payload)
+	})
+
+	t.Run("Mismatch/HS256 signed verified as HS384", func(t *testing.T) {
+		// HS256 and HS384 both accept symmetric []byte keys, so
+		// validateAlgorithmForKey passes and the new header cross-check
+		// is the discipline that catches the divergence.
+		signed, err := jws.Sign([]byte("payload"), jws.WithKey(jwa.HS256(), hmacKey))
+		require.NoError(t, err)
+
+		_, err = jws.VerifyCompactFast(hmacKey, signed, jwa.HS384())
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jws.VerifyError()), `error should be VerifyError`)
+		require.True(t, errors.Is(err, jws.VerificationError()), `error should be VerificationError`)
+		require.Contains(t, err.Error(), `"alg"`)
+		require.Contains(t, err.Error(), "HS256")
+		require.Contains(t, err.Error(), "HS384")
+	})
+
+	t.Run("Missing alg in header", func(t *testing.T) {
+		// Hand-assemble a compact JWS whose protected header omits "alg".
+		hdr := base64.EncodeToString([]byte(`{"typ":"JWT"}`))
+		payload := base64.EncodeToString([]byte("payload"))
+		sig := base64.EncodeToString([]byte("not-a-real-signature"))
+		compact := []byte(hdr + "." + payload + "." + sig)
+
+		_, err := jws.VerifyCompactFast(hmacKey, compact, jwa.HS256())
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jws.VerifyError()), `error should be VerifyError`)
+		require.True(t, errors.Is(err, jws.VerificationError()), `error should be VerificationError`)
+		require.Contains(t, err.Error(), `"alg"`)
+	})
+}


### PR DESCRIPTION
`VerifyCompactFast` previously ignored the protected header `alg` and verified purely against the caller-supplied algorithm. A message advertising one alg could be accepted or rejected under a verifier for a different alg, silently diverging from the discipline the message itself declared — a footgun for JWT consumers that trust the header alg downstream.

Cross-check the header `alg` against the caller's alg after the crit probe, reusing the single parsed `Header`. Missing or mismatched `alg` returns a verification error wrapped as both `VerifyError` and `VerificationError`, so existing `errors.Is` checks keep working.

v3 backport of #1892.