### PR TITLE
fix v4 jwt package docs

### DIFF
--- a/jwt/doc.go
+++ b/jwt/doc.go
@@ -1,0 +1,56 @@
+// Package jwt implements JSON Web Tokens as described in RFC 7519.
+//
+// # Parsing and Verification
+//
+// Parse verifies signed tokens by default. Pass WithKey, WithKeySet,
+// WithKeyProvider, or WithVerifyAuto when the token is signed. A bare
+// Parse call returns an error instead of silently accepting an unverified
+// token.
+//
+// To intentionally skip verification, pass WithVerify(false). Use
+// ParseInsecure only when the input is already trusted: it disables both
+// signature verification and validation, and it rejects key-bearing options
+// so that stray verification settings cannot silently be ignored.
+//
+// # Validation
+//
+// Parse validates registered time claims by default after decoding. In
+// particular, exp, nbf, and iat are checked automatically. Validate can also
+// be called directly on an existing Token. Pass WithValidate(false) to skip
+// automatic validation for a particular parse.
+//
+// Use WithCollectErrors(true) to run all validators and return joined
+// failures instead of stopping at the first one.
+//
+// # Errors
+//
+// Most exported errors in this package are concrete struct types. Use
+// errors.Is with a zero-value struct to check for a class of failure, and
+// errors.AsType[T] to recover structured details:
+//
+//	err := jwt.Validate(token)
+//	if errors.Is(err, jwt.TokenExpiredError{}) { /* ... */ }
+//	if expErr, ok := errors.AsType[jwt.TokenExpiredError](err); ok { /* ... */ }
+//
+// # Time Claims
+//
+// Numeric date claims are decoded into time.Time values. Validation uses
+// exact timestamps by default; configure WithAcceptableSkew for clock skew
+// and WithTruncation when you need truncated comparisons.
+//
+// # OpenID Connect and Nested Tokens
+//
+// Use package github.com/lestrrat-go/jwx/v4/jwt/openid when you want a Token
+// implementation with typed OpenID Connect claim accessors.
+//
+// Parse handles compact JWS JWTs and raw JSON tokens. It does not decrypt
+// JWE envelopes for you. To produce nested JWTs, use
+// NewSerializer().Sign(...).Encrypt(...).Serialize(...), and decrypt any
+// outer JWE before calling Parse.
+//
+// # Migration from v3
+//
+// v4 tightened parse defaults and changed JWT errors from sentinel functions
+// to struct types. If you are migrating from v3, consult MIGRATION.md in the
+// repository before porting old parse flows or errors.Is checks.
+package jwt

--- a/jwt/http.go
+++ b/jwt/http.go
@@ -29,7 +29,7 @@ func ParseCookie(req *http.Request, name string, options ...ParseOption) (Token,
 	}
 	tok, err := ParseString(cookie.Value, options...)
 	if err != nil {
-		return nil, fmt.Errorf(`jws.ParseCookie: failed to parse token stored in cookie: %w`, err)
+		return nil, fmt.Errorf(`jwt.ParseCookie: failed to parse token stored in cookie: %w`, err)
 	}
 
 	if dst != nil {
@@ -85,13 +85,13 @@ func ParseForm(values url.Values, name string, options ...ParseOption) (Token, e
 // are specified, you must explicitly re-enable searching for "Authorization" header
 // if you also want to search for it.
 //
-//	# searches for "Authorization"
+//	// searches for "Authorization"
 //	jwt.ParseRequest(req)
 //
-//	# searches for "x-my-token" ONLY.
+//	// searches for "x-my-token" ONLY.
 //	jwt.ParseRequest(req, jwt.WithHeaderKey("x-my-token"))
 //
-//	# searches for "Authorization" AND "x-my-token"
+//	// searches for "Authorization" AND "x-my-token"
 //	jwt.ParseRequest(req, jwt.WithHeaderKey("Authorization"), jwt.WithHeaderKey("x-my-token"))
 //
 // Cookies are searched using (http.Request).Cookie(). If you have multiple

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -1,7 +1,6 @@
 //go:generate ../scripts/jwxcodegen.sh generate-jwt -objects=objects.yml
 //go:generate stringer -type=TokenOption -output=token_options_gen.go
 
-// Package jwt implements JSON Web Tokens as described in https://tools.ietf.org/html/rfc7519
 package jwt
 
 import (
@@ -115,27 +114,32 @@ func ParseString(s string, options ...ParseOption) (Token, error) {
 // The token must be encoded in JWS compact format, or a raw JSON form of JWT
 // without any signatures.
 //
-// If you need JWE support on top of JWS, you will need to rollout your
-// own workaround.
+// Signed input is verified by default. Pass `jwt.WithKey()`,
+// `jwt.WithKeySet()`, `jwt.WithKeyProvider()`, or `jwt.WithVerifyAuto()`
+// when verification is required. A bare `jwt.Parse()` call returns an error;
+// to intentionally skip verification, pass `jwt.WithVerify(false)` or use
+// `jwt.ParseInsecure()`.
 //
-// If the token is signed, and you want to verify the payload matches the signature,
-// you must pass the jwt.WithKey(alg, key) or jwt.WithKeySet(jwk.Set) option.
-// If you do not specify these parameters, no verification will be performed.
+// `Parse()` also accepts `ValidateOption` values. Validation runs by default
+// after parsing, so `jwt.WithValidate(true)` is only needed to override a
+// prior `jwt.WithValidate(false)` in the same option set. Pass
+// `jwt.WithValidate(false)` if you need to defer validation and call
+// `Validate()` yourself later.
+//
+// To produce nested JWTs, use
+// `jwt.NewSerializer().Sign(...).Encrypt(...).Serialize(...)`. `Parse()` does
+// not decrypt JWE envelopes; decrypt the outer JWE before calling it.
 //
 // During verification, if the JWS headers specify a key ID (`kid`), the
 // key used for verification must match the specified ID. If you are somehow
 // using a key without a `kid` (which is highly unlikely if you are working
-// with a JWT from a well-know provider), you can work around this by modifying
-// the `jwk.Key` and setting the `kid` header.
-//
-// If you also want to assert the validity of the JWT itself (i.e. expiration
-// and such), use the `Validate()` function on the returned token, or pass the
-// `WithValidate(true)` option. Validate options can also be passed to
-// `Parse`
+// with a JWT from a well-known provider), you can work around this by
+// modifying the `jwk.Key` and setting its `kid` field.
 //
 // This function takes both ParseOption and ValidateOption types:
-// ParseOptions control the parsing behavior, and ValidateOptions are
-// passed to `Validate()` when `jwt.WithValidate` is specified.
+// ParseOptions control parsing and verification behavior, and
+// ValidateOptions are passed to `Validate()` when automatic validation is
+// enabled.
 func Parse(s []byte, options ...ParseOption) (Token, error) {
 	tok, err := parseBytes(s, options...)
 	if err != nil {

--- a/jwt/options.go
+++ b/jwt/options.go
@@ -173,9 +173,6 @@ type withKeySet struct {
 // and you do not mind the verification process having to possibly
 // attempt using multiple times before succeeding to verify. See
 // `jws.InferAlgorithmFromKey` option
-//
-// If you have only one key in the set, and are sure you want to
-// use that key, you can use the `jwt.WithDefaultKey` option.
 func WithKeySet(set jwk.Set, options ...any) ParseOption {
 	return &parseOption{option.New(identKeySet{}, &withKeySet{
 		set:     set,


### PR DESCRIPTION
- add jwt package overview for parse, validation, and migration guidance
- fix misleading Parse docs and remove stale jwt.WithDefaultKey reference
- correct jwt HTTP helper doc strings and example comments
