### PR TITLE
ci: split Bazel checks into their own workflow

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,9 +1,5 @@
 name: Bazel
 on:
-  pull_request:
-    branches:
-      - v*
-      - develop/*
   push:
     branches-ignore:
       - main

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,0 +1,31 @@
+name: Bazel
+on:
+  pull_request:
+    branches:
+      - v*
+      - develop/*
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: "Bazel"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Cache Bazel
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cache/bazel
+            ~/.cache/bazelisk
+          key: ${{ runner.os }}-bazel-${{ hashFiles('MODULE.bazel.lock', '**/BUILD.bazel') }}
+          restore-keys: |
+            ${{ runner.os }}-bazel-
+      - uses: bazelbuild/setup-bazelisk@b39c379c82683a5f25d34f0d062761f62693e0b2 # v3.0.0
+      - run: bazel build //...
+      - run: bazel mod tidy
+      - name: Check difference between generation code and commit code
+        run: make check_diffs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-            ~/.cache/bazel
-            ~/.cache/bazelisk
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
@@ -37,7 +35,5 @@ jobs:
         run: make tidy
       - name: Test with coverage
         run: make cover
-      - uses: bazelbuild/setup-bazelisk@v3
-      - run: bazel mod tidy
       - name: Check difference between generation code and commit code
         run: make check_diffs

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -29,8 +29,6 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-            ~/.cache/bazel
-            ~/.cache/bazelisk
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
@@ -50,5 +48,3 @@ jobs:
         run: make tidy
       - name: Run smoke tests
         run: make smoke
-      - uses: bazelbuild/setup-bazelisk@b39c379c82683a5f25d34f0d062761f62693e0b2 # v3.0.0
-      - run: bazel build //...


### PR DESCRIPTION
## Summary
- Add `.github/workflows/bazel.yml` that runs `bazel build //...`, `bazel mod tidy`, and `make check_diffs` as a dedicated workflow on the same PR and push triggers used today.
- Drop the Bazel steps (and `~/.cache/bazel*` cache paths) from `.github/workflows/ci.yml` and `.github/workflows/smoke.yml` so those jobs finish as soon as the Go test suite does.
- Net effect: Bazel work runs in parallel with CI / Smoke Tests instead of serially after them, shortening the critical path on every PR/push while preserving the same gating signals.

## Test plan
- [ ] `Bazel`, `CI`, and `Smoke Tests` checks all appear on this PR and start in parallel.
- [ ] `Bazel` runs `bazel build //...`, then `bazel mod tidy`, then `make check_diffs` — green.
- [ ] `CI` and `Smoke Tests` pass with no Bazel steps in their logs.