### PR TITLE
warn about jws WithKey misuse in v4

### DIFF
--- a/docs/02-jws.md
+++ b/docs/02-jws.md
@@ -216,6 +216,12 @@ func Example_jws_sign() {
 source: [examples/jws_sign_example_test.go](https://github.com/jwx-go/examples/blob/v4/jws_sign_example_test.go)
 <!-- END INCLUDE -->
 
+For normal JWS code, prefer passing a concrete `jwa.SignatureAlgorithm` constant such as
+`jwa.HS256()` or `jwa.RS256()` to `jws.WithKey()`. The option accepts `jwa.KeyAlgorithm`
+so it can forward `(jwk.Key).Algorithm()`, but that metadata is still operation-specific:
+passing a JWE key-encryption algorithm such as `jwa.A128KW()` to `jws.WithKey()` compiles
+and then fails at runtime because JWS only accepts signature algorithms.
+
 ## Generating a JWS message in JSON serialization format
 
 Generally the only time you need to use a JSON serialization format is when you have to generate multiple signatures for a given payload using multiple signing algorithms and keys.
@@ -369,6 +375,11 @@ To verify a JWS message using a single key, use `jws.Verify()` with the `jws.Wit
 It will automatically do the right thing whether it's serialized in compact form or JSON form.
 
 The `alg` must be explicitly specified. See "[Why don't you automatically infer the algorithm for `jws.Verify`?](99-faq.md#why-dont-you-automatically-infer-the-algorithm-for-jwsverify-)"
+
+As with signing, prefer a concrete `jwa.SignatureAlgorithm` constant when you already know
+you are verifying a JWS. Passing `(jwk.Key).Algorithm()` through `jws.WithKey()` only works
+when that JWK is already marked with a signature algorithm; JWE algorithms are rejected at
+runtime.
 
 <!-- INCLUDE(examples/jws_verify_with_key_example_test.go) -->
 ```go

--- a/docs/99-faq.md
+++ b/docs/99-faq.md
@@ -99,11 +99,16 @@ Since version 2.0.0 `jwk.Key` now stores the `alg` field as a `jwa.KeyAlgorithm`
 
 Now you should be able to just pass the `alg` value to most high-level functions and methods such as `jwt.Verify`, `jws.Sign`, and `jwe.Encrypt`
 
+That convenience is still operation-specific. For JWS helpers such as `jws.Sign()` and
+`jws.Verify()`, the value must resolve to a `jwa.SignatureAlgorithm`. For JWE helpers, it
+must resolve to the appropriate key-encryption algorithm. Passing the wrong kind of
+algorithm, such as `jwa.A128KW()` to `jws.WithKey()`, compiles but fails at runtime.
+
 ### When do we use `jwa.KeyAlgorithm`
 
 There are some functions that accept `jwa.KeyAlgorithm`, while there are others that expect `jwa.SignatureAlgorithm` or `jwa.KeyEncryptionAlgorithm`. So when do we use which?
 
-The guideline is as follows: If it's a high-level function/method that the users regularly use, use `jwa.KeyAlgorithm`. For example, almost everybody who use `jwt` will want to verify the JWS signed payload, so `jwt.Sign()`, and `jwt.Verify()` expect `jwa.KeyAlgorithm`. On the other hand, `jwt.Serializer` uses `jwa.SignatureAlgorithm` and such. This is a low-level utility, and users are not really meant to use it for their most basic needs: therefore they use the specific algorithm type.
+The guideline is as follows: If it's a high-level function/method that the users regularly use, use `jwa.KeyAlgorithm`. For example, almost everybody who use `jwt` will want to verify the JWS signed payload, so `jwt.Sign()`, and `jwt.Verify()` expect `jwa.KeyAlgorithm`. On the other hand, `jwt.Serializer` uses `jwa.SignatureAlgorithm` and such. This is a low-level utility, and users are not really meant to use it for their most basic needs: therefore they use the specific algorithm type. This does not mean every algorithm kind is valid for every operation; the operation still decides whether it accepts signature or key-encryption algorithms.
 
 ## Why are your options objects, and not callbacks?
 

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -2151,17 +2151,26 @@ func TestAlgorithmsForKeyCryptoSigner(t *testing.T) {
 	})
 }
 
-func TestVerifyWithNonSignatureAlgorithm(t *testing.T) {
+func TestWithKeyRejectsNonSignatureAlgorithm(t *testing.T) {
 	hmacKey := jwxtest.GenerateSymmetricKey()
 	signed, err := jws.Sign([]byte("test"), jws.WithKey(jwa.HS256(), hmacKey))
 	require.NoError(t, err)
 
-	// jwa.A128KW is a KeyEncryptionAlgorithm, not a SignatureAlgorithm.
-	// Previously the unchecked type assertion in verify_context would panic.
-	_, err = jws.Verify(signed, jws.WithKey(jwa.A128KW(), hmacKey))
-	require.Error(t, err)
-	require.True(t, errors.Is(err, jws.VerifyError()))
-	require.Contains(t, err.Error(), "SignatureAlgorithm")
+	t.Run("Sign", func(t *testing.T) {
+		// jwa.A128KW is a KeyEncryptionAlgorithm, not a SignatureAlgorithm.
+		_, err := jws.Sign([]byte("test"), jws.WithKey(jwa.A128KW(), hmacKey))
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jws.SignError()))
+		require.Contains(t, err.Error(), "SignatureAlgorithm")
+	})
+
+	t.Run("Verify", func(t *testing.T) {
+		// Previously the unchecked type assertion in verify_context would panic.
+		_, err := jws.Verify(signed, jws.WithKey(jwa.A128KW(), hmacKey))
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jws.VerifyError()))
+		require.Contains(t, err.Error(), "SignatureAlgorithm")
+	})
 }
 
 func TestCompactErrorsUseSignError(t *testing.T) {

--- a/jws/options.go
+++ b/jws/options.go
@@ -92,11 +92,15 @@ func (w *withKey) Protected(v Headers) Headers {
 
 // WithKey is used to pass a static algorithm/key pair to either `jws.Sign()` or `jws.Verify()`.
 //
+// IMPORTANT: Although `alg` is typed as `jwa.KeyAlgorithm` for compatibility
+// with `(jwk.Key).Algorithm()`, JWS only accepts `jwa.SignatureAlgorithm`
+// values here. Passing a key-encryption algorithm such as `jwa.A128KW()` to
+// `jws.WithKey()` compiles, but `jws.Sign()` / `jws.Verify()` reject it at runtime.
+//
 // The `alg` parameter is the identifier for the signature algorithm that should be used.
-// It is of type `jwa.KeyAlgorithm` but in reality you can only pass `jwa.SignatureAlgorithm`
-// types. It is this way so that the value in `(jwk.Key).Algorithm()` can be directly
-// passed to the option. If you specify other algorithm types such as `jwa.KeyEncryptionAlgorithm`,
-// then you will get an error when `jws.Sign()` or `jws.Verify()` is executed.
+// It is of type `jwa.KeyAlgorithm` so that the value in `(jwk.Key).Algorithm()` can be
+// directly passed to the option, but that is only valid when the JWK is already known to
+// be intended for JWS and its `alg` value is a `jwa.SignatureAlgorithm`.
 //
 // The `alg` parameter cannot be "none" (jwa.NoSignature) for security reasons.
 // You will have to use a separate, more explicit option to allow the use of "none"


### PR DESCRIPTION
- move the `jws.WithKey()` warning to the top of its godoc
- clarify in the JWS guide and FAQ that algorithm metadata is operation-specific
- add sign/verify regression coverage for non-signature algorithms
