### PR TITLE
fix v3 rsa jwk validation

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -28,6 +28,7 @@ Algorithm identifiers per RFC 7518. Registry pattern with thread-safe lookup.
 
 JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 
+- **Configure(options ...GlobalOption)** — configure global jwk behavior (`WithStrictKeyUsage`, fetch defaults, RSA validation floors)
 - **Parse(src []byte, ...ParseOption) (Set, error)** / **ParseKey(data []byte, ...ParseOption) (Key, error)** — parse JWK/JWKS
 - **Fetch(ctx, url, ...FetchOption) (Set, error)** — HTTP fetch with optional whitelist, body size limit (default 10 MB via `WithMaxFetchBodySize`)
 - **DefaultHTTPClient() \*http.Client** — returns a new http.Client with library defaults (30s timeout, redirect policy)
@@ -36,6 +37,7 @@ JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 - **NewCache(ctx, client) (*Cache, error)** — auto-refreshing JWKS cache
 - **AssignKeyID(key Key, ...AssignKeyIDOption) error** — compute and set kid via thumbprint
 - **Pem(v any) ([]byte, error)** — PEM encode
+- Global options: `WithStrictKeyUsage(bool)`, `WithHTTPClient(HTTPClient)`, `WithMaxFetchBodySize(int64)`, `WithMinRSAModulusBits(int)`, `WithMinRSAPublicExponent(int)`
 - Key interfaces: `Key`, `Set`, `RSAPublicKey`, `RSAPrivateKey`, `ECDSAPublicKey`, `ECDSAPrivateKey`, `OKPPublicKey`, `OKPPrivateKey`, `SymmetricKey`
 - Extension: `RegisterCustomField()`, `RegisterKeyParser()`, `RegisterKeyImporter()`, `RegisterKeyExporter()`
 - Error sentinels: `ImportError()`, `ParseError()`, `WhitelistError()`, `ContinueError()`

--- a/Changes
+++ b/Changes
@@ -134,6 +134,12 @@ v3.1.0 UNRELEASED
   * [jwk] `jwk.Parse()` now limits PEM input to 1,000 blocks maximum to prevent
     resource exhaustion from inputs containing thousands of small PEM blocks. (#1626)
 
+  * [jwk] RSA JWK validation is now enforced consistently across JSON parse,
+    JWKS parse, PEM/X.509 parse, and `jwk.Import()`. Keys with moduli smaller
+    than 2048 bits or unsafe public exponents are now rejected by default.
+    Compatibility knobs were added to `jwk.Configure()` via
+    `jwk.WithMinRSAModulusBits(...)` and `jwk.WithMinRSAPublicExponent(...)`.
+
   * [jwt] `jwt.Validate()` now rejects negative durations passed to
     `jwt.WithAcceptableSkew()`. (#1627)
 

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -72,7 +72,16 @@ func Import(raw any) (Key, error) {
 		return nil, importerr(`failed to convert %T to jwk.Key: no converters were able to convert`, raw)
 	}
 
-	return conv.Import(raw)
+	key, err := conv.Import(raw)
+	if err != nil {
+		return nil, err
+	}
+	if v, ok := key.(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return nil, importerr(`key validation failed: %w`, err)
+		}
+	}
+	return key, nil
 }
 
 // PublicSetOf returns a new jwk.Set consisting of

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -753,7 +753,7 @@ func Configure(options ...GlobalOption) {
 	}
 
 	if minRSAPublicExponentPtr != nil {
-		rsaMinPublicExponent.Store(*minRSAPublicExponentPtr)
+		setMinRSAPublicExponent(int(*minRSAPublicExponentPtr))
 	}
 }
 

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -694,6 +694,8 @@ func Configure(options ...GlobalOption) {
 	var strictKeyUsagePtr *bool
 	var maxFetchBodySizePtr *int64
 	var httpClientPtr *HTTPClient
+	var minRSAModulusBitsPtr *int64
+	var minRSAPublicExponentPtr *int64
 	for _, option := range options {
 		switch option.Ident() {
 		case identStrictKeyUsage{}:
@@ -717,6 +719,20 @@ func Configure(options ...GlobalOption) {
 				continue
 			}
 			httpClientPtr = &v
+		case identMinRSAModulusBits{}:
+			var v int
+			if err := option.Value(&v); err != nil {
+				continue
+			}
+			v64 := int64(v)
+			minRSAModulusBitsPtr = &v64
+		case identMinRSAPublicExponent{}:
+			var v int
+			if err := option.Value(&v); err != nil {
+				continue
+			}
+			v64 := int64(v)
+			minRSAPublicExponentPtr = &v64
 		}
 	}
 
@@ -730,6 +746,14 @@ func Configure(options ...GlobalOption) {
 
 	if httpClientPtr != nil {
 		setFetchHTTPClient(*httpClientPtr)
+	}
+
+	if minRSAModulusBitsPtr != nil {
+		rsaMinModulusBits.Store(*minRSAModulusBitsPtr)
+	}
+
+	if minRSAPublicExponentPtr != nil {
+		rsaMinPublicExponent.Store(*minRSAPublicExponentPtr)
 	}
 }
 

--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -209,6 +209,25 @@ options:
       value. If this options is set to true, then the "use" field must
       be one of the registered values, and otherwise an error will be
       reported during parsing / assignment to `jwk.KeyUsageType`
+  - ident: MinRSAModulusBits
+    interface: GlobalOption
+    argument_type: int
+    comment: |
+      WithMinRSAModulusBits specifies the minimum RSA modulus size, in bits,
+      accepted by JWK validation and raw/PEM/X.509 import.
+
+      The default is 2048. Lower this only for legacy interoperability with
+      older key material. A value of 0 disables the modulus-size floor.
+  - ident: MinRSAPublicExponent
+    interface: GlobalOption
+    argument_type: int
+    comment: |
+      WithMinRSAPublicExponent specifies the minimum RSA public exponent
+      accepted by JWK validation and raw/PEM/X.509 import.
+
+      The default is 3. The exponent must still be odd and fit in a Go `int`.
+      Lower this only for legacy interoperability. A value of 0 disables the
+      minimum-exponent floor.
   - ident: AllowSymmetric
     interface: PublicSetOption
     argument_type: bool

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -186,6 +186,8 @@ type identHTTPClient struct{}
 type identIgnoreParseError struct{}
 type identLocalRegistry struct{}
 type identMaxFetchBodySize struct{}
+type identMinRSAModulusBits struct{}
+type identMinRSAPublicExponent struct{}
 type identPEM struct{}
 type identPEMDecoder struct{}
 type identStrictKeyUsage struct{}
@@ -223,6 +225,14 @@ func (identLocalRegistry) String() string {
 
 func (identMaxFetchBodySize) String() string {
 	return "WithMaxFetchBodySize"
+}
+
+func (identMinRSAModulusBits) String() string {
+	return "WithMinRSAModulusBits"
+}
+
+func (identMinRSAPublicExponent) String() string {
+	return "WithMinRSAPublicExponent"
 }
 
 func (identPEM) String() string {
@@ -365,6 +375,25 @@ func withLocalRegistry(v *json.Registry) ParseOption {
 // override.
 func WithMaxFetchBodySize(v int64) GlobalFetchOption {
 	return &globalFetchOption{option.New(identMaxFetchBodySize{}, v)}
+}
+
+// WithMinRSAModulusBits specifies the minimum RSA modulus size, in bits,
+// accepted by JWK validation and raw/PEM/X.509 import.
+//
+// The default is 2048. Lower this only for legacy interoperability with
+// older key material. A value of 0 disables the modulus-size floor.
+func WithMinRSAModulusBits(v int) GlobalOption {
+	return &globalOption{option.New(identMinRSAModulusBits{}, v)}
+}
+
+// WithMinRSAPublicExponent specifies the minimum RSA public exponent
+// accepted by JWK validation and raw/PEM/X.509 import.
+//
+// The default is 3. The exponent must still be odd and fit in a Go `int`.
+// Lower this only for legacy interoperability. A value of 0 disables the
+// minimum-exponent floor.
+func WithMinRSAPublicExponent(v int) GlobalOption {
+	return &globalOption{option.New(identMinRSAPublicExponent{}, v)}
 }
 
 // WithPEM specifies that the input to `Parse()` is a PEM encoded key.

--- a/jwk/options_gen_test.go
+++ b/jwk/options_gen_test.go
@@ -17,6 +17,8 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithIgnoreParseError", identIgnoreParseError{}.String())
 	require.Equal(t, "withLocalRegistry", identLocalRegistry{}.String())
 	require.Equal(t, "WithMaxFetchBodySize", identMaxFetchBodySize{}.String())
+	require.Equal(t, "WithMinRSAModulusBits", identMinRSAModulusBits{}.String())
+	require.Equal(t, "WithMinRSAPublicExponent", identMinRSAPublicExponent{}.String())
 	require.Equal(t, "WithPEM", identPEM{}.String())
 	require.Equal(t, "WithPEMDecoder", identPEMDecoder{}.String())
 	require.Equal(t, "WithStrictKeyUsage", identStrictKeyUsage{}.String())

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -18,6 +18,8 @@ func init() {
 	RegisterKeyExporter(KeyKind(jwa.RSA().String()), KeyExportFunc(rsaJWKToRaw))
 }
 
+const minRSAModulusBits = 2048
+
 func (k *rsaPrivateKey) Import(rawKey *rsa.PrivateKey) error {
 	k.mu.Lock()
 	defer k.mu.Unlock()
@@ -103,16 +105,44 @@ func (k *rsaPublicKey) Import(rawKey *rsa.PublicKey) error {
 	return nil
 }
 
-func buildRSAPublicKey(key *rsa.PublicKey, n, e []byte) error {
+func validateRSAModulusAndExponent(n, e []byte) (*big.Int, error) {
+	n = trimLeadingZeroBytes(n)
+	if len(n) == 0 {
+		return nil, fmt.Errorf(`missing "n" value`)
+	}
+
+	bigN := new(big.Int).SetBytes(n)
+	if bigN.BitLen() < minRSAModulusBits {
+		return nil, fmt.Errorf(`rsa modulus too small: got %d bits, need at least %d`, bigN.BitLen(), minRSAModulusBits)
+	}
+
+	e = trimLeadingZeroBytes(e)
+	if len(e) == 0 {
+		return nil, fmt.Errorf(`missing "e" value`)
+	}
+
 	bigE := new(big.Int).SetBytes(e)
+	if bigE.Cmp(big.NewInt(3)) < 0 || bigE.Bit(0) == 0 {
+		return nil, fmt.Errorf(`invalid rsa public exponent: must be an odd integer >= 3`)
+	}
+
 	// rsa.PublicKey.E is a Go int. Reject exponents that do not fit on the
 	// current platform (e.g. GOARCH=386). Without this guard, Int64()/int()
 	// silently truncates, causing the materialized key to disagree with the
 	// JSON bytes and breaking RFC 7638 thumbprint uniqueness.
 	if bigE.BitLen() >= bits.UintSize {
-		return fmt.Errorf(`rsa public exponent too large for this platform: %d bits (max %d)`, bigE.BitLen(), bits.UintSize-1)
+		return nil, fmt.Errorf(`rsa public exponent too large for this platform: %d bits (max %d)`, bigE.BitLen(), bits.UintSize-1)
 	}
-	key.N = new(big.Int).SetBytes(n)
+
+	return bigE, nil
+}
+
+func buildRSAPublicKey(key *rsa.PublicKey, n, e []byte) error {
+	bigE, err := validateRSAModulusAndExponent(n, e)
+	if err != nil {
+		return err
+	}
+	key.N = new(big.Int).SetBytes(trimLeadingZeroBytes(n))
 	key.E = int(bigE.Int64())
 	return nil
 }
@@ -377,15 +407,8 @@ func validateRSAKey(key interface {
 	if !ok {
 		return fmt.Errorf(`missing "e" value`)
 	}
-
-	if len(n) == 0 {
-		// Ideally we would like to check for the actual length, but unlike
-		// EC keys, we have nothing in the key itself that will tell us
-		// how many bits this key should have.
-		return fmt.Errorf(`missing "n" value`)
-	}
-	if len(e) == 0 {
-		return fmt.Errorf(`missing "e" value`)
+	if _, err := validateRSAModulusAndExponent(n, e); err != nil {
+		return err
 	}
 	if checkPrivate {
 		if priv, ok := key.(keyWithD); ok {

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"math/bits"
 	"reflect"
+	"sync/atomic"
 
 	"github.com/lestrrat-go/jwx/v3/internal/base64"
 	"github.com/lestrrat-go/jwx/v3/internal/pool"
@@ -19,6 +20,15 @@ func init() {
 }
 
 const minRSAModulusBits = 2048
+const minRSAPublicExponent = 3
+
+var rsaMinModulusBits = atomic.Int64{}
+var rsaMinPublicExponent = atomic.Int64{}
+
+func init() {
+	rsaMinModulusBits.Store(minRSAModulusBits)
+	rsaMinPublicExponent.Store(minRSAPublicExponent)
+}
 
 func (k *rsaPrivateKey) Import(rawKey *rsa.PrivateKey) error {
 	k.mu.Lock()
@@ -112,8 +122,9 @@ func validateRSAModulusAndExponent(n, e []byte) (*big.Int, error) {
 	}
 
 	bigN := new(big.Int).SetBytes(n)
-	if bigN.BitLen() < minRSAModulusBits {
-		return nil, fmt.Errorf(`rsa modulus too small: got %d bits, need at least %d`, bigN.BitLen(), minRSAModulusBits)
+	minBits := int(rsaMinModulusBits.Load())
+	if minBits > 0 && bigN.BitLen() < minBits {
+		return nil, fmt.Errorf(`rsa modulus too small: got %d bits, need at least %d`, bigN.BitLen(), minBits)
 	}
 
 	e = trimLeadingZeroBytes(e)
@@ -122,8 +133,12 @@ func validateRSAModulusAndExponent(n, e []byte) (*big.Int, error) {
 	}
 
 	bigE := new(big.Int).SetBytes(e)
-	if bigE.Cmp(big.NewInt(3)) < 0 || bigE.Bit(0) == 0 {
-		return nil, fmt.Errorf(`invalid rsa public exponent: must be an odd integer >= 3`)
+	minExponent := rsaMinPublicExponent.Load()
+	if bigE.Sign() <= 0 || bigE.Bit(0) == 0 {
+		return nil, fmt.Errorf(`invalid rsa public exponent: must be a positive odd integer`)
+	}
+	if minExponent > 0 && bigE.Cmp(big.NewInt(minExponent)) < 0 {
+		return nil, fmt.Errorf(`invalid rsa public exponent: got %s, need at least %d`, bigE.String(), minExponent)
 	}
 
 	// rsa.PublicKey.E is a Go int. Reject exponents that do not fit on the

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -23,11 +23,20 @@ const minRSAModulusBits = 2048
 const minRSAPublicExponent = 3
 
 var rsaMinModulusBits = atomic.Int64{}
-var rsaMinPublicExponent = atomic.Int64{}
+var rsaMinPublicExponent atomic.Pointer[big.Int]
 
 func init() {
 	rsaMinModulusBits.Store(minRSAModulusBits)
-	rsaMinPublicExponent.Store(minRSAPublicExponent)
+	setMinRSAPublicExponent(minRSAPublicExponent)
+}
+
+func setMinRSAPublicExponent(v int) {
+	if v <= 0 {
+		rsaMinPublicExponent.Store(nil)
+		return
+	}
+
+	rsaMinPublicExponent.Store(big.NewInt(int64(v)))
 }
 
 func (k *rsaPrivateKey) Import(rawKey *rsa.PrivateKey) error {
@@ -137,8 +146,8 @@ func validateRSAModulusAndExponent(n, e []byte) (*big.Int, error) {
 	if bigE.Sign() <= 0 || bigE.Bit(0) == 0 {
 		return nil, fmt.Errorf(`invalid rsa public exponent: must be a positive odd integer`)
 	}
-	if minExponent > 0 && bigE.Cmp(big.NewInt(minExponent)) < 0 {
-		return nil, fmt.Errorf(`invalid rsa public exponent: got %s, need at least %d`, bigE.String(), minExponent)
+	if minExponent != nil && bigE.Cmp(minExponent) < 0 {
+		return nil, fmt.Errorf(`invalid rsa public exponent: got %s, need at least %s`, bigE.String(), minExponent.String())
 	}
 
 	// rsa.PublicKey.E is a Go int. Reject exponents that do not fit on the

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -98,6 +98,9 @@ func importRsaPublicKeyByteValues(rawKey *rsa.PublicKey) ([]byte, []byte, error)
 	if err != nil {
 		return nil, nil, fmt.Errorf(`invalid rsa.PublicKey: %w`, err)
 	}
+	if rawKey.E <= 0 {
+		return nil, nil, fmt.Errorf(`invalid rsa.PublicKey: invalid rsa public exponent: must be a positive odd integer`)
+	}
 
 	data := make([]byte, 8)
 	binary.BigEndian.PutUint64(data, uint64(rawKey.E))

--- a/jwk/rsa_thumbprint_test.go
+++ b/jwk/rsa_thumbprint_test.go
@@ -2,7 +2,6 @@ package jwk_test
 
 import (
 	"crypto"
-	"crypto/rsa"
 	"encoding/hex"
 	"encoding/json"
 	"math/bits"
@@ -12,10 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const rfc7638RSAModulus = "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+
 // RFC 7638 Section 3.1 canonical example.
 const rfc7638RSAJWK = `{
   "kty": "RSA",
-  "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+  "n": "` + rfc7638RSAModulus + `",
   "e": "AQAB"
 }`
 
@@ -38,19 +39,15 @@ func TestRSA_Thumbprint_RFC7638Vector(t *testing.T) {
 
 // TestRSA_ExponentTruncation_Rejected verifies that an RSA public exponent
 // whose bit length does not fit in a Go `int` on this platform is rejected
-// at export time, rather than being silently truncated.
+// at parse time, rather than being silently truncated later at export time.
 //
 // Regression for JWK-20260415151950-008.
 func TestRSA_ExponentTruncation_Rejected(t *testing.T) {
 	// e = 0x01_00_00_00_00_00_00_01 (65 bits) — fits neither 32-bit nor 64-bit int.
-	payload := `{"kty":"RSA","n":"AQAB","e":"AQAAAAAAAAAB"}`
+	payload := rsaPublicJWK(rfc7638RSAModulus, "AQAAAAAAAAAB")
 
-	k, err := jwk.ParseKey([]byte(payload))
-	require.NoError(t, err, "parse should accept the raw bytes")
-
-	var out rsa.PublicKey
-	err = jwk.Export(k, &out)
-	require.Error(t, err, "export must reject oversized exponent")
+	_, err := jwk.ParseKey(payload)
+	require.Error(t, err, "parse must reject oversized exponent")
 	require.Contains(t, err.Error(), "rsa public exponent too large")
 }
 
@@ -64,14 +61,14 @@ func TestRSA_ExponentTruncation_Rejected(t *testing.T) {
 // Regression for JWK-20260415151950-008.
 func TestRSA_Thumbprint_UsesStoredBytes(t *testing.T) {
 	// Standard F4 = 0x10001
-	jwkF4 := `{"kty":"RSA","n":"AQAB","e":"AQAB"}`
+	jwkF4 := rsaPublicJWK(rfc7638RSAModulus, "AQAB")
 	// Same exponent with an added leading zero byte: e = 0x00_01_00_01
-	jwkF4PaddedE := `{"kty":"RSA","n":"AQAB","e":"AAEAAQ"}`
+	jwkF4PaddedE := rsaPublicJWK(rfc7638RSAModulus, "AAEAAQ")
 	// Different exponent entirely: e = 3
-	jwkE3 := `{"kty":"RSA","n":"AQAB","e":"Aw"}`
+	jwkE3 := rsaPublicJWK(rfc7638RSAModulus, "Aw")
 
-	thumb := func(payload string) []byte {
-		k, err := jwk.ParseKey([]byte(payload))
+	thumb := func(payload []byte) []byte {
+		k, err := jwk.ParseKey(payload)
 		require.NoError(t, err)
 		tp, err := k.Thumbprint(crypto.SHA256)
 		require.NoError(t, err)

--- a/jwk/rsa_validate_test.go
+++ b/jwk/rsa_validate_test.go
@@ -1,0 +1,96 @@
+package jwk_test
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/internal/base64"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+func rsaPublicJWK(n, e string) []byte {
+	return []byte(`{"kty":"RSA","n":"` + n + `","e":"` + e + `"}`)
+}
+
+func mustBigIntFromBase64(t *testing.T, src string) *big.Int {
+	t.Helper()
+
+	body, err := base64.DecodeString(src)
+	require.NoError(t, err)
+	return new(big.Int).SetBytes(body)
+}
+
+func mustRSAPublicPEM(t *testing.T, key *rsa.PublicKey) []byte {
+	t.Helper()
+
+	der, err := x509.MarshalPKIXPublicKey(key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: der,
+	})
+}
+
+func TestRSAInvalidParametersRejectedOnParse(t *testing.T) {
+	t.Run("small modulus", func(t *testing.T) {
+		payload := rsaPublicJWK("AQAB", "AQAB")
+
+		_, err := jwk.ParseKey(payload)
+		require.Error(t, err)
+		require.True(t, jwk.IsKeyValidationError(err))
+		require.Contains(t, err.Error(), "rsa modulus too small")
+
+		_, err = jwk.Parse([]byte(`{"keys":[` + string(payload) + `]}`))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "rsa modulus too small")
+	})
+
+	t.Run("unsafe exponent", func(t *testing.T) {
+		payload := rsaPublicJWK(rfc7638RSAModulus, "AQ")
+
+		_, err := jwk.ParseKey(payload)
+		require.Error(t, err)
+		require.True(t, jwk.IsKeyValidationError(err))
+		require.Contains(t, err.Error(), "invalid rsa public exponent")
+	})
+}
+
+func TestRSAImportRejectsInvalidParameters(t *testing.T) {
+	t.Run("small modulus", func(t *testing.T) {
+		bad := &rsa.PublicKey{
+			N: mustBigIntFromBase64(t, "AQAB"),
+			E: 65537,
+		}
+
+		_, err := jwk.Import(bad)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "rsa modulus too small")
+	})
+
+	t.Run("unsafe exponent", func(t *testing.T) {
+		bad := &rsa.PublicKey{
+			N: mustBigIntFromBase64(t, rfc7638RSAModulus),
+			E: 1,
+		}
+
+		_, err := jwk.Import(bad)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid rsa public exponent")
+	})
+}
+
+func TestRSAPEMImportRunsValidation(t *testing.T) {
+	bad := &rsa.PublicKey{
+		N: mustBigIntFromBase64(t, "AQAB"),
+		E: 65537,
+	}
+
+	_, err := jwk.ParseKey(mustRSAPublicPEM(t, bad), jwk.WithPEM(true))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "rsa modulus too small")
+}

--- a/jwk/rsa_validate_test.go
+++ b/jwk/rsa_validate_test.go
@@ -92,6 +92,17 @@ func TestRSAImportRejectsInvalidParameters(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid rsa public exponent")
 	})
+
+	t.Run("negative exponent", func(t *testing.T) {
+		bad := &rsa.PublicKey{
+			N: mustBigIntFromBase64(t, rfc7638RSAModulus),
+			E: -3,
+		}
+
+		_, err := jwk.Import(bad)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid rsa public exponent")
+	})
 }
 
 func TestRSAPEMImportRunsValidation(t *testing.T) {

--- a/jwk/rsa_validate_test.go
+++ b/jwk/rsa_validate_test.go
@@ -1,6 +1,7 @@
 package jwk_test
 
 import (
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
@@ -34,6 +35,15 @@ func mustRSAPublicPEM(t *testing.T, key *rsa.PublicKey) []byte {
 		Type:  "PUBLIC KEY",
 		Bytes: der,
 	})
+}
+
+func rsaPublicJWKFromRaw(t *testing.T, key *rsa.PublicKey) []byte {
+	t.Helper()
+
+	return rsaPublicJWK(
+		base64.EncodeToString(key.N.Bytes()),
+		base64.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+	)
 }
 
 func TestRSAInvalidParametersRejectedOnParse(t *testing.T) {
@@ -93,4 +103,33 @@ func TestRSAPEMImportRunsValidation(t *testing.T) {
 	_, err := jwk.ParseKey(mustRSAPublicPEM(t, bad), jwk.WithPEM(true))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "rsa modulus too small")
+}
+
+func TestRSAConfigureCompatibilityKnobs(t *testing.T) {
+	t.Run("allow legacy 1024-bit modulus", func(t *testing.T) {
+		jwk.Configure(jwk.WithMinRSAModulusBits(1024))
+		t.Cleanup(func() {
+			jwk.Configure(jwk.WithMinRSAModulusBits(2048))
+		})
+
+		raw, err := rsa.GenerateKey(rand.Reader, 1024)
+		require.NoError(t, err)
+
+		payload := rsaPublicJWKFromRaw(t, &raw.PublicKey)
+
+		_, err = jwk.ParseKey(payload)
+		require.NoError(t, err)
+	})
+
+	t.Run("allow exponent 1 explicitly", func(t *testing.T) {
+		jwk.Configure(jwk.WithMinRSAPublicExponent(1))
+		t.Cleanup(func() {
+			jwk.Configure(jwk.WithMinRSAPublicExponent(3))
+		})
+
+		payload := rsaPublicJWK(rfc7638RSAModulus, "AQ")
+
+		_, err := jwk.ParseKey(payload)
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
- reject RSA JWKs with small moduli or unsafe exponents
- validate imported RSA keys so PEM and raw-key paths use the same checks
- add regressions for Parse, ParseKey, Import, and PEM inputs
