### PR TITLE
fix jwxio limitedreader bounds

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -143,6 +143,6 @@ Shared utilities. Not public API.
 | `keyconv` | Key type conversions between jwk.Key and Go crypto types |
 | `jose` | Test helper for jose CLI integration |
 | `jwxtest` | Test key generation helpers (RSA, ECDSA, Ed25519, symmetric) |
-| `jwxio` | Safe IO: `ReadAllFromFiniteSource()` |
+| `jwxio` | Safe IO: `ReadAllFromFiniteSource(rdr, maxBytes)` |
 | `tokens` | String constants for algorithm names and separators |
 | `pool` | Generic object pool (`Pool[T]`, `SlicePool[T]`) |

--- a/internal/jwxio/jwxio.go
+++ b/internal/jwxio/jwxio.go
@@ -8,22 +8,40 @@ import (
 )
 
 var errNonFiniteSource = errors.New(`cannot read from non-finite source`)
+var errInputTooLarge = errors.New(`input exceeds maximum size`)
 
 func NonFiniteSourceError() error {
 	return errNonFiniteSource
 }
 
-// ReadAllFromFiniteSource reads all data from a io.Reader _if_ it comes from a
-// finite source.
-func ReadAllFromFiniteSource(rdr io.Reader) ([]byte, error) {
-	switch rdr.(type) {
-	case *bytes.Reader, *bytes.Buffer, *io.LimitedReader, *strings.Reader:
-		data, err := io.ReadAll(rdr)
-		if err != nil {
-			return nil, err
-		}
-		return data, nil
+func InputTooLargeError() error {
+	return errInputTooLarge
+}
+
+// ReadAllFromFiniteSource reads all data from a io.Reader if it comes from a
+// finite source whose remaining size does not exceed maxBytes.
+func ReadAllFromFiniteSource(rdr io.Reader, maxBytes int64) ([]byte, error) {
+	var remaining int64
+	switch rdr := rdr.(type) {
+	case *bytes.Reader:
+		remaining = int64(rdr.Len())
+	case *bytes.Buffer:
+		remaining = int64(rdr.Len())
+	case *io.LimitedReader:
+		remaining = rdr.N
+	case *strings.Reader:
+		remaining = int64(rdr.Len())
 	default:
 		return nil, errNonFiniteSource
 	}
+
+	if remaining > maxBytes {
+		return nil, errInputTooLarge
+	}
+
+	data, err := io.ReadAll(rdr)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
 }

--- a/internal/jwxio/jwxio_test.go
+++ b/internal/jwxio/jwxio_test.go
@@ -18,13 +18,26 @@ func (r *endlessReader) Read(p []byte) (int, error) {
 	return len(p), nil
 }
 
+type readTrackingReader struct {
+	b     byte
+	reads int
+}
+
+func (r *readTrackingReader) Read(p []byte) (int, error) {
+	r.reads++
+	for i := range p {
+		p[i] = r.b
+	}
+	return len(p), nil
+}
+
 func TestReadAllFromFiniteSource(t *testing.T) {
 	t.Parallel()
 
 	t.Run("limited reader from finite source", func(t *testing.T) {
 		t.Parallel()
 
-		data, err := jwxio.ReadAllFromFiniteSource(io.LimitReader(strings.NewReader("hello"), 3))
+		data, err := jwxio.ReadAllFromFiniteSource(io.LimitReader(strings.NewReader("hello"), 3), 4)
 		require.NoError(t, err)
 		require.Equal(t, []byte("hel"), data)
 	})
@@ -32,7 +45,7 @@ func TestReadAllFromFiniteSource(t *testing.T) {
 	t.Run("limited reader bounds endless source", func(t *testing.T) {
 		t.Parallel()
 
-		data, err := jwxio.ReadAllFromFiniteSource(io.LimitReader(&endlessReader{b: 'x'}, 4))
+		data, err := jwxio.ReadAllFromFiniteSource(io.LimitReader(&endlessReader{b: 'x'}, 4), 4)
 		require.NoError(t, err)
 		require.Equal(t, []byte("xxxx"), data)
 	})
@@ -40,7 +53,18 @@ func TestReadAllFromFiniteSource(t *testing.T) {
 	t.Run("endless source is rejected", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := jwxio.ReadAllFromFiniteSource(&endlessReader{b: 'x'})
+		tracker := &readTrackingReader{b: 'x'}
+		_, err := jwxio.ReadAllFromFiniteSource(tracker, 4)
 		require.ErrorIs(t, err, jwxio.NonFiniteSourceError())
+		require.Zero(t, tracker.reads)
+	})
+
+	t.Run("oversized limited reader is rejected before reading", func(t *testing.T) {
+		t.Parallel()
+
+		tracker := &readTrackingReader{b: 'x'}
+		_, err := jwxio.ReadAllFromFiniteSource(&io.LimitedReader{R: tracker, N: 6}, 4)
+		require.ErrorIs(t, err, jwxio.InputTooLargeError())
+		require.Zero(t, tracker.reads)
 	})
 }

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -376,13 +376,16 @@ func ParseReader(src io.Reader, options ...ParseOption) (*Message, error) {
 		}
 	}
 
-	limited := io.LimitReader(src, maxSize+1)
-	data, err := jwxio.ReadAllFromFiniteSource(limited)
+	data, err := jwxio.ReadAllFromFiniteSource(src, maxSize+1)
 	if err == nil {
 		if int64(len(data)) > maxSize {
 			return nil, makeParseError(`jws.ParseReader`, `input exceeded max size of %d bytes`, maxSize)
 		}
 		return Parse(data, options...)
+	}
+
+	if errors.Is(err, jwxio.InputTooLargeError()) {
+		return nil, makeParseError(`jws.ParseReader`, `input exceeded max size of %d bytes`, maxSize)
 	}
 
 	if !errors.Is(err, jwxio.NonFiniteSourceError()) {

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -39,6 +39,15 @@ const examplePayload = `{"iss":"joe",` + "\r\n" + ` "exp":1300819380,` + "\r\n" 
 const exampleCompactSerialization = `eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk`
 const badValue = "%badvalue%"
 
+type infiniteByteReader struct{ b byte }
+
+func (r *infiniteByteReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = r.b
+	}
+	return len(p), nil
+}
+
 var hasES256K bool
 
 func TestSanity(t *testing.T) {
@@ -1872,6 +1881,13 @@ func TestMaxParseInputSize(t *testing.T) {
 		data := make([]byte, 200)
 		_, err := jws.ParseReader(bytes.NewReader(data), jws.WithMaxParseInputSize(100))
 		require.Error(t, err, `jws.ParseReader should reject input exceeding per-call max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("direct oversized limited reader is rejected", func(t *testing.T) {
+		rdr := &io.LimitedReader{R: &infiniteByteReader{b: 'x'}, N: 103}
+		_, err := jws.ParseReader(rdr, jws.WithMaxParseInputSize(100))
+		require.Error(t, err, `jws.ParseReader should reject oversized limited readers`)
+		require.ErrorIs(t, err, jws.ParseError())
 		require.Contains(t, err.Error(), `exceeded max size`)
 	})
 	t.Run("input within limit is accepted", func(t *testing.T) {

--- a/jws/jwsbb/format.go
+++ b/jws/jwsbb/format.go
@@ -179,16 +179,16 @@ func SplitCompactString(src string) (protected, payload, signature []byte, err e
 //
 // The function validates that exactly 3 segments are present, separated by periods.
 func SplitCompactReader(rdr io.Reader) (protected, payload, signature []byte, err error) {
-	// Wrap with a size cap before the finite-source check so that even
-	// recognized finite types (e.g. *io.LimitedReader with a large N)
-	// cannot cause unbounded allocation.
-	capped := io.LimitReader(rdr, maxSplitCompactReaderSize+1)
-	data, err := jwxio.ReadAllFromFiniteSource(capped)
+	data, err := jwxio.ReadAllFromFiniteSource(rdr, maxSplitCompactReaderSize+1)
 	if err == nil {
 		if int64(len(data)) > maxSplitCompactReaderSize {
 			return nil, nil, nil, InputTooLargeError()
 		}
 		return SplitCompact(data)
+	}
+
+	if errors.Is(err, jwxio.InputTooLargeError()) {
+		return nil, nil, nil, InputTooLargeError()
 	}
 
 	if !errors.Is(err, jwxio.NonFiniteSourceError()) {


### PR DESCRIPTION
- reject oversized whitelisted finite readers in `internal/jwxio`
- preserve existing size-limit failures in `jws.ParseReader` and `jwsbb.SplitCompactReader`
- add `io.LimitedReader` regressions and update `.claude/docs/packages.md`
