### PR TITLE
jwk: remove unused RegisterKeyImporterI

### DIFF
--- a/docs/design/v4-generics.md
+++ b/docs/design/v4-generics.md
@@ -30,7 +30,7 @@ func myFunc(src *rsa.PrivateKey) (jwk.Key, error) {
 
 Implementation: `RegisterKeyImporter[T any](fn func(T) (Key, error))` uses `reflect.TypeFor[T]()` to derive the map key at registration time. The runtime dispatch in `Import()` still uses `reflect.TypeOf(raw)` — this is unavoidable since the input type is only known at call time.
 
-`RegisterKeyImporterI(from any, conv KeyImporter)` is available for cases requiring the full `KeyImporter` interface.
+Callers holding a full `KeyImporter` value can register it through the same entry point by passing `imp.Import` as the function: `RegisterKeyImporter[T](imp.Import)`.
 
 ### Type-safe generic accessors
 

--- a/jwk/convert.go
+++ b/jwk/convert.go
@@ -75,21 +75,6 @@ func RegisterKeyImporter[T any](fn func(T) (Key, error)) error {
 	return nil
 }
 
-// RegisterKeyImporterI registers a KeyImporter interface for the given raw key type.
-// This is the interface-based variant for cases where a full KeyImporter implementation
-// is needed instead of a simple function.
-//
-// The error return is reserved for future validation. The current
-// implementation always returns nil, but callers — especially extension
-// modules calling this from init() — must check the return value and panic
-// on failure to stay forward-compatible.
-func RegisterKeyImporterI(from any, conv KeyImporter) error {
-	muKeyImporters.Lock()
-	defer muKeyImporters.Unlock()
-	keyImporters[reflect.TypeOf(from)] = conv
-	return nil
-}
-
 // RegisterKeyExporter registers a [KeyExporter] for the given [KeyKind] identity.
 //
 // When [Export] is called, the library resolves exporters in two steps:


### PR DESCRIPTION
## Summary

- Delete `RegisterKeyImporterI`: zero callers across main module and all 12 companion clones
- Redundant with `RegisterKeyImporter[T]` — callers holding a `KeyImporter` can register via `RegisterKeyImporter[T](imp.Import)`
- Never shipped in v3, so no migration note required