### PR TITLE
remove internal/json.Dump debug helper

### DIFF
--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -3,7 +3,7 @@ package json
 import (
 	"bytes"
 	"fmt"
-	"os"
+
 	"sync/atomic"
 
 	"github.com/lestrrat-go/jwx/v3/internal/base64"
@@ -163,11 +163,4 @@ func (dc *decodeCtx) Registry() *Registry {
 
 func (dc *decodeCtx) StrictStrings() bool {
 	return dc.strictStrings
-}
-
-func Dump(v any) {
-	enc := NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
-	//nolint:errchkjson
-	_ = enc.Encode(v)
 }

--- a/internal/pool/bytes_buffer.go
+++ b/internal/pool/bytes_buffer.go
@@ -9,6 +9,13 @@ func allocBytesBuffer() *bytes.Buffer {
 }
 
 func freeBytesBuffer(b *bytes.Buffer) *bytes.Buffer {
+	// Zero the backing array before returning to pool — the buffer
+	// may hold private-key material, plaintext, or HMAC input.
+	// b.Bytes() shares the internal slice (offset is always 0 in
+	// our write-only usage); reslicing to cap reaches all residual bytes.
+	if buf := b.Bytes(); cap(buf) > 0 {
+		clear(buf[:cap(buf)])
+	}
 	b.Reset()
 	return b
 }


### PR DESCRIPTION
- remove unused `Dump` function from `internal/json` that writes any value to stdout
- prevents accidental private key material leakage if debug call left in production code