### PR TITLE
Move base64 encoder/decoder config into jwx.Settings

### DIFF
--- a/.claude/docs/internals.md
+++ b/.claude/docs/internals.md
@@ -113,10 +113,11 @@ Internal `internal/json` package provides the abstraction. Custom field registry
 
 ## Base64 Backend
 
-Pluggable at runtime via `SetBase64Encoder`/`SetBase64Decoder` (exposed as `jwx.SetBase64Encoder`/`jwx.SetBase64Decoder` in the top-level package):
-- Default: `encoding/base64`
+Pluggable at runtime via `jwx.Settings(jwx.WithBase64Encoder(...), jwx.WithBase64Decoder(...))`:
+- Default encoder: `encoding/base64.RawURLEncoding`
+- Default decoder: encoding-variant-detecting decoder in `internal/base64`
 
-Internal `internal/base64` package abstracts the choice.
+Internal `internal/base64` package abstracts the choice; the encoder/decoder are held in `atomic.Value` slots and `jwx.Settings` dispatches to `base64.SetEncoder`/`base64.SetDecoder`.
 
 ## Multi-Module Layout
 

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -6,13 +6,15 @@ Module: `github.com/lestrrat-go/jwx/v4` — flat layout, no physical `v3/` direc
 
 ## jwx (root)
 
-Format detection and global JSON decoder settings.
+Format detection and process-global settings (JSON decoder + base64 backend).
 
 - **GuessFormat(payload []byte) FormatKind** — heuristic detection of JWE/JWS/JWK/JWKS/JWT
-- **Settings(options ...GlobalOption)** — configure global settings (e.g., `WithUseNumber`)
+- **Settings(options ...GlobalOption)** — configure global settings (JSON, base64)
 - **WithUseNumber(v bool) GlobalOption** — decode JSON numbers as `json.Number` instead of `float64`
-- Key types: `FormatKind` (InvalidFormat, UnknownFormat, JWE, JWS, JWK, JWKS, JWT), `GlobalOption`
-- Files: `jwx.go`, `format.go`, `options.go`
+- **WithBase64Encoder(v Base64Encoder) GlobalOption** — replace the process-global base64 encoder (default: `encoding/base64.RawURLEncoding`)
+- **WithBase64Decoder(v Base64Decoder) GlobalOption** — replace the process-global base64 decoder (default: variant-detecting decoder)
+- Key types: `FormatKind` (InvalidFormat, UnknownFormat, JWE, JWS, JWK, JWKS, JWT), `GlobalOption`, `Base64Encoder` (alias of `internal/base64.Encoder`), `Base64Decoder` (alias of `internal/base64.Decoder`)
+- Files: `jwx.go`, `format.go`, `options.go`, `base64.go`
 
 ## jwa/
 

--- a/Changes-v4.md
+++ b/Changes-v4.md
@@ -57,6 +57,11 @@ For a step-by-step migration guide with before/after code examples, see [MIGRATI
   sub-package convention. `jwx.Settings(jwx.WithUseNumber(true))` preserves
   JSON numbers as `json.Number` in private/custom fields.
 
+* `jwx.SetBase64Encoder()` and `jwx.SetBase64Decoder()` have been removed.
+  Configure the base64 backend through `jwx.Settings()` instead:
+  `jwx.Settings(jwx.WithBase64Encoder(enc), jwx.WithBase64Decoder(dec))`.
+  The `jwx.Base64Encoder` / `jwx.Base64Decoder` interface types are unchanged.
+
 * `github.com/lestrrat-go/blackmagic` has been removed. Reflection-based conversions
   have been replaced with generics.
 

--- a/base64.go
+++ b/base64.go
@@ -4,20 +4,11 @@ import "github.com/lestrrat-go/jwx/v4/internal/base64"
 
 // Base64Encoder is the interface for base64 encoding backends.
 // The default implementation uses encoding/base64.RawURLEncoding.
-// Custom backends can replace the default by calling SetBase64Encoder.
+// Custom backends can replace the default by passing them to
+// [Settings] with [WithBase64Encoder].
 type Base64Encoder = base64.Encoder
 
 // Base64Decoder is the interface for base64 decoding backends.
-// Extension modules can replace the default by calling SetBase64Decoder
-// in their init().
+// Extension modules can replace the default by passing them to
+// [Settings] with [WithBase64Decoder] in their init().
 type Base64Decoder = base64.Decoder
-
-// SetBase64Encoder replaces the base64 encoder used by the library.
-func SetBase64Encoder(enc Base64Encoder) {
-	base64.SetEncoder(enc)
-}
-
-// SetBase64Decoder replaces the base64 decoder used by the library.
-func SetBase64Decoder(dec Base64Decoder) {
-	base64.SetDecoder(dec)
-}

--- a/docs/10-extensions.md
+++ b/docs/10-extensions.md
@@ -818,4 +818,4 @@ Activate via a blank import — no API surface of its own:
 import _ "github.com/jwx-go/asmbase64/v4"
 ```
 
-The import registers an optimized RawURL encoder via `jwx.SetBase64Encoder()` and a decoder with automatic encoding detection via `jwx.SetBase64Decoder()`. All JWK, JWS, and JWT operations pick up the new backend automatically. See [`examples/jwx_asmbase64_example_test.go`](https://github.com/jwx-go/examples/blob/v4/jwx_asmbase64_example_test.go) for a runnable example.
+The import registers an optimized RawURL encoder and a decoder with automatic encoding detection via `jwx.Settings(jwx.WithBase64Encoder(...), jwx.WithBase64Decoder(...))`. All JWK, JWS, and JWT operations pick up the new backend automatically. See [`examples/jwx_asmbase64_example_test.go`](https://github.com/jwx-go/examples/blob/v4/jwx_asmbase64_example_test.go) for a runnable example.

--- a/jwx.go
+++ b/jwx.go
@@ -23,6 +23,7 @@
 package jwx
 
 import (
+	"github.com/lestrrat-go/jwx/v4/internal/base64"
 	"github.com/lestrrat-go/jwx/v4/internal/json"
 	"github.com/lestrrat-go/option/v3"
 )
@@ -67,6 +68,10 @@ func Settings(options ...GlobalOption) {
 		switch opt.Ident() {
 		case identUseNumber{}:
 			json.SetUseNumber(option.MustGet[bool](opt))
+		case identBase64Encoder{}:
+			base64.SetEncoder(option.MustGet[Base64Encoder](opt))
+		case identBase64Decoder{}:
+			base64.SetDecoder(option.MustGet[Base64Decoder](opt))
 		}
 	}
 }

--- a/jwx_test.go
+++ b/jwx_test.go
@@ -7,8 +7,10 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/rsa"
+	stdbase64 "encoding/base64"
 	stdjson "encoding/json"
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v4"
@@ -131,6 +133,91 @@ func TestUseNumber(t *testing.T) {
 		_, err = jwe.Decrypt(encrypted, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
 		require.NoError(t, err, `jwe.Decrypt should succeed`)
 	})
+}
+
+type countingBase64Encoder struct {
+	calls atomic.Int64
+}
+
+func (c *countingBase64Encoder) Encode(dst, src []byte) {
+	c.calls.Add(1)
+	stdbase64.RawURLEncoding.Encode(dst, src)
+}
+
+func (c *countingBase64Encoder) EncodedLen(n int) int {
+	return stdbase64.RawURLEncoding.EncodedLen(n)
+}
+
+func (c *countingBase64Encoder) EncodeToString(src []byte) string {
+	c.calls.Add(1)
+	return stdbase64.RawURLEncoding.EncodeToString(src)
+}
+
+func (c *countingBase64Encoder) AppendEncode(dst, src []byte) []byte {
+	c.calls.Add(1)
+	return stdbase64.RawURLEncoding.AppendEncode(dst, src)
+}
+
+type countingBase64Decoder struct {
+	calls atomic.Int64
+}
+
+func (c *countingBase64Decoder) Decode(src []byte) ([]byte, error) {
+	c.calls.Add(1)
+	dst := make([]byte, stdbase64.RawURLEncoding.DecodedLen(len(src)))
+	n, err := stdbase64.RawURLEncoding.Decode(dst, src)
+	if err != nil {
+		return nil, err
+	}
+	return dst[:n], nil
+}
+
+// DO NOT MAKE THIS TEST PARALLEL. This test uses features with global side effects.
+func TestBase64Settings(t *testing.T) {
+	key, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err, `jwxtest.GenerateRsaKey should succeed`)
+
+	t.Run("WithBase64Encoder routes through Settings", func(t *testing.T) {
+		enc := &countingBase64Encoder{}
+		jwx.Settings(jwx.WithBase64Encoder(enc))
+		t.Cleanup(func() {
+			jwx.Settings(jwx.WithBase64Encoder(stdbase64.RawURLEncoding))
+		})
+
+		_, err := jws.Sign([]byte("Lorem ipsum"), jws.WithKey(jwa.RS256(), key))
+		require.NoError(t, err, `jws.Sign should succeed`)
+		require.Greater(t, enc.calls.Load(), int64(0), `custom encoder should be invoked`)
+	})
+
+	t.Run("WithBase64Decoder routes through Settings", func(t *testing.T) {
+		signed, err := jws.Sign([]byte("Lorem ipsum"), jws.WithKey(jwa.RS256(), key))
+		require.NoError(t, err, `jws.Sign should succeed`)
+
+		dec := &countingBase64Decoder{}
+		jwx.Settings(jwx.WithBase64Decoder(dec))
+		t.Cleanup(func() {
+			// Restore the default decoder by installing a fresh detect-variant
+			// decoder. There is no exported sentinel for "default", but the
+			// base64.RawURLEncoding suffices for the remainder of the test run
+			// because every jwx payload is RawURL-encoded.
+			jwx.Settings(jwx.WithBase64Decoder(rawURLDecoder{}))
+		})
+
+		_, err = jws.Verify(signed, jws.WithKey(jwa.RS256(), key.PublicKey))
+		require.NoError(t, err, `jws.Verify should succeed`)
+		require.Greater(t, dec.calls.Load(), int64(0), `custom decoder should be invoked`)
+	})
+}
+
+type rawURLDecoder struct{}
+
+func (rawURLDecoder) Decode(src []byte) ([]byte, error) {
+	dst := make([]byte, stdbase64.RawURLEncoding.DecodedLen(len(src)))
+	n, err := stdbase64.RawURLEncoding.Decode(dst, src)
+	if err != nil {
+		return nil, err
+	}
+	return dst[:n], nil
 }
 
 // Test compatibility against `jose` tool

--- a/options.go
+++ b/options.go
@@ -35,3 +35,37 @@ type identUseNumber struct{}
 func WithUseNumber(v bool) GlobalOption {
 	return &globalOption{option.New(identUseNumber{}, v)}
 }
+
+type identBase64Encoder struct{}
+
+// WithBase64Encoder replaces the base64 encoder used by the library.
+// The default implementation uses encoding/base64.RawURLEncoding.
+//
+// This setting has process-global effect and must be applied once
+// at program startup (typically from func init() or early in main())
+// before any goroutine begins encoding JWx payloads. The underlying
+// encoder is read atomically, so swapping it at runtime is race-free,
+// but any in-flight or subsequent encoders will observe a mix of
+// backends in concurrently-encoded outputs. There is no per-call
+// override at this layer; per-operation overrides exist on the
+// jws/jwt packages (see jws.WithBase64Encoder / jwt.WithBase64Encoder).
+func WithBase64Encoder(v Base64Encoder) GlobalOption {
+	return &globalOption{option.New(identBase64Encoder{}, v)}
+}
+
+type identBase64Decoder struct{}
+
+// WithBase64Decoder replaces the base64 decoder used by the library.
+// The default implementation detects the encoding variant of the input
+// and decodes accordingly.
+//
+// This setting has process-global effect and must be applied once
+// at program startup (typically from func init() or early in main())
+// before any goroutine begins decoding JWx payloads. The underlying
+// decoder is read atomically, so swapping it at runtime is race-free,
+// but any in-flight or subsequent decoders will observe a mix of
+// backends for concurrently-decoded inputs. There is no per-call
+// override.
+func WithBase64Decoder(v Base64Decoder) GlobalOption {
+	return &globalOption{option.New(identBase64Decoder{}, v)}
+}


### PR DESCRIPTION
## Summary

- Remove `jwx.SetBase64Encoder` / `jwx.SetBase64Decoder` in favor of the unified `jwx.Settings(...)` entry point, matching the existing `WithUseNumber` pattern.
- Add `jwx.WithBase64Encoder(enc)` and `jwx.WithBase64Decoder(dec)` `GlobalOption` constructors; dispatch in `Settings()` calls the existing internal setters in `internal/base64`.
- Update docs (`Changes-v4.md`, `docs/10-extensions.md`, `.claude/docs/internals.md`, `.claude/docs/packages.md`) and add `TestBase64Settings` in `jwx_test.go` that round-trips through counting encoder/decoder wrappers.

The `Base64Encoder` / `Base64Decoder` interface types and the atomic-backed storage in `internal/base64` are untouched — only the top-level API surface changes.

### New API

```go
jwx.Settings(
    jwx.WithBase64Encoder(enc),
    jwx.WithBase64Decoder(dec),
)
```

### Companion coordination

The `github.com/jwx-go/asmbase64/v4` companion currently calls the removed setters from its `init()`. A matching update (switch to `jwx.Settings(jwx.WithBase64Encoder(...), jwx.WithBase64Decoder(...))`) is prepared locally and needs to ship alongside this change before a tagged main-module release can be consumed next to asmbase64. The `examples` repo's `jwx_asmbase64_example_test.go` doc comment is also updated locally.

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go build ./...`
- [x] `GOEXPERIMENT=jsonv2 go vet ./...`
- [x] `GOEXPERIMENT=jsonv2 go test -short -count=1 ./...` (all packages pass)
- [x] New `TestBase64Settings` exercises `jws.Sign` + `jws.Verify` through counting encoder/decoder wrappers installed via `jwx.Settings` and asserts both are invoked.
- [x] `cmd/jwx` sub-module builds clean.
- [x] With local `go.work` pointing at the updated `asmbase64` companion, `Example_jwx_asmbase64` runs green end-to-end.
