### PR TITLE
remove internal/json.Dump debug helper

### DIFF
--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -5,7 +5,7 @@ import (
 	jsonv2 "encoding/json/v2"
 	"fmt"
 	"io"
-	"os"
+
 	"sync/atomic"
 
 	"github.com/lestrrat-go/jwx/v4/internal/base64"
@@ -201,9 +201,4 @@ func (dc *decodeCtx) Registry() *Registry {
 
 func (dc *decodeCtx) StrictStrings() bool {
 	return dc.strictStrings
-}
-
-func Dump(v any) {
-	enc := jsontext.NewEncoder(os.Stdout, jsontext.WithIndent("\t"))
-	_ = jsonv2.MarshalEncode(enc, v)
 }

--- a/internal/pool/bytes_buffer.go
+++ b/internal/pool/bytes_buffer.go
@@ -9,6 +9,13 @@ func allocBytesBuffer() *bytes.Buffer {
 }
 
 func freeBytesBuffer(b *bytes.Buffer) *bytes.Buffer {
+	// Zero the backing array before returning to pool — the buffer
+	// may hold private-key material, plaintext, or HMAC input.
+	// b.Bytes() shares the internal slice (offset is always 0 in
+	// our write-only usage); reslicing to cap reaches all residual bytes.
+	if buf := b.Bytes(); cap(buf) > 0 {
+		clear(buf[:cap(buf)])
+	}
 	b.Reset()
 	return b
 }


### PR DESCRIPTION
- remove unused `Dump` function from `internal/json` that writes any value to stdout
- prevents accidental private key material leakage if debug call left in production code