### PR TITLE
document jwe compression caveats

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -233,6 +233,13 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 // Read the documentation for `jwe.WithKey()` to learn more about the
 // possible values that can be used for `alg` and `key`.
 //
+// If you enable `jwe.WithCompress()`, this library does not enforce a
+// producer-side payload size limit before compression. Callers that accept
+// untrusted or arbitrarily large plaintext must bound the input size before
+// calling `jwe.Encrypt()`. Recipients may also reject compressed messages
+// whose decompressed payload exceeds their `jwe.WithMaxDecompressBufferSize()`
+// setting.
+//
 // Look for options that return `jwe.EncryptOption` or `jwe.EncryptDecryptOption`
 // for a complete list of options that can be passed to this function.
 func Encrypt(payload []byte, options ...EncryptOption) ([]byte, error) {

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -85,6 +85,17 @@ options:
       a payload using `jwe.Encrypt` (Yes, we know it can only be "" or "DEF",
       but the way the specification is written it could allow for more options,
       and therefore this option takes an argument)
+
+      Compression can leak information about the plaintext through message
+      length, so enable it only when you understand that tradeoff.
+
+      This library does not enforce an encrypt-side plaintext size limit before
+      compression. Callers that accept untrusted or arbitrarily large payloads
+      must bound the input size before calling `jwe.Encrypt` with this option.
+
+      Recipients may independently reject compressed messages whose
+      decompressed payload exceeds their `jwe.WithMaxDecompressBufferSize`
+      setting.
   - ident: ContentEncryptionAlgorithm
     interface: EncryptOption
     option_name: WithContentEncryption

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -291,6 +291,17 @@ func WithCEK(v *[]byte) DecryptOption {
 // a payload using `jwe.Encrypt` (Yes, we know it can only be "" or "DEF",
 // but the way the specification is written it could allow for more options,
 // and therefore this option takes an argument)
+//
+// Compression can leak information about the plaintext through message
+// length, so enable it only when you understand that tradeoff.
+//
+// This library does not enforce an encrypt-side plaintext size limit before
+// compression. Callers that accept untrusted or arbitrarily large payloads
+// must bound the input size before calling `jwe.Encrypt` with this option.
+//
+// Recipients may independently reject compressed messages whose
+// decompressed payload exceeds their `jwe.WithMaxDecompressBufferSize`
+// setting.
 func WithCompress(v jwa.CompressionAlgorithm) EncryptOption {
 	return &encryptOption{option.New(identCompress{}, v)}
 }


### PR DESCRIPTION
- document the producer-side size responsibility for `jwe.WithCompress`
- warn about compression length leakage and receiver decompress caps
- regenerate `jwe/options_gen.go` from `jwe/options.yaml`
