### PR TITLE
fix v3 ecdsa algorithms snapshot

### DIFF
--- a/jwk/ecdsa/ecdsa.go
+++ b/jwk/ecdsa/ecdsa.go
@@ -45,13 +45,16 @@ func rebuildCurves() {
 	}
 }
 
-// Algorithms returns the list of registered jwa.EllipticCurveAlgorithms
-// that ca be used for ECDSA keys.
+// Algorithms returns a snapshot of the registered
+// jwa.EllipticCurveAlgorithms that can be used for ECDSA keys.
+//
+// The returned slice is caller-owned. Modifying it does not affect the
+// package registry, and ordering is unspecified.
 func Algorithms() []jwa.EllipticCurveAlgorithm {
 	muCurves.RLock()
 	defer muCurves.RUnlock()
 
-	return algList
+	return append([]jwa.EllipticCurveAlgorithm(nil), algList...)
 }
 
 func AlgorithmFromCurve(crv elliptic.Curve) (jwa.EllipticCurveAlgorithm, error) {

--- a/jwk/ecdsa/ecdsa_test.go
+++ b/jwk/ecdsa/ecdsa_test.go
@@ -3,6 +3,7 @@ package ecdsa
 import (
 	"crypto/elliptic"
 	"fmt"
+	"slices"
 	"sync"
 	"testing"
 
@@ -78,15 +79,6 @@ func TestAlgorithmsReturnsSnapshot(t *testing.T) {
 	require.True(t, found, `Algorithms snapshot should include the registered curve`)
 
 	refreshed := Algorithms()
-	require.True(t, containsAlgorithm(refreshed, registered), `registry snapshot should still contain the registered curve`)
-	require.False(t, containsAlgorithm(refreshed, tampered), `mutating the returned slice must not modify the registry`)
-}
-
-func containsAlgorithm(list []jwa.EllipticCurveAlgorithm, target jwa.EllipticCurveAlgorithm) bool {
-	for _, alg := range list {
-		if alg == target {
-			return true
-		}
-	}
-	return false
+	require.True(t, slices.Contains(refreshed, registered), `registry snapshot should still contain the registered curve`)
+	require.False(t, slices.Contains(refreshed, tampered), `mutating the returned slice must not modify the registry`)
 }

--- a/jwk/ecdsa/ecdsa_test.go
+++ b/jwk/ecdsa/ecdsa_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/stretchr/testify/require"
 )
 
 // TestConcurrentRegisterAndLookup is a race-detector test. It runs many
 // goroutines that call the read-side lookup functions while a writer
-// goroutine repeatedly calls RegisterCurve. Without RLock on the reads,
-// `go test -race` flags the concurrent map access; with RLock, the test
-// passes cleanly.
+// goroutine repeatedly calls RegisterCurve. The Algorithms path also
+// iterates the returned slice so `go test -race` exercises the snapshot
+// semantics rather than only the map lookups.
 //
 // The writer reuses elliptic.P256() as the curve value and registers a
 // sequence of synthetic algorithm names, so the standard-curve entries
@@ -38,6 +39,9 @@ func TestConcurrentRegisterAndLookup(_ *testing.T) {
 					_, _ = CurveFromAlgorithm(jwa.P256())
 					_, _ = AlgorithmFromCurve(elliptic.P256())
 					_ = IsCurveAvailable(jwa.P256())
+					for _, alg := range Algorithms() {
+						_ = alg
+					}
 				}
 			}
 		})
@@ -50,4 +54,39 @@ func TestConcurrentRegisterAndLookup(_ *testing.T) {
 
 	close(done)
 	wg.Wait()
+}
+
+func TestAlgorithmsReturnsSnapshot(t *testing.T) {
+	registered := jwa.NewEllipticCurveAlgorithm("snapshot-test-registered")
+	tampered := jwa.NewEllipticCurveAlgorithm("snapshot-test-tampered")
+
+	RegisterCurve(registered, elliptic.P256())
+
+	algorithms := Algorithms()
+	require.NotEmpty(t, algorithms, `Algorithms should return registered curves`)
+
+	found := false
+	for i, alg := range algorithms {
+		if alg != registered {
+			continue
+		}
+
+		algorithms[i] = tampered
+		found = true
+		break
+	}
+	require.True(t, found, `Algorithms snapshot should include the registered curve`)
+
+	refreshed := Algorithms()
+	require.True(t, containsAlgorithm(refreshed, registered), `registry snapshot should still contain the registered curve`)
+	require.False(t, containsAlgorithm(refreshed, tampered), `mutating the returned slice must not modify the registry`)
+}
+
+func containsAlgorithm(list []jwa.EllipticCurveAlgorithm, target jwa.EllipticCurveAlgorithm) bool {
+	for _, alg := range list {
+		if alg == target {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
- return snapshot copies from `jwk/ecdsa.Algorithms()`
- document caller-owned slice semantics and unspecified ordering
- add aliasing and race regression coverage
