### PR TITLE
fix jwe p2c validation

### DIFF
--- a/jwe/decrypt.go
+++ b/jwe/decrypt.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	stdjson "encoding/json"
 	"fmt"
+	"math"
 
 	"github.com/lestrrat-go/jwx/v4/internal/base64"
 	"github.com/lestrrat-go/jwx/v4/jwa"
@@ -94,6 +95,10 @@ func decryptKeyPBES2(recipientKey []byte, alg string, key any, headers Headers, 
 		}
 	default:
 		return nil, fmt.Errorf(`jwe: decrypt key: %q field is not a number`, CountKey)
+	}
+
+	if math.IsNaN(countFlt) || math.IsInf(countFlt, 0) || math.Trunc(countFlt) != countFlt {
+		return nil, fmt.Errorf("jwe: decrypt key: invalid 'p2c' value")
 	}
 
 	if countFlt > float64(maxCount) || countFlt < float64(minCount) {

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1071,6 +1071,26 @@ func TestGHSA_7f9x_gw85_8grf(t *testing.T) {
 	}
 }
 
+func rewriteCompactPBES2Count(t *testing.T, token []byte, count any) []byte {
+	t.Helper()
+
+	segs := bytes.Split(token, []byte{'.'})
+	require.Len(t, segs, 5, `compact JWE should have 5 segments`)
+
+	protectedJSON, err := base64.RawURLEncoding.DecodeString(string(segs[0]))
+	require.NoError(t, err, `protected header should decode`)
+
+	var protected map[string]any
+	require.NoError(t, json.Unmarshal(protectedJSON, &protected), `protected header should parse`)
+	protected[jwe.CountKey] = count
+
+	protectedJSON, err = json.Marshal(protected)
+	require.NoError(t, err, `protected header should marshal`)
+
+	segs[0] = []byte(base64.RawURLEncoding.EncodeToString(protectedJSON))
+	return bytes.Join(segs, []byte{'.'})
+}
+
 func TestMinPBES2Count(t *testing.T) {
 	// Encrypt with an explicit small p2c so the min-check assertions
 	// don't depend on the (per-variant, six-digit) encrypt defaults.
@@ -1209,6 +1229,36 @@ func TestPBES2CountEncrypt(t *testing.T) {
 		decrypted, err := jwe.Decrypt(encrypted2, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
 		require.NoError(t, err)
 		require.Equal(t, payload, decrypted)
+	})
+}
+
+func TestPBES2RejectsNonIntegerCount(t *testing.T) {
+	password := []byte(`supersecret`)
+	key, err := jwk.Import[jwk.Key](password)
+	require.NoError(t, err, `jwk.Import should succeed`)
+
+	encrypted, err := jwe.Encrypt(
+		[]byte(`hello world`),
+		jwe.WithKey(jwa.PBES2_HS256_A128KW(), key),
+		jwe.WithPBES2Count(2000),
+	)
+	require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+	tampered := rewriteCompactPBES2Count(t, encrypted, 1500.9)
+
+	t.Run("default decoder rejects fractional count", func(t *testing.T) {
+		_, err := jwe.Decrypt(tampered, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+		require.Error(t, err, `jwe.Decrypt should fail`)
+		require.Contains(t, err.Error(), `invalid 'p2c' value`)
+	})
+
+	t.Run("UseNumber decoder rejects fractional count", func(t *testing.T) {
+		json.SetUseNumber(true)
+		defer json.SetUseNumber(false)
+
+		_, err := jwe.Decrypt(tampered, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
+		require.Error(t, err, `jwe.Decrypt should fail`)
+		require.Contains(t, err.Error(), `invalid 'p2c' value`)
 	})
 }
 


### PR DESCRIPTION
- reject non-integer PBES2 p2c values before the decrypt-side int cast
- keep the existing max/min count enforcement and error shape
- add compact-token regressions for default and UseNumber decode paths
