### PR TITLE
docs: warn about short symmetric keys

### DIFF
--- a/docs/01-jwt.md
+++ b/docs/01-jwt.md
@@ -1347,6 +1347,8 @@ func Example_jwt_serialize_jws() {
 source: [examples/jwt_serialize_jws_example_test.go](https://github.com/jwx-go/examples/blob/v4/jwt_serialize_jws_example_test.go)
 <!-- END INCLUDE -->
 
+> Warning: the symmetric literals in these examples are deliberately short for readability. Production `HS*` keys should be random secrets that meet the minimum sizes described in [the JWK docs](04-jwk.md).
+
 ## Serialize using JWE and JWS
 
 The `jwt` package provides a `Serializer` object to allow users to serialize a token using an arbitrary combination of processors.

--- a/docs/02-jws.md
+++ b/docs/02-jws.md
@@ -216,6 +216,8 @@ func Example_jws_sign() {
 source: [examples/jws_sign_example_test.go](https://github.com/jwx-go/examples/blob/v4/jws_sign_example_test.go)
 <!-- END INCLUDE -->
 
+> Warning: the symmetric literals in the examples are deliberately short for readability. Production `HS*` keys should be random secrets that meet the minimum sizes described in [the JWK docs](04-jwk.md).
+
 For normal JWS code, prefer passing a concrete `jwa.SignatureAlgorithm` constant such as
 `jwa.HS256()` or `jwa.RS256()` to `jws.WithKey()`. The option accepts `jwa.KeyAlgorithm`
 so it can forward `(jwk.Key).Algorithm()`, but that metadata is still operation-specific:

--- a/docs/04-jwk.md
+++ b/docs/04-jwk.md
@@ -525,6 +525,8 @@ func Example_jwk_import() {
 source: [examples/jwk_import_example_test.go](https://github.com/jwx-go/examples/blob/v4/jwk_import_example_test.go)
 <!-- END INCLUDE -->
 
+> Warning: `jwk.Import[jwk.SymmetricKey]([]byte(...))` only requires a non-empty octet string. When the key is used with a specific algorithm, size it yourself: use at least 32/48/64 bytes for `HS256`/`HS384`/`HS512`; 16/24/32 bytes for `A128KW`/`A192KW`/`A256KW`, `A128GCM`/`A192GCM`/`A256GCM`, and `A128GCMKW`/`A192GCMKW`/`A256GCMKW`; and 32/48/64 bytes for `A128CBC-HS256`/`A192CBC-HS384`/`A256CBC-HS512`.
+
 # Fetching JWK Sets
 
 HTTP-based JWK Set retrieval has moved out of the core `jwk` package. The main jwx module no longer depends on `net/http` or [`httprc`](https://github.com/lestrrat-go/httprc), and there is no `jwk.Fetch` function. All HTTP fetching lives in the [`github.com/jwx-go/jwkfetch/v4`](https://github.com/jwx-go/jwkfetch) companion.

--- a/docs/10-extensions.md
+++ b/docs/10-extensions.md
@@ -172,6 +172,11 @@ func Example_mldsa_jwk() {
 	// JWK keys can be serialized to JSON for storage or transmission.
 	// The JSON representation follows the AKP key format with base64url-encoded
 	// "pub" (public key bytes) and "priv" (seed bytes) fields.
+	//
+	// Note: core jwk validation for AKP keys only checks that "alg" is set
+	// and that "pub"/"priv" are non-empty. Parameter-set-specific length
+	// checks are performed by the companion module when it reconstructs or
+	// uses the key.
 	serialized, err := json.Marshal(privJWK)
 	if err != nil {
 		fmt.Printf("failed to serialize JWK: %s\n", err)

--- a/docs/21-frameworks.md
+++ b/docs/21-frameworks.md
@@ -27,6 +27,8 @@ s.signKey = symKey
 s.verifyKey = s.signKey
 ```
 
+For `HS256`, use at least 32 random bytes in real deployments. The short literal above is for readability only; production code should load the key from configuration or secret storage.
+
 ### Using RS256
 
 In this example we assume that your keys are stored in PEM-encoded files `private-key.pem` and `public-key.pem`.


### PR DESCRIPTION
- add warnings that symmetric JWK imports accept any non-empty octet string
- point JWS and JWT readers to the JWK sizing guidance
- note AKP validation boundaries in the extension docs
