### PR TITLE
centralize jwk import validation

### DIFF
--- a/docs/04-jwk.md
+++ b/docs/04-jwk.md
@@ -422,6 +422,8 @@ There are other ways to creating keys from a raw key, but they require knowing i
 Use [`jwk.Import()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#Import) when you have a key type which you do not know its underlying type in advance.
 
 It automatically creates the appropriate underlying key based on the given argument type.
+The returned key has already passed `Validate()`, so malformed raw keys fail at
+import time instead of being returned for later validation.
 
 | Argument Type | Key Type | Note |
 |---------------|----------|------|

--- a/jwk/doc.go
+++ b/jwk/doc.go
@@ -9,8 +9,8 @@
 // work for third party key types (see section on "Registering a key type" below).
 //
 // Users can create a JWK in two ways. One is to unmarshal a JSON representation of a
-// key. The second one is to use `jwk.Import()` to import a raw key and convert it to
-// a jwk.Key.
+// key. The second one is to use `jwk.Import()` to import a raw key, validate it,
+// and convert it to a jwk.Key.
 //
 // # Simple Usage
 //

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -3,6 +3,7 @@ package jwk_test
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"errors"
 	"math/big"
 	"testing"
 
@@ -86,6 +87,8 @@ func TestECDSAImportRejectsInvalidPoints(t *testing.T) {
 		}
 		_, err := jwk.Import[jwk.Key](bad)
 		require.Error(t, err, `jwk.Import must reject an off-curve ecdsa.PublicKey`)
+		require.ErrorIs(t, err, jwk.ImportError(), `Import error should be classified as jwk.ImportError`)
+		require.True(t, errors.Is(err, jwk.ImportError()), `errors.Is should match jwk.ImportError`)
 	})
 
 	t.Run("identity public key", func(t *testing.T) {
@@ -96,5 +99,7 @@ func TestECDSAImportRejectsInvalidPoints(t *testing.T) {
 		}
 		_, err := jwk.Import[jwk.Key](bad)
 		require.Error(t, err, `jwk.Import must reject the identity point`)
+		require.ErrorIs(t, err, jwk.ImportError(), `Import error should be classified as jwk.ImportError`)
+		require.True(t, errors.Is(err, jwk.ImportError()), `errors.Is should match jwk.ImportError`)
 	})
 }

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -87,8 +87,8 @@ func doImport(raw any) (Key, error) {
 	if err != nil {
 		return nil, importerr(`%w`, err)
 	}
-	if err := validateReturnedKey(`jwk.Import`, key); err != nil {
-		return nil, importError{err}
+	if err := validateReturnedKey(key); err != nil {
+		return nil, importerr(`%w`, err)
 	}
 	return key, nil
 }
@@ -143,12 +143,12 @@ func importRawKey(raw any) (Key, error) {
 	return conv.Import(raw)
 }
 
-func validateReturnedKey(prefix string, key Key) error {
+func validateReturnedKey(key Key) error {
 	if key == nil {
 		return nil
 	}
 	if err := key.Validate(); err != nil {
-		return fmt.Errorf(`%s: %w`, prefix, err)
+		return err
 	}
 	return nil
 }
@@ -376,8 +376,8 @@ func doParseKey(data []byte, options ...ParseOption) (Key, error) {
 		if err != nil {
 			return nil, fmt.Errorf(`jwk.Parse: failed to create jwk.Key from %T: %w`, raw, err)
 		}
-		if err := validateReturnedKey(`jwk.Parse`, key); err != nil {
-			return nil, err
+		if err := validateReturnedKey(key); err != nil {
+			return nil, fmt.Errorf(`jwk.Parse: %w`, err)
 		}
 		return key, nil
 	}
@@ -398,8 +398,8 @@ func doParseKey(data []byte, options ...ParseOption) (Key, error) {
 		parser := parsers[i]
 		key, err := parser.ParseKey(probe, &unmarshaler, data)
 		if err == nil {
-			if err := validateReturnedKey(`jwk.Parse`, key); err != nil {
-				return nil, err
+			if err := validateReturnedKey(key); err != nil {
+				return nil, fmt.Errorf(`jwk.Parse: %w`, err)
 			}
 			return key, nil
 		}
@@ -469,8 +469,8 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 			if err != nil {
 				return nil, parseerr(`failed to create jwk.Key from %T: %w`, raw, err)
 			}
-			if err := validateReturnedKey(`jwk.Parse`, key); err != nil {
-				return nil, parseError{err}
+			if err := validateReturnedKey(key); err != nil {
+				return nil, parseerr(`%w`, err)
 			}
 			if err := s.AddKey(key); err != nil {
 				return nil, parseerr(`failed to add jwk.Key to set: %w`, err)

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -46,7 +46,8 @@ func init() {
 	}
 }
 
-// Import creates a jwk.Key from the given key (RSA/ECDSA/symmetric keys).
+// Import creates a validated jwk.Key from the given key
+// (RSA/ECDSA/symmetric keys).
 //
 // The constructor auto-detects the type of key to be instantiated
 // based on the input type:
@@ -65,6 +66,9 @@ func init() {
 // Use a concrete key type to obtain a typed result directly:
 //
 //	rsaKey, err := jwk.Import[jwk.RSAPrivateKey](rawRSAKey)
+//
+// Import validates the populated JWK before returning it. Malformed raw
+// keys fail at import time instead of being returned for later validation.
 func Import[T Key](raw any) (T, error) {
 	var zero T
 	key, err := doImport(raw)
@@ -79,8 +83,19 @@ func Import[T Key](raw any) (T, error) {
 }
 
 func doImport(raw any) (Key, error) {
+	key, err := importRawKey(raw)
+	if err != nil {
+		return nil, importerr(`%w`, err)
+	}
+	if err := validateReturnedKey(`jwk.Import`, key); err != nil {
+		return nil, importError{err}
+	}
+	return key, nil
+}
+
+func importRawKey(raw any) (Key, error) {
 	if raw == nil {
-		return nil, importerr(`a non-nil key is required`)
+		return nil, fmt.Errorf(`a non-nil key is required`)
 	}
 
 	// Fast path: type switch for built-in types avoids reflect.TypeOf + mutex
@@ -122,10 +137,20 @@ func doImport(raw any) (Key, error) {
 	conv, ok := keyImporters[reflect.TypeOf(raw)]
 	muKeyImporters.RUnlock()
 	if !ok {
-		return nil, importerr(`failed to convert %T to jwk.Key: no converters were able to convert`, raw)
+		return nil, fmt.Errorf(`failed to convert %T to jwk.Key: no converters were able to convert`, raw)
 	}
 
 	return conv.Import(raw)
+}
+
+func validateReturnedKey(prefix string, key Key) error {
+	if key == nil {
+		return nil
+	}
+	if err := key.Validate(); err != nil {
+		return fmt.Errorf(`%s: %w`, prefix, err)
+	}
+	return nil
 }
 
 // PublicSetOf returns a new jwk.Set consisting of
@@ -347,7 +372,14 @@ func doParseKey(data []byte, options ...ParseOption) (Key, error) {
 		if err != nil {
 			return nil, fmt.Errorf(`failed to decode PEM/X.509 encoded key: %w`, err)
 		}
-		return doImport(raw)
+		key, err := importRawKey(raw)
+		if err != nil {
+			return nil, fmt.Errorf(`jwk.Parse: failed to create jwk.Key from %T: %w`, raw, err)
+		}
+		if err := validateReturnedKey(`jwk.Parse`, key); err != nil {
+			return nil, err
+		}
+		return key, nil
 	}
 
 	probe, err := keyProbe.Probe(data)
@@ -366,6 +398,9 @@ func doParseKey(data []byte, options ...ParseOption) (Key, error) {
 		parser := parsers[i]
 		key, err := parser.ParseKey(probe, &unmarshaler, data)
 		if err == nil {
+			if err := validateReturnedKey(`jwk.Parse`, key); err != nil {
+				return nil, err
+			}
 			return key, nil
 		}
 
@@ -430,9 +465,12 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 			if err != nil {
 				return nil, parseerr(`failed to parse PEM encoded key: %w`, err)
 			}
-			key, err := doImport(raw)
+			key, err := importRawKey(raw)
 			if err != nil {
 				return nil, parseerr(`failed to create jwk.Key from %T: %w`, raw, err)
+			}
+			if err := validateReturnedKey(`jwk.Parse`, key); err != nil {
+				return nil, parseError{err}
 			}
 			if err := s.AddKey(key); err != nil {
 				return nil, parseerr(`failed to add jwk.Key to set: %w`, err)

--- a/jwk/okp_length_test.go
+++ b/jwk/okp_length_test.go
@@ -2,6 +2,7 @@ package jwk_test
 
 import (
 	"crypto/ed25519"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -56,11 +57,15 @@ func TestOKPImportRejectsInvalidEd25519Lengths(t *testing.T) {
 		_, err := jwk.Import[jwk.OKPPublicKey](ed25519.PublicKey(make([]byte, ed25519.PublicKeySize-1)))
 		require.Error(t, err)
 		require.ErrorContains(t, err, "wrong public key size")
+		require.ErrorIs(t, err, jwk.ImportError())
+		require.True(t, errors.Is(err, jwk.ImportError()))
 	})
 
 	t.Run("PrivateKey", func(t *testing.T) {
 		_, err := jwk.Import[jwk.OKPPrivateKey](ed25519.PrivateKey(make([]byte, ed25519.PrivateKeySize-1)))
 		require.Error(t, err)
 		require.ErrorContains(t, err, "wrong private key size")
+		require.ErrorIs(t, err, jwk.ImportError())
+		require.True(t, errors.Is(err, jwk.ImportError()))
 	})
 }

--- a/jwk/parser.go
+++ b/jwk/parser.go
@@ -109,15 +109,6 @@ func defaultParseKey(probe *KeyProbe, unmarshaler KeyUnmarshaler, data []byte) (
 	if err := unmarshaler.UnmarshalKey(data, key); err != nil {
 		return nil, fmt.Errorf(`failed to unmarshal JSON into key (%T): %w`, key, err)
 	}
-	// Enforce the trust boundary: a key that fails its own Validate() must
-	// never escape Parse/ParseKey. All built-in key types implement this
-	// interface via NewKeyValidationError, so callers can still use
-	// jwk.IsKeyValidationError on the wrapped error.
-	if v, ok := key.(interface{ Validate() error }); ok {
-		if err := v.Validate(); err != nil {
-			return nil, fmt.Errorf(`jwk.Parse: key validation failed: %w`, err)
-		}
-	}
 	return key, nil
 }
 

--- a/jwk/validation_boundary_test.go
+++ b/jwk/validation_boundary_test.go
@@ -1,0 +1,126 @@
+package jwk_test
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"sync"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+type invalidImportRaw struct{}
+
+type invalidPEMDecoder struct{}
+
+func (invalidPEMDecoder) Decode([]byte) (any, []byte, error) {
+	return invalidImportRaw{}, nil, nil
+}
+
+type invalidReturningParser struct{}
+
+func (invalidReturningParser) ParseKey(_ *jwk.KeyProbe, _ jwk.KeyUnmarshaler, payload []byte) (jwk.Key, error) {
+	if !bytes.Contains(payload, []byte(`"force-invalid-parser":true`)) {
+		return nil, jwk.ContinueError()
+	}
+	return makeInvalidECDSAJWK()
+}
+
+var registerInvalidImporterOnce sync.Once
+var registerInvalidParserOnce sync.Once
+
+func invalidECDSAPublicKey() *ecdsa.PublicKey {
+	return &ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     big.NewInt(1),
+		Y:     big.NewInt(1),
+	}
+}
+
+func makeInvalidECDSAJWK() (jwk.Key, error) {
+	raw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	key, err := jwk.Import[jwk.ECDSAPublicKey](&raw.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	x, ok := key.X()
+	if !ok || len(x) < 2 {
+		return nil, fmt.Errorf("missing valid ECDSA X coordinate")
+	}
+	if err := key.Set(jwk.ECDSAXKey, x[:len(x)/2]); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func registerInvalidImporter(t *testing.T) {
+	t.Helper()
+	registerInvalidImporterOnce.Do(func() {
+		err := jwk.RegisterKeyImporter(func(invalidImportRaw) (jwk.Key, error) {
+			return makeInvalidECDSAJWK()
+		})
+		require.NoError(t, err)
+	})
+}
+
+func registerInvalidParser(t *testing.T) {
+	t.Helper()
+	registerInvalidParserOnce.Do(func() {
+		err := jwk.RegisterKeyParser(invalidReturningParser{})
+		require.NoError(t, err)
+	})
+}
+
+func TestImportRejectsInvalidKeyFromCustomImporter(t *testing.T) {
+	registerInvalidImporter(t)
+
+	_, err := jwk.Import[jwk.Key](invalidImportRaw{})
+	require.Error(t, err)
+	require.ErrorIs(t, err, jwk.ImportError())
+	require.True(t, jwk.IsKeyValidationError(err), `Import should preserve key-validation identity`)
+}
+
+func TestParseWithPEMDecoderRejectsInvalidImportedKey(t *testing.T) {
+	_, err := jwk.Parse([]byte("dummy"), jwk.WithPEM(true), jwk.WithPEMDecoder(invalidPEMDecoder{}))
+	require.Error(t, err)
+	require.ErrorIs(t, err, jwk.ParseError())
+	require.True(t, jwk.IsKeyValidationError(err), `Parse should preserve key-validation identity`)
+}
+
+func TestParseKeyWithX509DecoderRejectsInvalidImportedKey(t *testing.T) {
+	ident := "test-invalid-x509-import-boundary"
+	err := jwk.RegisterX509Decoder(ident, jwk.X509DecodeFunc(func(block *pem.Block) (any, error) {
+		if block.Type != "INVALID ECDSA" {
+			return nil, fmt.Errorf("unsupported type")
+		}
+		return invalidImportRaw{}, nil
+	}))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		jwk.UnregisterX509Decoder(ident)
+	})
+
+	src := []byte(`-----BEGIN INVALID ECDSA-----
+ZHVtbXk=
+-----END INVALID ECDSA-----`)
+	_, err = jwk.ParseKey[jwk.Key](src, jwk.WithPEM(true))
+	require.Error(t, err)
+	require.True(t, jwk.IsKeyValidationError(err), `ParseKey should preserve key-validation identity`)
+}
+
+func TestParseKeyRejectsInvalidKeyFromCustomParser(t *testing.T) {
+	registerInvalidParser(t)
+
+	_, err := jwk.ParseKey[jwk.Key]([]byte(`{"kty":"EC","force-invalid-parser":true}`))
+	require.Error(t, err)
+	require.True(t, jwk.IsKeyValidationError(err), `ParseKey should validate keys returned from custom parsers`)
+}

--- a/jwk/validation_boundary_test.go
+++ b/jwk/validation_boundary_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"encoding/pem"
 	"fmt"
-	"math/big"
 	"sync"
 	"testing"
 
@@ -34,14 +33,6 @@ func (invalidReturningParser) ParseKey(_ *jwk.KeyProbe, _ jwk.KeyUnmarshaler, pa
 
 var registerInvalidImporterOnce sync.Once
 var registerInvalidParserOnce sync.Once
-
-func invalidECDSAPublicKey() *ecdsa.PublicKey {
-	return &ecdsa.PublicKey{
-		Curve: elliptic.P256(),
-		X:     big.NewInt(1),
-		Y:     big.NewInt(1),
-	}
-}
 
 func makeInvalidECDSAJWK() (jwk.Key, error) {
 	raw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)


### PR DESCRIPTION
- centralize key validation in jwk.Import and the shared parse path
- add regression coverage for custom importers, parsers, and PEM/X.509 decode flows
- document that malformed raw keys now fail at import time
