### PR TITLE
docs: clarify PublicKeyOf, jwt default validators, strict-b64 crit caveat

### DIFF
--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -235,7 +235,16 @@ func PublicSetOf(v Set, options ...PublicSetOption) (Set, error) {
 // that all fields will be copied onto the new public key. It is the caller's
 // responsibility to remove any fields, if necessary
 //
-// If `v` is a raw key, the key is first converted to a `jwk.Key`
+// If `v` is a raw key, the key is first converted to a `jwk.Key`.
+//
+// Symmetric (oct) key pass-through: a symmetric key has no distinct public
+// counterpart, so `PublicKeyOf` returns it unchanged. This is intentional,
+// but it means the returned value is NOT safe to publish: doing so would
+// leak the shared secret. Callers who intend to publish the result (for
+// example as part of a `/.well-known/jwks.json` document) must filter out
+// symmetric keys themselves, or use `PublicSetOf`, which rejects symmetric
+// keys by default and requires an explicit `jwk.WithAllowSymmetric(true)`
+// opt-in for the legacy pass-through behavior.
 func PublicKeyOf(v any) (Key, error) {
 	// This should catch all jwk.Key instances
 	if pk, ok := v.(PublicKeyer); ok {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -136,6 +136,14 @@ func ParseString(s string, options ...ParseOption) (Token, error) {
 // `jwt.WithValidate(false)` if you need to defer validation and call
 // `Validate()` yourself later.
 //
+// The default validators check only the time-based claims: `exp`
+// (via `IsExpirationValid`), `nbf` (via `IsNbfValid`), and `iat`
+// (via `IsIssuedAtValid`). Issuer (`iss`), audience (`aud`), subject
+// (`sub`), and any other claim are NOT validated unless the caller
+// explicitly requests it by passing the corresponding option, e.g.
+// `jwt.WithIssuer()`, `jwt.WithAudience()`, `jwt.WithSubject()`, or a
+// custom `jwt.WithValidator()`. See `jwt.Validate` for details.
+//
 // To produce nested JWTs, use
 // `jwt.NewSerializer().Sign(...).Encrypt(...).Serialize(...)`. `Parse()` does
 // not decrypt JWE envelopes; decrypt the outer JWE before calling it.

--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -311,3 +311,10 @@ options:
       which is faster and matches RFC 7515. Set to false to enable auto-detection
       for compatibility with non-conformant providers that may use padded or
       standard base64 encoding.
+
+      Caveat: strict decoding is applied on the fast path only. Messages
+      whose protected header carries a "crit" list bypass the fast path
+      (`jws.VerifyCompactFast` refuses them, see its godoc) and are
+      re-verified through `jws.Verify`, which uses the lenient
+      auto-detecting base64 decoder. As a result, "strict by default"
+      applies only when the message has no "crit" header.

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -459,6 +459,13 @@ func WithSignOption(v jws.SignOption) SignOption {
 // which is faster and matches RFC 7515. Set to false to enable auto-detection
 // for compatibility with non-conformant providers that may use padded or
 // standard base64 encoding.
+//
+// Caveat: strict decoding is applied on the fast path only. Messages
+// whose protected header carries a "crit" list bypass the fast path
+// (`jws.VerifyCompactFast` refuses them, see its godoc) and are
+// re-verified through `jws.Verify`, which uses the lenient
+// auto-detecting base64 decoder. As a result, "strict by default"
+// applies only when the message has no "crit" header.
 func WithStrictBase64Encoding(v bool) ParseOption {
 	return &parseOption{option.New(identStrictBase64Encoding{}, v)}
 }


### PR DESCRIPTION
Pure godoc PR, no behavior changes. Three spots where the package docs were silent on behavior that surprises readers:

- `jwk.PublicKeyOf`: symmetric keys pass through unchanged. Note this and point callers publishing results to `PublicSetOf`, which rejects oct keys by default.
- `jwt.Parse`: list the default validators (`exp`, `nbf`, `iat`) and make explicit that `iss`/`aud`/`sub` are only checked when the matching option is passed.
- `jwt.WithStrictBase64Encoding`: strict decoding only applies on the `VerifyCompactFast` fast path. Crit-bearing messages bypass the fast path and fall back to `jws.Verify`'s lenient decoder, so "strict by default" has this caveat.

`jws.VerifyCompactFast` already documents crit rejection + `ErrCritPresent` retry, so it was left as-is.