### PR TITLE
jwe: preserve all per-key decrypt attempt errors

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -553,7 +553,7 @@ func (dc *decryptContext) DecryptMessage(buf []byte) ([]byte, error) {
 
 func (dc *decryptContext) tryRecipient(msg *Message, recipient Recipient, protectedHeaders Headers, aad, computedAad []byte) ([]byte, error) {
 	var tried int
-	var lastError error
+	var attemptErrors []error
 	for i, kp := range dc.keyProviders {
 		var sink algKeySink
 		if err := kp.FetchKeys(dc.ctx, &sink, recipient, msg); err != nil {
@@ -571,7 +571,7 @@ func (dc *decryptContext) tryRecipient(msg *Message, recipient Recipient, protec
 
 			decrypted, err := dc.decryptContent(msg, alg, key, recipient, protectedHeaders, aad, computedAad)
 			if err != nil {
-				lastError = err
+				attemptErrors = append(attemptErrors, err)
 				continue
 			}
 
@@ -581,7 +581,11 @@ func (dc *decryptContext) tryRecipient(msg *Message, recipient Recipient, protec
 			return decrypted, nil
 		}
 	}
-	return nil, fmt.Errorf(`jwe.Decrypt: tried %d keys, but failed to match any of the keys with recipient (last error = %w)`, tried, lastError)
+	// Preserve every per-key attempt error via errors.Join so that each
+	// constituent remains reachable through errors.Is / errors.As on the
+	// outer error. The top-level "jwe.Decrypt:" prefix is added by the
+	// caller (Decrypt) via makeDecryptError.
+	return nil, fmt.Errorf(`tried %d keys, but failed to match any of the keys with recipient: %w`, tried, errors.Join(attemptErrors...))
 }
 
 func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgorithm, key any, recipient Recipient, protectedHeaders Headers, aad, computedAad []byte) ([]byte, error) {

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1584,6 +1584,44 @@ func TestDecrypt_fail(t *testing.T) {
 		require.ErrorIs(t, err, jwe.DecryptError(), `error should be of type jwe.DecryptError`)
 		require.ErrorIs(t, err, jwe.ParseError(), `error should be of type jwe.ParseError`)
 	})
+	t.Run("multiple keys all fail with different reasons", func(t *testing.T) {
+		// Encrypt with RSA-OAEP, then attempt decrypt with several keys that
+		// each fail for a different reason. The returned error chain must
+		// surface every per-key failure, not just the last one.
+		privkey, err := jwxtest.GenerateRsaJwk()
+		require.NoError(t, err, `jwxtest.GenerateRsaJwk should succeed`)
+
+		encrypted, err := jwe.Encrypt([]byte("Lorem Ipsum"), jwe.WithKey(jwa.RSA_OAEP(), privkey))
+		require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+		// Key 1: correct alg (RSA-OAEP), but a different RSA key → CEK decrypt fails.
+		wrongRSAKey, err := jwxtest.GenerateRsaJwk()
+		require.NoError(t, err, `jwxtest.GenerateRsaJwk should succeed`)
+
+		// Key 2: RSA-OAEP-256 alg, but the protected header says RSA-OAEP → alg mismatch.
+		anotherRSAKey, err := jwxtest.GenerateRsaJwk()
+		require.NoError(t, err, `jwxtest.GenerateRsaJwk should succeed`)
+
+		_, err = jwe.Decrypt(encrypted,
+			jwe.WithKey(jwa.RSA_OAEP(), wrongRSAKey),
+			jwe.WithKey(jwa.RSA_OAEP_256(), anotherRSAKey),
+		)
+		require.Error(t, err, `jwe.Decrypt should fail`)
+		require.ErrorIs(t, err, jwe.DecryptError(), `error should be of type jwe.DecryptError`)
+		require.ErrorIs(t, err, jwe.RecipientError(), `error should be of type jwe.RecipientError`)
+
+		// Both per-key failure reasons must be present in the error chain,
+		// not just the last one.
+		msg := err.Error()
+		require.Contains(t, msg, `failed to decrypt key`,
+			`error should preserve the first (wrong-key) attempt failure`)
+		require.Contains(t, msg, `algorithms do not match`,
+			`error should preserve the second (alg-mismatch) attempt failure`)
+		require.Contains(t, msg, `tried 2 keys`,
+			`error should report that 2 keys were tried`)
+		require.NotContains(t, msg, `last error =`,
+			`error should no longer use the "last error =" framing`)
+	})
 }
 func BenchmarkParseCompat(b *testing.B) {
 	buf := []byte(`eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ.OKOawDo13gRp2ojaHV7LFpZcgV7T6DVZKTyKOMTYUmKoTCVJRgckCL9kiMT03JGeipsEdY3mx_etLbbWSrFr05kLzcSr4qKAq7YN7e9jwQRb23nfa6c9d-StnImGyFDbSv04uVuxIp5Zms1gNxKKK2Da14B8S4rzVRltdYwam_lDp5XnZAYpQdb76FdIKLaVmqgfwX7XWRxv2322i-vDxRfqNzo_tETKzpVLzfiwQyeyPGLBIO56YJ7eObdv0je81860ppamavo35UgoRdbYaBcoh9QcfylQr66oc6vFWXRcZ_ZT2LawVCWTIy3brGPi6UklfCpIMfIjf7iGdXKHzg.48V1_ALb6US04U3b.5eym8TW_c8SuK0ltJ3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX_EFShS8iB7j6jiSdiwkIr3ajwQzaBtQD_A.XFBoMYUZodetZdvTiFvSkQ`)


### PR DESCRIPTION
## Summary

- `jwe.Decrypt` no longer drops all but the last per-key failure when iterating candidate keys. Per-attempt errors are accumulated and joined via `errors.Join`, so every cause remains reachable through `errors.Is` / `errors.As`.
- The misleading `last error = …` framing is dropped.
- `errors.Is(err, jwe.DecryptError())` and `jwe.RecipientError()` continue to match unchanged.

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go test ./jwe/...` passes
- [x] new test asserts both per-attempt failures are reachable in the rendered error chain
- [x] `GOEXPERIMENT=jsonv2 go vet ./jwe/...` clean