### PR TITLE
fix v4 ecdsa algorithms snapshot

### DIFF
--- a/jwk/ecdsa/BUILD.bazel
+++ b/jwk/ecdsa/BUILD.bazel
@@ -18,5 +18,8 @@ go_test(
     name = "ecdsa_test",
     srcs = ["ecdsa_test.go"],
     embed = [":ecdsa"],
-    deps = ["//jwa"],
+    deps = [
+        "//jwa",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/jwk/ecdsa/ecdsa.go
+++ b/jwk/ecdsa/ecdsa.go
@@ -134,13 +134,16 @@ func rebuildCurves() {
 	}
 }
 
-// Algorithms returns the list of registered jwa.EllipticCurveAlgorithms
-// that ca be used for ECDSA keys.
+// Algorithms returns a snapshot of the registered
+// jwa.EllipticCurveAlgorithms that can be used for ECDSA keys.
+//
+// The returned slice is caller-owned. Modifying it does not affect the
+// package registry, and ordering is unspecified.
 func Algorithms() []jwa.EllipticCurveAlgorithm {
 	muCurves.RLock()
 	defer muCurves.RUnlock()
 
-	return algList
+	return append([]jwa.EllipticCurveAlgorithm(nil), algList...)
 }
 
 func AlgorithmFromCurve(crv elliptic.Curve) (jwa.EllipticCurveAlgorithm, error) {

--- a/jwk/ecdsa/ecdsa_test.go
+++ b/jwk/ecdsa/ecdsa_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/stretchr/testify/require"
 )
 
 var noopValidator = PointValidatorFunc(func(_, _ *big.Int) error { return nil })
@@ -24,9 +25,9 @@ type uniqueTestCurve struct {
 
 // TestConcurrentRegisterAndLookup is a race-detector test. It runs many
 // goroutines that call the read-side lookup functions while a writer
-// goroutine repeatedly calls RegisterCurve. Without RLock on the reads,
-// `go test -race` flags the concurrent map access; with RLock, the test
-// passes cleanly.
+// goroutine repeatedly calls RegisterCurve. The Algorithms path also
+// iterates the returned slice so `go test -race` exercises the snapshot
+// semantics rather than only the map lookups.
 //
 // Each writer iteration wraps elliptic.P256() in a fresh uniqueTestCurve
 // pointer so it gets a distinct interface identity and passes the
@@ -52,6 +53,9 @@ func TestConcurrentRegisterAndLookup(_ *testing.T) {
 					_, _ = CurveFromAlgorithm(jwa.P256())
 					_, _ = AlgorithmFromCurve(elliptic.P256())
 					_ = IsCurveAvailable(jwa.P256())
+					for _, alg := range Algorithms() {
+						_ = alg
+					}
 				}
 			}
 		})
@@ -108,4 +112,40 @@ func TestRegisterCurveRejectsDuplicates(t *testing.T) {
 			t.Fatal(`RegisterCurve must refuse a nil validator`)
 		}
 	})
+}
+
+func TestAlgorithmsReturnsSnapshot(t *testing.T) {
+	registered := jwa.NewEllipticCurveAlgorithm("snapshot-test-registered")
+	tampered := jwa.NewEllipticCurveAlgorithm("snapshot-test-tampered")
+
+	err := RegisterCurve(registered, &uniqueTestCurve{Curve: elliptic.P256()}, noopValidator)
+	require.NoError(t, err, `RegisterCurve should succeed`)
+
+	algorithms := Algorithms()
+	require.NotEmpty(t, algorithms, `Algorithms should return registered curves`)
+
+	found := false
+	for i, alg := range algorithms {
+		if alg != registered {
+			continue
+		}
+
+		algorithms[i] = tampered
+		found = true
+		break
+	}
+	require.True(t, found, `Algorithms snapshot should include the registered curve`)
+
+	refreshed := Algorithms()
+	require.True(t, containsAlgorithm(refreshed, registered), `registry snapshot should still contain the registered curve`)
+	require.False(t, containsAlgorithm(refreshed, tampered), `mutating the returned slice must not modify the registry`)
+}
+
+func containsAlgorithm(list []jwa.EllipticCurveAlgorithm, target jwa.EllipticCurveAlgorithm) bool {
+	for _, alg := range list {
+		if alg == target {
+			return true
+		}
+	}
+	return false
 }

--- a/jwk/ecdsa/ecdsa_test.go
+++ b/jwk/ecdsa/ecdsa_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/elliptic"
 	"fmt"
 	"math/big"
+	"slices"
 	"sync"
 	"testing"
 
@@ -137,15 +138,6 @@ func TestAlgorithmsReturnsSnapshot(t *testing.T) {
 	require.True(t, found, `Algorithms snapshot should include the registered curve`)
 
 	refreshed := Algorithms()
-	require.True(t, containsAlgorithm(refreshed, registered), `registry snapshot should still contain the registered curve`)
-	require.False(t, containsAlgorithm(refreshed, tampered), `mutating the returned slice must not modify the registry`)
-}
-
-func containsAlgorithm(list []jwa.EllipticCurveAlgorithm, target jwa.EllipticCurveAlgorithm) bool {
-	for _, alg := range list {
-		if alg == target {
-			return true
-		}
-	}
-	return false
+	require.True(t, slices.Contains(refreshed, registered), `registry snapshot should still contain the registered curve`)
+	require.False(t, slices.Contains(refreshed, tampered), `mutating the returned slice must not modify the registry`)
 }


### PR DESCRIPTION
- return snapshot copies from `jwk/ecdsa.Algorithms()`
- document caller-owned slice semantics and unspecified ordering
- add aliasing and race regression coverage
