### PR TITLE
warn about jwe rsa1_5

### DIFF
--- a/jwe/README.md
+++ b/jwe/README.md
@@ -6,7 +6,7 @@ Package jwe implements JWE as described in [RFC 7516](https://tools.ietf.org/htm
 
 | Algorithm                                | Constant in [jwa](../jwa) | Note |
 |:-----------------------------------------|:--------------------------|:-----|
-| RSA-PKCS1v1.5                            | jwa.RSA1_5                |      |
+| RSA-PKCS1v1.5                            | jwa.RSA1_5                | Legacy interop only; prefer RSA-OAEP for new code |
 | RSA-OAEP-SHA1                            | jwa.RSA_OAEP              |      |
 | RSA-OAEP-SHA256                          | jwa.RSA_OAEP_256          |      |
 | AES key wrap (128/192/256)               | jwa.A128KW / A192KW / A256KW |   |

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -1,6 +1,11 @@
 //go:generate ../scripts/jwxcodegen.sh generate-headers -objects=objects.yml
 
-// Package jwe implements JWE as described in https://tools.ietf.org/html/rfc7516
+// Package jwe implements JWE as described in https://tools.ietf.org/html/rfc7516.
+//
+// Legacy note: RSA-PKCS1 v1.5 key encryption (`jwa.RSA1_5()`) is supported
+// only for interoperability with existing peers. New applications should
+// prefer an RSA-OAEP variant such as `jwa.RSA_OAEP_256()` because PKCS#1 v1.5
+// decryption is exposed to Bleichenbacher-style oracle attacks.
 package jwe
 
 // #region imports
@@ -232,6 +237,11 @@ func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryp
 //
 // Read the documentation for `jwe.WithKey()` to learn more about the
 // possible values that can be used for `alg` and `key`.
+//
+// `jwa.RSA1_5()` is supported only for interoperability with legacy peers.
+// New applications should prefer an RSA-OAEP variant such as
+// `jwa.RSA_OAEP_256()` because PKCS#1 v1.5 decryption is exposed to
+// Bleichenbacher-style oracle attacks.
 //
 // Look for options that return `jwe.EncryptOption` or `jwe.EncryptDecryptOption`
 // for a complete list of options that can be passed to this function.

--- a/jwe/options.go
+++ b/jwe/options.go
@@ -95,6 +95,11 @@ func WithPerRecipientHeaders(hdr Headers) WithKeySuboption {
 // passed to the option. If you specify other algorithm types such as `jwa.SignatureAlgorithm`,
 // then you will get an error when `jwe.Encrypt()` or `jwe.Decrypt()` is executed.
 //
+// `jwa.RSA1_5()` is supported only for interoperability with legacy peers.
+// New applications should prefer an RSA-OAEP variant such as
+// `jwa.RSA_OAEP_256()` because PKCS#1 v1.5 decryption is exposed to
+// Bleichenbacher-style oracle attacks.
+//
 // Unlike `jwe.WithKeySet()`, the `kid` field does not need to match for the key
 // to be tried.
 func WithKey(alg jwa.KeyAlgorithm, key any, options ...WithKeySuboption) EncryptDecryptOption {


### PR DESCRIPTION
- add RSA1_5 legacy-only warnings to JWE godoc
- label RSA1_5 as legacy-only in jwe/README.md
- verify with GOEXPERIMENT=jsonv2 go test ./jwe
