### PR TITLE
jwx.Settings: return error and reject nil encoder/decoder

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -61,7 +61,7 @@ Text output labels each finding as `(auto)` or `(manual)`, with migration notes 
 | `jws.RegisterSigner(alg, any)` | `jws.RegisterSigner(alg, Signer)` | Typed parameter |
 | `jws.RegisterVerifier(alg, any)` | `jws.RegisterVerifier(alg, Verifier)` | Typed parameter |
 | `jwx.DecoderSettings(jwx.WithUseNumber(true))` | `jwx.Settings(jwx.WithUseNumber(true))` | API renamed |
-| `jwt.Settings(...)` / `jws.Settings(...)` / `jwe.Settings(...)` / `cert.Settings(...)` (void, panicked on bad input) | same name, now returns `error` | Invalid values return an error instead of panicking |
+| `jwt.Settings(...)` / `jws.Settings(...)` / `jwe.Settings(...)` / `cert.Settings(...)` / `jwx.Settings(...)` (void) | same name, now returns `error` | Invalid values return an error instead of panicking (jwx validates nil encoder/decoder; others validate their size limits) |
 | `errors.Is(err, jwt.TokenExpiredError())` | `errors.Is(err, jwt.TokenExpiredError{})` | Sentinel funcs → struct types; see Recipe 13 |
 | `-tags=jwx_goccy` | _(removed)_ | json/v2 is the only backend |
 | `-tags=jwx_es256k` | `github.com/jwx-go/es256k/v4` | Extension module |
@@ -475,19 +475,25 @@ These changes cannot be mechanically transformed and need human judgment:
 
 4. **Code that catches specific error messages**: If you matched on error message strings from the crypto layer (e.g., during JWS signing), those errors may now occur earlier (at `WithKey()` time) due to algorithm-key validation.
 
-5. **`Settings()` calls**: `jwt.Settings`, `jws.Settings`, `jwe.Settings`, and `cert.Settings` now return `error` instead of panicking on invalid inputs (e.g. a non-positive `WithMaxParseInputSize`). Call sites need to either check the returned error or explicitly discard it:
+5. **`Settings()` calls**: `jwt.Settings`, `jws.Settings`, `jwe.Settings`, `cert.Settings`, and `jwx.Settings` now return `error` instead of panicking (or silently accepting invalid state) on bad inputs. Call sites need to either check the returned error or explicitly discard it:
 
    ```go
-   // Before (v3): invalid value panicked
+   // Before (v3): invalid value panicked (or silently accepted)
    jwt.Settings(jwt.WithMaxParseInputSize(n))
+   jwx.Settings(jwx.WithBase64Encoder(enc))
 
    // After (v4): check the error
    if err := jwt.Settings(jwt.WithMaxParseInputSize(n)); err != nil {
        return err
    }
+   if err := jwx.Settings(jwx.WithBase64Encoder(enc)); err != nil {
+       return err
+   }
    ```
 
-   `jwk.Settings` and `jwx.Settings` remain void; they have no validatable options today.
+   Extension modules that install a backend in `init()` (e.g. `asmbase64`) must panic on error, matching the house style for `Register*` failures.
+
+   `jwk.Settings` remains void; its options have no validatable state today.
 
 ## Build System Changes
 

--- a/jwx.go
+++ b/jwx.go
@@ -23,6 +23,8 @@
 package jwx
 
 import (
+	"fmt"
+
 	"github.com/lestrrat-go/jwx/v4/internal/base64"
 	"github.com/lestrrat-go/jwx/v4/internal/json"
 	"github.com/lestrrat-go/option/v3"
@@ -63,7 +65,26 @@ var _ implementationNoteStreaming
 // begins parsing JWx payloads. See the godoc on individual GlobalOption
 // constructors (e.g. [WithUseNumber]) for the concurrency contract of
 // each setting.
-func Settings(options ...GlobalOption) {
+//
+// Returns a non-nil error and applies no changes if any option fails
+// validation (for example, a nil [WithBase64Encoder] or [WithBase64Decoder]).
+func Settings(options ...GlobalOption) error {
+	// Validate first so the call is all-or-nothing on error.
+	// For interface-typed options, a nil value is unwrapped when passed
+	// through any, so option.Get returns ok=false — treat that as "nil".
+	for _, opt := range options {
+		switch opt.Ident() {
+		case identBase64Encoder{}:
+			if v, ok := option.Get[Base64Encoder](opt); !ok || v == nil {
+				return fmt.Errorf(`jwx.Settings: WithBase64Encoder must not be nil`)
+			}
+		case identBase64Decoder{}:
+			if v, ok := option.Get[Base64Decoder](opt); !ok || v == nil {
+				return fmt.Errorf(`jwx.Settings: WithBase64Decoder must not be nil`)
+			}
+		}
+	}
+
 	for _, opt := range options {
 		switch opt.Ident() {
 		case identUseNumber{}:
@@ -74,4 +95,5 @@ func Settings(options ...GlobalOption) {
 			base64.SetDecoder(option.MustGet[Base64Decoder](opt))
 		}
 	}
+	return nil
 }

--- a/jwx_test.go
+++ b/jwx_test.go
@@ -207,6 +207,16 @@ func TestBase64Settings(t *testing.T) {
 		require.NoError(t, err, `jws.Verify should succeed`)
 		require.Greater(t, dec.calls.Load(), int64(0), `custom decoder should be invoked`)
 	})
+
+	t.Run("nil encoder returns error and applies no changes", func(t *testing.T) {
+		require.Error(t, jwx.Settings(jwx.WithBase64Encoder(nil)),
+			`nil encoder should be rejected`)
+	})
+
+	t.Run("nil decoder returns error and applies no changes", func(t *testing.T) {
+		require.Error(t, jwx.Settings(jwx.WithBase64Decoder(nil)),
+			`nil decoder should be rejected`)
+	})
 }
 
 type rawURLDecoder struct{}


### PR DESCRIPTION
## Summary
- Following #1954, extend the same \`error\`-returning convention to \`jwx.Settings\`.
- Reject \`jwx.WithBase64Encoder(nil)\` / \`jwx.WithBase64Decoder(nil)\` up front. Previously they were stored silently and the next base64 operation would nil-deref far from the scene.
- This also unblocks the companion-module house-style rule: \`asmbase64\` (and any future extension that registers a backend via \`jwx.Settings\`) now has an error to panic on, matching the panic-on-registration-failure convention.
- MIGRATION.md's Settings-call recipe extended to cover \`jwx.Settings\`, with a note that extension modules must panic on error in \`init()\`.
- \`jwk.Settings\` intentionally stays void — its options don't have invalid values today.

## Test plan
- [x] \`GOEXPERIMENT=jsonv2 go test ./...\` passes
- [x] Added \`TestBase64Settings\` sub-cases for \`nil encoder\` and \`nil decoder\`
- [ ] CI green
- [ ] Follow-up: update \`asmbase64\` \`init()\` to panic on error and bump its jwx dep to the scratch release containing this change