### PR TITLE
jwt: fix redundant WithAudience error message (#1488)

### DIFF
--- a/jwt/structured_errors_test.go
+++ b/jwt/structured_errors_test.go
@@ -145,6 +145,7 @@ func TestStructuredErrors(t *testing.T) {
 		require.ErrorIs(t, err, jwt.InvalidIssuerError{})
 		_, ok := errors.AsType[jwt.ClaimValidationError](err)
 		require.False(t, ok, "issuer error should not be ClaimValidationError")
+		require.EqualError(t, err, `jwt.Validate: validation failed: "iss" not satisfied: claim "iss" does not have the expected value`)
 
 		// Audience mismatch
 		err = jwt.Validate(tok, jwt.WithAudience("wrong-aud"))
@@ -152,6 +153,7 @@ func TestStructuredErrors(t *testing.T) {
 		require.ErrorIs(t, err, jwt.InvalidAudienceError{})
 		_, ok = errors.AsType[jwt.ClaimValidationError](err)
 		require.False(t, ok, "audience error should not be ClaimValidationError")
+		require.EqualError(t, err, `jwt.Validate: validation failed: "aud" not satisfied: claim "aud" does not contain the expected value`)
 	})
 
 	t.Run("TimeDeltaError from MaxDeltaIs", func(t *testing.T) {

--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -449,10 +449,10 @@ func (ccs claimContainsString) Validate(_ context.Context, t Token) error {
 
 	if !slices.Contains(list, ccs.value) {
 		if ccs.makeErr != nil {
-			return ccs.makeErr(`%q not satisfied`, ccs.name)
+			return ccs.makeErr(`claim %q does not contain the expected value`, ccs.name)
 		}
 		return newClaimValidationError(ccs.name, ccs.value, list,
-			fmt.Sprintf(`%q not satisfied`, ccs.name))
+			fmt.Sprintf(`claim %q does not contain the expected value`, ccs.name))
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- `WithAudience` validation failure now returns `claim "aud" does not contain the expected value`, matching the style of the issuer error. Previously the user saw the redundant `"aud" not satisfied: "aud" not satisfied`.
- Added a structured-errors regression assertion covering both the issuer and audience rendered strings.

Fixes #1488.

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go test ./jwt/...` passes
- [x] `make lint` passes