### PR TITLE
fix akp public key z leak

### DIFF
--- a/docs/10-extensions.md
+++ b/docs/10-extensions.md
@@ -731,7 +731,7 @@ decrypted, _ := jwe.Decrypt(encrypted, jwe.WithKey(jwxmlkem.MLKEM768(), dk))
 
 Supported algorithms: `ML-KEM-768`, `ML-KEM-1024` (direct), and `ML-KEM-768+A192KW`, `ML-KEM-1024+A256KW` (key wrap variants). Raw `*mlkem.EncapsulationKey*`/`*mlkem.DecapsulationKey*` values and `jwk.Key` values are both accepted via `jwe.WithKey`. See [`examples/mlkem_encrypt_decrypt_example_test.go`](https://github.com/jwx-go/examples/blob/v4/mlkem_encrypt_decrypt_example_test.go) for a runnable example.
 
-**JWK round-trip caveat:** `draft-ietf-jose-pqc-kem` defines the `priv` field as the 32-byte `d` seed only, while stdlib `crypto/mlkem` requires the full 64-byte `d || z` seed. On re-import, a fresh random `z` is generated. Decapsulation of valid ciphertexts is unaffected, but JWK round-trips are not bitwise-identical. See the [module README](https://github.com/jwx-go/mlkem) for details.
+**JWK round-trip behavior:** `draft-ietf-jose-pqc-kem` defines the `priv` field as the 32-byte `d` seed only, while stdlib `crypto/mlkem` requires the full 64-byte `d || z` seed. This module stores `d` in `priv` and preserves the implicit-rejection value in a private `z` field so ML-KEM private JWKs round-trip back to the same stdlib seed. Legacy ML-KEM JWKs without `z` still import; on export, the module derives a deterministic fallback `z` from `d` and the ML-KEM parameter set so reconstructed keys remain stable across processes and restarts. See the [module README](https://github.com/jwx-go/mlkem) for details.
 
 ---
 

--- a/jwk/akp.go
+++ b/jwk/akp.go
@@ -23,6 +23,8 @@ func init() {
 	normalizedAKP = KeyKind(jwa.AKP().String()).normalize()
 }
 
+const akpPrivateZKey = "z"
+
 func akpKeyKind(algfn func() (jwa.KeyAlgorithm, bool)) KeyKind {
 	if alg, ok := algfn(); ok {
 		return KeyKind(jwa.AKP().String() + ":" + alg.String()).normalize()
@@ -37,7 +39,7 @@ func makeAKPPublicKey(src Key) (Key, error) {
 	newKey := newAKPPublicKey()
 	for _, k := range src.Keys() {
 		switch k {
-		case AKPPrivKey:
+		case AKPPrivKey, akpPrivateZKey:
 			continue
 		default:
 			v, ok := src.Field(k)

--- a/jwk/akp_test.go
+++ b/jwk/akp_test.go
@@ -64,3 +64,33 @@ func TestAKPThumbprintRequiresAlg(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestAKPPublicKeyDropsZButPreservesOtherCustomFields(t *testing.T) {
+	pub := []byte("pub-bytes")
+	priv := []byte("priv-bytes")
+	z := []byte("mlkem-private-z")
+	alg := jwa.RS256()
+
+	k := newAKPPrivateKey()
+	require.NoError(t, k.Set(AKPPubKey, pub))
+	require.NoError(t, k.Set(AKPPrivKey, priv))
+	require.NoError(t, k.Set(AlgorithmKey, alg))
+	require.NoError(t, k.Set(akpPrivateZKey, z))
+	require.NoError(t, k.Set("custom", "keep-me"))
+
+	pubKey, err := k.PublicKey()
+	require.NoError(t, err)
+	require.False(t, pubKey.Has(AKPPrivKey))
+	require.False(t, pubKey.Has(akpPrivateZKey))
+	require.True(t, pubKey.Has("custom"))
+
+	custom, ok := pubKey.Field("custom")
+	require.True(t, ok)
+	require.Equal(t, "keep-me", custom)
+
+	privThumbprint, err := k.Thumbprint(crypto.SHA256)
+	require.NoError(t, err)
+	pubThumbprint, err := pubKey.Thumbprint(crypto.SHA256)
+	require.NoError(t, err)
+	require.Equal(t, privThumbprint, pubThumbprint)
+}


### PR DESCRIPTION
- drop AKP z during public key projection
- add AKP regression coverage for private z handling
- update ML-KEM extension docs for preserved z round-trips
