### PR TITLE
fix rsa jwk validation

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -29,6 +29,7 @@ Algorithm identifiers per RFC 7518. Registry pattern with thread-safe lookup.
 
 JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 
+- **Settings(options ...GlobalOption)** — configure global jwk behavior (`WithStrictKeyUsage`, RSA validation floors)
 - **Parse(src []byte, ...ParseOption) (Set, error)** / **ParseKey(data []byte, ...ParseOption) (Key, error)** — parse JWK/JWKS
 - **Fetch(ctx, url, ...FetchOption) (Set, error)** — HTTP fetch with optional whitelist, body size limit (default 10 MB via `WithMaxFetchBodySize`)
 - **DefaultHTTPClient() \*http.Client** — returns a new http.Client with library defaults (30s timeout, redirect policy)
@@ -36,6 +37,7 @@ JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 - **PublicKeyOf(v any) (Key, error)** / **PublicSetOf(v Set, ...PublicSetOption) (Set, error)** — extract public keys. `PublicSetOf` rejects sets containing symmetric (oct) keys by default; pass `WithAllowSymmetric(true)` for legacy pass-through.
 - **AssignKeyID(key Key, ...AssignKeyIDOption) error** — compute and set kid via thumbprint
 - **Pem(v any) ([]byte, error)** — PEM encode
+- Global options: `WithStrictKeyUsage(bool)`, `WithMinRSAModulusBits(int)`, `WithMinRSAPublicExponent(int)`
 - JWKS caching moved to `github.com/jwx-go/jwkcache` — see [Extension Modules](../../docs/10-extensions.md)
 - Key interfaces: `Key`, `Set`, `RSAPublicKey`, `RSAPrivateKey`, `ECDSAPublicKey`, `ECDSAPrivateKey`, `OKPPublicKey`, `OKPPrivateKey`, `SymmetricKey`, `AKPPublicKey`, `AKPPrivateKey` (post-quantum, used by mldsa/mlkem extensions)
 - Extension: `RegisterCustomField[T]()`, `RegisterCustomDecoder[T]()`, `RegisterKeyParser()`, `RegisterKeyImporter()`, `RegisterKeyExporter()`

--- a/Changes-v4.md
+++ b/Changes-v4.md
@@ -102,6 +102,11 @@ For a step-by-step migration guide with before/after code examples, see [MIGRATI
   jwk.RegisterProbeField[string]("MyHint", "my_hint")
   ```
 
+* RSA JWK validation is now enforced consistently across JSON parse, JWKS parse,
+  PEM/X.509 parse, and `jwk.Import()`. Keys with moduli smaller than 2048 bits
+  or unsafe public exponents are now rejected by default. Compatibility knobs are available via
+  `jwk.Settings(jwk.WithMinRSAModulusBits(...), jwk.WithMinRSAPublicExponent(...))`.
+
 * The `AKP` key type (Algorithm Key Pair, RFC 9802) has been added, exposed as
   `jwa.AKP()` with `jwk.AKPPublicKey` / `jwk.AKPPrivateKey`. This is a generic
   key type for post-quantum algorithms and is used by both ML-DSA (signature)

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -78,54 +78,94 @@ func Import[T Key](raw any) (T, error) {
 	return result, nil
 }
 
+func validateImportedKey(key Key) error {
+	if v, ok := key.(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return importerr(`key validation failed: %w`, err)
+		}
+	}
+	return nil
+}
+
 func doImport(raw any) (Key, error) {
 	if raw == nil {
 		return nil, importerr(`a non-nil key is required`)
 	}
 
+	var (
+		key     Key
+		err     error
+		handled bool
+	)
+
 	// Fast path: type switch for built-in types avoids reflect.TypeOf + mutex
 	switch v := raw.(type) {
 	case *rsa.PrivateKey:
-		return importRSAPrivateKeyPtr(v)
+		handled = true
+		key, err = importRSAPrivateKeyPtr(v)
 	case *rsa.PublicKey:
-		return importRSAPublicKeyPtr(v)
+		handled = true
+		key, err = importRSAPublicKeyPtr(v)
 	case rsa.PrivateKey:
-		return importRSAPrivateKey(v)
+		handled = true
+		key, err = importRSAPrivateKey(v)
 	case rsa.PublicKey:
-		return importRSAPublicKey(v)
+		handled = true
+		key, err = importRSAPublicKey(v)
 	case *ecdsa.PrivateKey:
-		return importECDSAPrivateKeyPtr(v)
+		handled = true
+		key, err = importECDSAPrivateKeyPtr(v)
 	case *ecdsa.PublicKey:
-		return importECDSAPublicKeyPtr(v)
+		handled = true
+		key, err = importECDSAPublicKeyPtr(v)
 	case ecdsa.PrivateKey:
-		return importECDSAPrivateKey(v)
+		handled = true
+		key, err = importECDSAPrivateKey(v)
 	case ecdsa.PublicKey:
-		return importECDSAPublicKey(v)
+		handled = true
+		key, err = importECDSAPublicKey(v)
 	case ed25519.PrivateKey:
-		return importEd25519PrivateKey(v)
+		handled = true
+		key, err = importEd25519PrivateKey(v)
 	case ed25519.PublicKey:
-		return importEd25519PublicKey(v)
+		handled = true
+		key, err = importEd25519PublicKey(v)
 	case *ecdh.PrivateKey:
-		return importECDHPrivateKeyPtr(v)
+		handled = true
+		key, err = importECDHPrivateKeyPtr(v)
 	case *ecdh.PublicKey:
-		return importECDHPublicKeyPtr(v)
+		handled = true
+		key, err = importECDHPublicKeyPtr(v)
 	case ecdh.PrivateKey:
-		return importECDHPrivateKey(v)
+		handled = true
+		key, err = importECDHPrivateKey(v)
 	case ecdh.PublicKey:
-		return importECDHPublicKey(v)
+		handled = true
+		key, err = importECDHPublicKey(v)
 	case []byte:
-		return importSymmetricKey(v)
+		handled = true
+		key, err = importSymmetricKey(v)
 	}
 
-	// Slow path: registered importers for custom/extension types
-	muKeyImporters.RLock()
-	conv, ok := keyImporters[reflect.TypeOf(raw)]
-	muKeyImporters.RUnlock()
-	if !ok {
-		return nil, importerr(`failed to convert %T to jwk.Key: no converters were able to convert`, raw)
+	if !handled {
+		// Slow path: registered importers for custom/extension types
+		muKeyImporters.RLock()
+		conv, ok := keyImporters[reflect.TypeOf(raw)]
+		muKeyImporters.RUnlock()
+		if !ok {
+			return nil, importerr(`failed to convert %T to jwk.Key: no converters were able to convert`, raw)
+		}
+
+		key, err = conv.Import(raw)
 	}
 
-	return conv.Import(raw)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateImportedKey(key); err != nil {
+		return nil, err
+	}
+	return key, nil
 }
 
 // PublicSetOf returns a new jwk.Set consisting of

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -87,78 +87,7 @@ func validateImportedKey(key Key) error {
 	return nil
 }
 
-func doImport(raw any) (Key, error) {
-	if raw == nil {
-		return nil, importerr(`a non-nil key is required`)
-	}
-
-	var (
-		key     Key
-		err     error
-		handled bool
-	)
-
-	// Fast path: type switch for built-in types avoids reflect.TypeOf + mutex
-	switch v := raw.(type) {
-	case *rsa.PrivateKey:
-		handled = true
-		key, err = importRSAPrivateKeyPtr(v)
-	case *rsa.PublicKey:
-		handled = true
-		key, err = importRSAPublicKeyPtr(v)
-	case rsa.PrivateKey:
-		handled = true
-		key, err = importRSAPrivateKey(v)
-	case rsa.PublicKey:
-		handled = true
-		key, err = importRSAPublicKey(v)
-	case *ecdsa.PrivateKey:
-		handled = true
-		key, err = importECDSAPrivateKeyPtr(v)
-	case *ecdsa.PublicKey:
-		handled = true
-		key, err = importECDSAPublicKeyPtr(v)
-	case ecdsa.PrivateKey:
-		handled = true
-		key, err = importECDSAPrivateKey(v)
-	case ecdsa.PublicKey:
-		handled = true
-		key, err = importECDSAPublicKey(v)
-	case ed25519.PrivateKey:
-		handled = true
-		key, err = importEd25519PrivateKey(v)
-	case ed25519.PublicKey:
-		handled = true
-		key, err = importEd25519PublicKey(v)
-	case *ecdh.PrivateKey:
-		handled = true
-		key, err = importECDHPrivateKeyPtr(v)
-	case *ecdh.PublicKey:
-		handled = true
-		key, err = importECDHPublicKeyPtr(v)
-	case ecdh.PrivateKey:
-		handled = true
-		key, err = importECDHPrivateKey(v)
-	case ecdh.PublicKey:
-		handled = true
-		key, err = importECDHPublicKey(v)
-	case []byte:
-		handled = true
-		key, err = importSymmetricKey(v)
-	}
-
-	if !handled {
-		// Slow path: registered importers for custom/extension types
-		muKeyImporters.RLock()
-		conv, ok := keyImporters[reflect.TypeOf(raw)]
-		muKeyImporters.RUnlock()
-		if !ok {
-			return nil, importerr(`failed to convert %T to jwk.Key: no converters were able to convert`, raw)
-		}
-
-		key, err = conv.Import(raw)
-	}
-
+func validateImportedKeyResult(key Key, err error) (Key, error) {
 	if err != nil {
 		return nil, err
 	}
@@ -166,6 +95,68 @@ func doImport(raw any) (Key, error) {
 		return nil, err
 	}
 	return key, nil
+}
+
+var errNotBuiltinKey = errors.New(`not a builtin key`)
+
+func importBuiltinKey(raw any) (Key, error) {
+	switch v := raw.(type) {
+	case *rsa.PrivateKey:
+		return importRSAPrivateKeyPtr(v)
+	case *rsa.PublicKey:
+		return importRSAPublicKeyPtr(v)
+	case rsa.PrivateKey:
+		return importRSAPrivateKey(v)
+	case rsa.PublicKey:
+		return importRSAPublicKey(v)
+	case *ecdsa.PrivateKey:
+		return importECDSAPrivateKeyPtr(v)
+	case *ecdsa.PublicKey:
+		return importECDSAPublicKeyPtr(v)
+	case ecdsa.PrivateKey:
+		return importECDSAPrivateKey(v)
+	case ecdsa.PublicKey:
+		return importECDSAPublicKey(v)
+	case ed25519.PrivateKey:
+		return importEd25519PrivateKey(v)
+	case ed25519.PublicKey:
+		return importEd25519PublicKey(v)
+	case *ecdh.PrivateKey:
+		return importECDHPrivateKeyPtr(v)
+	case *ecdh.PublicKey:
+		return importECDHPublicKeyPtr(v)
+	case ecdh.PrivateKey:
+		return importECDHPrivateKey(v)
+	case ecdh.PublicKey:
+		return importECDHPublicKey(v)
+	case []byte:
+		return importSymmetricKey(v)
+	default:
+		return nil, errNotBuiltinKey
+	}
+}
+
+func doImport(raw any) (Key, error) {
+	if raw == nil {
+		return nil, importerr(`a non-nil key is required`)
+	}
+
+	key, err := importBuiltinKey(raw)
+	if err == nil {
+		return validateImportedKeyResult(key, nil)
+	}
+	if !errors.Is(err, errNotBuiltinKey) {
+		return nil, err
+	}
+
+	muKeyImporters.RLock()
+	conv, ok := keyImporters[reflect.TypeOf(raw)]
+	muKeyImporters.RUnlock()
+	if !ok {
+		return nil, importerr(`failed to convert %T to jwk.Key: no converters were able to convert`, raw)
+	}
+
+	return validateImportedKeyResult(conv.Import(raw))
 }
 
 // PublicSetOf returns a new jwk.Set consisting of

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -762,10 +762,14 @@ func IsKeyValidationError(err error) bool {
 	return errors.Is(err, &kve)
 }
 
-// Configure is used to configure global behavior of the jwk package.
-func Configure(options ...GlobalOption) {
+// Settings is used to configure global behavior of the jwk package.
+func Settings(options ...GlobalOption) {
 	for _, opt := range options {
 		switch opt.Ident() {
+		case identMinRSAModulusBits{}:
+			rsaMinModulusBits.Store(int64(option.MustGet[int](opt)))
+		case identMinRSAPublicExponent{}:
+			rsaMinPublicExponent.Store(int64(option.MustGet[int](opt)))
 		case identStrictKeyUsage{}:
 			strictKeyUsage.Store(option.MustGet[bool](opt))
 		}

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -87,16 +87,6 @@ func validateImportedKey(key Key) error {
 	return nil
 }
 
-func validateImportedKeyResult(key Key, err error) (Key, error) {
-	if err != nil {
-		return nil, err
-	}
-	if err := validateImportedKey(key); err != nil {
-		return nil, err
-	}
-	return key, nil
-}
-
 var errNotBuiltinKey = errors.New(`not a builtin key`)
 
 func importBuiltinKey(raw any) (Key, error) {
@@ -143,7 +133,10 @@ func doImport(raw any) (Key, error) {
 
 	key, err := importBuiltinKey(raw)
 	if err == nil {
-		return validateImportedKeyResult(key, nil)
+		if err := validateImportedKey(key); err != nil {
+			return nil, err
+		}
+		return key, nil
 	}
 	if !errors.Is(err, errNotBuiltinKey) {
 		return nil, err
@@ -156,7 +149,14 @@ func doImport(raw any) (Key, error) {
 		return nil, importerr(`failed to convert %T to jwk.Key: no converters were able to convert`, raw)
 	}
 
-	return validateImportedKeyResult(conv.Import(raw))
+	key, err = conv.Import(raw)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateImportedKey(key); err != nil {
+		return nil, err
+	}
+	return key, nil
 }
 
 // PublicSetOf returns a new jwk.Set consisting of

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -760,7 +760,7 @@ func Settings(options ...GlobalOption) {
 		case identMinRSAModulusBits{}:
 			rsaMinModulusBits.Store(int64(option.MustGet[int](opt)))
 		case identMinRSAPublicExponent{}:
-			rsaMinPublicExponent.Store(int64(option.MustGet[int](opt)))
+			setMinRSAPublicExponent(option.MustGet[int](opt))
 		case identStrictKeyUsage{}:
 			strictKeyUsage.Store(option.MustGet[bool](opt))
 		}

--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -7,7 +7,7 @@ interfaces:
       ParseOption is a type of Option that can be passed to `jwk.Parse()`
   - name: GlobalOption
     comment: |
-      GlobalOption is a type of Option that can be passed to the `jwk.Configure()` to
+      GlobalOption is a type of Option that can be passed to `jwk.Settings()` to
       change the global configuration of the jwk package.
   - name: PublicSetOption
     comment: |
@@ -89,6 +89,25 @@ options:
       value. If this options is set to true, then the "use" field must
       be one of the registered values, and otherwise an error will be
       reported during parsing / assignment to `jwk.KeyUsageType`
+  - ident: MinRSAModulusBits
+    interface: GlobalOption
+    argument_type: int
+    comment: |
+      WithMinRSAModulusBits specifies the minimum RSA modulus size, in bits,
+      accepted by JWK validation and raw/PEM/X.509 import.
+
+      The default is 2048. Lower this only for legacy interoperability with
+      older key material. A value of 0 disables the modulus-size floor.
+  - ident: MinRSAPublicExponent
+    interface: GlobalOption
+    argument_type: int
+    comment: |
+      WithMinRSAPublicExponent specifies the minimum RSA public exponent
+      accepted by JWK validation and raw/PEM/X.509 import.
+
+      The default is 3. The exponent must still be odd and fit in a Go `int`.
+      Lower this only for legacy interoperability. A value of 0 disables the
+      minimum-exponent floor.
   - ident: AllowSymmetric
     interface: PublicSetOption
     argument_type: bool

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -22,7 +22,7 @@ type assignKeyIDOption struct {
 
 func (*assignKeyIDOption) assignKeyIDOption() {}
 
-// GlobalOption is a type of Option that can be passed to the `jwk.Configure()` to
+// GlobalOption is a type of Option that can be passed to `jwk.Settings()` to
 // change the global configuration of the jwk package.
 type GlobalOption interface {
 	Option
@@ -63,6 +63,8 @@ type identAllowSymmetric struct{}
 type identForceAssign struct{}
 type identIgnoreParseError struct{}
 type identLocalRegistry struct{}
+type identMinRSAModulusBits struct{}
+type identMinRSAPublicExponent struct{}
 type identPEM struct{}
 type identPEMDecoder struct{}
 type identStrictKeyUsage struct{}
@@ -83,6 +85,14 @@ func (identIgnoreParseError) String() string {
 
 func (identLocalRegistry) String() string {
 	return "withLocalRegistry"
+}
+
+func (identMinRSAModulusBits) String() string {
+	return "WithMinRSAModulusBits"
+}
+
+func (identMinRSAPublicExponent) String() string {
+	return "WithMinRSAPublicExponent"
 }
 
 func (identPEM) String() string {
@@ -157,6 +167,25 @@ func WithIgnoreParseError(v bool) ParseOption {
 // This option is only available for internal code. Users don't get to play with it
 func withLocalRegistry(v *json.Registry) ParseOption {
 	return &parseOption{option.New(identLocalRegistry{}, v)}
+}
+
+// WithMinRSAModulusBits specifies the minimum RSA modulus size, in bits,
+// accepted by JWK validation and raw/PEM/X.509 import.
+//
+// The default is 2048. Lower this only for legacy interoperability with
+// older key material. A value of 0 disables the modulus-size floor.
+func WithMinRSAModulusBits(v int) GlobalOption {
+	return &globalOption{option.New(identMinRSAModulusBits{}, v)}
+}
+
+// WithMinRSAPublicExponent specifies the minimum RSA public exponent
+// accepted by JWK validation and raw/PEM/X.509 import.
+//
+// The default is 3. The exponent must still be odd and fit in a Go `int`.
+// Lower this only for legacy interoperability. A value of 0 disables the
+// minimum-exponent floor.
+func WithMinRSAPublicExponent(v int) GlobalOption {
+	return &globalOption{option.New(identMinRSAPublicExponent{}, v)}
 }
 
 // WithPEM specifies that the input to `Parse()` is a PEM encoded key.

--- a/jwk/options_gen_test.go
+++ b/jwk/options_gen_test.go
@@ -13,6 +13,8 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithForceAssign", identForceAssign{}.String())
 	require.Equal(t, "WithIgnoreParseError", identIgnoreParseError{}.String())
 	require.Equal(t, "withLocalRegistry", identLocalRegistry{}.String())
+	require.Equal(t, "WithMinRSAModulusBits", identMinRSAModulusBits{}.String())
+	require.Equal(t, "WithMinRSAPublicExponent", identMinRSAPublicExponent{}.String())
 	require.Equal(t, "WithPEM", identPEM{}.String())
 	require.Equal(t, "WithPEMDecoder", identPEMDecoder{}.String())
 	require.Equal(t, "WithStrictKeyUsage", identStrictKeyUsage{}.String())

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -18,6 +18,8 @@ func init() {
 	panicOnRegistrationError(RegisterKeyExporter(KeyKind(jwa.RSA().String()), KeyExportFunc(rsaJWKToRaw)))
 }
 
+const minRSAModulusBits = 2048
+
 func (k *rsaPrivateKey) Import(rawKey *rsa.PrivateKey) error {
 	k.mu.Lock()
 	defer k.mu.Unlock()
@@ -103,16 +105,44 @@ func (k *rsaPublicKey) Import(rawKey *rsa.PublicKey) error {
 	return nil
 }
 
-func buildRSAPublicKey(key *rsa.PublicKey, n, e []byte) error {
+func validateRSAModulusAndExponent(n, e []byte) (*big.Int, error) {
+	n = trimLeadingZeroBytes(n)
+	if len(n) == 0 {
+		return nil, fmt.Errorf(`missing "n" value`)
+	}
+
+	bigN := new(big.Int).SetBytes(n)
+	if bigN.BitLen() < minRSAModulusBits {
+		return nil, fmt.Errorf(`rsa modulus too small: got %d bits, need at least %d`, bigN.BitLen(), minRSAModulusBits)
+	}
+
+	e = trimLeadingZeroBytes(e)
+	if len(e) == 0 {
+		return nil, fmt.Errorf(`missing "e" value`)
+	}
+
 	bigE := new(big.Int).SetBytes(e)
+	if bigE.Cmp(big.NewInt(3)) < 0 || bigE.Bit(0) == 0 {
+		return nil, fmt.Errorf(`invalid rsa public exponent: must be an odd integer >= 3`)
+	}
+
 	// rsa.PublicKey.E is a Go int. Reject exponents that do not fit on the
 	// current platform (e.g. GOARCH=386). Without this guard, Int64()/int()
 	// silently truncates, causing the materialized key to disagree with the
 	// JSON bytes and breaking RFC 7638 thumbprint uniqueness.
 	if bigE.BitLen() >= bits.UintSize {
-		return fmt.Errorf(`rsa public exponent too large for this platform: %d bits (max %d)`, bigE.BitLen(), bits.UintSize-1)
+		return nil, fmt.Errorf(`rsa public exponent too large for this platform: %d bits (max %d)`, bigE.BitLen(), bits.UintSize-1)
 	}
-	key.N = new(big.Int).SetBytes(n)
+
+	return bigE, nil
+}
+
+func buildRSAPublicKey(key *rsa.PublicKey, n, e []byte) error {
+	bigE, err := validateRSAModulusAndExponent(n, e)
+	if err != nil {
+		return err
+	}
+	key.N = new(big.Int).SetBytes(trimLeadingZeroBytes(n))
 	key.E = int(bigE.Int64())
 	return nil
 }
@@ -367,15 +397,8 @@ func validateRSAKey(key interface {
 	if !ok {
 		return fmt.Errorf(`missing "e" value`)
 	}
-
-	if len(n) == 0 {
-		// Ideally we would like to check for the actual length, but unlike
-		// EC keys, we have nothing in the key itself that will tell us
-		// how many bits this key should have.
-		return fmt.Errorf(`missing "n" value`)
-	}
-	if len(e) == 0 {
-		return fmt.Errorf(`missing "e" value`)
+	if _, err := validateRSAModulusAndExponent(n, e); err != nil {
+		return err
 	}
 	if checkPrivate {
 		if priv, ok := key.(keyWithD); ok {

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"math/bits"
 	"reflect"
+	"sync/atomic"
 
 	"github.com/lestrrat-go/jwx/v4/internal/base64"
 	"github.com/lestrrat-go/jwx/v4/internal/pool"
@@ -19,6 +20,15 @@ func init() {
 }
 
 const minRSAModulusBits = 2048
+const minRSAPublicExponent = 3
+
+var rsaMinModulusBits = atomic.Int64{}
+var rsaMinPublicExponent = atomic.Int64{}
+
+func init() {
+	rsaMinModulusBits.Store(minRSAModulusBits)
+	rsaMinPublicExponent.Store(minRSAPublicExponent)
+}
 
 func (k *rsaPrivateKey) Import(rawKey *rsa.PrivateKey) error {
 	k.mu.Lock()
@@ -112,8 +122,9 @@ func validateRSAModulusAndExponent(n, e []byte) (*big.Int, error) {
 	}
 
 	bigN := new(big.Int).SetBytes(n)
-	if bigN.BitLen() < minRSAModulusBits {
-		return nil, fmt.Errorf(`rsa modulus too small: got %d bits, need at least %d`, bigN.BitLen(), minRSAModulusBits)
+	minBits := int(rsaMinModulusBits.Load())
+	if minBits > 0 && bigN.BitLen() < minBits {
+		return nil, fmt.Errorf(`rsa modulus too small: got %d bits, need at least %d`, bigN.BitLen(), minBits)
 	}
 
 	e = trimLeadingZeroBytes(e)
@@ -122,8 +133,12 @@ func validateRSAModulusAndExponent(n, e []byte) (*big.Int, error) {
 	}
 
 	bigE := new(big.Int).SetBytes(e)
-	if bigE.Cmp(big.NewInt(3)) < 0 || bigE.Bit(0) == 0 {
-		return nil, fmt.Errorf(`invalid rsa public exponent: must be an odd integer >= 3`)
+	minExponent := rsaMinPublicExponent.Load()
+	if bigE.Sign() <= 0 || bigE.Bit(0) == 0 {
+		return nil, fmt.Errorf(`invalid rsa public exponent: must be a positive odd integer`)
+	}
+	if minExponent > 0 && bigE.Cmp(big.NewInt(minExponent)) < 0 {
+		return nil, fmt.Errorf(`invalid rsa public exponent: got %s, need at least %d`, bigE.String(), minExponent)
 	}
 
 	// rsa.PublicKey.E is a Go int. Reject exponents that do not fit on the

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -23,11 +23,20 @@ const minRSAModulusBits = 2048
 const minRSAPublicExponent = 3
 
 var rsaMinModulusBits = atomic.Int64{}
-var rsaMinPublicExponent = atomic.Int64{}
+var rsaMinPublicExponent atomic.Pointer[big.Int]
 
 func init() {
 	rsaMinModulusBits.Store(minRSAModulusBits)
-	rsaMinPublicExponent.Store(minRSAPublicExponent)
+	setMinRSAPublicExponent(minRSAPublicExponent)
+}
+
+func setMinRSAPublicExponent(v int) {
+	if v <= 0 {
+		rsaMinPublicExponent.Store(nil)
+		return
+	}
+
+	rsaMinPublicExponent.Store(big.NewInt(int64(v)))
 }
 
 func (k *rsaPrivateKey) Import(rawKey *rsa.PrivateKey) error {
@@ -137,8 +146,8 @@ func validateRSAModulusAndExponent(n, e []byte) (*big.Int, error) {
 	if bigE.Sign() <= 0 || bigE.Bit(0) == 0 {
 		return nil, fmt.Errorf(`invalid rsa public exponent: must be a positive odd integer`)
 	}
-	if minExponent > 0 && bigE.Cmp(big.NewInt(minExponent)) < 0 {
-		return nil, fmt.Errorf(`invalid rsa public exponent: got %s, need at least %d`, bigE.String(), minExponent)
+	if minExponent != nil && bigE.Cmp(minExponent) < 0 {
+		return nil, fmt.Errorf(`invalid rsa public exponent: got %s, need at least %s`, bigE.String(), minExponent.String())
 	}
 
 	// rsa.PublicKey.E is a Go int. Reject exponents that do not fit on the

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -98,6 +98,9 @@ func importRsaPublicKeyByteValues(rawKey *rsa.PublicKey) ([]byte, []byte, error)
 	if err != nil {
 		return nil, nil, fmt.Errorf(`invalid rsa.PublicKey: %w`, err)
 	}
+	if rawKey.E <= 0 {
+		return nil, nil, fmt.Errorf(`invalid rsa.PublicKey: invalid rsa public exponent: must be a positive odd integer`)
+	}
 
 	data := make([]byte, 8)
 	binary.BigEndian.PutUint64(data, uint64(rawKey.E))

--- a/jwk/rsa_thumbprint_test.go
+++ b/jwk/rsa_thumbprint_test.go
@@ -2,7 +2,6 @@ package jwk_test
 
 import (
 	"crypto"
-	"crypto/rsa"
 	"encoding/hex"
 	"encoding/json"
 	"math/bits"
@@ -12,10 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const rfc7638RSAModulus = "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+
 // RFC 7638 Section 3.1 canonical example.
 const rfc7638RSAJWK = `{
   "kty": "RSA",
-  "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+  "n": "` + rfc7638RSAModulus + `",
   "e": "AQAB"
 }`
 
@@ -38,18 +39,15 @@ func TestRSA_Thumbprint_RFC7638Vector(t *testing.T) {
 
 // TestRSA_ExponentTruncation_Rejected verifies that an RSA public exponent
 // whose bit length does not fit in a Go `int` on this platform is rejected
-// at export time, rather than being silently truncated.
+// at parse time, rather than being silently truncated later at export time.
 //
 // Regression for JWK-20260415151950-008.
 func TestRSA_ExponentTruncation_Rejected(t *testing.T) {
 	// e = 0x01_00_00_00_00_00_00_01 (65 bits) — fits neither 32-bit nor 64-bit int.
-	payload := `{"kty":"RSA","n":"AQAB","e":"AQAAAAAAAAAB"}`
+	payload := rsaPublicJWK(rfc7638RSAModulus, "AQAAAAAAAAAB")
 
-	k, err := jwk.ParseKey[jwk.Key]([]byte(payload))
-	require.NoError(t, err, "parse should accept the raw bytes")
-
-	_, err = jwk.Export[*rsa.PublicKey](k)
-	require.Error(t, err, "export must reject oversized exponent")
+	_, err := jwk.ParseKey[jwk.Key](payload)
+	require.Error(t, err, "parse must reject oversized exponent")
 	require.Contains(t, err.Error(), "rsa public exponent too large")
 }
 
@@ -63,14 +61,14 @@ func TestRSA_ExponentTruncation_Rejected(t *testing.T) {
 // Regression for JWK-20260415151950-008.
 func TestRSA_Thumbprint_UsesStoredBytes(t *testing.T) {
 	// Standard F4 = 0x10001
-	jwkF4 := `{"kty":"RSA","n":"AQAB","e":"AQAB"}`
+	jwkF4 := rsaPublicJWK(rfc7638RSAModulus, "AQAB")
 	// Same exponent with an added leading zero byte: e = 0x00_01_00_01
-	jwkF4PaddedE := `{"kty":"RSA","n":"AQAB","e":"AAEAAQ"}`
+	jwkF4PaddedE := rsaPublicJWK(rfc7638RSAModulus, "AAEAAQ")
 	// Different exponent entirely: e = 3
-	jwkE3 := `{"kty":"RSA","n":"AQAB","e":"Aw"}`
+	jwkE3 := rsaPublicJWK(rfc7638RSAModulus, "Aw")
 
-	thumb := func(payload string) []byte {
-		k, err := jwk.ParseKey[jwk.Key]([]byte(payload))
+	thumb := func(payload []byte) []byte {
+		k, err := jwk.ParseKey[jwk.Key](payload)
 		require.NoError(t, err)
 		tp, err := k.Thumbprint(crypto.SHA256)
 		require.NoError(t, err)

--- a/jwk/rsa_validate_test.go
+++ b/jwk/rsa_validate_test.go
@@ -1,0 +1,96 @@
+package jwk_test
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/internal/base64"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+func rsaPublicJWK(n, e string) []byte {
+	return []byte(`{"kty":"RSA","n":"` + n + `","e":"` + e + `"}`)
+}
+
+func mustBigIntFromBase64(t *testing.T, src string) *big.Int {
+	t.Helper()
+
+	body, err := base64.DecodeString(src)
+	require.NoError(t, err)
+	return new(big.Int).SetBytes(body)
+}
+
+func mustRSAPublicPEM(t *testing.T, key *rsa.PublicKey) []byte {
+	t.Helper()
+
+	der, err := x509.MarshalPKIXPublicKey(key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: der,
+	})
+}
+
+func TestRSAInvalidParametersRejectedOnParse(t *testing.T) {
+	t.Run("small modulus", func(t *testing.T) {
+		payload := rsaPublicJWK("AQAB", "AQAB")
+
+		_, err := jwk.ParseKey[jwk.Key](payload)
+		require.Error(t, err)
+		require.True(t, jwk.IsKeyValidationError(err))
+		require.Contains(t, err.Error(), "rsa modulus too small")
+
+		_, err = jwk.Parse([]byte(`{"keys":[` + string(payload) + `]}`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "rsa modulus too small")
+	})
+
+	t.Run("unsafe exponent", func(t *testing.T) {
+		payload := rsaPublicJWK(rfc7638RSAModulus, "AQ")
+
+		_, err := jwk.ParseKey[jwk.Key](payload)
+		require.Error(t, err)
+		require.True(t, jwk.IsKeyValidationError(err))
+		require.Contains(t, err.Error(), "invalid rsa public exponent")
+	})
+}
+
+func TestRSAImportRejectsInvalidParameters(t *testing.T) {
+	t.Run("small modulus", func(t *testing.T) {
+		bad := &rsa.PublicKey{
+			N: mustBigIntFromBase64(t, "AQAB"),
+			E: 65537,
+		}
+
+		_, err := jwk.Import[jwk.Key](bad)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "rsa modulus too small")
+	})
+
+	t.Run("unsafe exponent", func(t *testing.T) {
+		bad := &rsa.PublicKey{
+			N: mustBigIntFromBase64(t, rfc7638RSAModulus),
+			E: 1,
+		}
+
+		_, err := jwk.Import[jwk.Key](bad)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid rsa public exponent")
+	})
+}
+
+func TestRSAPEMImportRunsValidation(t *testing.T) {
+	bad := &rsa.PublicKey{
+		N: mustBigIntFromBase64(t, "AQAB"),
+		E: 65537,
+	}
+
+	_, err := jwk.ParseKey[jwk.Key](mustRSAPublicPEM(t, bad), jwk.WithPEM(true))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "rsa modulus too small")
+}

--- a/jwk/rsa_validate_test.go
+++ b/jwk/rsa_validate_test.go
@@ -1,6 +1,7 @@
 package jwk_test
 
 import (
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
@@ -36,6 +37,15 @@ func mustRSAPublicPEM(t *testing.T, key *rsa.PublicKey) []byte {
 	})
 }
 
+func rsaPublicJWKFromRaw(t *testing.T, key *rsa.PublicKey) []byte {
+	t.Helper()
+
+	return rsaPublicJWK(
+		base64.EncodeToString(key.N.Bytes()),
+		base64.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+	)
+}
+
 func TestRSAInvalidParametersRejectedOnParse(t *testing.T) {
 	t.Run("small modulus", func(t *testing.T) {
 		payload := rsaPublicJWK("AQAB", "AQAB")
@@ -57,6 +67,35 @@ func TestRSAInvalidParametersRejectedOnParse(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, jwk.IsKeyValidationError(err))
 		require.Contains(t, err.Error(), "invalid rsa public exponent")
+	})
+}
+
+func TestRSAConfigureCompatibilityKnobs(t *testing.T) {
+	t.Run("allow legacy 1024-bit modulus", func(t *testing.T) {
+		jwk.Settings(jwk.WithMinRSAModulusBits(1024))
+		t.Cleanup(func() {
+			jwk.Settings(jwk.WithMinRSAModulusBits(2048))
+		})
+
+		raw, err := rsa.GenerateKey(rand.Reader, 1024)
+		require.NoError(t, err)
+
+		payload := rsaPublicJWKFromRaw(t, &raw.PublicKey)
+
+		_, err = jwk.ParseKey[jwk.Key](payload)
+		require.NoError(t, err)
+	})
+
+	t.Run("allow exponent 1 explicitly", func(t *testing.T) {
+		jwk.Settings(jwk.WithMinRSAPublicExponent(1))
+		t.Cleanup(func() {
+			jwk.Settings(jwk.WithMinRSAPublicExponent(3))
+		})
+
+		payload := rsaPublicJWK(rfc7638RSAModulus, "AQ")
+
+		_, err := jwk.ParseKey[jwk.Key](payload)
+		require.NoError(t, err)
 	})
 }
 

--- a/jwk/rsa_validate_test.go
+++ b/jwk/rsa_validate_test.go
@@ -121,6 +121,17 @@ func TestRSAImportRejectsInvalidParameters(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid rsa public exponent")
 	})
+
+	t.Run("negative exponent", func(t *testing.T) {
+		bad := &rsa.PublicKey{
+			N: mustBigIntFromBase64(t, rfc7638RSAModulus),
+			E: -3,
+		}
+
+		_, err := jwk.Import[jwk.Key](bad)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid rsa public exponent")
+	})
 }
 
 func TestRSAPEMImportRunsValidation(t *testing.T) {


### PR DESCRIPTION
- reject RSA JWKs with small moduli or unsafe exponents
- validate imported RSA keys so PEM and raw-key paths use the same checks
- add regressions for Parse, ParseKey, Import, and PEM inputs
