### PR TITLE
jwk: split ParseKey into non-generic ParseKey + typed ParseKeyAs

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -38,6 +38,19 @@ Only `jwt.UnknownPayloadTypeError()` remains a sentinel function (no struct type
 | `ClaimTypeMismatchError` | `Name`, `Got`, `Want` | Claim present but wrong type (`jwt.Get` type assertion failed) |
 | `ClaimAssignmentFailedError` | `Err` | Claim value assignment failed |
 
+## Exported Error Types (jwk)
+
+| Type | Structured Fields | Meaning |
+|------|------------------|---------|
+| `KeyTypeMismatchError` | `Got`, `Want` (both `reflect.Type`) | Generic type parameter on `Import[T]` / `ParseKeyAs[T]` does not match the resolved key type |
+
+## Exported Error Types (jwe)
+
+| Type | Structured Fields | Meaning |
+|------|------------------|---------|
+| `MissingContentEncryptionError` | *(none)* | `enc` missing from protected headers during `Decrypt` |
+| `AlgorithmMismatchError` | `Expected`, `Got` (both `jwa.KeyEncryptionAlgorithm`) | Per-recipient/protected `alg` does not match the key's algorithm |
+
 ## Sentinel Function Registry
 
 | Package | Function | Meaning |

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -33,7 +33,7 @@ Algorithm identifiers per RFC 7518. Registry pattern with thread-safe lookup.
 JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 
 - **Settings(options ...GlobalOption)** — configure global jwk behavior (`WithStrictKeyUsage`, RSA validation floors)
-- **Parse(src []byte, ...ParseOption) (Set, error)** / **ParseKey(data []byte, ...ParseOption) (Key, error)** — parse JWK/JWKS
+- **Parse(src []byte, ...ParseOption) (Set, error)** / **ParseKey(data []byte, ...ParseOption) (Key, error)** / **ParseKeyAs[T Key](data []byte, ...ParseOption) (T, error)** — parse JWK/JWKS; `ParseKeyAs` returns [`KeyTypeMismatchError`] on generic-type mismatch
 - **Fetch(ctx, url, ...FetchOption) (Set, error)** — HTTP fetch with optional whitelist, body size limit (default 10 MB via `WithMaxFetchBodySize`)
 - **DefaultHTTPClient() \*http.Client** — returns a new http.Client with library defaults (30s timeout, redirect policy)
 - **Import[T Key](raw any) (T, error)** / **Export[T any](key Key) (T, error)** / **ExportAll[T any](set Set) ([]T, error)** — convert between Go crypto types and JWK (generic). `ExportAll` exports every key in a `Set`, preserving order; `T = any` handles heterogeneous sets.

--- a/Changes-v4.md
+++ b/Changes-v4.md
@@ -93,11 +93,11 @@ For a step-by-step migration guide with before/after code examples, see [MIGRATI
   and fails fast on the first mismatch. For a heterogeneous set, use
   `T = any`; each element's dynamic type matches its source key's raw form.
 
-* `jwk.ParseKey()` returns `jwk.Key` directly (no generic type parameter).
-  Use `jwk.ParseKeyAs[T Key](data []byte, options ...ParseOption) (T, error)`
-  when a concrete subtype is required. On a type mismatch, `ParseKeyAs`
-  returns a `jwk.KeyTypeMismatchError` matching the shape used by
-  `jwk.Import[T]`.
+* `jwk.ParseKeyAs[T Key](data []byte, options ...ParseOption) (T, error)` is new.
+  Use it when you need a concrete subtype such as `jwk.RSAPrivateKey`; on a
+  type mismatch it returns a typed `jwk.KeyTypeMismatchError` matching the
+  shape used by `jwk.Import[T]`. `jwk.ParseKey()` itself is unchanged from
+  v3 and still returns `jwk.Key`.
 
 * `jwk.Fetch()` and `jwk.Cache` have both been removed from the main module, along
   with every other HTTP-touching entry point. The core `jwk` package no longer

--- a/Changes-v4.md
+++ b/Changes-v4.md
@@ -93,7 +93,11 @@ For a step-by-step migration guide with before/after code examples, see [MIGRATI
   and fails fast on the first mismatch. For a heterogeneous set, use
   `T = any`; each element's dynamic type matches its source key's raw form.
 
-* `jwk.ParseKey()` is now generic: `jwk.ParseKey[T Key](data []byte, ...options) (T, error)`.
+* `jwk.ParseKey()` returns `jwk.Key` directly (no generic type parameter).
+  Use `jwk.ParseKeyAs[T Key](data []byte, options ...ParseOption) (T, error)`
+  when a concrete subtype is required. On a type mismatch, `ParseKeyAs`
+  returns a `jwk.KeyTypeMismatchError` matching the shape used by
+  `jwk.Import[T]`.
 
 * `jwk.Fetch()` and `jwk.Cache` have both been removed from the main module, along
   with every other HTTP-touching entry point. The core `jwk` package no longer

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -45,7 +45,7 @@ Text output labels each finding as `(auto)` or `(manual)`, with migration notes 
 | `RegisterCustomField(name, obj)` | `RegisterCustomField[T](name)` | All packages |
 | `jwk.RegisterProbeField(reflect.StructField{...})` | `jwk.RegisterProbeField[T](name, jsonKey)` | No `reflect` import needed |
 | `jwk.Import(raw)` | `jwk.Import[T](raw)` | Generic return type |
-| `jwk.ParseKey(data)` | `jwk.ParseKey[T](data)` | Generic return type |
+| `jwk.ParseKey(data)` | `jwk.ParseKey(data)` *(unchanged — returns `jwk.Key`)* / `jwk.ParseKeyAs[T](data)` | Typed subtype moved to `ParseKeyAs[T]` |
 | `jwk.NewCache(ctx, client)` | `jwkfetch.NewCache(ctx, client)` | Extension module (see Recipe 6) |
 | `jwk.Fetch(ctx, url, opts...)` | `jwkfetch.NewClient(opts...).Fetch(ctx, url)` | Extension module (see Recipe 6) |
 | `jwk.WithHTTPClient(c)` | `jwkfetch.WithHTTPClient(c)` | Extension module |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ import (
 
 func Example() {
   // Parse, serialize, slice and dice JWKs!
-  privkey, err := jwk.ParseKey[jwk.Key](jsonRSAPrivateKey)
+  privkey, err := jwk.ParseKey(jsonRSAPrivateKey)
   if err != nil {
     fmt.Printf("failed to parse JWK: %s\n", err)
     return

--- a/docs/01-jwt.md
+++ b/docs/01-jwt.md
@@ -337,7 +337,7 @@ func Example_jwt_parse_with_key() {
   // and only the verifier side sees the key material — we do both here
   // so the example is self-contained.
   const keysrc = `{"kty":"oct","k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"}`
-  key, err := jwk.ParseKey[jwk.Key]([]byte(keysrc))
+  key, err := jwk.ParseKey([]byte(keysrc))
   if err != nil {
     fmt.Printf("jwk.ParseKey failed: %s\n", err)
     return

--- a/docs/04-jwk.md
+++ b/docs/04-jwk.md
@@ -134,7 +134,7 @@ func Example_jwk_parse_key() {
     "kid":"1"
   }`
 
-  key, err := jwk.ParseKey[jwk.ECDSAPublicKey]([]byte(src))
+  key, err := jwk.ParseKeyAs[jwk.ECDSAPublicKey]([]byte(src))
   if err != nil {
     fmt.Printf("failed parse key: %s\n", err)
     return
@@ -193,7 +193,7 @@ z8CjezfckLs7UKJOlhu3OU9TFsiGDzSDBZdDWO1/uciJ/AAWeSmsBt8cKL0MirIr
 c4wOvhbalcX0FqTM3mXCgMFRbibquhwdxbU=
 -----END CERTIFICATE-----`
 
-  key, err := jwk.ParseKey[jwk.RSAPublicKey]([]byte(src), jwk.WithPEM(true))
+  key, err := jwk.ParseKeyAs[jwk.RSAPublicKey]([]byte(src), jwk.WithPEM(true))
   if err != nil {
     fmt.Printf("failed to parse key in PEM format: %s\n", err)
     return
@@ -396,7 +396,7 @@ func Example_jwk_struct_field() {
 
   // Parse the intercepted `Proxy.Key` as a `jwk.Key`
   // and assign it to `Container.Key`
-  key, err := jwk.ParseKey[jwk.Key](p.Key)
+  key, err := jwk.ParseKey(p.Key)
   if err != nil {
     fmt.Printf("failed to parse key: %s\n", err)
     return
@@ -465,7 +465,7 @@ func Example_jwk_import() {
   // What you want to do is to _parse_ `buf`.
   //
   //  keyset, _ := jwk.Parse(buf)
-  //  key, _    := jwk.ParseKey[jwk.Key](buf)
+  //  key, _    := jwk.ParseKey(buf)
   //
   // See other examples in examples/jwk_parse_key_example_test.go and
   // examples/jwk_parse_jwks_example_test.go

--- a/docs/10-extensions.md
+++ b/docs/10-extensions.md
@@ -186,7 +186,7 @@ func Example_mldsa_jwk() {
 	// Parse back from JSON. Because the mldsa package registered the ML-DSA
 	// signature algorithms at init time, jwk.ParseKey can resolve "ML-DSA-44"
 	// in the "alg" field and reconstruct the key correctly.
-	parsed, err := jwk.ParseKey[jwk.Key](serialized)
+	parsed, err := jwk.ParseKey(serialized)
 	if err != nil {
 		fmt.Printf("failed to parse JWK: %s\n", err)
 		return
@@ -368,7 +368,7 @@ func Example_jws_ed448() {
 		return
 	}
 
-	parsed, err := jwk.ParseKey[jwk.Key](buf)
+	parsed, err := jwk.ParseKey(buf)
 	if err != nil {
 		fmt.Printf("failed to parse JWK: %s\n", err)
 		return

--- a/docs/99-faq.md
+++ b/docs/99-faq.md
@@ -38,7 +38,7 @@ If you are in an environment where API changes disrupts your environment, you sh
 
 As stated in the documentation, `jwk.Import[T]()` creates different types of keys depending on the type of the input.
 
-Use `jwk.Import[T]()` to construct a JWK from a [*raw* key](./04-jwk.md#raw-key) such as `*rsa.PrivateKey`, `*ecdsa.PublicKey`, `[]byte`, etc. Use `jwk.Parse()` or `jwk.ParseKey[T]()` to parse a piece of data (`[]byte` and the like) that already holds an encoded JWK and create the appropriate key type from its contents.
+Use `jwk.Import[T]()` to construct a JWK from a [*raw* key](./04-jwk.md#raw-key) such as `*rsa.PrivateKey`, `*ecdsa.PublicKey`, `[]byte`, etc. Use `jwk.Parse()` or `jwk.ParseKey()` to parse a piece of data (`[]byte` and the like) that already holds an encoded JWK and create the appropriate key type from its contents. When you need a concrete key subtype (e.g. `jwk.RSAPublicKey`) use `jwk.ParseKeyAs[T]()`.
 
 See ["Using jwk.Import()"](./04-jwk.md#using-jwkimport) for more details.
 

--- a/internal/jwxcodegen/genunmarshal.go
+++ b/internal/jwxcodegen/genunmarshal.go
@@ -42,7 +42,7 @@ func GenerateUnmarshalCases(o *codegen.Output, cfg CaseConfig, decodeCtxExpr str
 			o.L("if err != nil {")
 			o.L("return fmt.Errorf(`failed to decode value for key %%s: %%w`, %s, err)", keyName)
 			o.L("}")
-			o.L("key, err := jwk.ParseKey[jwk.Key](raw)")
+			o.L("key, err := jwk.ParseKey(raw)")
 			o.L("if err != nil {")
 			o.L("return fmt.Errorf(`failed to parse JWK for key %%s: %%w`, %s, err)", keyName)
 			o.L("}")

--- a/internal/jwxtest/jwxtest.go
+++ b/internal/jwxtest/jwxtest.go
@@ -291,7 +291,7 @@ func ParseJwkFile(_ context.Context, file string) (jwk.Key, error) {
 		return nil, fmt.Errorf(`failed to read from key file %s: %w`, file, err)
 	}
 
-	key, err := jwk.ParseKeyAs[jwk.Key](buf)
+	key, err := jwk.ParseKey(buf)
 	if err != nil {
 		return nil, fmt.Errorf(`filed to parse JWK in key file %s: %w`, file, err)
 	}

--- a/internal/jwxtest/jwxtest.go
+++ b/internal/jwxtest/jwxtest.go
@@ -291,7 +291,7 @@ func ParseJwkFile(_ context.Context, file string) (jwk.Key, error) {
 		return nil, fmt.Errorf(`failed to read from key file %s: %w`, file, err)
 	}
 
-	key, err := jwk.ParseKey[jwk.Key](buf)
+	key, err := jwk.ParseKey(buf)
 	if err != nil {
 		return nil, fmt.Errorf(`filed to parse JWK in key file %s: %w`, file, err)
 	}

--- a/internal/jwxtest/jwxtest.go
+++ b/internal/jwxtest/jwxtest.go
@@ -291,7 +291,7 @@ func ParseJwkFile(_ context.Context, file string) (jwk.Key, error) {
 		return nil, fmt.Errorf(`failed to read from key file %s: %w`, file, err)
 	}
 
-	key, err := jwk.ParseKey(buf)
+	key, err := jwk.ParseKeyAs[jwk.Key](buf)
 	if err != nil {
 		return nil, fmt.Errorf(`filed to parse JWK in key file %s: %w`, file, err)
 	}

--- a/jwe/headers_gen.go
+++ b/jwe/headers_gen.go
@@ -734,7 +734,7 @@ func (h *stdHeaders) UnmarshalJSON(buf []byte) error {
 			if err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, EphemeralPublicKeyKey, err)
 			}
-			key, err := jwk.ParseKey[jwk.Key](raw)
+			key, err := jwk.ParseKey(raw)
 			if err != nil {
 				return fmt.Errorf(`failed to parse JWK for key %s: %w`, EphemeralPublicKeyKey, err)
 			}
@@ -744,7 +744,7 @@ func (h *stdHeaders) UnmarshalJSON(buf []byte) error {
 			if err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, JWKKey, err)
 			}
-			key, err := jwk.ParseKey[jwk.Key](raw)
+			key, err := jwk.ParseKey(raw)
 			if err != nil {
 				return fmt.Errorf(`failed to parse JWK for key %s: %w`, JWKKey, err)
 			}

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -47,7 +47,7 @@ func init() {
       "qi":"VIMpMYbPf47dT1w_zDUXfPimsSegnMOA1zTaX7aGk_8urY6R8-ZW1FxU7AlWAyLWybqq6t16VFd7hQd0y6flUK4SlOydB61gwanOsXGOAOv82cHq0E3eL4HrtZkUuKvnPrMnsUUFlfUdybVzxyjz9JF_XyaY14ardLSjf4L_FNY"
      }`)
 
-	privkey, err := jwk.ParseKey(jwkstr)
+	privkey, err := jwk.ParseKeyAs[jwk.Key](jwkstr)
 	if err != nil {
 		panic(err)
 	}
@@ -146,7 +146,7 @@ func TestParse_RSAES_OAEP_AES_GCM(t *testing.T) {
       "qi":"VIMpMYbPf47dT1w_zDUXfPimsSegnMOA1zTaX7aGk_8urY6R8-ZW1FxU7AlWAyLWybqq6t16VFd7hQd0y6flUK4SlOydB61gwanOsXGOAOv82cHq0E3eL4HrtZkUuKvnPrMnsUUFlfUdybVzxyjz9JF_XyaY14ardLSjf4L_FNY"
      }`)
 
-	privkey, err := jwk.ParseKey(jwkstr)
+	privkey, err := jwk.ParseKeyAs[jwk.Key](jwkstr)
 	require.NoError(t, err, `parsing jwk should succeed`)
 
 	rawkey, err := jwk.Export[*rsa.PrivateKey](privkey)
@@ -421,7 +421,7 @@ func Test_GHIssue207(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			webKey, err := jwk.ParseKey([]byte(tc.Key))
+			webKey, err := jwk.ParseKeyAs[jwk.Key]([]byte(tc.Key))
 			require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 			thumbprint, err := webKey.Thumbprint(crypto.SHA1)
@@ -571,7 +571,7 @@ func TestDecodePredefined_Direct(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Algorithm.String(), func(t *testing.T) {
-			webKey, err := jwk.ParseKey([]byte(tc.Key))
+			webKey, err := jwk.ParseKeyAs[jwk.Key]([]byte(tc.Key))
 			require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 			thumbprint, err := webKey.Thumbprint(crypto.SHA1)
@@ -757,7 +757,7 @@ func TestGH840(t *testing.T) {
 		"d": "870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"
 	}`)
 
-	_, err := jwk.ParseKey(untrustedJWK)
+	_, err := jwk.ParseKeyAs[jwk.Key](untrustedJWK)
 	require.Error(t, err, `jwk.ParseKey must reject an off-curve ECDSA JWK`)
 }
 

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -47,7 +47,7 @@ func init() {
       "qi":"VIMpMYbPf47dT1w_zDUXfPimsSegnMOA1zTaX7aGk_8urY6R8-ZW1FxU7AlWAyLWybqq6t16VFd7hQd0y6flUK4SlOydB61gwanOsXGOAOv82cHq0E3eL4HrtZkUuKvnPrMnsUUFlfUdybVzxyjz9JF_XyaY14ardLSjf4L_FNY"
      }`)
 
-	privkey, err := jwk.ParseKeyAs[jwk.Key](jwkstr)
+	privkey, err := jwk.ParseKey(jwkstr)
 	if err != nil {
 		panic(err)
 	}
@@ -146,7 +146,7 @@ func TestParse_RSAES_OAEP_AES_GCM(t *testing.T) {
       "qi":"VIMpMYbPf47dT1w_zDUXfPimsSegnMOA1zTaX7aGk_8urY6R8-ZW1FxU7AlWAyLWybqq6t16VFd7hQd0y6flUK4SlOydB61gwanOsXGOAOv82cHq0E3eL4HrtZkUuKvnPrMnsUUFlfUdybVzxyjz9JF_XyaY14ardLSjf4L_FNY"
      }`)
 
-	privkey, err := jwk.ParseKeyAs[jwk.Key](jwkstr)
+	privkey, err := jwk.ParseKey(jwkstr)
 	require.NoError(t, err, `parsing jwk should succeed`)
 
 	rawkey, err := jwk.Export[*rsa.PrivateKey](privkey)
@@ -421,7 +421,7 @@ func Test_GHIssue207(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			webKey, err := jwk.ParseKeyAs[jwk.Key]([]byte(tc.Key))
+			webKey, err := jwk.ParseKey([]byte(tc.Key))
 			require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 			thumbprint, err := webKey.Thumbprint(crypto.SHA1)
@@ -571,7 +571,7 @@ func TestDecodePredefined_Direct(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Algorithm.String(), func(t *testing.T) {
-			webKey, err := jwk.ParseKeyAs[jwk.Key]([]byte(tc.Key))
+			webKey, err := jwk.ParseKey([]byte(tc.Key))
 			require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 			thumbprint, err := webKey.Thumbprint(crypto.SHA1)
@@ -757,7 +757,7 @@ func TestGH840(t *testing.T) {
 		"d": "870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"
 	}`)
 
-	_, err := jwk.ParseKeyAs[jwk.Key](untrustedJWK)
+	_, err := jwk.ParseKey(untrustedJWK)
 	require.Error(t, err, `jwk.ParseKey must reject an off-curve ECDSA JWK`)
 }
 

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -47,7 +47,7 @@ func init() {
       "qi":"VIMpMYbPf47dT1w_zDUXfPimsSegnMOA1zTaX7aGk_8urY6R8-ZW1FxU7AlWAyLWybqq6t16VFd7hQd0y6flUK4SlOydB61gwanOsXGOAOv82cHq0E3eL4HrtZkUuKvnPrMnsUUFlfUdybVzxyjz9JF_XyaY14ardLSjf4L_FNY"
      }`)
 
-	privkey, err := jwk.ParseKey[jwk.Key](jwkstr)
+	privkey, err := jwk.ParseKey(jwkstr)
 	if err != nil {
 		panic(err)
 	}
@@ -146,7 +146,7 @@ func TestParse_RSAES_OAEP_AES_GCM(t *testing.T) {
       "qi":"VIMpMYbPf47dT1w_zDUXfPimsSegnMOA1zTaX7aGk_8urY6R8-ZW1FxU7AlWAyLWybqq6t16VFd7hQd0y6flUK4SlOydB61gwanOsXGOAOv82cHq0E3eL4HrtZkUuKvnPrMnsUUFlfUdybVzxyjz9JF_XyaY14ardLSjf4L_FNY"
      }`)
 
-	privkey, err := jwk.ParseKey[jwk.Key](jwkstr)
+	privkey, err := jwk.ParseKey(jwkstr)
 	require.NoError(t, err, `parsing jwk should succeed`)
 
 	rawkey, err := jwk.Export[*rsa.PrivateKey](privkey)
@@ -421,7 +421,7 @@ func Test_GHIssue207(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			webKey, err := jwk.ParseKey[jwk.Key]([]byte(tc.Key))
+			webKey, err := jwk.ParseKey([]byte(tc.Key))
 			require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 			thumbprint, err := webKey.Thumbprint(crypto.SHA1)
@@ -571,7 +571,7 @@ func TestDecodePredefined_Direct(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Algorithm.String(), func(t *testing.T) {
-			webKey, err := jwk.ParseKey[jwk.Key]([]byte(tc.Key))
+			webKey, err := jwk.ParseKey([]byte(tc.Key))
 			require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 			thumbprint, err := webKey.Thumbprint(crypto.SHA1)
@@ -757,7 +757,7 @@ func TestGH840(t *testing.T) {
 		"d": "870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"
 	}`)
 
-	_, err := jwk.ParseKey[jwk.Key](untrustedJWK)
+	_, err := jwk.ParseKey(untrustedJWK)
 	require.Error(t, err, `jwk.ParseKey must reject an off-curve ECDSA JWK`)
 }
 

--- a/jwk/doc.go
+++ b/jwk/doc.go
@@ -16,7 +16,7 @@
 //
 // You can parse a JWK from a JSON payload:
 //
-//	jwk.ParseKey[jwk.Key]([]byte(`{"kty":"EC",...}`))
+//	jwk.ParseKey([]byte(`{"kty":"EC",...}`))
 //
 // You can go back and forth between raw key types and JWKs:
 //
@@ -26,7 +26,7 @@
 // When you know the expected key type, use a concrete type parameter:
 //
 //	rsaKey, _ := jwk.Import[jwk.RSAPrivateKey](rsaPrivateKey)
-//	ecKey, _ := jwk.ParseKey[jwk.ECDSAPublicKey](jsonData)
+//	ecKey, _ := jwk.ParseKeyAs[jwk.ECDSAPublicKey](jsonData)
 //
 // You can use them to sign/verify/encrypt/decrypt:
 //

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -47,7 +47,7 @@ func TestECDSAInvalidPointsRejectedOnParse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			body := ecdsaPointJWK(t, elliptic.P256(), "P-256", tc.x, tc.y)
 
-			_, err := jwk.ParseKeyAs[jwk.Key](body)
+			_, err := jwk.ParseKey(body)
 			require.Error(t, err, `ParseKey must reject invalid ECDSA point at parse time`)
 			require.True(t, jwk.IsKeyValidationError(err), `ParseKey error must unwrap to a key-validation error: %v`, err)
 
@@ -67,7 +67,7 @@ func TestECDSAInvalidPointsRejectedOnParse(t *testing.T) {
 			"x": "AYwhwiE1hXWdfwu-HlBSsY5Chxycu-LyE6WsZ_w2DO4",
 			"y": "zumemGclMFkimMsKMXlLdKYWtLle58e4N9hDPcN7lig"
 		}`)
-		key, err := jwk.ParseKeyAs[jwk.Key](body)
+		key, err := jwk.ParseKey(body)
 		require.NoError(t, err, `ParseKey on a valid P-256 key should succeed`)
 		require.NoError(t, key.Validate(), `Validate on a valid P-256 key should succeed`)
 		_, err = jwk.Export[*ecdsa.PublicKey](key)

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -47,7 +47,7 @@ func TestECDSAInvalidPointsRejectedOnParse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			body := ecdsaPointJWK(t, elliptic.P256(), "P-256", tc.x, tc.y)
 
-			_, err := jwk.ParseKey[jwk.Key](body)
+			_, err := jwk.ParseKey(body)
 			require.Error(t, err, `ParseKey must reject invalid ECDSA point at parse time`)
 			require.True(t, jwk.IsKeyValidationError(err), `ParseKey error must unwrap to a key-validation error: %v`, err)
 
@@ -67,7 +67,7 @@ func TestECDSAInvalidPointsRejectedOnParse(t *testing.T) {
 			"x": "AYwhwiE1hXWdfwu-HlBSsY5Chxycu-LyE6WsZ_w2DO4",
 			"y": "zumemGclMFkimMsKMXlLdKYWtLle58e4N9hDPcN7lig"
 		}`)
-		key, err := jwk.ParseKey[jwk.Key](body)
+		key, err := jwk.ParseKey(body)
 		require.NoError(t, err, `ParseKey on a valid P-256 key should succeed`)
 		require.NoError(t, key.Validate(), `Validate on a valid P-256 key should succeed`)
 		_, err = jwk.Export[*ecdsa.PublicKey](key)

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -47,7 +47,7 @@ func TestECDSAInvalidPointsRejectedOnParse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			body := ecdsaPointJWK(t, elliptic.P256(), "P-256", tc.x, tc.y)
 
-			_, err := jwk.ParseKey(body)
+			_, err := jwk.ParseKeyAs[jwk.Key](body)
 			require.Error(t, err, `ParseKey must reject invalid ECDSA point at parse time`)
 			require.True(t, jwk.IsKeyValidationError(err), `ParseKey error must unwrap to a key-validation error: %v`, err)
 
@@ -67,7 +67,7 @@ func TestECDSAInvalidPointsRejectedOnParse(t *testing.T) {
 			"x": "AYwhwiE1hXWdfwu-HlBSsY5Chxycu-LyE6WsZ_w2DO4",
 			"y": "zumemGclMFkimMsKMXlLdKYWtLle58e4N9hDPcN7lig"
 		}`)
-		key, err := jwk.ParseKey(body)
+		key, err := jwk.ParseKeyAs[jwk.Key](body)
 		require.NoError(t, err, `ParseKey on a valid P-256 key should succeed`)
 		require.NoError(t, key.Validate(), `Validate on a valid P-256 key should succeed`)
 		_, err = jwk.Export[*ecdsa.PublicKey](key)

--- a/jwk/fuzz_test.go
+++ b/jwk/fuzz_test.go
@@ -17,7 +17,7 @@ func FuzzParseKey(f *testing.F) {
 	f.Add([]byte(`not-json`))
 
 	f.Fuzz(func(_ *testing.T, data []byte) {
-		_, _ = jwk.ParseKey[jwk.Key](data)
+		_, _ = jwk.ParseKey(data)
 	})
 }
 
@@ -39,7 +39,7 @@ func FuzzParseKeyRoundtrip(f *testing.F) {
 	f.Add([]byte(`{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`))
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		key, err := jwk.ParseKey[jwk.Key](data)
+		key, err := jwk.ParseKey(data)
 		if err != nil {
 			return
 		}
@@ -47,7 +47,7 @@ func FuzzParseKeyRoundtrip(f *testing.F) {
 		serialized, err := json.Marshal(key)
 		require.NoError(t, err)
 
-		_, err = jwk.ParseKey[jwk.Key](serialized)
+		_, err = jwk.ParseKey(serialized)
 		require.NoError(t, err)
 	})
 }

--- a/jwk/fuzz_test.go
+++ b/jwk/fuzz_test.go
@@ -17,7 +17,7 @@ func FuzzParseKey(f *testing.F) {
 	f.Add([]byte(`not-json`))
 
 	f.Fuzz(func(_ *testing.T, data []byte) {
-		_, _ = jwk.ParseKey(data)
+		_, _ = jwk.ParseKeyAs[jwk.Key](data)
 	})
 }
 
@@ -39,7 +39,7 @@ func FuzzParseKeyRoundtrip(f *testing.F) {
 	f.Add([]byte(`{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`))
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		key, err := jwk.ParseKey(data)
+		key, err := jwk.ParseKeyAs[jwk.Key](data)
 		if err != nil {
 			return
 		}
@@ -47,7 +47,7 @@ func FuzzParseKeyRoundtrip(f *testing.F) {
 		serialized, err := json.Marshal(key)
 		require.NoError(t, err)
 
-		_, err = jwk.ParseKey(serialized)
+		_, err = jwk.ParseKeyAs[jwk.Key](serialized)
 		require.NoError(t, err)
 	})
 }

--- a/jwk/fuzz_test.go
+++ b/jwk/fuzz_test.go
@@ -17,7 +17,7 @@ func FuzzParseKey(f *testing.F) {
 	f.Add([]byte(`not-json`))
 
 	f.Fuzz(func(_ *testing.T, data []byte) {
-		_, _ = jwk.ParseKeyAs[jwk.Key](data)
+		_, _ = jwk.ParseKey(data)
 	})
 }
 
@@ -39,7 +39,7 @@ func FuzzParseKeyRoundtrip(f *testing.F) {
 	f.Add([]byte(`{"kty":"OKP","crv":"Ed25519","x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`))
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		key, err := jwk.ParseKeyAs[jwk.Key](data)
+		key, err := jwk.ParseKey(data)
 		if err != nil {
 			return
 		}
@@ -47,7 +47,7 @@ func FuzzParseKeyRoundtrip(f *testing.F) {
 		serialized, err := json.Marshal(key)
 		require.NoError(t, err)
 
-		_, err = jwk.ParseKeyAs[jwk.Key](serialized)
+		_, err = jwk.ParseKey(serialized)
 		require.NoError(t, err)
 	})
 }

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -327,9 +327,9 @@ func (ctx *setDecodeCtx) IgnoreParseError() bool {
 	return ctx.ignoreParseError
 }
 
-// ParseKey parses a single key JWK. Unlike `jwk.Parse` this method will
-// report failure if you attempt to pass a JWK set. Only use this function
-// when you know that the data is a single JWK.
+// ParseKey parses a single key JWK and returns it as a [Key]. Unlike
+// [Parse] this method reports failure if the input is a JWK set. Only
+// use this function when you know that the data is a single JWK.
 //
 // Given a WithPEM(true) option, this function assumes that the given input
 // is PEM encoded ASN.1 DER format key.
@@ -339,15 +339,19 @@ func (ctx *setDecodeCtx) IgnoreParseError() bool {
 // are performed for certificate expiration, no checks against missing
 // parameters are performed, etc.
 //
-// The type parameter T specifies the expected key type. Use [Key] when you
-// do not need a specific subtype:
+// Use [ParseKeyAs] when a concrete key subtype (e.g. [RSAPrivateKey],
+// [ECDSAPublicKey]) is required.
+func ParseKey(data []byte, options ...ParseOption) (Key, error) {
+	return doParseKey(data, options...)
+}
+
+// ParseKeyAs behaves like [ParseKey] but asserts the parsed key to the
+// concrete type T. On a type mismatch it returns a [KeyTypeMismatchError]
+// carrying the parsed and requested types; the underlying error chain also
+// satisfies [errors.Is] with a sentinel [ParseError].
 //
-//	key, err := jwk.ParseKey[jwk.Key](data)
-//
-// Use a concrete key type to obtain a typed result directly:
-//
-//	ecKey, err := jwk.ParseKey[jwk.ECDSAPublicKey](data)
-func ParseKey[T Key](data []byte, options ...ParseOption) (T, error) {
+//	ecKey, err := jwk.ParseKeyAs[jwk.ECDSAPublicKey](data)
+func ParseKeyAs[T Key](data []byte, options ...ParseOption) (T, error) {
 	var zero T
 	key, err := doParseKey(data, options...)
 	if err != nil {
@@ -355,7 +359,10 @@ func ParseKey[T Key](data []byte, options ...ParseOption) (T, error) {
 	}
 	result, ok := key.(T)
 	if !ok {
-		return zero, parseerr(`parsed key is %T, not %T`, key, zero)
+		return zero, parseerr(`%w`, KeyTypeMismatchError{
+			Got:  reflect.TypeOf(key),
+			Want: reflect.TypeFor[T](),
+		})
 	}
 	return result, nil
 }

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -193,7 +193,7 @@ func VerifyKey(t *testing.T, def map[string]keyDef) {
 	t.Helper()
 
 	def = complimentDef(def)
-	key, err := jwk.ParseKey(makeKeyJSON(def))
+	key, err := jwk.ParseKeyAs[jwk.Key](makeKeyJSON(def))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 	t.Run("Fields", func(t *testing.T) {
@@ -248,7 +248,7 @@ func VerifyKey(t *testing.T, def map[string]keyDef) {
 					t.Logf("%s", buf)
 				}
 
-				newkey, err := jwk.ParseKey(buf, jwk.WithPEM(usePEM))
+				newkey, err := jwk.ParseKeyAs[jwk.Key](buf, jwk.WithPEM(usePEM))
 				require.NoError(t, err, `jwk.ParseKey should succeed`)
 			LOOP:
 				for _, k := range key.Keys() {
@@ -463,7 +463,26 @@ func TestExportAll(t *testing.T) {
 
 const testOctKeyJSON = `{"kty":"oct","k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"}`
 
-func TestGenericParseKey(t *testing.T) {
+// TestParseKey exercises the non-generic entry point that returns jwk.Key.
+func TestParseKey(t *testing.T) {
+	t.Parallel()
+	t.Run("Valid", func(t *testing.T) {
+		t.Parallel()
+		key, err := jwk.ParseKey([]byte(testOctKeyJSON))
+		require.NoError(t, err)
+		require.NotNil(t, key)
+		require.Equal(t, jwa.OctetSeq(), key.KeyType())
+	})
+	t.Run("Invalid", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwk.ParseKey([]byte(`not json`))
+		require.Error(t, err)
+	})
+}
+
+// TestParseKeyAs exercises the typed entry point and the
+// KeyTypeMismatchError it returns on a generic-parameter mismatch.
+func TestParseKeyAs(t *testing.T) {
 	t.Parallel()
 	t.Run("JSON", func(t *testing.T) {
 		t.Parallel()
@@ -512,16 +531,11 @@ func TestGenericParseKey(t *testing.T) {
 	})
 	t.Run("BaseInterface", func(t *testing.T) {
 		t.Parallel()
-		// Non-generic ParseKey always returns jwk.Key for valid input.
-		key, err := jwk.ParseKey([]byte(testOctKeyJSON))
+		// ParseKeyAs[jwk.Key] is the typed form of the non-generic ParseKey.
+		key, err := jwk.ParseKeyAs[jwk.Key]([]byte(testOctKeyJSON))
 		require.NoError(t, err)
 		require.NotNil(t, key)
 		require.Equal(t, jwa.OctetSeq(), key.KeyType())
-	})
-	t.Run("ErrorPropagation", func(t *testing.T) {
-		t.Parallel()
-		_, err := jwk.ParseKey([]byte(`not json`))
-		require.Error(t, err)
 	})
 }
 
@@ -559,7 +573,7 @@ func TestParse(t *testing.T) {
 		})
 		t.Run("jwk.ParseKey", func(t *testing.T) {
 			t.Helper()
-			key, err := jwk.ParseKey([]byte(src))
+			key, err := jwk.ParseKeyAs[jwk.Key]([]byte(src))
 			require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 			t.Run("Raw", func(t *testing.T) {
@@ -1266,7 +1280,7 @@ func TestIssue207(t *testing.T) {
 	// Using a loop here because we're using sync.Pool
 	// just for sanity.
 	for range 10 {
-		k, err := jwk.ParseKey([]byte(src))
+		k, err := jwk.ParseKeyAs[jwk.Key]([]byte(src))
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		thumb, err := k.Thumbprint(crypto.SHA1)
@@ -1278,7 +1292,7 @@ func TestIssue207(t *testing.T) {
 func TestIssue270(t *testing.T) {
 	t.Parallel()
 	const src = `{"kty":"EC","alg":"ECMR","crv":"P-521","key_ops":["deriveKey"],"x":"AJwCS845x9VljR-fcrN2WMzIJHDYuLmFShhyu8ci14rmi2DMFp8txIvaxG8n7ZcODeKIs1EO4E_Bldm_pxxs8cUn","y":"ASjz754cIQHPJObihPV8D7vVNfjp_nuwP76PtbLwUkqTk9J1mzCDKM3VADEk-Z1tP-DHiwib6If8jxnb_FjNkiLJ"}`
-	k, err := jwk.ParseKey([]byte(src))
+	k, err := jwk.ParseKeyAs[jwk.Key]([]byte(src))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 	for _, usage := range []string{"sig", "enc"} {
@@ -1405,7 +1419,7 @@ func TestRSA(t *testing.T) {
 	   			"n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
 	   		}`
 
-		key, err := jwk.ParseKey([]byte(src))
+		key, err := jwk.ParseKeyAs[jwk.Key]([]byte(src))
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		tp, err := key.Thumbprint(crypto.SHA256)
@@ -1699,7 +1713,7 @@ func TestCustomField(t *testing.T) {
 	src := b.String()
 
 	t.Run("jwk.ParseKey", func(t *testing.T) {
-		key, err := jwk.ParseKey([]byte(src))
+		key, err := jwk.ParseKeyAs[jwk.Key]([]byte(src))
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		for _, name := range []string{rfc3339Key, rfc1123Key} {
@@ -1740,7 +1754,7 @@ ox0RaBsMD70mvTwKKmlCSD5HgZZTC0CfGWk4dQp/Mct5Z0x0HJMEJCJzpgTn3CRX
 z8CjezfckLs7UKJOlhu3OU9TFsiGDzSDBZdDWO1/uciJ/AAWeSmsBt8cKL0MirIr
 c4wOvhbalcX0FqTM3mXCgMFRbibquhwdxbU=
 -----END CERTIFICATE-----`
-	key, err := jwk.ParseKey([]byte(src), jwk.WithPEM(true))
+	key, err := jwk.ParseKeyAs[jwk.Key]([]byte(src), jwk.WithPEM(true))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 	require.Equal(t, jwa.RSA(), key.KeyType(), `key type should be RSA`)
 
@@ -1845,7 +1859,7 @@ func TestTypedFields(t *testing.T) {
 		t.Run(fmt.Sprintf("%T", key), func(t *testing.T) {
 			for _, tc := range testcases {
 				t.Run(tc.Name, func(t *testing.T) {
-					got, err := jwk.ParseKey(serialized, tc.Options...)
+					got, err := jwk.ParseKeyAs[jwk.Key](serialized, tc.Options...)
 					require.NoError(t, err, `jwk.Parse should succeed`)
 					v, ok := got.Field("typed-field")
 					require.True(t, ok, `got.Field() should succeed`)
@@ -2116,10 +2130,10 @@ func TestGH567(t *testing.T) {
 		buf, err := json.Marshal(key)
 		require.NoError(t, err, `json.Marshal should succeed`)
 
-		_, err = jwk.ParseKey(buf)
+		_, err = jwk.ParseKeyAs[jwk.Key](buf)
 		require.NoError(t, err, `jwk.ParseKey (no WithIgnoreParseError) should succeed`)
 
-		_, err = jwk.ParseKey(buf, jwk.WithIgnoreParseError(true))
+		_, err = jwk.ParseKeyAs[jwk.Key](buf, jwk.WithIgnoreParseError(true))
 		require.Error(t, err, `jwk.ParseKey (no WithIgnoreParseError) should fail`)
 	})
 }
@@ -2155,7 +2169,7 @@ func TestGH664(t *testing.T) {
 			require.NoError(t, err, `jwk.Import should succeed`)
 
 			buf, _ := json.MarshalIndent(jwkPrivkey, "", "  ")
-			parsed, err := jwk.ParseKey(buf)
+			parsed, err := jwk.ParseKeyAs[jwk.Key](buf)
 			require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 			payload := []byte(`hello , world!`)
@@ -2181,7 +2195,7 @@ func TestGH730(t *testing.T) {
 // This test was lifted from #875. See tests under Roundtrip/WithPEM(true) for other key types
 func TestECDSAPEM(t *testing.T) {
 	// go make an EC key at https://mkjwk.org/
-	key, err := jwk.ParseKey([]byte(`{
+	key, err := jwk.ParseKeyAs[jwk.Key]([]byte(`{
 		"kty": "EC",
 		"d": "zqYPTs5gMEwtidOqjlFJSk6L4BQSfhCJX6FTgbuuiE0",
 		"crv": "P-256",
@@ -2195,7 +2209,7 @@ func TestECDSAPEM(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = jwk.ParseKey(pem, jwk.WithPEM(true))
+	_, err = jwk.ParseKeyAs[jwk.Key](pem, jwk.WithPEM(true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2208,7 +2222,7 @@ func TestGH947(t *testing.T) {
 	// Validate() on the freshly-unmarshaled key, the zero-length coordinate
 	// is rejected cleanly at parse time — no bad key is ever handed back.
 	raw := []byte(`{"crv":"Ed25519","d":"","x":"","kty":"OKP"}`)
-	_, err := jwk.ParseKey(raw)
+	_, err := jwk.ParseKeyAs[jwk.Key](raw)
 	require.Error(t, err, `jwk.ParseKey must reject an OKP key with empty coordinates`)
 }
 
@@ -2324,7 +2338,7 @@ func TestGH1262(t *testing.T) {
 		_ = secretSrv // doing some non-standard encryption & response with encrypted data
 
 		// client
-		jwkCli, err := jwk.ParseKey(jwkBuf) // extract jwkBuf
+		jwkCli, err := jwk.ParseKeyAs[jwk.Key](jwkBuf) // extract jwkBuf
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		pubSrv, err := jwk.Export[*ecdh.PublicKey](jwkCli)
@@ -2480,7 +2494,7 @@ dGVzdCBkYXRh
 -----END TEST CUSTOM KEY-----`
 
 	// Test that our custom decoder can handle this via ParseKey
-	parsedKey, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey, err := jwk.ParseKeyAs[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
 	require.NoError(t, err)
 	require.NotNil(t, parsedKey)
 
@@ -2514,7 +2528,7 @@ dGVzdCBkYXRh
 -----END TEST UNREGISTER-----`
 
 	// Verify it works when registered
-	parsedKey1, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey1, err := jwk.ParseKeyAs[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
 	require.NoError(t, err)
 	require.NotNil(t, parsedKey1)
 
@@ -2522,7 +2536,7 @@ dGVzdCBkYXRh
 	jwk.UnregisterX509Decoder(customIdent)
 
 	// Verify it no longer works
-	parsedKey2, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey2, err := jwk.ParseKeyAs[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
 	require.Error(t, err)
 	require.Nil(t, parsedKey2)
 }
@@ -2559,7 +2573,7 @@ dGVzdCBkYXRh
 -----END TEST DUPLICATE-----`
 
 	// Verify it works after first registration
-	parsedKey1, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey1, err := jwk.ParseKeyAs[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
 	require.NoError(t, err)
 	require.NotNil(t, parsedKey1)
 	require.Equal(t, 1, callCount, "Decoder should be called once")
@@ -2568,7 +2582,7 @@ dGVzdCBkYXRh
 	jwk.RegisterX509Decoder(customIdent, decoder)
 
 	// Verify it still works after duplicate registration and decoder wasn't added twice
-	parsedKey2, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey2, err := jwk.ParseKeyAs[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
 	require.NoError(t, err)
 	require.NotNil(t, parsedKey2)
 	require.Equal(t, 2, callCount, "Decoder should be called once more, not duplicated")
@@ -2634,13 +2648,13 @@ func TestUnregisterX509Decoder_StaleIndexMiddle(t *testing.T) {
 	jwk.UnregisterX509Decoder(identB)
 
 	// B must no longer decode.
-	_, err := jwk.ParseKey(pemFor("TRIO B"), jwk.WithPEM(true))
+	_, err := jwk.ParseKeyAs[jwk.Key](pemFor("TRIO B"), jwk.WithPEM(true))
 	require.Error(t, err, "TRIO B should fail after unregister")
 
 	// A and C must still decode.
-	_, err = jwk.ParseKey(pemFor("TRIO A"), jwk.WithPEM(true))
+	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO A"), jwk.WithPEM(true))
 	require.NoError(t, err, "TRIO A should still decode")
-	_, err = jwk.ParseKey(pemFor("TRIO C"), jwk.WithPEM(true))
+	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
 	require.NoError(t, err, "TRIO C should still decode")
 
 	// Now unregister C by ident. Before the fix this would panic
@@ -2650,9 +2664,9 @@ func TestUnregisterX509Decoder_StaleIndexMiddle(t *testing.T) {
 	})
 
 	// C must no longer decode; A must still decode.
-	_, err = jwk.ParseKey(pemFor("TRIO C"), jwk.WithPEM(true))
+	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
 	require.Error(t, err, "TRIO C should fail after second unregister")
-	_, err = jwk.ParseKey(pemFor("TRIO A"), jwk.WithPEM(true))
+	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO A"), jwk.WithPEM(true))
 	require.NoError(t, err, "TRIO A must survive unrelated unregister")
 
 	// Keep identA alive until cleanup fires.
@@ -2668,20 +2682,20 @@ func TestUnregisterX509Decoder_StaleIndexFirst(t *testing.T) {
 
 	jwk.UnregisterX509Decoder(identA)
 
-	_, err := jwk.ParseKey(pemFor("TRIO A"), jwk.WithPEM(true))
+	_, err := jwk.ParseKeyAs[jwk.Key](pemFor("TRIO A"), jwk.WithPEM(true))
 	require.Error(t, err)
-	_, err = jwk.ParseKey(pemFor("TRIO B"), jwk.WithPEM(true))
+	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO B"), jwk.WithPEM(true))
 	require.NoError(t, err)
-	_, err = jwk.ParseKey(pemFor("TRIO C"), jwk.WithPEM(true))
+	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
 	require.NoError(t, err)
 
 	require.NotPanics(t, func() {
 		jwk.UnregisterX509Decoder(identC)
 	})
 
-	_, err = jwk.ParseKey(pemFor("TRIO C"), jwk.WithPEM(true))
+	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
 	require.Error(t, err)
-	_, err = jwk.ParseKey(pemFor("TRIO B"), jwk.WithPEM(true))
+	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO B"), jwk.WithPEM(true))
 	require.NoError(t, err, "TRIO B must survive unrelated unregister")
 
 	_ = identB
@@ -2716,7 +2730,7 @@ func TestX509DecoderConcurrent(t *testing.T) {
 				// Best-effort parse; error is fine (decoder may be
 				// unregistered at this moment). The point is that
 				// the read path must not race on the decoder slice.
-				_, _ = jwk.ParseKey(pemData, jwk.WithPEM(true))
+				_, _ = jwk.ParseKeyAs[jwk.Key](pemData, jwk.WithPEM(true))
 			}
 		})
 	}

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -193,7 +193,7 @@ func VerifyKey(t *testing.T, def map[string]keyDef) {
 	t.Helper()
 
 	def = complimentDef(def)
-	key, err := jwk.ParseKeyAs[jwk.Key](makeKeyJSON(def))
+	key, err := jwk.ParseKey(makeKeyJSON(def))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 	t.Run("Fields", func(t *testing.T) {
@@ -248,7 +248,7 @@ func VerifyKey(t *testing.T, def map[string]keyDef) {
 					t.Logf("%s", buf)
 				}
 
-				newkey, err := jwk.ParseKeyAs[jwk.Key](buf, jwk.WithPEM(usePEM))
+				newkey, err := jwk.ParseKey(buf, jwk.WithPEM(usePEM))
 				require.NoError(t, err, `jwk.ParseKey should succeed`)
 			LOOP:
 				for _, k := range key.Keys() {
@@ -531,7 +531,9 @@ func TestParseKeyAs(t *testing.T) {
 	})
 	t.Run("BaseInterface", func(t *testing.T) {
 		t.Parallel()
-		// ParseKeyAs[jwk.Key] is the typed form of the non-generic ParseKey.
+		// Guards the generic constraint: the Key interface itself must
+		// remain a legal instantiation even though callers should prefer
+		// plain jwk.ParseKey for that case.
 		key, err := jwk.ParseKeyAs[jwk.Key]([]byte(testOctKeyJSON))
 		require.NoError(t, err)
 		require.NotNil(t, key)
@@ -573,7 +575,7 @@ func TestParse(t *testing.T) {
 		})
 		t.Run("jwk.ParseKey", func(t *testing.T) {
 			t.Helper()
-			key, err := jwk.ParseKeyAs[jwk.Key]([]byte(src))
+			key, err := jwk.ParseKey([]byte(src))
 			require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 			t.Run("Raw", func(t *testing.T) {
@@ -1280,7 +1282,7 @@ func TestIssue207(t *testing.T) {
 	// Using a loop here because we're using sync.Pool
 	// just for sanity.
 	for range 10 {
-		k, err := jwk.ParseKeyAs[jwk.Key]([]byte(src))
+		k, err := jwk.ParseKey([]byte(src))
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		thumb, err := k.Thumbprint(crypto.SHA1)
@@ -1292,7 +1294,7 @@ func TestIssue207(t *testing.T) {
 func TestIssue270(t *testing.T) {
 	t.Parallel()
 	const src = `{"kty":"EC","alg":"ECMR","crv":"P-521","key_ops":["deriveKey"],"x":"AJwCS845x9VljR-fcrN2WMzIJHDYuLmFShhyu8ci14rmi2DMFp8txIvaxG8n7ZcODeKIs1EO4E_Bldm_pxxs8cUn","y":"ASjz754cIQHPJObihPV8D7vVNfjp_nuwP76PtbLwUkqTk9J1mzCDKM3VADEk-Z1tP-DHiwib6If8jxnb_FjNkiLJ"}`
-	k, err := jwk.ParseKeyAs[jwk.Key]([]byte(src))
+	k, err := jwk.ParseKey([]byte(src))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 	for _, usage := range []string{"sig", "enc"} {
@@ -1419,7 +1421,7 @@ func TestRSA(t *testing.T) {
 	   			"n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
 	   		}`
 
-		key, err := jwk.ParseKeyAs[jwk.Key]([]byte(src))
+		key, err := jwk.ParseKey([]byte(src))
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		tp, err := key.Thumbprint(crypto.SHA256)
@@ -1713,7 +1715,7 @@ func TestCustomField(t *testing.T) {
 	src := b.String()
 
 	t.Run("jwk.ParseKey", func(t *testing.T) {
-		key, err := jwk.ParseKeyAs[jwk.Key]([]byte(src))
+		key, err := jwk.ParseKey([]byte(src))
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		for _, name := range []string{rfc3339Key, rfc1123Key} {
@@ -1754,7 +1756,7 @@ ox0RaBsMD70mvTwKKmlCSD5HgZZTC0CfGWk4dQp/Mct5Z0x0HJMEJCJzpgTn3CRX
 z8CjezfckLs7UKJOlhu3OU9TFsiGDzSDBZdDWO1/uciJ/AAWeSmsBt8cKL0MirIr
 c4wOvhbalcX0FqTM3mXCgMFRbibquhwdxbU=
 -----END CERTIFICATE-----`
-	key, err := jwk.ParseKeyAs[jwk.Key]([]byte(src), jwk.WithPEM(true))
+	key, err := jwk.ParseKey([]byte(src), jwk.WithPEM(true))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 	require.Equal(t, jwa.RSA(), key.KeyType(), `key type should be RSA`)
 
@@ -1859,7 +1861,7 @@ func TestTypedFields(t *testing.T) {
 		t.Run(fmt.Sprintf("%T", key), func(t *testing.T) {
 			for _, tc := range testcases {
 				t.Run(tc.Name, func(t *testing.T) {
-					got, err := jwk.ParseKeyAs[jwk.Key](serialized, tc.Options...)
+					got, err := jwk.ParseKey(serialized, tc.Options...)
 					require.NoError(t, err, `jwk.Parse should succeed`)
 					v, ok := got.Field("typed-field")
 					require.True(t, ok, `got.Field() should succeed`)
@@ -2130,10 +2132,10 @@ func TestGH567(t *testing.T) {
 		buf, err := json.Marshal(key)
 		require.NoError(t, err, `json.Marshal should succeed`)
 
-		_, err = jwk.ParseKeyAs[jwk.Key](buf)
+		_, err = jwk.ParseKey(buf)
 		require.NoError(t, err, `jwk.ParseKey (no WithIgnoreParseError) should succeed`)
 
-		_, err = jwk.ParseKeyAs[jwk.Key](buf, jwk.WithIgnoreParseError(true))
+		_, err = jwk.ParseKey(buf, jwk.WithIgnoreParseError(true))
 		require.Error(t, err, `jwk.ParseKey (no WithIgnoreParseError) should fail`)
 	})
 }
@@ -2169,7 +2171,7 @@ func TestGH664(t *testing.T) {
 			require.NoError(t, err, `jwk.Import should succeed`)
 
 			buf, _ := json.MarshalIndent(jwkPrivkey, "", "  ")
-			parsed, err := jwk.ParseKeyAs[jwk.Key](buf)
+			parsed, err := jwk.ParseKey(buf)
 			require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 			payload := []byte(`hello , world!`)
@@ -2195,7 +2197,7 @@ func TestGH730(t *testing.T) {
 // This test was lifted from #875. See tests under Roundtrip/WithPEM(true) for other key types
 func TestECDSAPEM(t *testing.T) {
 	// go make an EC key at https://mkjwk.org/
-	key, err := jwk.ParseKeyAs[jwk.Key]([]byte(`{
+	key, err := jwk.ParseKey([]byte(`{
 		"kty": "EC",
 		"d": "zqYPTs5gMEwtidOqjlFJSk6L4BQSfhCJX6FTgbuuiE0",
 		"crv": "P-256",
@@ -2209,7 +2211,7 @@ func TestECDSAPEM(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = jwk.ParseKeyAs[jwk.Key](pem, jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pem, jwk.WithPEM(true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2222,7 +2224,7 @@ func TestGH947(t *testing.T) {
 	// Validate() on the freshly-unmarshaled key, the zero-length coordinate
 	// is rejected cleanly at parse time — no bad key is ever handed back.
 	raw := []byte(`{"crv":"Ed25519","d":"","x":"","kty":"OKP"}`)
-	_, err := jwk.ParseKeyAs[jwk.Key](raw)
+	_, err := jwk.ParseKey(raw)
 	require.Error(t, err, `jwk.ParseKey must reject an OKP key with empty coordinates`)
 }
 
@@ -2338,7 +2340,7 @@ func TestGH1262(t *testing.T) {
 		_ = secretSrv // doing some non-standard encryption & response with encrypted data
 
 		// client
-		jwkCli, err := jwk.ParseKeyAs[jwk.Key](jwkBuf) // extract jwkBuf
+		jwkCli, err := jwk.ParseKey(jwkBuf) // extract jwkBuf
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		pubSrv, err := jwk.Export[*ecdh.PublicKey](jwkCli)
@@ -2494,7 +2496,7 @@ dGVzdCBkYXRh
 -----END TEST CUSTOM KEY-----`
 
 	// Test that our custom decoder can handle this via ParseKey
-	parsedKey, err := jwk.ParseKeyAs[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
 	require.NoError(t, err)
 	require.NotNil(t, parsedKey)
 
@@ -2528,7 +2530,7 @@ dGVzdCBkYXRh
 -----END TEST UNREGISTER-----`
 
 	// Verify it works when registered
-	parsedKey1, err := jwk.ParseKeyAs[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey1, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
 	require.NoError(t, err)
 	require.NotNil(t, parsedKey1)
 
@@ -2536,7 +2538,7 @@ dGVzdCBkYXRh
 	jwk.UnregisterX509Decoder(customIdent)
 
 	// Verify it no longer works
-	parsedKey2, err := jwk.ParseKeyAs[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey2, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
 	require.Error(t, err)
 	require.Nil(t, parsedKey2)
 }
@@ -2573,7 +2575,7 @@ dGVzdCBkYXRh
 -----END TEST DUPLICATE-----`
 
 	// Verify it works after first registration
-	parsedKey1, err := jwk.ParseKeyAs[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey1, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
 	require.NoError(t, err)
 	require.NotNil(t, parsedKey1)
 	require.Equal(t, 1, callCount, "Decoder should be called once")
@@ -2582,7 +2584,7 @@ dGVzdCBkYXRh
 	jwk.RegisterX509Decoder(customIdent, decoder)
 
 	// Verify it still works after duplicate registration and decoder wasn't added twice
-	parsedKey2, err := jwk.ParseKeyAs[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey2, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
 	require.NoError(t, err)
 	require.NotNil(t, parsedKey2)
 	require.Equal(t, 2, callCount, "Decoder should be called once more, not duplicated")
@@ -2648,13 +2650,13 @@ func TestUnregisterX509Decoder_StaleIndexMiddle(t *testing.T) {
 	jwk.UnregisterX509Decoder(identB)
 
 	// B must no longer decode.
-	_, err := jwk.ParseKeyAs[jwk.Key](pemFor("TRIO B"), jwk.WithPEM(true))
+	_, err := jwk.ParseKey(pemFor("TRIO B"), jwk.WithPEM(true))
 	require.Error(t, err, "TRIO B should fail after unregister")
 
 	// A and C must still decode.
-	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO A"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO A"), jwk.WithPEM(true))
 	require.NoError(t, err, "TRIO A should still decode")
-	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO C"), jwk.WithPEM(true))
 	require.NoError(t, err, "TRIO C should still decode")
 
 	// Now unregister C by ident. Before the fix this would panic
@@ -2664,9 +2666,9 @@ func TestUnregisterX509Decoder_StaleIndexMiddle(t *testing.T) {
 	})
 
 	// C must no longer decode; A must still decode.
-	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO C"), jwk.WithPEM(true))
 	require.Error(t, err, "TRIO C should fail after second unregister")
-	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO A"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO A"), jwk.WithPEM(true))
 	require.NoError(t, err, "TRIO A must survive unrelated unregister")
 
 	// Keep identA alive until cleanup fires.
@@ -2682,20 +2684,20 @@ func TestUnregisterX509Decoder_StaleIndexFirst(t *testing.T) {
 
 	jwk.UnregisterX509Decoder(identA)
 
-	_, err := jwk.ParseKeyAs[jwk.Key](pemFor("TRIO A"), jwk.WithPEM(true))
+	_, err := jwk.ParseKey(pemFor("TRIO A"), jwk.WithPEM(true))
 	require.Error(t, err)
-	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO B"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO B"), jwk.WithPEM(true))
 	require.NoError(t, err)
-	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO C"), jwk.WithPEM(true))
 	require.NoError(t, err)
 
 	require.NotPanics(t, func() {
 		jwk.UnregisterX509Decoder(identC)
 	})
 
-	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO C"), jwk.WithPEM(true))
 	require.Error(t, err)
-	_, err = jwk.ParseKeyAs[jwk.Key](pemFor("TRIO B"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO B"), jwk.WithPEM(true))
 	require.NoError(t, err, "TRIO B must survive unrelated unregister")
 
 	_ = identB
@@ -2730,7 +2732,7 @@ func TestX509DecoderConcurrent(t *testing.T) {
 				// Best-effort parse; error is fine (decoder may be
 				// unregistered at this moment). The point is that
 				// the read path must not race on the decoder slice.
-				_, _ = jwk.ParseKeyAs[jwk.Key](pemData, jwk.WithPEM(true))
+				_, _ = jwk.ParseKey(pemData, jwk.WithPEM(true))
 			}
 		})
 	}

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -193,7 +193,7 @@ func VerifyKey(t *testing.T, def map[string]keyDef) {
 	t.Helper()
 
 	def = complimentDef(def)
-	key, err := jwk.ParseKey[jwk.Key](makeKeyJSON(def))
+	key, err := jwk.ParseKey(makeKeyJSON(def))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 	t.Run("Fields", func(t *testing.T) {
@@ -248,7 +248,7 @@ func VerifyKey(t *testing.T, def map[string]keyDef) {
 					t.Logf("%s", buf)
 				}
 
-				newkey, err := jwk.ParseKey[jwk.Key](buf, jwk.WithPEM(usePEM))
+				newkey, err := jwk.ParseKey(buf, jwk.WithPEM(usePEM))
 				require.NoError(t, err, `jwk.ParseKey should succeed`)
 			LOOP:
 				for _, k := range key.Keys() {
@@ -467,7 +467,7 @@ func TestGenericParseKey(t *testing.T) {
 	t.Parallel()
 	t.Run("JSON", func(t *testing.T) {
 		t.Parallel()
-		key, err := jwk.ParseKey[jwk.SymmetricKey]([]byte(testOctKeyJSON))
+		key, err := jwk.ParseKeyAs[jwk.SymmetricKey]([]byte(testOctKeyJSON))
 		require.NoError(t, err)
 		require.NotNil(t, key)
 		require.Equal(t, jwa.OctetSeq(), key.KeyType())
@@ -484,25 +484,43 @@ func TestGenericParseKey(t *testing.T) {
 			Type:  "EC PRIVATE KEY",
 			Bytes: derBytes,
 		})
-		key, err := jwk.ParseKey[jwk.ECDSAPrivateKey](pemData, jwk.WithPEM(true))
+		key, err := jwk.ParseKeyAs[jwk.ECDSAPrivateKey](pemData, jwk.WithPEM(true))
 		require.NoError(t, err)
 		require.NotNil(t, key)
 		require.Equal(t, jwa.EC(), key.KeyType())
 	})
 	t.Run("TypeMismatch", func(t *testing.T) {
 		t.Parallel()
-		_, err := jwk.ParseKey[jwk.RSAPrivateKey]([]byte(testOctKeyJSON))
+		// testOctKeyJSON parses to a SymmetricKey, not an RSAPrivateKey.
+		_, err := jwk.ParseKeyAs[jwk.RSAPrivateKey]([]byte(testOctKeyJSON))
 		require.Error(t, err)
+
+		// Still classified as a jwk.ParseError so existing callers
+		// that match on the sentinel keep working.
+		require.ErrorIs(t, err, jwk.ParseError(), `should remain a ParseError`)
+		// Also classified as the typed mismatch error shared with jwk.Import.
+		require.ErrorIs(t, err, jwk.KeyTypeMismatchError{}, `should be a KeyTypeMismatchError`)
+
+		mismatch, ok := errors.AsType[jwk.KeyTypeMismatchError](err)
+		require.True(t, ok, `errors.AsType should recover KeyTypeMismatchError`)
+		require.NotNil(t, mismatch.Got, `Got should be populated`)
+		require.NotNil(t, mismatch.Want, `Want should be populated`)
+		require.True(t, mismatch.Got.Implements(reflect.TypeFor[jwk.SymmetricKey]()),
+			`Got (%s) should implement SymmetricKey`, mismatch.Got)
+		require.Equal(t, reflect.TypeFor[jwk.RSAPrivateKey](), mismatch.Want,
+			`Want should equal the requested type parameter`)
 	})
 	t.Run("BaseInterface", func(t *testing.T) {
 		t.Parallel()
-		key, err := jwk.ParseKey[jwk.Key]([]byte(testOctKeyJSON))
+		// Non-generic ParseKey always returns jwk.Key for valid input.
+		key, err := jwk.ParseKey([]byte(testOctKeyJSON))
 		require.NoError(t, err)
 		require.NotNil(t, key)
+		require.Equal(t, jwa.OctetSeq(), key.KeyType())
 	})
 	t.Run("ErrorPropagation", func(t *testing.T) {
 		t.Parallel()
-		_, err := jwk.ParseKey[jwk.Key]([]byte(`not json`))
+		_, err := jwk.ParseKey([]byte(`not json`))
 		require.Error(t, err)
 	})
 }
@@ -541,7 +559,7 @@ func TestParse(t *testing.T) {
 		})
 		t.Run("jwk.ParseKey", func(t *testing.T) {
 			t.Helper()
-			key, err := jwk.ParseKey[jwk.Key]([]byte(src))
+			key, err := jwk.ParseKey([]byte(src))
 			require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 			t.Run("Raw", func(t *testing.T) {
@@ -1248,7 +1266,7 @@ func TestIssue207(t *testing.T) {
 	// Using a loop here because we're using sync.Pool
 	// just for sanity.
 	for range 10 {
-		k, err := jwk.ParseKey[jwk.Key]([]byte(src))
+		k, err := jwk.ParseKey([]byte(src))
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		thumb, err := k.Thumbprint(crypto.SHA1)
@@ -1260,7 +1278,7 @@ func TestIssue207(t *testing.T) {
 func TestIssue270(t *testing.T) {
 	t.Parallel()
 	const src = `{"kty":"EC","alg":"ECMR","crv":"P-521","key_ops":["deriveKey"],"x":"AJwCS845x9VljR-fcrN2WMzIJHDYuLmFShhyu8ci14rmi2DMFp8txIvaxG8n7ZcODeKIs1EO4E_Bldm_pxxs8cUn","y":"ASjz754cIQHPJObihPV8D7vVNfjp_nuwP76PtbLwUkqTk9J1mzCDKM3VADEk-Z1tP-DHiwib6If8jxnb_FjNkiLJ"}`
-	k, err := jwk.ParseKey[jwk.Key]([]byte(src))
+	k, err := jwk.ParseKey([]byte(src))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 	for _, usage := range []string{"sig", "enc"} {
@@ -1387,7 +1405,7 @@ func TestRSA(t *testing.T) {
 	   			"n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
 	   		}`
 
-		key, err := jwk.ParseKey[jwk.Key]([]byte(src))
+		key, err := jwk.ParseKey([]byte(src))
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		tp, err := key.Thumbprint(crypto.SHA256)
@@ -1681,7 +1699,7 @@ func TestCustomField(t *testing.T) {
 	src := b.String()
 
 	t.Run("jwk.ParseKey", func(t *testing.T) {
-		key, err := jwk.ParseKey[jwk.Key]([]byte(src))
+		key, err := jwk.ParseKey([]byte(src))
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		for _, name := range []string{rfc3339Key, rfc1123Key} {
@@ -1722,7 +1740,7 @@ ox0RaBsMD70mvTwKKmlCSD5HgZZTC0CfGWk4dQp/Mct5Z0x0HJMEJCJzpgTn3CRX
 z8CjezfckLs7UKJOlhu3OU9TFsiGDzSDBZdDWO1/uciJ/AAWeSmsBt8cKL0MirIr
 c4wOvhbalcX0FqTM3mXCgMFRbibquhwdxbU=
 -----END CERTIFICATE-----`
-	key, err := jwk.ParseKey[jwk.Key]([]byte(src), jwk.WithPEM(true))
+	key, err := jwk.ParseKey([]byte(src), jwk.WithPEM(true))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 	require.Equal(t, jwa.RSA(), key.KeyType(), `key type should be RSA`)
 
@@ -1827,7 +1845,7 @@ func TestTypedFields(t *testing.T) {
 		t.Run(fmt.Sprintf("%T", key), func(t *testing.T) {
 			for _, tc := range testcases {
 				t.Run(tc.Name, func(t *testing.T) {
-					got, err := jwk.ParseKey[jwk.Key](serialized, tc.Options...)
+					got, err := jwk.ParseKey(serialized, tc.Options...)
 					require.NoError(t, err, `jwk.Parse should succeed`)
 					v, ok := got.Field("typed-field")
 					require.True(t, ok, `got.Field() should succeed`)
@@ -2098,10 +2116,10 @@ func TestGH567(t *testing.T) {
 		buf, err := json.Marshal(key)
 		require.NoError(t, err, `json.Marshal should succeed`)
 
-		_, err = jwk.ParseKey[jwk.Key](buf)
+		_, err = jwk.ParseKey(buf)
 		require.NoError(t, err, `jwk.ParseKey (no WithIgnoreParseError) should succeed`)
 
-		_, err = jwk.ParseKey[jwk.Key](buf, jwk.WithIgnoreParseError(true))
+		_, err = jwk.ParseKey(buf, jwk.WithIgnoreParseError(true))
 		require.Error(t, err, `jwk.ParseKey (no WithIgnoreParseError) should fail`)
 	})
 }
@@ -2137,7 +2155,7 @@ func TestGH664(t *testing.T) {
 			require.NoError(t, err, `jwk.Import should succeed`)
 
 			buf, _ := json.MarshalIndent(jwkPrivkey, "", "  ")
-			parsed, err := jwk.ParseKey[jwk.Key](buf)
+			parsed, err := jwk.ParseKey(buf)
 			require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 			payload := []byte(`hello , world!`)
@@ -2163,7 +2181,7 @@ func TestGH730(t *testing.T) {
 // This test was lifted from #875. See tests under Roundtrip/WithPEM(true) for other key types
 func TestECDSAPEM(t *testing.T) {
 	// go make an EC key at https://mkjwk.org/
-	key, err := jwk.ParseKey[jwk.Key]([]byte(`{
+	key, err := jwk.ParseKey([]byte(`{
 		"kty": "EC",
 		"d": "zqYPTs5gMEwtidOqjlFJSk6L4BQSfhCJX6FTgbuuiE0",
 		"crv": "P-256",
@@ -2177,7 +2195,7 @@ func TestECDSAPEM(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = jwk.ParseKey[jwk.Key](pem, jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pem, jwk.WithPEM(true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2190,7 +2208,7 @@ func TestGH947(t *testing.T) {
 	// Validate() on the freshly-unmarshaled key, the zero-length coordinate
 	// is rejected cleanly at parse time — no bad key is ever handed back.
 	raw := []byte(`{"crv":"Ed25519","d":"","x":"","kty":"OKP"}`)
-	_, err := jwk.ParseKey[jwk.Key](raw)
+	_, err := jwk.ParseKey(raw)
 	require.Error(t, err, `jwk.ParseKey must reject an OKP key with empty coordinates`)
 }
 
@@ -2306,7 +2324,7 @@ func TestGH1262(t *testing.T) {
 		_ = secretSrv // doing some non-standard encryption & response with encrypted data
 
 		// client
-		jwkCli, err := jwk.ParseKey[jwk.Key](jwkBuf) // extract jwkBuf
+		jwkCli, err := jwk.ParseKey(jwkBuf) // extract jwkBuf
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		pubSrv, err := jwk.Export[*ecdh.PublicKey](jwkCli)
@@ -2462,7 +2480,7 @@ dGVzdCBkYXRh
 -----END TEST CUSTOM KEY-----`
 
 	// Test that our custom decoder can handle this via ParseKey
-	parsedKey, err := jwk.ParseKey[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
 	require.NoError(t, err)
 	require.NotNil(t, parsedKey)
 
@@ -2496,7 +2514,7 @@ dGVzdCBkYXRh
 -----END TEST UNREGISTER-----`
 
 	// Verify it works when registered
-	parsedKey1, err := jwk.ParseKey[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey1, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
 	require.NoError(t, err)
 	require.NotNil(t, parsedKey1)
 
@@ -2504,7 +2522,7 @@ dGVzdCBkYXRh
 	jwk.UnregisterX509Decoder(customIdent)
 
 	// Verify it no longer works
-	parsedKey2, err := jwk.ParseKey[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey2, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
 	require.Error(t, err)
 	require.Nil(t, parsedKey2)
 }
@@ -2541,7 +2559,7 @@ dGVzdCBkYXRh
 -----END TEST DUPLICATE-----`
 
 	// Verify it works after first registration
-	parsedKey1, err := jwk.ParseKey[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey1, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
 	require.NoError(t, err)
 	require.NotNil(t, parsedKey1)
 	require.Equal(t, 1, callCount, "Decoder should be called once")
@@ -2550,7 +2568,7 @@ dGVzdCBkYXRh
 	jwk.RegisterX509Decoder(customIdent, decoder)
 
 	// Verify it still works after duplicate registration and decoder wasn't added twice
-	parsedKey2, err := jwk.ParseKey[jwk.Key]([]byte(testPEMData), jwk.WithPEM(true))
+	parsedKey2, err := jwk.ParseKey([]byte(testPEMData), jwk.WithPEM(true))
 	require.NoError(t, err)
 	require.NotNil(t, parsedKey2)
 	require.Equal(t, 2, callCount, "Decoder should be called once more, not duplicated")
@@ -2616,13 +2634,13 @@ func TestUnregisterX509Decoder_StaleIndexMiddle(t *testing.T) {
 	jwk.UnregisterX509Decoder(identB)
 
 	// B must no longer decode.
-	_, err := jwk.ParseKey[jwk.Key](pemFor("TRIO B"), jwk.WithPEM(true))
+	_, err := jwk.ParseKey(pemFor("TRIO B"), jwk.WithPEM(true))
 	require.Error(t, err, "TRIO B should fail after unregister")
 
 	// A and C must still decode.
-	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO A"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO A"), jwk.WithPEM(true))
 	require.NoError(t, err, "TRIO A should still decode")
-	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO C"), jwk.WithPEM(true))
 	require.NoError(t, err, "TRIO C should still decode")
 
 	// Now unregister C by ident. Before the fix this would panic
@@ -2632,9 +2650,9 @@ func TestUnregisterX509Decoder_StaleIndexMiddle(t *testing.T) {
 	})
 
 	// C must no longer decode; A must still decode.
-	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO C"), jwk.WithPEM(true))
 	require.Error(t, err, "TRIO C should fail after second unregister")
-	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO A"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO A"), jwk.WithPEM(true))
 	require.NoError(t, err, "TRIO A must survive unrelated unregister")
 
 	// Keep identA alive until cleanup fires.
@@ -2650,20 +2668,20 @@ func TestUnregisterX509Decoder_StaleIndexFirst(t *testing.T) {
 
 	jwk.UnregisterX509Decoder(identA)
 
-	_, err := jwk.ParseKey[jwk.Key](pemFor("TRIO A"), jwk.WithPEM(true))
+	_, err := jwk.ParseKey(pemFor("TRIO A"), jwk.WithPEM(true))
 	require.Error(t, err)
-	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO B"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO B"), jwk.WithPEM(true))
 	require.NoError(t, err)
-	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO C"), jwk.WithPEM(true))
 	require.NoError(t, err)
 
 	require.NotPanics(t, func() {
 		jwk.UnregisterX509Decoder(identC)
 	})
 
-	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO C"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO C"), jwk.WithPEM(true))
 	require.Error(t, err)
-	_, err = jwk.ParseKey[jwk.Key](pemFor("TRIO B"), jwk.WithPEM(true))
+	_, err = jwk.ParseKey(pemFor("TRIO B"), jwk.WithPEM(true))
 	require.NoError(t, err, "TRIO B must survive unrelated unregister")
 
 	_ = identB
@@ -2698,7 +2716,7 @@ func TestX509DecoderConcurrent(t *testing.T) {
 				// Best-effort parse; error is fine (decoder may be
 				// unregistered at this moment). The point is that
 				// the read path must not race on the decoder slice.
-				_, _ = jwk.ParseKey[jwk.Key](pemData, jwk.WithPEM(true))
+				_, _ = jwk.ParseKey(pemData, jwk.WithPEM(true))
 			}
 		})
 	}

--- a/jwk/okp_length_test.go
+++ b/jwk/okp_length_test.go
@@ -45,7 +45,7 @@ func TestOKPRejectsInvalidBuiltinLengths(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := jwk.ParseKey[jwk.Key]([]byte(tc.src))
+			_, err := jwk.ParseKey([]byte(tc.src))
 			require.Error(t, err)
 			require.ErrorContains(t, err, tc.want)
 		})

--- a/jwk/okp_length_test.go
+++ b/jwk/okp_length_test.go
@@ -45,7 +45,7 @@ func TestOKPRejectsInvalidBuiltinLengths(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := jwk.ParseKey([]byte(tc.src))
+			_, err := jwk.ParseKeyAs[jwk.Key]([]byte(tc.src))
 			require.Error(t, err)
 			require.ErrorContains(t, err, tc.want)
 		})

--- a/jwk/okp_length_test.go
+++ b/jwk/okp_length_test.go
@@ -45,7 +45,7 @@ func TestOKPRejectsInvalidBuiltinLengths(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := jwk.ParseKeyAs[jwk.Key]([]byte(tc.src))
+			_, err := jwk.ParseKey([]byte(tc.src))
 			require.Error(t, err)
 			require.ErrorContains(t, err, tc.want)
 		})

--- a/jwk/rsa_thumbprint_test.go
+++ b/jwk/rsa_thumbprint_test.go
@@ -28,7 +28,7 @@ const rfc7638RSAJWK = `{
 const rfc7638ExpectedThumbprintHex = "3736cbb1787cb8309c77ee8c3705c5e16ffb9e859715901f1e4c59b11182f57b"
 
 func TestRSA_Thumbprint_RFC7638Vector(t *testing.T) {
-	k, err := jwk.ParseKey[jwk.Key]([]byte(rfc7638RSAJWK))
+	k, err := jwk.ParseKey([]byte(rfc7638RSAJWK))
 	require.NoError(t, err)
 
 	got, err := k.Thumbprint(crypto.SHA256)
@@ -46,7 +46,7 @@ func TestRSA_ExponentTruncation_Rejected(t *testing.T) {
 	// e = 0x01_00_00_00_00_00_00_01 (65 bits) — fits neither 32-bit nor 64-bit int.
 	payload := rsaPublicJWK(rfc7638RSAModulus, "AQAAAAAAAAAB")
 
-	_, err := jwk.ParseKey[jwk.Key](payload)
+	_, err := jwk.ParseKey(payload)
 	require.Error(t, err, "parse must reject oversized exponent")
 	require.Contains(t, err.Error(), "rsa public exponent too large")
 }
@@ -68,7 +68,7 @@ func TestRSA_Thumbprint_UsesStoredBytes(t *testing.T) {
 	jwkE3 := rsaPublicJWK(rfc7638RSAModulus, "Aw")
 
 	thumb := func(payload []byte) []byte {
-		k, err := jwk.ParseKey[jwk.Key](payload)
+		k, err := jwk.ParseKey(payload)
 		require.NoError(t, err)
 		tp, err := k.Thumbprint(crypto.SHA256)
 		require.NoError(t, err)
@@ -92,13 +92,13 @@ func TestRSA_BitsUintSize(t *testing.T) {
 // ensure the tests don't drift from Parse/Export behavior. Marshal the
 // RFC 7638 JWK back out and confirm it round-trips.
 func TestRSA_RFC7638_RoundTrip(t *testing.T) {
-	k, err := jwk.ParseKey[jwk.Key]([]byte(rfc7638RSAJWK))
+	k, err := jwk.ParseKey([]byte(rfc7638RSAJWK))
 	require.NoError(t, err)
 
 	buf, err := json.Marshal(k)
 	require.NoError(t, err)
 
-	k2, err := jwk.ParseKey[jwk.Key](buf)
+	k2, err := jwk.ParseKey(buf)
 	require.NoError(t, err)
 
 	tp1, err := k.Thumbprint(crypto.SHA256)

--- a/jwk/rsa_thumbprint_test.go
+++ b/jwk/rsa_thumbprint_test.go
@@ -28,7 +28,7 @@ const rfc7638RSAJWK = `{
 const rfc7638ExpectedThumbprintHex = "3736cbb1787cb8309c77ee8c3705c5e16ffb9e859715901f1e4c59b11182f57b"
 
 func TestRSA_Thumbprint_RFC7638Vector(t *testing.T) {
-	k, err := jwk.ParseKeyAs[jwk.Key]([]byte(rfc7638RSAJWK))
+	k, err := jwk.ParseKey([]byte(rfc7638RSAJWK))
 	require.NoError(t, err)
 
 	got, err := k.Thumbprint(crypto.SHA256)
@@ -46,7 +46,7 @@ func TestRSA_ExponentTruncation_Rejected(t *testing.T) {
 	// e = 0x01_00_00_00_00_00_00_01 (65 bits) — fits neither 32-bit nor 64-bit int.
 	payload := rsaPublicJWK(rfc7638RSAModulus, "AQAAAAAAAAAB")
 
-	_, err := jwk.ParseKeyAs[jwk.Key](payload)
+	_, err := jwk.ParseKey(payload)
 	require.Error(t, err, "parse must reject oversized exponent")
 	require.Contains(t, err.Error(), "rsa public exponent too large")
 }
@@ -68,7 +68,7 @@ func TestRSA_Thumbprint_UsesStoredBytes(t *testing.T) {
 	jwkE3 := rsaPublicJWK(rfc7638RSAModulus, "Aw")
 
 	thumb := func(payload []byte) []byte {
-		k, err := jwk.ParseKeyAs[jwk.Key](payload)
+		k, err := jwk.ParseKey(payload)
 		require.NoError(t, err)
 		tp, err := k.Thumbprint(crypto.SHA256)
 		require.NoError(t, err)
@@ -92,13 +92,13 @@ func TestRSA_BitsUintSize(t *testing.T) {
 // ensure the tests don't drift from Parse/Export behavior. Marshal the
 // RFC 7638 JWK back out and confirm it round-trips.
 func TestRSA_RFC7638_RoundTrip(t *testing.T) {
-	k, err := jwk.ParseKeyAs[jwk.Key]([]byte(rfc7638RSAJWK))
+	k, err := jwk.ParseKey([]byte(rfc7638RSAJWK))
 	require.NoError(t, err)
 
 	buf, err := json.Marshal(k)
 	require.NoError(t, err)
 
-	k2, err := jwk.ParseKeyAs[jwk.Key](buf)
+	k2, err := jwk.ParseKey(buf)
 	require.NoError(t, err)
 
 	tp1, err := k.Thumbprint(crypto.SHA256)

--- a/jwk/rsa_thumbprint_test.go
+++ b/jwk/rsa_thumbprint_test.go
@@ -28,7 +28,7 @@ const rfc7638RSAJWK = `{
 const rfc7638ExpectedThumbprintHex = "3736cbb1787cb8309c77ee8c3705c5e16ffb9e859715901f1e4c59b11182f57b"
 
 func TestRSA_Thumbprint_RFC7638Vector(t *testing.T) {
-	k, err := jwk.ParseKey([]byte(rfc7638RSAJWK))
+	k, err := jwk.ParseKeyAs[jwk.Key]([]byte(rfc7638RSAJWK))
 	require.NoError(t, err)
 
 	got, err := k.Thumbprint(crypto.SHA256)
@@ -46,7 +46,7 @@ func TestRSA_ExponentTruncation_Rejected(t *testing.T) {
 	// e = 0x01_00_00_00_00_00_00_01 (65 bits) — fits neither 32-bit nor 64-bit int.
 	payload := rsaPublicJWK(rfc7638RSAModulus, "AQAAAAAAAAAB")
 
-	_, err := jwk.ParseKey(payload)
+	_, err := jwk.ParseKeyAs[jwk.Key](payload)
 	require.Error(t, err, "parse must reject oversized exponent")
 	require.Contains(t, err.Error(), "rsa public exponent too large")
 }
@@ -68,7 +68,7 @@ func TestRSA_Thumbprint_UsesStoredBytes(t *testing.T) {
 	jwkE3 := rsaPublicJWK(rfc7638RSAModulus, "Aw")
 
 	thumb := func(payload []byte) []byte {
-		k, err := jwk.ParseKey(payload)
+		k, err := jwk.ParseKeyAs[jwk.Key](payload)
 		require.NoError(t, err)
 		tp, err := k.Thumbprint(crypto.SHA256)
 		require.NoError(t, err)
@@ -92,13 +92,13 @@ func TestRSA_BitsUintSize(t *testing.T) {
 // ensure the tests don't drift from Parse/Export behavior. Marshal the
 // RFC 7638 JWK back out and confirm it round-trips.
 func TestRSA_RFC7638_RoundTrip(t *testing.T) {
-	k, err := jwk.ParseKey([]byte(rfc7638RSAJWK))
+	k, err := jwk.ParseKeyAs[jwk.Key]([]byte(rfc7638RSAJWK))
 	require.NoError(t, err)
 
 	buf, err := json.Marshal(k)
 	require.NoError(t, err)
 
-	k2, err := jwk.ParseKey(buf)
+	k2, err := jwk.ParseKeyAs[jwk.Key](buf)
 	require.NoError(t, err)
 
 	tp1, err := k.Thumbprint(crypto.SHA256)

--- a/jwk/rsa_validate_test.go
+++ b/jwk/rsa_validate_test.go
@@ -50,7 +50,7 @@ func TestRSAInvalidParametersRejectedOnParse(t *testing.T) {
 	t.Run("small modulus", func(t *testing.T) {
 		payload := rsaPublicJWK("AQAB", "AQAB")
 
-		_, err := jwk.ParseKeyAs[jwk.Key](payload)
+		_, err := jwk.ParseKey(payload)
 		require.Error(t, err)
 		require.True(t, jwk.IsKeyValidationError(err))
 		require.Contains(t, err.Error(), "rsa modulus too small")
@@ -63,7 +63,7 @@ func TestRSAInvalidParametersRejectedOnParse(t *testing.T) {
 	t.Run("unsafe exponent", func(t *testing.T) {
 		payload := rsaPublicJWK(rfc7638RSAModulus, "AQ")
 
-		_, err := jwk.ParseKeyAs[jwk.Key](payload)
+		_, err := jwk.ParseKey(payload)
 		require.Error(t, err)
 		require.True(t, jwk.IsKeyValidationError(err))
 		require.Contains(t, err.Error(), "invalid rsa public exponent")
@@ -82,7 +82,7 @@ func TestRSAConfigureCompatibilityKnobs(t *testing.T) {
 
 		payload := rsaPublicJWKFromRaw(t, &raw.PublicKey)
 
-		_, err = jwk.ParseKeyAs[jwk.Key](payload)
+		_, err = jwk.ParseKey(payload)
 		require.NoError(t, err)
 	})
 
@@ -94,7 +94,7 @@ func TestRSAConfigureCompatibilityKnobs(t *testing.T) {
 
 		payload := rsaPublicJWK(rfc7638RSAModulus, "AQ")
 
-		_, err := jwk.ParseKeyAs[jwk.Key](payload)
+		_, err := jwk.ParseKey(payload)
 		require.NoError(t, err)
 	})
 }
@@ -140,7 +140,7 @@ func TestRSAPEMImportRunsValidation(t *testing.T) {
 		E: 65537,
 	}
 
-	_, err := jwk.ParseKeyAs[jwk.Key](mustRSAPublicPEM(t, bad), jwk.WithPEM(true))
+	_, err := jwk.ParseKey(mustRSAPublicPEM(t, bad), jwk.WithPEM(true))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "rsa modulus too small")
 }

--- a/jwk/rsa_validate_test.go
+++ b/jwk/rsa_validate_test.go
@@ -50,7 +50,7 @@ func TestRSAInvalidParametersRejectedOnParse(t *testing.T) {
 	t.Run("small modulus", func(t *testing.T) {
 		payload := rsaPublicJWK("AQAB", "AQAB")
 
-		_, err := jwk.ParseKey(payload)
+		_, err := jwk.ParseKeyAs[jwk.Key](payload)
 		require.Error(t, err)
 		require.True(t, jwk.IsKeyValidationError(err))
 		require.Contains(t, err.Error(), "rsa modulus too small")
@@ -63,7 +63,7 @@ func TestRSAInvalidParametersRejectedOnParse(t *testing.T) {
 	t.Run("unsafe exponent", func(t *testing.T) {
 		payload := rsaPublicJWK(rfc7638RSAModulus, "AQ")
 
-		_, err := jwk.ParseKey(payload)
+		_, err := jwk.ParseKeyAs[jwk.Key](payload)
 		require.Error(t, err)
 		require.True(t, jwk.IsKeyValidationError(err))
 		require.Contains(t, err.Error(), "invalid rsa public exponent")
@@ -82,7 +82,7 @@ func TestRSAConfigureCompatibilityKnobs(t *testing.T) {
 
 		payload := rsaPublicJWKFromRaw(t, &raw.PublicKey)
 
-		_, err = jwk.ParseKey(payload)
+		_, err = jwk.ParseKeyAs[jwk.Key](payload)
 		require.NoError(t, err)
 	})
 
@@ -94,7 +94,7 @@ func TestRSAConfigureCompatibilityKnobs(t *testing.T) {
 
 		payload := rsaPublicJWK(rfc7638RSAModulus, "AQ")
 
-		_, err := jwk.ParseKey(payload)
+		_, err := jwk.ParseKeyAs[jwk.Key](payload)
 		require.NoError(t, err)
 	})
 }
@@ -140,7 +140,7 @@ func TestRSAPEMImportRunsValidation(t *testing.T) {
 		E: 65537,
 	}
 
-	_, err := jwk.ParseKey(mustRSAPublicPEM(t, bad), jwk.WithPEM(true))
+	_, err := jwk.ParseKeyAs[jwk.Key](mustRSAPublicPEM(t, bad), jwk.WithPEM(true))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "rsa modulus too small")
 }

--- a/jwk/rsa_validate_test.go
+++ b/jwk/rsa_validate_test.go
@@ -50,7 +50,7 @@ func TestRSAInvalidParametersRejectedOnParse(t *testing.T) {
 	t.Run("small modulus", func(t *testing.T) {
 		payload := rsaPublicJWK("AQAB", "AQAB")
 
-		_, err := jwk.ParseKey[jwk.Key](payload)
+		_, err := jwk.ParseKey(payload)
 		require.Error(t, err)
 		require.True(t, jwk.IsKeyValidationError(err))
 		require.Contains(t, err.Error(), "rsa modulus too small")
@@ -63,7 +63,7 @@ func TestRSAInvalidParametersRejectedOnParse(t *testing.T) {
 	t.Run("unsafe exponent", func(t *testing.T) {
 		payload := rsaPublicJWK(rfc7638RSAModulus, "AQ")
 
-		_, err := jwk.ParseKey[jwk.Key](payload)
+		_, err := jwk.ParseKey(payload)
 		require.Error(t, err)
 		require.True(t, jwk.IsKeyValidationError(err))
 		require.Contains(t, err.Error(), "invalid rsa public exponent")
@@ -82,7 +82,7 @@ func TestRSAConfigureCompatibilityKnobs(t *testing.T) {
 
 		payload := rsaPublicJWKFromRaw(t, &raw.PublicKey)
 
-		_, err = jwk.ParseKey[jwk.Key](payload)
+		_, err = jwk.ParseKey(payload)
 		require.NoError(t, err)
 	})
 
@@ -94,7 +94,7 @@ func TestRSAConfigureCompatibilityKnobs(t *testing.T) {
 
 		payload := rsaPublicJWK(rfc7638RSAModulus, "AQ")
 
-		_, err := jwk.ParseKey[jwk.Key](payload)
+		_, err := jwk.ParseKey(payload)
 		require.NoError(t, err)
 	})
 }
@@ -140,7 +140,7 @@ func TestRSAPEMImportRunsValidation(t *testing.T) {
 		E: 65537,
 	}
 
-	_, err := jwk.ParseKey[jwk.Key](mustRSAPublicPEM(t, bad), jwk.WithPEM(true))
+	_, err := jwk.ParseKey(mustRSAPublicPEM(t, bad), jwk.WithPEM(true))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "rsa modulus too small")
 }

--- a/jwk/validation_boundary_test.go
+++ b/jwk/validation_boundary_test.go
@@ -103,7 +103,7 @@ func TestParseKeyWithX509DecoderRejectsInvalidImportedKey(t *testing.T) {
 	src := []byte(`-----BEGIN INVALID ECDSA-----
 ZHVtbXk=
 -----END INVALID ECDSA-----`)
-	_, err = jwk.ParseKey[jwk.Key](src, jwk.WithPEM(true))
+	_, err = jwk.ParseKey(src, jwk.WithPEM(true))
 	require.Error(t, err)
 	require.True(t, jwk.IsKeyValidationError(err), `ParseKey should preserve key-validation identity`)
 }
@@ -111,7 +111,7 @@ ZHVtbXk=
 func TestParseKeyRejectsInvalidKeyFromCustomParser(t *testing.T) {
 	registerInvalidParser(t)
 
-	_, err := jwk.ParseKey[jwk.Key]([]byte(`{"kty":"EC","force-invalid-parser":true}`))
+	_, err := jwk.ParseKey([]byte(`{"kty":"EC","force-invalid-parser":true}`))
 	require.Error(t, err)
 	require.True(t, jwk.IsKeyValidationError(err), `ParseKey should validate keys returned from custom parsers`)
 }

--- a/jwk/validation_boundary_test.go
+++ b/jwk/validation_boundary_test.go
@@ -103,7 +103,7 @@ func TestParseKeyWithX509DecoderRejectsInvalidImportedKey(t *testing.T) {
 	src := []byte(`-----BEGIN INVALID ECDSA-----
 ZHVtbXk=
 -----END INVALID ECDSA-----`)
-	_, err = jwk.ParseKey(src, jwk.WithPEM(true))
+	_, err = jwk.ParseKeyAs[jwk.Key](src, jwk.WithPEM(true))
 	require.Error(t, err)
 	require.True(t, jwk.IsKeyValidationError(err), `ParseKey should preserve key-validation identity`)
 }
@@ -111,7 +111,7 @@ ZHVtbXk=
 func TestParseKeyRejectsInvalidKeyFromCustomParser(t *testing.T) {
 	registerInvalidParser(t)
 
-	_, err := jwk.ParseKey([]byte(`{"kty":"EC","force-invalid-parser":true}`))
+	_, err := jwk.ParseKeyAs[jwk.Key]([]byte(`{"kty":"EC","force-invalid-parser":true}`))
 	require.Error(t, err)
 	require.True(t, jwk.IsKeyValidationError(err), `ParseKey should validate keys returned from custom parsers`)
 }

--- a/jwk/validation_boundary_test.go
+++ b/jwk/validation_boundary_test.go
@@ -103,7 +103,7 @@ func TestParseKeyWithX509DecoderRejectsInvalidImportedKey(t *testing.T) {
 	src := []byte(`-----BEGIN INVALID ECDSA-----
 ZHVtbXk=
 -----END INVALID ECDSA-----`)
-	_, err = jwk.ParseKeyAs[jwk.Key](src, jwk.WithPEM(true))
+	_, err = jwk.ParseKey(src, jwk.WithPEM(true))
 	require.Error(t, err)
 	require.True(t, jwk.IsKeyValidationError(err), `ParseKey should preserve key-validation identity`)
 }
@@ -111,7 +111,7 @@ ZHVtbXk=
 func TestParseKeyRejectsInvalidKeyFromCustomParser(t *testing.T) {
 	registerInvalidParser(t)
 
-	_, err := jwk.ParseKeyAs[jwk.Key]([]byte(`{"kty":"EC","force-invalid-parser":true}`))
+	_, err := jwk.ParseKey([]byte(`{"kty":"EC","force-invalid-parser":true}`))
 	require.Error(t, err)
 	require.True(t, jwk.IsKeyValidationError(err), `ParseKey should validate keys returned from custom parsers`)
 }

--- a/jwk/x5c_test.go
+++ b/jwk/x5c_test.go
@@ -41,7 +41,7 @@ func Test_X5CHeader(t *testing.T) {
   "x5c": ["bm90IGEgY2VydGlmaWNhdGU="]
 }`
 
-		_, err := jwk.ParseKeyAs[jwk.Key]([]byte(src))
+		_, err := jwk.ParseKey([]byte(src))
 		require.Error(t, err, `jwk.ParseKey should reject invalid x5c entries`)
 	})
 }

--- a/jwk/x5c_test.go
+++ b/jwk/x5c_test.go
@@ -41,7 +41,7 @@ func Test_X5CHeader(t *testing.T) {
   "x5c": ["bm90IGEgY2VydGlmaWNhdGU="]
 }`
 
-		_, err := jwk.ParseKey([]byte(src))
+		_, err := jwk.ParseKeyAs[jwk.Key]([]byte(src))
 		require.Error(t, err, `jwk.ParseKey should reject invalid x5c entries`)
 	})
 }

--- a/jwk/x5c_test.go
+++ b/jwk/x5c_test.go
@@ -41,7 +41,7 @@ func Test_X5CHeader(t *testing.T) {
   "x5c": ["bm90IGEgY2VydGlmaWNhdGU="]
 }`
 
-		_, err := jwk.ParseKey[jwk.Key]([]byte(src))
+		_, err := jwk.ParseKey([]byte(src))
 		require.Error(t, err, `jwk.ParseKey should reject invalid x5c entries`)
 	})
 }

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -504,7 +504,7 @@ func (h *stdHeaders) UnmarshalJSON(buf []byte) error {
 			if err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, JWKKey, err)
 			}
-			key, err := jwk.ParseKey[jwk.Key](raw)
+			key, err := jwk.ParseKey(raw)
 			if err != nil {
 				return fmt.Errorf(`failed to parse JWK for key %s: %w`, JWKKey, err)
 			}

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -20,7 +20,7 @@ func TestHeader(t *testing.T) {
 	             "e":"AQAB",
 	             "alg":"RS256",
 	             "kid":"2011-04-29"}`
-	jwkPublicKey, err := jwk.ParseKey([]byte(publicKey))
+	jwkPublicKey, err := jwk.ParseKeyAs[jwk.Key]([]byte(publicKey))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 	var chain cert.Chain

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -20,7 +20,7 @@ func TestHeader(t *testing.T) {
 	             "e":"AQAB",
 	             "alg":"RS256",
 	             "kid":"2011-04-29"}`
-	jwkPublicKey, err := jwk.ParseKeyAs[jwk.Key]([]byte(publicKey))
+	jwkPublicKey, err := jwk.ParseKey([]byte(publicKey))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 	var chain cert.Chain

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -20,7 +20,7 @@ func TestHeader(t *testing.T) {
 	             "e":"AQAB",
 	             "alg":"RS256",
 	             "kid":"2011-04-29"}`
-	jwkPublicKey, err := jwk.ParseKey[jwk.Key]([]byte(publicKey))
+	jwkPublicKey, err := jwk.ParseKey([]byte(publicKey))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 	var chain cert.Chain

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -54,7 +54,7 @@ func (r *infiniteByteReader) Read(p []byte) (int, error) {
 
 func TestSanity(t *testing.T) {
 	t.Run("sanity: Verify with single key", func(t *testing.T) {
-		key, err := jwk.ParseKey([]byte(`{
+		key, err := jwk.ParseKeyAs[jwk.Key]([]byte(`{
     "kty": "oct",
     "k": "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
   }`))
@@ -1005,7 +1005,7 @@ func TestRFC7797(t *testing.T) {
       "k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
      }`
 
-	key, err := jwk.ParseKey([]byte(keysrc))
+	key, err := jwk.ParseKeyAs[jwk.Key]([]byte(keysrc))
 	require.NoError(t, err, `jwk.Parse should succeed`)
 
 	t.Run("Invalid payload when b64 = false and NOT detached", func(t *testing.T) {
@@ -1597,7 +1597,7 @@ func TestGH840(t *testing.T) {
 		"d": "870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"
 	}`)
 
-	_, err := jwk.ParseKey(untrustedJWK)
+	_, err := jwk.ParseKeyAs[jwk.Key](untrustedJWK)
 	require.Error(t, err, `jwk.ParseKey must reject an off-curve ECDSA JWK`)
 }
 
@@ -1756,7 +1756,7 @@ func TestUnpaddedSignatureR(t *testing.T) {
 	// This is the private key used to sign the payload
 	keySrc := `{"crv":"P-256","d":"MqGwMl-dlJFrMnu7rFyslPV8EdsVC7I4V19N-ADVqaU","kty":"EC","x":"Anf1p2lRrcXgZKpVRRC1xLxPiw_45PbOlygfbxvD8Es","y":"d0HiZq-aurVVLLtK-xqXPpzpWloZJNwKNve7akBDuvg"}`
 
-	privKey, err := jwk.ParseKey([]byte(keySrc))
+	privKey, err := jwk.ParseKeyAs[jwk.Key]([]byte(keySrc))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 	pubKey, err := jwk.PublicKeyOf(privKey)

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -54,7 +54,7 @@ func (r *infiniteByteReader) Read(p []byte) (int, error) {
 
 func TestSanity(t *testing.T) {
 	t.Run("sanity: Verify with single key", func(t *testing.T) {
-		key, err := jwk.ParseKey[jwk.Key]([]byte(`{
+		key, err := jwk.ParseKey([]byte(`{
     "kty": "oct",
     "k": "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
   }`))
@@ -1005,7 +1005,7 @@ func TestRFC7797(t *testing.T) {
       "k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
      }`
 
-	key, err := jwk.ParseKey[jwk.Key]([]byte(keysrc))
+	key, err := jwk.ParseKey([]byte(keysrc))
 	require.NoError(t, err, `jwk.Parse should succeed`)
 
 	t.Run("Invalid payload when b64 = false and NOT detached", func(t *testing.T) {
@@ -1597,7 +1597,7 @@ func TestGH840(t *testing.T) {
 		"d": "870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"
 	}`)
 
-	_, err := jwk.ParseKey[jwk.Key](untrustedJWK)
+	_, err := jwk.ParseKey(untrustedJWK)
 	require.Error(t, err, `jwk.ParseKey must reject an off-curve ECDSA JWK`)
 }
 
@@ -1756,7 +1756,7 @@ func TestUnpaddedSignatureR(t *testing.T) {
 	// This is the private key used to sign the payload
 	keySrc := `{"crv":"P-256","d":"MqGwMl-dlJFrMnu7rFyslPV8EdsVC7I4V19N-ADVqaU","kty":"EC","x":"Anf1p2lRrcXgZKpVRRC1xLxPiw_45PbOlygfbxvD8Es","y":"d0HiZq-aurVVLLtK-xqXPpzpWloZJNwKNve7akBDuvg"}`
 
-	privKey, err := jwk.ParseKey[jwk.Key]([]byte(keySrc))
+	privKey, err := jwk.ParseKey([]byte(keySrc))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 	pubKey, err := jwk.PublicKeyOf(privKey)

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -54,7 +54,7 @@ func (r *infiniteByteReader) Read(p []byte) (int, error) {
 
 func TestSanity(t *testing.T) {
 	t.Run("sanity: Verify with single key", func(t *testing.T) {
-		key, err := jwk.ParseKeyAs[jwk.Key]([]byte(`{
+		key, err := jwk.ParseKey([]byte(`{
     "kty": "oct",
     "k": "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
   }`))
@@ -1005,7 +1005,7 @@ func TestRFC7797(t *testing.T) {
       "k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
      }`
 
-	key, err := jwk.ParseKeyAs[jwk.Key]([]byte(keysrc))
+	key, err := jwk.ParseKey([]byte(keysrc))
 	require.NoError(t, err, `jwk.Parse should succeed`)
 
 	t.Run("Invalid payload when b64 = false and NOT detached", func(t *testing.T) {
@@ -1597,7 +1597,7 @@ func TestGH840(t *testing.T) {
 		"d": "870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"
 	}`)
 
-	_, err := jwk.ParseKeyAs[jwk.Key](untrustedJWK)
+	_, err := jwk.ParseKey(untrustedJWK)
 	require.Error(t, err, `jwk.ParseKey must reject an off-curve ECDSA JWK`)
 }
 
@@ -1756,7 +1756,7 @@ func TestUnpaddedSignatureR(t *testing.T) {
 	// This is the private key used to sign the payload
 	keySrc := `{"crv":"P-256","d":"MqGwMl-dlJFrMnu7rFyslPV8EdsVC7I4V19N-ADVqaU","kty":"EC","x":"Anf1p2lRrcXgZKpVRRC1xLxPiw_45PbOlygfbxvD8Es","y":"d0HiZq-aurVVLLtK-xqXPpzpWloZJNwKNve7akBDuvg"}`
 
-	privKey, err := jwk.ParseKeyAs[jwk.Key]([]byte(keySrc))
+	privKey, err := jwk.ParseKey([]byte(keySrc))
 	require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 	pubKey, err := jwk.PublicKeyOf(privKey)

--- a/jwx_test.go
+++ b/jwx_test.go
@@ -110,7 +110,7 @@ func TestUseNumber(t *testing.T) {
 		defer jwx.Settings(jwx.WithUseNumber(false))
 
 		const jwkSrc = `{"kty":"oct","k":"c2VjcmV0","x-custom-num":12345}`
-		key, err := jwk.ParseKeyAs[jwk.Key]([]byte(jwkSrc))
+		key, err := jwk.ParseKey([]byte(jwkSrc))
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		num, err := jwk.Get[stdjson.Number](key, "x-custom-num")

--- a/jwx_test.go
+++ b/jwx_test.go
@@ -110,7 +110,7 @@ func TestUseNumber(t *testing.T) {
 		defer jwx.Settings(jwx.WithUseNumber(false))
 
 		const jwkSrc = `{"kty":"oct","k":"c2VjcmV0","x-custom-num":12345}`
-		key, err := jwk.ParseKey[jwk.Key]([]byte(jwkSrc))
+		key, err := jwk.ParseKey([]byte(jwkSrc))
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		num, err := jwk.Get[stdjson.Number](key, "x-custom-num")

--- a/jwx_test.go
+++ b/jwx_test.go
@@ -110,7 +110,7 @@ func TestUseNumber(t *testing.T) {
 		defer jwx.Settings(jwx.WithUseNumber(false))
 
 		const jwkSrc = `{"kty":"oct","k":"c2VjcmV0","x-custom-num":12345}`
-		key, err := jwk.ParseKey([]byte(jwkSrc))
+		key, err := jwk.ParseKeyAs[jwk.Key]([]byte(jwkSrc))
 		require.NoError(t, err, `jwk.ParseKey should succeed`)
 
 		num, err := jwk.Get[stdjson.Number](key, "x-custom-num")


### PR DESCRIPTION
## Summary

`jwk.ParseKey` was generic over the returned key type (`ParseKey[T Key]`), but Go can't infer `T` from a `[]byte` argument — so every caller had to name it explicitly. In the main repo, 34 of ~37 `ParseKey` call sites passed `jwk.Key` as the witness, making the common "give me any key" path noisier than it needed to be, and the code generator at `internal/jwxcodegen/genunmarshal.go:45` baked `jwk.ParseKey[jwk.Key](raw)` into generated headers.

This PR splits the API:

- `jwk.ParseKey(data []byte, options ...ParseOption) (jwk.Key, error)` — the common path, no generic witness.
- `jwk.ParseKeyAs[T Key](data []byte, options ...ParseOption) (T, error)` — the typed path; on mismatch returns `jwk.KeyTypeMismatchError{Got, Want}`, matching the pattern used by `jwk.Import[T]` (#1963).

The `As` suffix follows the existing `internal/keyconv.KeyAs[T]` precedent.

v4 is still pre-release (tags are only `v4.0.0-scratch.*`) so this is landed as a direct breaking change — no deprecation shim.

## Changes

- `jwk/jwk.go` — split the function; typed variant returns `KeyTypeMismatchError`.
- `internal/jwxcodegen/genunmarshal.go:45` — emit non-generic `jwk.ParseKey(raw)`.
- `jwe/headers_gen.go`, `jws/headers_gen.go` — regenerated; diff is the mechanical witness drop only.
- Call-site sweep across tests, examples, `README.md`, `MIGRATION.md`, `Changes-v4.md`, `docs/04-jwk.md`, `docs/99-faq.md`, `docs/01-jwt.md`, `docs/10-extensions.md`.
- `.claude/docs/packages.md` — added `ParseKeyAs` to the jwk signature line.
- `.claude/docs/error-formatting.md` — added exported-error-type sections for `jwk` (`KeyTypeMismatchError`, landed in #1963) and `jwe` (`MissingContentEncryptionError`, `AlgorithmMismatchError`, landed in #1964). These rows were overdue from those PRs.

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go test ./...` — passes
- [x] `GOEXPERIMENT=jsonv2 go vet ./...` — clean
- [x] `make lint` — 0 issues
- [x] `grep -rn 'jwk\.ParseKey\[' .` in the main module returns nothing
- [x] New `TypeMismatch` assertions cover `errors.Is(err, jwk.KeyTypeMismatchError{})`, `errors.Is(err, jwk.ParseError())`, and `errors.AsType[jwk.KeyTypeMismatchError]` field extraction

## Follow-ups (separate PRs)

- Companion modules (`.companions/repo/*` and the external repos under `github.com/jwx-go/*`) still reference `jwk.ParseKey[jwk.Key]` in tests/examples. Sweep via `/jwx-companion-bulk`.
- `github.com/jwx-go/jwxmigrate` — add a rule for the ParseKey split so users on in-flight v4-scratch branches get an automated rewrite.
- `github.com/jwx-go/examples` — two examples (`jwk_parse_key_example_test.go`, `jwk_parse_with_pem_example_test.go`) use `ParseKey[T]`; matching PR needed so autodoc stays consistent post-merge.