### PR TITLE
jwk: add typed KeyTypeMismatchError for Import

### DIFF
--- a/jwk/errors.go
+++ b/jwk/errors.go
@@ -3,6 +3,7 @@ package jwk
 import (
 	"errors"
 	"fmt"
+	"reflect"
 )
 
 var cpe = &continueError{}
@@ -76,4 +77,42 @@ var errDefaultParseError = parseError{errors.New(`parse error`)}
 
 func ParseError() error {
 	return errDefaultParseError
+}
+
+//-------------------------------------------------------------------
+// KeyTypeMismatchError
+//-------------------------------------------------------------------
+
+// KeyTypeMismatchError is returned by [Import] when the imported key's
+// concrete type does not match the generic type parameter supplied by
+// the caller.
+//
+// Callers that need to distinguish "wrong generic type parameter" from
+// "key validation failed" should use [errors.Is] with
+// KeyTypeMismatchError{}, or [errors.AsType] to recover the Got and
+// Want fields.
+type KeyTypeMismatchError struct {
+	// Got is the runtime type of the key that was imported.
+	Got reflect.Type
+	// Want is the type requested via the Import type parameter.
+	Want reflect.Type
+}
+
+func (e KeyTypeMismatchError) Error() string {
+	return fmt.Sprintf(`imported key is %s, not %s`, typeName(e.Got), typeName(e.Want))
+}
+
+func (e KeyTypeMismatchError) Is(target error) bool {
+	_, ok := target.(KeyTypeMismatchError)
+	return ok
+}
+
+// typeName renders a reflect.Type similarly to the %T verb so that
+// KeyTypeMismatchError's message remains recognizable when either
+// field is nil.
+func typeName(t reflect.Type) string {
+	if t == nil {
+		return "<nil>"
+	}
+	return t.String()
 }

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -78,7 +78,10 @@ func Import[T Key](raw any) (T, error) {
 	}
 	result, ok := key.(T)
 	if !ok {
-		return zero, importerr(`imported key is %T, not %T`, key, zero)
+		return zero, importerr(`%w`, KeyTypeMismatchError{
+			Got:  reflect.TypeOf(key),
+			Want: reflect.TypeFor[T](),
+		})
 	}
 	return result, nil
 }

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -357,6 +357,22 @@ func TestGenericImport(t *testing.T) {
 		// Importing []byte produces SymmetricKey, not RSAPrivateKey
 		_, err := jwk.Import[jwk.RSAPrivateKey]([]byte("symmetric"))
 		require.Error(t, err)
+
+		// Still classified as a jwk.ImportError so existing callers
+		// that match on the sentinel keep working.
+		require.ErrorIs(t, err, jwk.ImportError(), `should remain an ImportError`)
+		// Also classified as the new typed mismatch error.
+		require.ErrorIs(t, err, jwk.KeyTypeMismatchError{}, `should be a KeyTypeMismatchError`)
+
+		mismatch, ok := errors.AsType[jwk.KeyTypeMismatchError](err)
+		require.True(t, ok, `errors.AsType should recover KeyTypeMismatchError`)
+		require.NotNil(t, mismatch.Got, `Got should be populated`)
+		require.NotNil(t, mismatch.Want, `Want should be populated`)
+		// []byte is imported as a SymmetricKey interface implementation.
+		require.True(t, mismatch.Got.Implements(reflect.TypeFor[jwk.SymmetricKey]()),
+			`Got (%s) should implement SymmetricKey`, mismatch.Got)
+		require.Equal(t, reflect.TypeFor[jwk.RSAPrivateKey](), mismatch.Want,
+			`Want should equal the requested type parameter`)
 	})
 	t.Run("BaseInterface", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
## Summary

- Adds `jwk.KeyTypeMismatchError{Got, Want reflect.Type}` returned by `jwk.Import[T]` when the imported key's runtime type does not match the caller's generic parameter.
- `errors.Is(err, jwk.ImportError())` continues to match; new `errors.Is(err, jwk.KeyTypeMismatchError{})` and `errors.AsType[jwk.KeyTypeMismatchError](err)` are now supported.
- Incidental rendering fix: the error string previously printed `not <nil>` because `%T` on a typed-nil interface value renders `<nil>`; now uses `reflect.TypeFor[T]()` so the requested type name appears.

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go test ./jwk/...` passes
- [x] `GOEXPERIMENT=jsonv2 go vet ./jwk/...` clean
- [x] new test covers `errors.Is` (both `ImportError()` and `KeyTypeMismatchError{}`) and `errors.AsType` field extraction

## Follow-up (not in this PR)

- `.claude/docs/error-formatting.md` should gain a jwk typed-errors row once the jwe companion PR also lands.