### PR TITLE
Settings: return error instead of panicking on invalid input

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -61,6 +61,7 @@ Text output labels each finding as `(auto)` or `(manual)`, with migration notes 
 | `jws.RegisterSigner(alg, any)` | `jws.RegisterSigner(alg, Signer)` | Typed parameter |
 | `jws.RegisterVerifier(alg, any)` | `jws.RegisterVerifier(alg, Verifier)` | Typed parameter |
 | `jwx.DecoderSettings(jwx.WithUseNumber(true))` | `jwx.Settings(jwx.WithUseNumber(true))` | API renamed |
+| `jwt.Settings(...)` / `jws.Settings(...)` / `jwe.Settings(...)` / `cert.Settings(...)` (void, panicked on bad input) | same name, now returns `error` | Invalid values return an error instead of panicking |
 | `errors.Is(err, jwt.TokenExpiredError())` | `errors.Is(err, jwt.TokenExpiredError{})` | Sentinel funcs → struct types; see Recipe 13 |
 | `-tags=jwx_goccy` | _(removed)_ | json/v2 is the only backend |
 | `-tags=jwx_es256k` | `github.com/jwx-go/es256k/v4` | Extension module |
@@ -473,6 +474,20 @@ These changes cannot be mechanically transformed and need human judgment:
 3. **`json.Number` usage**: If you relied on `json.Number` type preservation via `jwx.WithUseNumber(true)`, use `jwx.Settings(jwx.WithUseNumber(true))` instead. The API was renamed from `DecoderSettings` to `Settings` to match the sub-package convention.
 
 4. **Code that catches specific error messages**: If you matched on error message strings from the crypto layer (e.g., during JWS signing), those errors may now occur earlier (at `WithKey()` time) due to algorithm-key validation.
+
+5. **`Settings()` calls**: `jwt.Settings`, `jws.Settings`, `jwe.Settings`, and `cert.Settings` now return `error` instead of panicking on invalid inputs (e.g. a non-positive `WithMaxParseInputSize`). Call sites need to either check the returned error or explicitly discard it:
+
+   ```go
+   // Before (v3): invalid value panicked
+   jwt.Settings(jwt.WithMaxParseInputSize(n))
+
+   // After (v4): check the error
+   if err := jwt.Settings(jwt.WithMaxParseInputSize(n)); err != nil {
+       return err
+   }
+   ```
+
+   `jwk.Settings` and `jwx.Settings` remain void; they have no validatable options today.
 
 ## Build System Changes
 

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -157,14 +157,12 @@ func TestSettingsRejectNegativeValues(t *testing.T) {
 	defer restoreCertSettings()
 
 	t.Run(`WithMaxChainLength`, func(t *testing.T) {
-		require.Panics(t, func() {
-			cert.Settings(cert.WithMaxChainLength(-1))
-		}, `negative max chain length should panic`)
+		require.Error(t, cert.Settings(cert.WithMaxChainLength(-1)),
+			`negative max chain length should return an error`)
 	})
 
 	t.Run(`WithMaxCertificateSize`, func(t *testing.T) {
-		require.Panics(t, func() {
-			cert.Settings(cert.WithMaxCertificateSize(-1))
-		}, `negative max certificate size should panic`)
+		require.Error(t, cert.Settings(cert.WithMaxCertificateSize(-1)),
+			`negative max certificate size should return an error`)
 	})
 }

--- a/cert/settings.go
+++ b/cert/settings.go
@@ -26,23 +26,34 @@ func init() {
 // These settings are read atomically, so changing them at runtime is race-free.
 // However, concurrent parses may observe a mix of old and new values. Configure
 // them once at program startup when possible.
-func Settings(options ...GlobalOption) {
+//
+// Returns a non-nil error and applies no changes if any option fails
+// validation (for example, a negative [WithMaxChainLength] or
+// [WithMaxCertificateSize]).
+func Settings(options ...GlobalOption) error {
+	// Validate first so the call is all-or-nothing on error.
 	for _, opt := range options {
 		switch opt.Ident() {
 		case identMaxChainLength{}:
-			v := option.MustGet[int](opt)
-			if v < 0 {
-				panic("cert.Settings: WithMaxChainLength must be greater than or equal to zero")
+			if v := option.MustGet[int](opt); v < 0 {
+				return fmt.Errorf(`cert.Settings: WithMaxChainLength must be greater than or equal to zero, got %d`, v)
 			}
-			maxChainLength.Store(int64(v))
 		case identMaxCertificateSize{}:
-			v := option.MustGet[int64](opt)
-			if v < 0 {
-				panic("cert.Settings: WithMaxCertificateSize must be greater than or equal to zero")
+			if v := option.MustGet[int64](opt); v < 0 {
+				return fmt.Errorf(`cert.Settings: WithMaxCertificateSize must be greater than or equal to zero, got %d`, v)
 			}
-			maxCertificateSize.Store(v)
 		}
 	}
+
+	for _, opt := range options {
+		switch opt.Ident() {
+		case identMaxChainLength{}:
+			maxChainLength.Store(int64(option.MustGet[int](opt)))
+		case identMaxCertificateSize{}:
+			maxCertificateSize.Store(option.MustGet[int64](opt))
+		}
+	}
+	return nil
 }
 
 func currentMaxChainLength() int64 {

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -56,7 +56,20 @@ func init() {
 	maxParseInputSize.Store(10 * 1024 * 1024)       // 10MB
 }
 
-func Settings(options ...GlobalOption) {
+// Settings configures process-global behavior for JWE operations.
+//
+// Returns a non-nil error and applies no changes if any option fails
+// validation (for example, a non-positive [WithMaxParseInputSize]).
+func Settings(options ...GlobalOption) error {
+	// Validate first so the call is all-or-nothing on error.
+	for _, opt := range options {
+		if opt.Ident() == (identMaxParseInputSize{}) {
+			if v := option.MustGet[int64](opt); v <= 0 {
+				return fmt.Errorf(`jwe.Settings: WithMaxParseInputSize must be greater than zero, got %d`, v)
+			}
+		}
+	}
+
 	for _, opt := range options {
 		switch opt.Ident() {
 		case identMaxPBES2Count{}:
@@ -74,13 +87,10 @@ func Settings(options ...GlobalOption) {
 		case identCBCBufferSize{}:
 			aescbc.SetMaxBufferSize(option.MustGet[int64](opt))
 		case identMaxParseInputSize{}:
-			v := option.MustGet[int64](opt)
-			if v <= 0 {
-				panic("jwe.Settings: WithMaxParseInputSize must be greater than zero")
-			}
-			maxParseInputSize.Store(v)
+			maxParseInputSize.Store(option.MustGet[int64](opt))
 		}
 	}
+	return nil
 }
 
 const (

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -741,23 +741,37 @@ func hasCustomSigVerifier(alg jwa.SignatureAlgorithm) bool {
 }
 
 // Settings allows you to set global settings for JWS operations.
-func Settings(options ...GlobalOption) {
+//
+// Returns a non-nil error and applies no changes if any option fails
+// validation (for example, a non-positive [WithMaxParseInputSize] or
+// [WithMaxSignatures]).
+func Settings(options ...GlobalOption) error {
+	var newMaxParseInputSize int64
+	var newMaxSignatures int64
 	for _, opt := range options {
 		switch opt.Ident() {
 		case identMaxParseInputSize{}:
 			v := option.MustGet[int64](opt)
 			if v <= 0 {
-				panic("jws.Settings: WithMaxParseInputSize must be greater than zero")
+				return fmt.Errorf(`jws.Settings: WithMaxParseInputSize must be greater than zero, got %d`, v)
 			}
-			maxParseInputSize.Store(v)
+			newMaxParseInputSize = v
 		case identMaxSignatures{}:
 			v := option.MustGet[int](opt)
 			if v <= 0 {
-				panic("jws.Settings: WithMaxSignatures must be greater than zero")
+				return fmt.Errorf(`jws.Settings: WithMaxSignatures must be greater than zero, got %d`, v)
 			}
-			maxSignatures.Store(int64(v))
+			newMaxSignatures = int64(v)
 		}
 	}
+
+	if newMaxParseInputSize > 0 {
+		maxParseInputSize.Store(newMaxParseInputSize)
+	}
+	if newMaxSignatures > 0 {
+		maxSignatures.Store(newMaxSignatures)
+	}
+	return nil
 }
 
 // VerifyCompactFast is a fast path verification function for JWS messages

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1973,15 +1973,11 @@ func TestMaxParseInputSize(t *testing.T) {
 			require.NotContains(t, err.Error(), `exceeded max size`)
 		}
 	})
-	t.Run("negative value panics in Settings", func(t *testing.T) {
-		require.Panics(t, func() {
-			jws.Settings(jws.WithMaxParseInputSize(-1))
-		})
+	t.Run("negative value returns error from Settings", func(t *testing.T) {
+		require.Error(t, jws.Settings(jws.WithMaxParseInputSize(-1)))
 	})
-	t.Run("zero value panics in Settings", func(t *testing.T) {
-		require.Panics(t, func() {
-			jws.Settings(jws.WithMaxParseInputSize(0))
-		})
+	t.Run("zero value returns error from Settings", func(t *testing.T) {
+		require.Error(t, jws.Settings(jws.WithMaxParseInputSize(0)))
 	})
 	t.Run("negative per-call value returns error", func(t *testing.T) {
 		data := []byte(`test`)

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -30,15 +30,16 @@ func init() {
 }
 
 // Settings controls global settings that are specific to JWTs.
-func Settings(options ...GlobalOption) {
-	muSettings.Lock()
-	defer muSettings.Unlock()
-
+//
+// Returns a non-nil error and applies no changes if any option fails
+// validation (for example, a non-positive [WithMaxParseInputSize]).
+func Settings(options ...GlobalOption) error {
 	var flattenAudience bool
 	var parsePedantic bool
 	var parsePrecision = types.MaxPrecision + 1  // illegal value, so we can detect nothing was set
 	var formatPrecision = types.MaxPrecision + 1 // illegal value, so we can detect nothing was set
 	truncation := time.Duration(-1)
+	var newMaxParseInputSize int64
 	for _, opt := range options {
 		switch opt.Ident() {
 		case identTruncation{}:
@@ -62,10 +63,17 @@ func Settings(options ...GlobalOption) {
 		case identMaxParseInputSize{}:
 			v := option.MustGet[int64](opt)
 			if v <= 0 {
-				panic("jwt.Settings: WithMaxParseInputSize must be greater than zero")
+				return fmt.Errorf(`jwt.Settings: WithMaxParseInputSize must be greater than zero, got %d`, v)
 			}
-			maxParseInputSize.Store(v)
+			newMaxParseInputSize = v
 		}
+	}
+
+	muSettings.Lock()
+	defer muSettings.Unlock()
+
+	if newMaxParseInputSize > 0 {
+		maxParseInputSize.Store(newMaxParseInputSize)
 	}
 
 	if parsePrecision <= types.MaxPrecision { // remember we set default to max + 1
@@ -97,6 +105,8 @@ func Settings(options ...GlobalOption) {
 	if truncation >= 0 {
 		defaultTruncation.Store(int64(truncation))
 	}
+
+	return nil
 }
 
 var registry = json.NewRegistry()


### PR DESCRIPTION
## Summary
- `jwt.Settings`, `jws.Settings`, `jwe.Settings`, and `cert.Settings` used to **panic** on invalid values (e.g. non-positive `WithMaxParseInputSize`, negative `WithMaxChainLength`). That's unrecoverable for callers that load config dynamically (env, YAML, flags) and awkward to test.
- Change the signature from `func Settings(...GlobalOption)` to `func Settings(...GlobalOption) error`.
- Validate all options first; the call is all-or-nothing on error (no partial state mutation).
- `jwk.Settings` and `jwx.Settings` remain void — they have no validatable options today.
- MIGRATION.md gains a quick-reference row and a manual-review entry with before/after snippets.
- Previously panic-asserting tests in `cert/` and `jws/` now assert on the returned error.

This is a breaking API change, which is why it is done before `v4.0.0` tags.

## Test plan
- [x] `GOEXPERIMENT=jsonv2 go test ./...` passes
- [x] `GOEXPERIMENT=jsonv2 go test ./...` in `cmd/jwx/` passes
- [x] `go build ./...` / `go vet ./...` clean
- [ ] CI green