### PR TITLE
fix jwt required claim matching

### DIFF
--- a/jwt/errors.go
+++ b/jwt/errors.go
@@ -301,13 +301,21 @@ type MissingRequiredClaimError struct {
 	Claim string
 }
 
-func (err *MissingRequiredClaimError) Is(target error) bool {
-	_, ok := target.(*MissingRequiredClaimError)
-	return ok
+func (err MissingRequiredClaimError) Is(target error) bool {
+	switch target.(type) {
+	case MissingRequiredClaimError, *MissingRequiredClaimError:
+		return true
+	default:
+		return false
+	}
+}
+
+func (err MissingRequiredClaimError) Unwrap() error {
+	return err.error
 }
 
 func missingRequiredClaimErrorf(name string) error {
-	return &MissingRequiredClaimError{Claim: name, error: fmt.Errorf(`required claim "%s" is missing`, name)}
+	return MissingRequiredClaimError{Claim: name, error: fmt.Errorf(`required claim "%s" is missing`, name)}
 }
 
 //-------------------------------------------------------------------

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1401,7 +1401,12 @@ func TestGH430(t *testing.T) {
 func TestGH706(t *testing.T) {
 	err := jwt.Validate(jwt.New(), jwt.WithRequiredClaim("foo"))
 	require.ErrorIs(t, err, jwt.ValidationError{}, `error should be a validation error`)
+	require.ErrorIs(t, err, jwt.MissingRequiredClaimError{}, `err should be jwt.ErrRequiredClaim`)
 	require.ErrorIs(t, err, &jwt.MissingRequiredClaimError{}, `err should be jwt.ErrRequiredClaim`)
+
+	requiredClaimErr, ok := errors.AsType[jwt.MissingRequiredClaimError](err)
+	require.True(t, ok, `errors.AsType should find MissingRequiredClaimError`)
+	require.Equal(t, "foo", requiredClaimErr.Claim, `Claim should identify the missing required claim`)
 }
 
 func TestBenHigginsByPassRegression(t *testing.T) {


### PR DESCRIPTION
- align `MissingRequiredClaimError` with the other v4 JWT value errors
- keep `errors.Is` compatibility for both value and pointer targets
- add regression coverage for `errors.Is` and `errors.AsType`
