### PR TITLE
warn about jws WithKey misuse in v3

### DIFF
--- a/docs/02-jws.md
+++ b/docs/02-jws.md
@@ -215,6 +215,12 @@ func Example_jws_sign() {
 source: [examples/jws_sign_example_test.go](https://github.com/lestrrat-go/jwx/blob/v3/examples/jws_sign_example_test.go)
 <!-- END INCLUDE -->
 
+For normal JWS code, prefer passing a concrete `jwa.SignatureAlgorithm` constant such as
+`jwa.HS256()` or `jwa.RS256()` to `jws.WithKey()`. The option accepts `jwa.KeyAlgorithm`
+so it can forward `(jwk.Key).Algorithm()`, but that metadata is still operation-specific:
+passing a JWE key-encryption algorithm such as `jwa.A128KW()` to `jws.WithKey()` compiles
+and then fails at runtime because JWS only accepts signature algorithms.
+
 ## Generating a JWS message in JSON serialization format
 
 Generally the only time you need to use a JSON serialization format is when you have to generate multiple signatures for a given payload using multiple signing algorithms and keys.
@@ -368,6 +374,11 @@ To verify a JWS message using a single key, use `jws.Verify()` with the `jws.Wit
 It will automatically do the right thing whether it's serialized in compact form or JSON form.
 
 The `alg` must be explicitly specified. See "[Why don't you automatically infer the algorithm for `jws.Verify`?](99-faq.md#why-dont-you-automatically-infer-the-algorithm-for-jwsverify-)"
+
+As with signing, prefer a concrete `jwa.SignatureAlgorithm` constant when you already know
+you are verifying a JWS. Passing `(jwk.Key).Algorithm()` through `jws.WithKey()` only works
+when that JWK is already marked with a signature algorithm; JWE algorithms are rejected at
+runtime.
 
 <!-- INCLUDE(examples/jws_verify_with_key_example_test.go) -->
 ```go

--- a/docs/99-faq.md
+++ b/docs/99-faq.md
@@ -99,13 +99,17 @@ Since version 2.0.0 `jwk.Key` now stores the `alg` field as a `jwa.KeyAlgorithm`
 
 Now you should be able to just pass the `alg` value to most high-level functions and methods such as `jwt.Verify`, `jws.Sign`, and `jwe.Encrypt`
 
+That convenience is still operation-specific. For JWS helpers such as `jws.Sign()` and
+`jws.Verify()`, the value must resolve to a `jwa.SignatureAlgorithm`. For JWE helpers, it
+must resolve to the appropriate key-encryption algorithm. Passing the wrong kind of
+algorithm, such as `jwa.A128KW()` to `jws.WithKey()`, compiles but fails at runtime.
+
 ### When do we use `jwa.KeyAlgorithm`
 
 There are some functions that accept `jwa.KeyAlgorithm`, while there are others that expect `jwa.SignatureAlgorithm` or `jwa.KeyEncryptionAlgorithm`. So when do we use which?
 
-The guideline is as follows: If it's a high-level function/method that the users regularly use, use `jwa.KeyAlgorithm`. For example, almost everybody who use `jwt` will want to verify the JWS signed payload, so `jwt.Sign()`, and `jwt.Verify()` expect `jwa.KeyAlgorithm`. On the other hand, `jwt.Serializer` uses `jwa.SignatureAlgorithm` and such. This is a low-level utility, and users are not really meant to use it for their most basic needs: therefore they use the specific algorithm type.
+The guideline is as follows: If it's a high-level function/method that the users regularly use, use `jwa.KeyAlgorithm`. For example, almost everybody who use `jwt` will want to verify the JWS signed payload, so `jwt.Sign()`, and `jwt.Verify()` expect `jwa.KeyAlgorithm`. On the other hand, `jwt.Serializer` uses `jwa.SignatureAlgorithm` and such. This is a low-level utility, and users are not really meant to use it for their most basic needs: therefore they use the specific algorithm type. This does not mean every algorithm kind is valid for every operation; the operation still decides whether it accepts signature or key-encryption algorithms.
 
-<<<<<<< HEAD
 ## Why are your options objects, and not callbacks?
 
 We get this one a lot. The short answer is that 1) the options API is not designed to be extended by users, and 2) callbacks introduce tight coupling between the options and the consumers.
@@ -150,10 +154,6 @@ Based on the reasons above, we decided to **decouple the option data** and the *
 
 Yes, we understand that this way we introduce more boilerplate code in each method's starting section. But our design choice is that this way fulfills our goals better, namely that **the overall structure is simpler**, **we do not expose unnecessary internal data to the end-user**, and because the options are all data, it's far **easier to re-use the same options for multiple methods** (as we do in cases such as `jws.WithKey()`, for example).
 
-
-=======
-<<<<<<< HEAD
->>>>>>> 666d74d (Add FAQ about option format (#1102))
 ## Design
 
 ### Why does this library not provide a method similar to `Range()`?
@@ -168,55 +168,4 @@ obj.Range(func(k string, v interface{}) bool) { // This needs a read lock
 
 `sync.Map` actually solves this problem, but it involves a fairly complicated workaround. While it is theoretically possible to implement the same logic in this package, we have decided that it is not worth the effort for our purposes.
 
-If you would like to iterate through the keys,  use `Keys()` to retireve the list of keys. This also requires a read lock, but by necessity you can only proceed to execute the next piece of code only after the read lock has been released.
-<<<<<<< HEAD
-=======
-=======
-## Why are your options objects, and not callbacks?
-
-We get this one a lot. The short answer is that 1) the options API is not designed to be extended by users, and 2) callbacks introduce tight coupling between the options and the consumers.
-
-(1) should be obvious. We just never intended it to be extensible for end-users. That's a design choice, and at the point of writing this, we have no intention to change this.
-
-(2) is subtler: consider a case where you are setting a few instance variables on an object:
-
-```go
-func MyOption(obj *Object) {
-    obj.FieldA = ...
-    obj.FieldB = ...
-}
-```
-
-From this design you can see that we need to make a few assumptions.
-
-First, the callback must have a specific signature. This is not a deal breaker, but you have to be conscious of the fact that you are tying your option to this object type specifically, and you will not be able to change this.
-
-Second, you are setting values to an object. The library can either provide exported fields, or it can provide setter methods, but either way, it will need to expose those knobs to the end user. This means that internal details of the object _will_ have to be visible, even if this option is the only logical place that detail is to be used. You could maybe use a state (or a config) variable to avoid assigning to the object itself, and localize the effect of the option for the method:
-
-```go
-func (obj *Object) Method(options ...Options) error {
-    var cfg MethodConfig
-    for _, option := range options {
-        option(obj, cfg)
-    }
-    ...
-}
-
-func MyOption(obj *Object, cfg *MethodConfig) {
-    cfg.FieldA = ...
-    cfg.FieldB = ...
-}
-```
-
-But this means that you will have to have a state/config object for _each_ method call that takes options, and we have a lot of methods.
-
-And finally, as you have seen above, with a callback based option object you will have to change its signature for each usecase. It's just a lot of hassle to remember which option uses which signature.
-
-Based on the reasons above, we decided to **decouple the option data** and the **option handling logic**. Our option objects are simply data containers. They have an identity (`Ident()`), and they have a value (`Value()`). The option objects themselves do not know how they are going to be used. The consumers (the methods) are the ones who know how to deal with the data the options carry.
-
-Yes, we understand that this way we introduce more boilerplate code in each method's starting section. But our design choice is that this way fulfills our goals better, namely that **the overall structure is simpler**, **we do not expose unnecessary internal data to the end-user**, and because the options are all data, it's far **easier to re-use the same options for multiple methods** (as we do in cases such as `jws.WithKey()`, for example).
-
-
-
->>>>>>> 548968cd (Add FAQ about option format (#1102))
->>>>>>> 666d74d (Add FAQ about option format (#1102))
+If you would like to iterate through the keys, use `Keys()` to retrieve the list of keys. This also requires a read lock, but by necessity you can only proceed to execute the next piece of code only after the read lock has been released.

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -2095,15 +2095,24 @@ func TestAlgorithmsForKeyCryptoSigner(t *testing.T) {
 	})
 }
 
-func TestVerifyWithNonSignatureAlgorithm(t *testing.T) {
+func TestWithKeyRejectsNonSignatureAlgorithm(t *testing.T) {
 	hmacKey := jwxtest.GenerateSymmetricKey()
 	signed, err := jws.Sign([]byte("test"), jws.WithKey(jwa.HS256(), hmacKey))
 	require.NoError(t, err)
 
-	// jwa.A128KW is a KeyEncryptionAlgorithm, not a SignatureAlgorithm.
-	// Previously the unchecked type assertion in verify_context would panic.
-	_, err = jws.Verify(signed, jws.WithKey(jwa.A128KW(), hmacKey))
-	require.Error(t, err)
-	require.True(t, errors.Is(err, jws.VerifyError()))
-	require.Contains(t, err.Error(), "SignatureAlgorithm")
+	t.Run("Sign", func(t *testing.T) {
+		// jwa.A128KW is a KeyEncryptionAlgorithm, not a SignatureAlgorithm.
+		_, err := jws.Sign([]byte("test"), jws.WithKey(jwa.A128KW(), hmacKey))
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jws.SignError()))
+		require.Contains(t, err.Error(), "SignatureAlgorithm")
+	})
+
+	t.Run("Verify", func(t *testing.T) {
+		// Previously the unchecked type assertion in verify_context would panic.
+		_, err := jws.Verify(signed, jws.WithKey(jwa.A128KW(), hmacKey))
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jws.VerifyError()))
+		require.Contains(t, err.Error(), "SignatureAlgorithm")
+	})
 }

--- a/jws/options.go
+++ b/jws/options.go
@@ -87,11 +87,15 @@ func (w *withKey) Protected(v Headers) Headers {
 
 // WithKey is used to pass a static algorithm/key pair to either `jws.Sign()` or `jws.Verify()`.
 //
+// IMPORTANT: Although `alg` is typed as `jwa.KeyAlgorithm` for compatibility
+// with `(jwk.Key).Algorithm()`, JWS only accepts `jwa.SignatureAlgorithm`
+// values here. Passing a key-encryption algorithm such as `jwa.A128KW()` to
+// `jws.WithKey()` compiles, but `jws.Sign()` / `jws.Verify()` reject it at runtime.
+//
 // The `alg` parameter is the identifier for the signature algorithm that should be used.
-// It is of type `jwa.KeyAlgorithm` but in reality you can only pass `jwa.SignatureAlgorithm`
-// types. It is this way so that the value in `(jwk.Key).Algorithm()` can be directly
-// passed to the option. If you specify other algorithm types such as `jwa.KeyEncryptionAlgorithm`,
-// then you will get an error when `jws.Sign()` or `jws.Verify()` is executed.
+// It is of type `jwa.KeyAlgorithm` so that the value in `(jwk.Key).Algorithm()` can be
+// directly passed to the option, but that is only valid when the JWK is already known to
+// be intended for JWS and its `alg` value is a `jwa.SignatureAlgorithm`.
 //
 // The `alg` parameter cannot be "none" (jwa.NoSignature) for security reasons.
 // You will have to use a separate, more explicit option to allow the use of "none"


### PR DESCRIPTION
- move the `jws.WithKey()` warning to the top of its godoc
- clarify in the JWS guide and FAQ that algorithm metadata is operation-specific
- add sign/verify regression coverage and clean the touched FAQ conflict markers
