### PR TITLE
document v3 transform.AsMap aliasing

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -110,7 +110,7 @@ Generic filtering utilities using Go generics.
 
 - **Apply[T Filterable[T]](object T, logic FilterLogic) (T, error)** — include matching fields
 - **Reject[T Filterable[T]](object T, logic FilterLogic) (T, error)** — exclude matching fields
-- **AsMap(m Mappable, dst map[string]any) error** — convert to map (EXPERIMENTAL)
+- **AsMap(m Mappable, dst map[string]any) error** — convert to map; values are whatever `Get()` returns, so mutable values may be live aliases of source object (EXPERIMENTAL)
 - Key types: `FilterLogic`, `FilterLogicFunc`, `Filterable[T]`, `NameBasedFilter[T]`, `Mappable`
 - Files: `filter.go`, `map.go`
 - Imports: (external only: blackmagic)

--- a/transform/map.go
+++ b/transform/map.go
@@ -23,6 +23,11 @@ type Mappable interface {
 // Many objects in jwe, jwk, jws, and jwt packages including
 // `jwt.Token`, `jwk.Key`, `jws.Header`, etc.
 //
+// The values stored in `dst` are the exact values returned by `m.Get()`.
+// Mutable values such as slices, maps, and pointers may therefore be live
+// aliases to the original object's backing storage. AsMap is not a deep-copy
+// or snapshot helper.
+//
 // EXPERIMENTAL: This API is experimental and its interface and behavior is
 // subject to change in future releases. This API is not subject to semver
 // compatibility guarantees.


### PR DESCRIPTION
- document that transform.AsMap stores exact Get() values
- warn that mutable values may be live aliases, not snapshots
