### PR TITLE
fix jwe aescbc append

### DIFF
--- a/jwe/internal/aescbc/aescbc.go
+++ b/jwe/internal/aescbc/aescbc.go
@@ -199,10 +199,7 @@ func ensureSize(dst []byte, n int) []byte {
 	}
 
 	const maxInt = int64(^uint(0) >> 1)
-	maxAlloc := maxBufSize.Load()
-	if maxAlloc > maxInt {
-		maxAlloc = maxInt
-	}
+	maxAlloc := min(maxBufSize.Load(), maxInt)
 
 	if int64(len(dst)) > maxAlloc-int64(n) {
 		panic(fmt.Errorf("failed to allocate buffer"))

--- a/jwe/internal/aescbc/aescbc.go
+++ b/jwe/internal/aescbc/aescbc.go
@@ -193,6 +193,11 @@ func (c Hmac) ComputeAuthTag(aad, nonce, ciphertext []byte) ([]byte, error) {
 func ensureSize(dst []byte, n int) []byte {
 	// Grow dst by n bytes, preserving its current contents as the prefix.
 	// This matches the crypto.AEAD append contract used by Seal/Open.
+	const maxInt = int(^uint(0) >> 1)
+	if n > maxInt-len(dst) {
+		panic(fmt.Errorf("failed to allocate buffer"))
+	}
+
 	retlen := len(dst) + n
 	if cap(dst) >= retlen {
 		return dst[:retlen]

--- a/jwe/internal/aescbc/aescbc.go
+++ b/jwe/internal/aescbc/aescbc.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"hash"
+	"slices"
 	"sync/atomic"
 
 	"github.com/lestrrat-go/jwx/v4/internal/pool"
@@ -193,19 +194,23 @@ func (c Hmac) ComputeAuthTag(aad, nonce, ciphertext []byte) ([]byte, error) {
 func ensureSize(dst []byte, n int) []byte {
 	// Grow dst by n bytes, preserving its current contents as the prefix.
 	// This matches the crypto.AEAD append contract used by Seal/Open.
-	const maxInt = int(^uint(0) >> 1)
-	if n > maxInt-len(dst) {
+	if n < 0 {
+		panic(fmt.Errorf("failed to allocate buffer"))
+	}
+
+	const maxInt = int64(^uint(0) >> 1)
+	maxAlloc := maxBufSize.Load()
+	if maxAlloc > maxInt {
+		maxAlloc = maxInt
+	}
+
+	if int64(len(dst)) > maxAlloc-int64(n) {
 		panic(fmt.Errorf("failed to allocate buffer"))
 	}
 
 	retlen := len(dst) + n
-	if cap(dst) >= retlen {
-		return dst[:retlen]
-	}
-
-	ret := make([]byte, retlen)
-	copy(ret, dst)
-	return ret
+	dst = slices.Grow(dst, n)
+	return dst[:retlen]
 }
 
 // Seal fulfills the crypto.AEAD interface

--- a/jwe/internal/aescbc/aescbc.go
+++ b/jwe/internal/aescbc/aescbc.go
@@ -191,15 +191,15 @@ func (c Hmac) ComputeAuthTag(aad, nonce, ciphertext []byte) ([]byte, error) {
 }
 
 func ensureSize(dst []byte, n int) []byte {
-	// if the dst buffer has enough length just copy the relevant parts to it.
-	// Otherwise create a new slice that's big enough, and operate on that
-	// Note: I think go-jose has a bug in that it checks for cap(), but not len().
-	ret := dst
-	if diff := n - len(dst); diff > 0 {
-		// dst is not big enough
-		ret = make([]byte, n)
-		copy(ret, dst)
+	// Grow dst by n bytes, preserving its current contents as the prefix.
+	// This matches the crypto.AEAD append contract used by Seal/Open.
+	retlen := len(dst) + n
+	if cap(dst) >= retlen {
+		return dst[:retlen]
 	}
+
+	ret := make([]byte, retlen)
+	copy(ret, dst)
 	return ret
 }
 
@@ -226,9 +226,7 @@ func (c Hmac) Seal(dst, nonce, plaintext, data []byte) []byte {
 		panic(fmt.Errorf("failed to seal on hmac: %v", err))
 	}
 
-	retlen := len(dst) + len(ciphertext) + len(authtag)
-
-	ret := ensureSize(dst, retlen)
+	ret := ensureSize(dst, len(ciphertext)+len(authtag))
 	out := ret[len(dst):]
 	n := copy(out, ciphertext)
 	copy(out[n:], authtag)

--- a/jwe/internal/aescbc/aescbc_test.go
+++ b/jwe/internal/aescbc/aescbc_test.go
@@ -127,6 +127,15 @@ func TestSealAndOpenAppendToDst(t *testing.T) {
 	})
 }
 
+func TestEnsureSizeRejectsOverflow(t *testing.T) {
+	dst := []byte("x")
+	maxInt := int(^uint(0) >> 1)
+
+	require.PanicsWithError(t, "failed to allocate buffer", func() {
+		_ = ensureSize(dst, maxInt)
+	})
+}
+
 func TestPad(t *testing.T) {
 	for i := range 256 {
 		buf := make([]byte, i)

--- a/jwe/internal/aescbc/aescbc_test.go
+++ b/jwe/internal/aescbc/aescbc_test.go
@@ -1,6 +1,7 @@
 package aescbc
 
 import (
+	"bytes"
 	"crypto/aes"
 	"testing"
 
@@ -86,6 +87,43 @@ func TestOpenOpaqueErrors(t *testing.T) {
 		tampered[len(tampered)-1] ^= 0xFF
 		_, err := enc.Open(nil, nonce, tampered, aad)
 		require.EqualError(t, err, "invalid ciphertext")
+	})
+}
+
+func TestSealAndOpenAppendToDst(t *testing.T) {
+	key := make([]byte, 32)
+	enc, err := New(key, aes.NewCipher)
+	require.NoError(t, err, "aescbc.New")
+
+	aad := []byte("aad")
+	plaintext := []byte("hello world")
+	nonce := make([]byte, enc.blockCipher.BlockSize())
+	sealed := enc.Seal(nil, nonce, plaintext, aad)
+
+	t.Run("Seal appends after dst prefix", func(t *testing.T) {
+		prefix := []byte("dst")
+		got := enc.Seal(prefix, nonce, plaintext, aad)
+
+		expected := append(append([]byte(nil), prefix...), sealed...)
+		require.Equal(t, expected, got)
+	})
+
+	t.Run("Open appends after short dst prefix", func(t *testing.T) {
+		prefix := []byte("dst")
+		got, err := enc.Open(prefix, nonce, sealed, aad)
+		require.NoError(t, err, "Open should succeed")
+
+		expected := append(append([]byte(nil), prefix...), plaintext...)
+		require.Equal(t, expected, got)
+	})
+
+	t.Run("Open appends after long dst prefix", func(t *testing.T) {
+		prefix := bytes.Repeat([]byte{'x'}, len(plaintext)+3)
+		got, err := enc.Open(prefix, nonce, sealed, aad)
+		require.NoError(t, err, "Open should succeed")
+
+		expected := append(append([]byte(nil), prefix...), plaintext...)
+		require.Equal(t, expected, got)
 	})
 }
 


### PR DESCRIPTION
- fix aescbc dst growth to preserve the caller prefix on Seal and Open
- keep Hmac behaving like a standard append-style crypto.AEAD implementation
- add regressions for short and long non-empty dst prefixes
