### PR TITLE
fix v3 jwe gcmkw header typing

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -639,7 +639,10 @@ func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgo
 		}
 	case jwa.A128GCMKW(), jwa.A192GCMKW(), jwa.A256GCMKW():
 		var ivB64 string
-		if err := h2.Get(InitializationVectorKey, &ivB64); err == nil {
+		if h2.Has(InitializationVectorKey) {
+			if err := h2.Get(InitializationVectorKey, &ivB64); err != nil {
+				return nil, fmt.Errorf(`field %q is not a string: %w`, InitializationVectorKey, err)
+			}
 			iv, err := base64.DecodeString(ivB64)
 			if err != nil {
 				return nil, fmt.Errorf(`failed to b64-decode 'iv': %w`, err)
@@ -647,7 +650,10 @@ func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgo
 			dec.KeyInitializationVector(iv)
 		}
 		var tagB64 string
-		if err := h2.Get(TagKey, &tagB64); err == nil {
+		if h2.Has(TagKey) {
+			if err := h2.Get(TagKey, &tagB64); err != nil {
+				return nil, fmt.Errorf(`field %q is not a string: %w`, TagKey, err)
+			}
 			tag, err := base64.DecodeString(tagB64)
 			if err != nil {
 				return nil, fmt.Errorf(`failed to b64-decode 'tag': %w`, err)

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -794,6 +794,47 @@ func TestGH924(t *testing.T) {
 	require.Equal(t, payload, decrypted, `decrypt messages match`)
 }
 
+func TestDecryptRejectsNonStringAESGCMKWHeaders(t *testing.T) {
+	sharedKey := []byte("0123456789abcdef")
+	payload := []byte("Lorem Ipsum")
+
+	encrypted, err := jwe.Encrypt(
+		payload,
+		jwe.WithJSON(),
+		jwe.WithKey(jwa.A128GCMKW(), sharedKey),
+		jwe.WithContentEncryption(jwa.A128GCM()),
+	)
+	require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+	decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.A128GCMKW(), sharedKey))
+	require.NoError(t, err, `baseline jwe.Decrypt should succeed`)
+	require.Equal(t, payload, decrypted, `baseline plaintext should round-trip`)
+
+	for _, field := range []string{jwe.InitializationVectorKey, jwe.TagKey} {
+		t.Run(field, func(t *testing.T) {
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal(encrypted, &parsed), `freshly encrypted JWE should parse as JSON`)
+
+			header, ok := parsed["header"].(map[string]any)
+			require.True(t, ok, `flattened JSON JWE should contain a recipient header`)
+
+			_, ok = header[field]
+			require.True(t, ok, `recipient header should contain %q`, field)
+
+			header[field] = 1
+
+			tampered, err := json.Marshal(parsed)
+			require.NoError(t, err, `re-marshaling tampered JWE should succeed`)
+
+			_, err = jwe.Decrypt(tampered, jwe.WithKey(jwa.A128GCMKW(), sharedKey))
+			require.Error(t, err, `jwe.Decrypt must reject non-string AES-GCM-KW headers`)
+			require.Contains(t, err.Error(), field)
+			require.Contains(t, err.Error(), `not a string`)
+			require.NotContains(t, err.Error(), `GCM requires`)
+		})
+	}
+}
+
 func TestGH1001(t *testing.T) {
 	rawKey, err := jwxtest.GenerateRsaKey()
 	require.NoError(t, err, `jwxtest.GenerateRsaKey should succeed`)


### PR DESCRIPTION
- reject non-string AES-GCM-KW `iv` and `tag` values during decrypt
- add regression coverage for tampered recipient header types
- test: `go test ./jwe`
