### PR TITLE
jwk: add ExportAll[T any](set Set) ([]T, error)

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -36,7 +36,7 @@ JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 - **Parse(src []byte, ...ParseOption) (Set, error)** / **ParseKey(data []byte, ...ParseOption) (Key, error)** — parse JWK/JWKS
 - **Fetch(ctx, url, ...FetchOption) (Set, error)** — HTTP fetch with optional whitelist, body size limit (default 10 MB via `WithMaxFetchBodySize`)
 - **DefaultHTTPClient() \*http.Client** — returns a new http.Client with library defaults (30s timeout, redirect policy)
-- **Import[T Key](raw any) (T, error)** / **Export[T any](key Key) (T, error)** — convert between Go crypto types and JWK (generic)
+- **Import[T Key](raw any) (T, error)** / **Export[T any](key Key) (T, error)** / **ExportAll[T any](set Set) ([]T, error)** — convert between Go crypto types and JWK (generic). `ExportAll` exports every key in a `Set`, preserving order; `T = any` handles heterogeneous sets.
 - **PublicKeyOf(v any) (Key, error)** / **PublicSetOf(v Set, ...PublicSetOption) (Set, error)** — extract public keys. `PublicSetOf` rejects sets containing symmetric (oct) keys by default; pass `WithAllowSymmetric(true)` for legacy pass-through.
 - **AssignKeyID(key Key, ...AssignKeyIDOption) error** — compute and set kid via thumbprint
 - **Pem(v any) ([]byte, error)** — PEM encode

--- a/Changes-v4.md
+++ b/Changes-v4.md
@@ -88,6 +88,11 @@ For a step-by-step migration guide with before/after code examples, see [MIGRATI
 
 * `jwk.Export()` is now generic: `jwk.Export[T any](key Key) (T, error)`.
 
+* `jwk.ExportAll[T any](set Set) ([]T, error)` is new — the plural counterpart
+  to `jwk.Export[T]`. Exports every key in a [Set], preserving insertion order,
+  and fails fast on the first mismatch. For a heterogeneous set, use
+  `T = any`; each element's dynamic type matches its source key's raw form.
+
 * `jwk.ParseKey()` is now generic: `jwk.ParseKey[T Key](data []byte, ...options) (T, error)`.
 
 * `jwk.Fetch()` and `jwk.Cache` have both been removed from the main module, along

--- a/jwk/convert.go
+++ b/jwk/convert.go
@@ -430,6 +430,41 @@ func Export[T any](key Key) (T, error) {
 	return result, nil
 }
 
+// ExportAll exports every key in the given [Set] to type T, preserving
+// insertion order. It is the plural counterpart to [Export] and fails
+// fast on the first key whose raw representation cannot be asserted to
+// T.
+//
+// For a heterogeneous [Set] whose members don't share a concrete raw
+// type, use `T = any`:
+//
+//	raws, err := jwk.ExportAll[any](set)
+//
+// Each element's dynamic type then matches the source key's raw form
+// (e.g. *rsa.PrivateKey, *ecdsa.PrivateKey, ed25519.PrivateKey).
+//
+// Use a concrete T when every member shares a representation:
+//
+//	privkeys, err := jwk.ExportAll[*rsa.PrivateKey](set)
+//
+// An empty [Set] returns an empty slice and a nil error.
+func ExportAll[T any](set Set) ([]T, error) {
+	if set == nil {
+		return nil, fmt.Errorf(`jwk.ExportAll: set must not be nil`)
+	}
+	out := make([]T, 0, set.Len())
+	i := 0
+	for _, k := range set.All() {
+		v, err := Export[T](k)
+		if err != nil {
+			return nil, fmt.Errorf(`jwk.ExportAll: key #%d: %w`, i, err)
+		}
+		out = append(out, v)
+		i++
+	}
+	return out, nil
+}
+
 func doExport(key Key, hint any) (any, error) {
 	muKeyExporters.RLock()
 	exporters := findExporters(key)

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -383,6 +383,84 @@ func TestGenericImport(t *testing.T) {
 	})
 }
 
+func TestExportAll(t *testing.T) {
+	t.Parallel()
+
+	rsaRaw, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err)
+	ecdsaRaw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	_, ed25519Raw, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	rsaKey, err := jwk.Import[jwk.Key](rsaRaw)
+	require.NoError(t, err)
+	ecdsaKey, err := jwk.Import[jwk.Key](ecdsaRaw)
+	require.NoError(t, err)
+	ed25519Key, err := jwk.Import[jwk.Key](ed25519Raw)
+	require.NoError(t, err)
+
+	newMixedSet := func(t *testing.T) jwk.Set {
+		t.Helper()
+		set := jwk.NewSet()
+		require.NoError(t, set.AddKey(rsaKey))
+		require.NoError(t, set.AddKey(ecdsaKey))
+		require.NoError(t, set.AddKey(ed25519Key))
+		return set
+	}
+
+	t.Run("Heterogeneous T=any", func(t *testing.T) {
+		t.Parallel()
+		raws, err := jwk.ExportAll[any](newMixedSet(t))
+		require.NoError(t, err)
+		require.Len(t, raws, 3)
+		require.IsType(t, (*rsa.PrivateKey)(nil), raws[0])
+		require.IsType(t, (*ecdsa.PrivateKey)(nil), raws[1])
+		require.IsType(t, ed25519.PrivateKey(nil), raws[2])
+	})
+
+	t.Run("Homogeneous concrete T", func(t *testing.T) {
+		t.Parallel()
+		set := jwk.NewSet()
+		rsaRaw2, err := jwxtest.GenerateRsaKey()
+		require.NoError(t, err)
+		k1, err := jwk.Import[jwk.Key](rsaRaw)
+		require.NoError(t, err)
+		k2, err := jwk.Import[jwk.Key](rsaRaw2)
+		require.NoError(t, err)
+		require.NoError(t, set.AddKey(k1))
+		require.NoError(t, set.AddKey(k2))
+
+		privkeys, err := jwk.ExportAll[*rsa.PrivateKey](set)
+		require.NoError(t, err)
+		require.Len(t, privkeys, 2)
+		require.Equal(t, rsaRaw.N, privkeys[0].N)
+		require.Equal(t, rsaRaw2.N, privkeys[1].N)
+	})
+
+	t.Run("Narrow T fails on first mismatch", func(t *testing.T) {
+		t.Parallel()
+		// set ordering: rsa, ecdsa, ed25519 — narrow to *rsa.PrivateKey
+		// must error on index 1.
+		_, err := jwk.ExportAll[*rsa.PrivateKey](newMixedSet(t))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "key #1")
+	})
+
+	t.Run("Empty set", func(t *testing.T) {
+		t.Parallel()
+		raws, err := jwk.ExportAll[any](jwk.NewSet())
+		require.NoError(t, err)
+		require.Empty(t, raws)
+	})
+
+	t.Run("Nil set", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwk.ExportAll[any](nil)
+		require.Error(t, err)
+	})
+}
+
 const testOctKeyJSON = `{"kty":"oct","k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"}`
 
 func TestGenericParseKey(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds `jwk.ExportAll[T any](set Set) ([]T, error)` — the plural counterpart to the existing `jwk.Export[T]`. Exports every key in a `Set` in insertion order and fails fast on the first mismatch.

For a heterogeneous `Set` whose members don't share a concrete raw type, use `T = any`; each element's dynamic type then matches the source key's raw form (e.g. `*rsa.PrivateKey`, `*ecdsa.PrivateKey`, `ed25519.PrivateKey`). A concrete `T` like `*rsa.PrivateKey` is expected to work only when every key in the `Set` can be exported to that type.

```go
// Heterogeneous: take whatever raw types come out
raws, err := jwk.ExportAll[any](set)

// Homogeneous: assert a concrete type, fail-fast on non-matching members
privkeys, err := jwk.ExportAll[*rsa.PrivateKey](set)
```

Edge cases:

- Empty `Set` → empty slice, nil error.
- Nil `Set` → error.
- First key that fails the assertion → error wrapping `jwk.Export`'s mismatch message, annotated with the failing index (`key #N`).

## Motivation

`jwk.Export[T]` has always been single-key. Bulk export was only available through the legacy `jwk.Pem(set)` path, which hardcodes PEM encoding and bypasses the exporter registry. With `ExportAll`, bulk extraction becomes a first-class primitive that's reusable beyond PEM output — e.g. extracting all keys from a fetched JWK Set into a homogeneous `[]*rsa.PublicKey` for a signature-verification flow.

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go test ./...` passes
- [x] `GOEXPERIMENT=jsonv2 go vet ./...` clean
- [x] `make lint` — 0 issues
- [x] `TestExportAll` covers: heterogeneous `T=any`, homogeneous concrete `T`, narrow `T` fails on first mismatch, empty set, nil set

## Docs

- `Changes-v4.md` — new entry under the jwk changes block.
- `.claude/docs/packages.md` — jwk signature line updated.