### PR TITLE
fix SplitCompactReader LimitedReader size bypass

### DIFF
--- a/jws/jwsbb/format.go
+++ b/jws/jwsbb/format.go
@@ -110,9 +110,9 @@ func InvalidNumberOfSegmentsError() error {
 }
 
 // maxSplitCompactReaderSize caps the number of bytes SplitCompactReader will
-// consume from a non-finite io.Reader. It matches the default
-// jws.maxParseInputSize (10 MiB). Callers that need a different limit should
-// wrap their reader with io.LimitReader before calling SplitCompactReader.
+// consume from any io.Reader. It matches the default jws.maxParseInputSize
+// (10 MiB). Callers that need a different limit should wrap their reader
+// with io.LimitReader before calling SplitCompactReader.
 const maxSplitCompactReaderSize = 10 * 1024 * 1024
 
 var errInputTooLarge = errors.New(`jwsbb: input exceeds maximum size`)
@@ -181,8 +181,15 @@ func SplitCompactString(src string) (protected, payload, signature []byte, err e
 //
 // The function validates that exactly 3 segments are present, separated by periods.
 func SplitCompactReader(rdr io.Reader) (protected, payload, signature []byte, err error) {
-	data, err := jwxio.ReadAllFromFiniteSource(rdr)
+	// Wrap with a size cap before the finite-source check so that even
+	// recognized finite types (e.g. *io.LimitedReader with a large N)
+	// cannot cause unbounded allocation.
+	capped := io.LimitReader(rdr, maxSplitCompactReaderSize+1)
+	data, err := jwxio.ReadAllFromFiniteSource(capped)
 	if err == nil {
+		if int64(len(data)) > maxSplitCompactReaderSize {
+			return nil, nil, nil, InputTooLargeError()
+		}
 		return SplitCompact(data)
 	}
 
@@ -190,8 +197,8 @@ func SplitCompactReader(rdr io.Reader) (protected, payload, signature []byte, er
 		return nil, nil, nil, err
 	}
 
-	// Cap total bytes read from a non-finite source. Read one extra byte so
-	// we can distinguish "exactly at the limit" from "over".
+	// Streaming fallback: the type switch in ReadAllFromFiniteSource
+	// rejected before reading any bytes, so rdr is still at position 0.
 	limited := io.LimitReader(rdr, maxSplitCompactReaderSize+1)
 
 	var periods int

--- a/jws/jwsbb/jwsbb_test.go
+++ b/jws/jwsbb/jwsbb_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"hash"
+	"io"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v4/internal/base64"
@@ -17,6 +18,43 @@ import (
 	"github.com/lestrrat-go/jwx/v4/jws/jwsbb"
 	"github.com/stretchr/testify/require"
 )
+
+// endlessReader is a non-finite io.Reader that fills buf with b indefinitely
+// and never returns EOF. It is intentionally not a
+// *bytes.Reader/*bytes.Buffer/*strings.Reader so that
+// jwxio.ReadAllFromFiniteSource classifies it as non-finite.
+type endlessReader struct{ b byte }
+
+func (r *endlessReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = r.b
+	}
+	return len(p), nil
+}
+
+func TestSplitCompactReaderNonFiniteSizeCap(t *testing.T) {
+	t.Parallel()
+	//nolint:dogsled // SplitCompactReader returns 4 values; we only need err here
+	_, _, _, err := jwsbb.SplitCompactReader(&endlessReader{b: 'X'})
+	require.Error(t, err, "SplitCompactReader should fail on oversized non-finite input")
+	require.ErrorIs(t, err, jwsbb.InputTooLargeError(), "error should be InputTooLargeError")
+}
+
+func TestSplitCompactReaderLimitedReaderLargeN(t *testing.T) {
+	t.Parallel()
+
+	// A *io.LimitedReader with a very large N passes the finite-source
+	// type check. Without a size cap on the finite path, io.ReadAll would
+	// attempt to allocate N bytes (DoS via OOM). Verify that
+	// SplitCompactReader caps the read on the finite path too.
+	const oversized = 11 * 1024 * 1024 // > maxSplitCompactReaderSize (10 MiB)
+	rdr := &io.LimitedReader{R: &endlessReader{b: 'X'}, N: oversized}
+
+	//nolint:dogsled
+	_, _, _, err := jwsbb.SplitCompactReader(rdr)
+	require.Error(t, err, "SplitCompactReader should reject oversized LimitedReader")
+	require.ErrorIs(t, err, jwsbb.InputTooLargeError(), "error should be InputTooLargeError")
+}
 
 const sampleHeader = "eyJmb28iOiJiYXIifQ" // Base64URL of {"foo":"bar"}
 


### PR DESCRIPTION
- wrap reader with io.LimitReader before ReadAllFromFiniteSource so *io.LimitedReader with large N is capped
- add regression test with oversized LimitedReader
- add missing endlessReader helper and non-finite size cap test