### PR TITLE
jwe: add typed errors for decrypt substep failures

### DIFF
--- a/jwe/errors.go
+++ b/jwe/errors.go
@@ -3,6 +3,8 @@ package jwe
 import (
 	"errors"
 	"fmt"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
 )
 
 type encryptError struct {
@@ -131,4 +133,65 @@ func ParseError() error {
 
 func makeParseError(prefix string, f string, args ...any) error {
 	return parseError{fmt.Errorf(prefix+": "+f, args...)}
+}
+
+//-------------------------------------------------------------------
+// MissingContentEncryptionError
+//-------------------------------------------------------------------
+
+// MissingContentEncryptionError is returned when jwe.Decrypt cannot
+// locate the content encryption algorithm ("enc") in the protected
+// headers of the JWE message.
+//
+// Use errors.Is with a zero-value MissingContentEncryptionError{} to
+// detect this failure mode programmatically:
+//
+//	if errors.Is(err, jwe.MissingContentEncryptionError{}) { ... }
+type MissingContentEncryptionError struct{}
+
+func (MissingContentEncryptionError) Error() string {
+	return `failed to retrieve content encryption algorithm from protected headers`
+}
+
+func (MissingContentEncryptionError) Is(target error) bool {
+	_, ok := target.(MissingContentEncryptionError)
+	return ok
+}
+
+//-------------------------------------------------------------------
+// AlgorithmMismatchError
+//-------------------------------------------------------------------
+
+// AlgorithmMismatchError is returned when jwe.Decrypt detects that
+// the key encryption algorithm ("alg") declared in the JWE headers
+// does not match the algorithm associated with the decryption key
+// supplied by the caller.
+//
+// Expected holds the algorithm bound to the caller's key (for example
+// via jwe.WithKey). Got holds the algorithm found in the per-recipient
+// or protected headers of the message.
+//
+// Use errors.Is with a zero-value AlgorithmMismatchError{} to detect
+// this failure mode, or errors.AsType to recover the Expected and Got
+// fields:
+//
+//	if mismatch, ok := errors.AsType[jwe.AlgorithmMismatchError](err); ok {
+//	    log.Printf("alg mismatch: expected %s, got %s", mismatch.Expected, mismatch.Got)
+//	}
+type AlgorithmMismatchError struct {
+	// Expected is the key encryption algorithm associated with the
+	// decryption key supplied by the caller.
+	Expected jwa.KeyEncryptionAlgorithm
+	// Got is the key encryption algorithm declared in the JWE
+	// per-recipient or protected headers.
+	Got jwa.KeyEncryptionAlgorithm
+}
+
+func (e AlgorithmMismatchError) Error() string {
+	return fmt.Sprintf(`key (%q) and recipient (%q) algorithms do not match`, e.Expected, e.Got)
+}
+
+func (AlgorithmMismatchError) Is(target error) bool {
+	_, ok := target.(AlgorithmMismatchError)
+	return ok
 }

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -599,7 +599,7 @@ func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgo
 
 	ce, ok := msg.protectedHeaders.ContentEncryption()
 	if !ok {
-		return nil, fmt.Errorf(`jwe.Decrypt: failed to retrieve content encryption algorithm from protected headers`)
+		return nil, decryptError{fmt.Errorf(`jwe.Decrypt: %w`, MissingContentEncryptionError{})}
 	}
 
 	// The "alg" header can be in either protected/unprotected headers.
@@ -617,7 +617,7 @@ func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgo
 			break
 		}
 		// if we found something but didn't match, it's a failure
-		return nil, fmt.Errorf(`jwe.Decrypt: key (%q) and recipient (%q) algorithms do not match`, alg, v)
+		return nil, decryptError{fmt.Errorf(`jwe.Decrypt: %w`, AlgorithmMismatchError{Expected: alg, Got: v})}
 	}
 	if !algMatched {
 		return nil, fmt.Errorf(`jwe.Decrypt: failed to find "alg" header in either protected or per-recipient headers`)

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -1985,4 +1986,89 @@ func TestDecryptIgnoresUnprotectedHeader(t *testing.T) {
 	decrypted, err = jwe.Decrypt(tampered, jwe.WithKey(jwa.RSA_OAEP(), privkey))
 	require.NoError(t, err, `jwe.Decrypt must ignore unprotected-header overrides`)
 	require.Equal(t, []byte(payload), decrypted, `plaintext should still round-trip through the tampered JWE`)
+}
+
+// TestDecryptSubstepTypedErrors pins the contract that
+// jwe.decryptContent surfaces programmatically distinguishable errors
+// for its well-known substep failures. Callers should be able to match
+// these with errors.Is / errors.AsType without falling back to
+// substring checks on the error message.
+func TestDecryptSubstepTypedErrors(t *testing.T) {
+	t.Run("MissingContentEncryptionError when enc is absent from protected header", func(t *testing.T) {
+		privkey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err, `rsa.GenerateKey should succeed`)
+
+		const payload = `lorem ipsum`
+		encrypted, err := jwe.Encrypt(
+			[]byte(payload),
+			jwe.WithKey(jwa.RSA_OAEP(), &privkey.PublicKey),
+			jwe.WithContentEncryption(jwa.A128GCM()),
+			jwe.WithJSON(),
+		)
+		require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(encrypted, &parsed), `freshly encrypted JWE should parse as JSON`)
+
+		// Strip "enc" from the base64url-encoded protected header and
+		// re-encode. The AEAD tag will no longer verify, but that never
+		// matters because decryptContent checks for "enc" in the
+		// protected header BEFORE any AEAD work happens.
+		protectedEncoded, ok := parsed["protected"].(string)
+		require.True(t, ok, `protected header should be a string`)
+		protectedBytes, err := base64.RawURLEncoding.DecodeString(protectedEncoded)
+		require.NoError(t, err, `protected header should decode as base64url`)
+		var protectedJSON map[string]any
+		require.NoError(t, json.Unmarshal(protectedBytes, &protectedJSON), `protected header should parse as JSON`)
+		delete(protectedJSON, "enc")
+		newProtected, err := json.Marshal(protectedJSON)
+		require.NoError(t, err, `re-marshaling protected header should succeed`)
+		parsed["protected"] = base64.RawURLEncoding.EncodeToString(newProtected)
+
+		tampered, err := json.Marshal(parsed)
+		require.NoError(t, err, `re-marshaling tampered JWE should succeed`)
+
+		_, err = jwe.Decrypt(tampered, jwe.WithKey(jwa.RSA_OAEP(), privkey))
+		require.Error(t, err, `jwe.Decrypt should fail when "enc" is missing`)
+		require.ErrorIs(t, err, jwe.DecryptError(), `error should wrap jwe.DecryptError`)
+		require.ErrorIs(t, err, jwe.MissingContentEncryptionError{}, `error should be programmatically matchable as jwe.MissingContentEncryptionError`)
+	})
+
+	t.Run("AlgorithmMismatchError when per-recipient alg differs from key alg", func(t *testing.T) {
+		privkey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err, `rsa.GenerateKey should succeed`)
+
+		const payload = `lorem ipsum`
+		encrypted, err := jwe.Encrypt(
+			[]byte(payload),
+			jwe.WithKey(jwa.RSA_OAEP(), &privkey.PublicKey),
+			jwe.WithContentEncryption(jwa.A128GCM()),
+			jwe.WithJSON(),
+		)
+		require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(encrypted, &parsed), `freshly encrypted JWE should parse as JSON`)
+
+		// Overwrite the flattened per-recipient header's "alg" with a
+		// different valid algorithm. decryptContent's alg-match loop
+		// inspects recipient.Headers() first and surfaces a typed
+		// mismatch when it does not match the caller's key alg.
+		parsed["header"] = map[string]any{
+			"alg": jwa.RSA1_5().String(),
+		}
+
+		tampered, err := json.Marshal(parsed)
+		require.NoError(t, err, `re-marshaling tampered JWE should succeed`)
+
+		_, err = jwe.Decrypt(tampered, jwe.WithKey(jwa.RSA_OAEP(), privkey))
+		require.Error(t, err, `jwe.Decrypt should fail when per-recipient alg differs from the key alg`)
+		require.ErrorIs(t, err, jwe.DecryptError(), `error should wrap jwe.DecryptError`)
+		require.ErrorIs(t, err, jwe.AlgorithmMismatchError{}, `error should be programmatically matchable as jwe.AlgorithmMismatchError`)
+
+		mismatch, ok := errors.AsType[jwe.AlgorithmMismatchError](err)
+		require.True(t, ok, `errors.AsType should extract jwe.AlgorithmMismatchError`)
+		require.Equal(t, jwa.RSA_OAEP(), mismatch.Expected, `Expected should be the caller's key algorithm`)
+		require.Equal(t, jwa.RSA1_5(), mismatch.Got, `Got should be the algorithm declared in the per-recipient header`)
+	})
 }


### PR DESCRIPTION
## Summary

Introduces typed errors for two enumerable substep failures inside `jwe.decryptContent`:

- `jwe.MissingContentEncryptionError{}` — `enc` missing from protected headers.
- `jwe.AlgorithmMismatchError{Expected, Got jwa.KeyEncryptionAlgorithm}` — key alg vs. recipient/protected `alg` mismatch.

Both preserve `errors.Is(err, jwe.DecryptError())` at the outer envelope; zero-value matching and `errors.AsType` work via a jwt-style `Is(error) bool` method.

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go test ./jwe/...` passes
- [x] `GOEXPERIMENT=jsonv2 go vet ./jwe/...` clean
- [x] new `TestDecryptSubstepTypedErrors` covers both typed errors with `errors.Is` + `errors.AsType` assertions

## Scope

Deliberately did NOT type:

- Header `Clone`/`Merge` failures — infrastructure plumbing, not caller-distinguishable semantics.
- CEK decrypt failures — already surface `HPKEError` / `RecipientError` and family-specific errors.
- Content AEAD / decompression failures — passthrough of primitive errors; no enumerable substep.
- `jwk.Export` failures — belongs to the jwk error chain.

## Follow-up (not in this PR)

- `.claude/docs/error-formatting.md` should gain a jwe struct-errors section once the jwk companion PR also lands.