### PR TITLE
zero bytes.Buffer backing array on pool return

### DIFF
--- a/internal/pool/bytes_buffer.go
+++ b/internal/pool/bytes_buffer.go
@@ -9,6 +9,13 @@ func allocBytesBuffer() *bytes.Buffer {
 }
 
 func freeBytesBuffer(b *bytes.Buffer) *bytes.Buffer {
+	// Zero the backing array before returning to pool — the buffer
+	// may hold private-key material, plaintext, or HMAC input.
+	// b.Bytes() shares the internal slice (offset is always 0 in
+	// our write-only usage); reslicing to cap reaches all residual bytes.
+	if buf := b.Bytes(); cap(buf) > 0 {
+		clear(buf[:cap(buf)])
+	}
 	b.Reset()
 	return b
 }


### PR DESCRIPTION
- zero backing array in freeBytesBuffer before Reset, matching byte_slice.go scrub
- prevents residual private-key material / plaintext from persisting across pool reuse