### PR TITLE
jws/jwe: harmonize missing-key error messages

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -401,7 +401,7 @@ func (dc *decryptContext) ProcessOptions(options []DecryptOption) error {
 	}
 
 	if len(dc.keyProviders) < 1 {
-		return fmt.Errorf(`jwe.Decrypt: no key providers have been provided (see jwe.WithKey(), jwe.WithKeySet(), and jwe.WithKeyProvider()`)
+		return fmt.Errorf(`jwe.Decrypt: no decrypters available. Specify an algorithm and a key using jwe.WithKey() (or jwe.WithKeySet() or jwe.WithKeyProvider())`)
 	}
 
 	return nil
@@ -773,7 +773,7 @@ func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
 	// We need to have at least one builder
 	switch l := len(ec.builders); {
 	case l == 0:
-		return fmt.Errorf(`missing key encryption builders: use jwe.WithKey() to specify one`)
+		return fmt.Errorf(`no encrypters available. Specify an algorithm and a key using jwe.WithKey()`)
 	case l > 1:
 		if ec.format == fmtCompact {
 			return fmt.Errorf(`cannot use compact serialization when multiple recipients exist (check the number of WithKey() argument, or use WithJSON())`)

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -122,7 +122,7 @@ func (vc *verifyContext) ProcessOptions(options []VerifyOption) error {
 	}
 
 	if len(vc.keyProviders) < 1 {
-		return makeVerifyError(`no key providers have been provided (see jws.WithKey(), jws.WithKeySet(), jws.WithVerifyAuto(), and jws.WithKeyProvider()`)
+		return makeVerifyError(`no verifiers available. Specify an algorithm and a key using jws.WithKey() (or jws.WithKeySet(), jws.WithKeyProvider(), or jws.WithVerifyAuto())`)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Four code paths raise an error when the caller forgot to pass a key. They used three different phrasings, and two of them had an unclosed paren in the `(see ...)` parenthetical.
- Harmonized on the `jws.Sign` template: `no <role> available. Specify an algorithm and a key using <pkg>.WithKey() (or ...)`.

| Site | Before | After |
| --- | --- | --- |
| `jws.Verify` | `no key providers have been provided (see jws.WithKey(), jws.WithKeySet(), jws.WithVerifyAuto(), and jws.WithKeyProvider()` (unclosed paren) | `no verifiers available. Specify an algorithm and a key using jws.WithKey() (or jws.WithKeySet(), jws.WithKeyProvider(), or jws.WithVerifyAuto())` |
| `jwe.Decrypt` | `jwe.Decrypt: no key providers have been provided (see jwe.WithKey(), jwe.WithKeySet(), and jwe.WithKeyProvider()` (unclosed paren) | `jwe.Decrypt: no decrypters available. Specify an algorithm and a key using jwe.WithKey() (or jwe.WithKeySet() or jwe.WithKeyProvider())` |
| `jwe.Encrypt` | `missing key encryption builders: use jwe.WithKey() to specify one` | `no encrypters available. Specify an algorithm and a key using jwe.WithKey()` |
| `jws.Sign` | _(unchanged; this was the template)_ | `no signers available. Specify an algorithm and a key using jws.WithKey()` |

No tests asserted the old strings.

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go test ./jws/... ./jwe/...` passes locally
- [ ] CI test/lint/smoke green