### PR TITLE
fix v3 jws parse autodetect

### DIFF
--- a/jws/format_detect_test.go
+++ b/jws/format_detect_test.go
@@ -1,0 +1,55 @@
+package jws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectParseFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  []byte
+		want int
+	}{
+		{
+			name: "space then BOM then JSON stays compact",
+			src:  []byte(" \uFEFF{\"payload\":\"x\"}"),
+			want: fmtCompact,
+		},
+		{
+			name: "leading unicode whitespace then JSON",
+			src:  []byte("\u3000{\"payload\":\"x\"}"),
+			want: fmtJSON,
+		},
+		{
+			name: "leading unicode whitespace then compact",
+			src:  []byte("\u3000eyJhbGciOiJIUzI1NiJ9"),
+			want: fmtCompact,
+		},
+		{
+			name: "empty input",
+			want: 0,
+		},
+		{
+			name: "all whitespace input",
+			src:  []byte("\t\r\n "),
+			want: 0,
+		},
+		{
+			name: "unicode whitespace only",
+			src:  []byte("\u3000"),
+			want: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, detectParseFormat(tc.src))
+		})
+	}
+}

--- a/jws/format_detect_test.go
+++ b/jws/format_detect_test.go
@@ -46,7 +46,6 @@ func TestDetectParseFormat(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tc.want, detectParseFormat(tc.src))

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -258,6 +258,24 @@ func getB64Value(hdr Headers) bool {
 	return b64
 }
 
+func detectParseFormat(src []byte) int {
+	for i := 0; i < len(src); {
+		r := rune(src[i])
+		width := 1
+		if r >= utf8.RuneSelf {
+			r, width = utf8.DecodeRune(src[i:])
+		}
+		if !unicode.IsSpace(r) {
+			if r == tokens.OpenCurlyBracket {
+				return fmtJSON
+			}
+			return fmtCompact
+		}
+		i += width
+	}
+	return 0
+}
+
 // Parse parses contents from the given source and creates a jws.Message
 // struct. By default the input can be in either compact or full JSON serialization.
 //
@@ -313,21 +331,7 @@ func Parse(src []byte, options ...ParseOption) (*Message, error) {
 
 	// if format is 0 or both JSON/Compact, auto detect
 	if v := formats & (fmtJSON | fmtCompact); v == 0 || v == fmtJSON|fmtCompact {
-	CHECKLOOP:
-		for i := range src {
-			r := rune(src[i])
-			if r >= utf8.RuneSelf {
-				r, _ = utf8.DecodeRune(src)
-			}
-			if !unicode.IsSpace(r) {
-				if r == tokens.OpenCurlyBracket {
-					formats = fmtJSON
-				} else {
-					formats = fmtCompact
-				}
-				break CHECKLOOP
-			}
-		}
+		formats = detectParseFormat(src)
 	}
 
 	if formats&fmtCompact == fmtCompact {


### PR DESCRIPTION
- decode multibyte prefixes from the current byte offset during format sniffing
- add direct regression tests for BOM and unicode whitespace prefixes
- verify with go test ./jws and make smoke
