### PR TITLE
jwk: make Settings() return error for consistency with other Settings functions

### DIFF
--- a/Changes-v4.md
+++ b/Changes-v4.md
@@ -172,6 +172,12 @@ For a step-by-step migration guide with before/after code examples, see [MIGRATI
   or unsafe public exponents are now rejected by default. Compatibility knobs are available via
   `jwk.Settings(jwk.WithMinRSAModulusBits(...), jwk.WithMinRSAPublicExponent(...))`.
 
+* `jwk.Settings()` now returns `error` for symmetry with `jwt.Settings`,
+  `jws.Settings`, `jwe.Settings`, `cert.Settings`, and `jwx.Settings`. The
+  current implementation always returns `nil` — the return is reserved for
+  future validation. Callers should check the error to stay
+  forward-compatible.
+
 * The `AKP` key type (Algorithm Key Pair, RFC 9802) has been added, exposed as
   `jwa.AKP()` with `jwk.AKPPublicKey` / `jwk.AKPPrivateKey`. This is a generic
   key type for post-quantum algorithms and is used by both ML-DSA (signature)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -70,7 +70,7 @@ Text output labels each finding as `(auto)` or `(manual)`, with migration notes 
 | `jws.RegisterSigner(alg, any)` | `jws.RegisterSigner(alg, Signer)` | Typed parameter |
 | `jws.RegisterVerifier(alg, any)` | `jws.RegisterVerifier(alg, Verifier)` | Typed parameter |
 | `jwx.DecoderSettings(jwx.WithUseNumber(true))` | `jwx.Settings(jwx.WithUseNumber(true))` | API renamed |
-| `jwt.Settings(...)` / `jws.Settings(...)` / `jwe.Settings(...)` / `cert.Settings(...)` / `jwx.Settings(...)` (void) | same name, now returns `error` | Invalid values return an error instead of panicking (jwx validates nil encoder/decoder; others validate their size limits) |
+| `jwt.Settings(...)` / `jws.Settings(...)` / `jwe.Settings(...)` / `cert.Settings(...)` / `jwx.Settings(...)` / `jwk.Settings(...)` (void) | same name, now returns `error` | Invalid values return an error instead of panicking (jwx validates nil encoder/decoder; others validate their size limits; jwk reserves the return for future validation) |
 | `errors.Is(err, jwt.TokenExpiredError())` | `errors.Is(err, jwt.TokenExpiredError{})` | Sentinel funcs → struct types; see Recipe 13 |
 | `-tags=jwx_goccy` | _(removed)_ | json/v2 is the only backend |
 | `-tags=jwx_es256k` | `github.com/jwx-go/es256k/v4` | Extension module |
@@ -496,7 +496,7 @@ These changes cannot be mechanically transformed and need human judgment:
 
 5. **Code that catches specific error messages**: If you matched on error message strings from the crypto layer (e.g., during JWS signing), those errors may now occur earlier (at `WithKey()` time) due to algorithm-key validation.
 
-6. **`Settings()` calls**: `jwt.Settings`, `jws.Settings`, `jwe.Settings`, `cert.Settings`, and `jwx.Settings` now return `error` instead of panicking (or silently accepting invalid state) on bad inputs. Call sites need to either check the returned error or explicitly discard it:
+6. **`Settings()` calls**: `jwt.Settings`, `jws.Settings`, `jwe.Settings`, `cert.Settings`, `jwx.Settings`, and `jwk.Settings` now return `error` instead of panicking (or silently accepting invalid state) on bad inputs. Call sites need to either check the returned error or explicitly discard it:
 
    ```go
    // Before (v3): invalid value panicked (or silently accepted)
@@ -514,7 +514,7 @@ These changes cannot be mechanically transformed and need human judgment:
 
    Extension modules that install a backend in `init()` (e.g. `asmbase64`) must panic on error, matching the house style for `Register*` failures.
 
-   `jwk.Settings` remains void; its options have no validatable state today.
+   `jwk.Settings` always returns `nil` today — its options (`WithMinRSAModulusBits`, `WithMinRSAPublicExponent`, `WithStrictKeyUsage`) have no validatable state, since `0` is a documented disable sentinel and `e=1` is a supported compatibility value. The `error` return exists for forward compatibility only.
 
 7. **Filter + transform usage**: All filter types/constructors and the `transform` package moved out of core into `github.com/jwx-go/jwxfilter/v4`. If your code references `jwt.TokenFilter`, `jws.HeaderFilter`, `jwe.HeaderFilter`, `jwk.KeyFilter`, any `New*Filter` / `*StandardFilter()` / `openid.StandardClaimsFilter`, or anything in `transform`, add a dependency on the new companion and update imports:
 

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -704,7 +704,12 @@ func IsKeyValidationError(err error) bool {
 }
 
 // Settings is used to configure global behavior of the jwk package.
-func Settings(options ...GlobalOption) {
+//
+// The error return is reserved for future validation. The current
+// implementation always returns nil, but callers — especially extension
+// modules calling this from init() — must check the return value and panic
+// on failure to stay forward-compatible.
+func Settings(options ...GlobalOption) error {
 	for _, opt := range options {
 		switch opt.Ident() {
 		case identMinRSAModulusBits{}:
@@ -715,6 +720,7 @@ func Settings(options ...GlobalOption) {
 			strictKeyUsage.Store(option.MustGet[bool](opt))
 		}
 	}
+	return nil
 }
 
 // These are used when validating keys.

--- a/jwk/rsa_validate_test.go
+++ b/jwk/rsa_validate_test.go
@@ -72,9 +72,9 @@ func TestRSAInvalidParametersRejectedOnParse(t *testing.T) {
 
 func TestRSAConfigureCompatibilityKnobs(t *testing.T) {
 	t.Run("allow legacy 1024-bit modulus", func(t *testing.T) {
-		jwk.Settings(jwk.WithMinRSAModulusBits(1024))
+		require.NoError(t, jwk.Settings(jwk.WithMinRSAModulusBits(1024)))
 		t.Cleanup(func() {
-			jwk.Settings(jwk.WithMinRSAModulusBits(2048))
+			require.NoError(t, jwk.Settings(jwk.WithMinRSAModulusBits(2048)))
 		})
 
 		raw, err := rsa.GenerateKey(rand.Reader, 1024)
@@ -87,9 +87,9 @@ func TestRSAConfigureCompatibilityKnobs(t *testing.T) {
 	})
 
 	t.Run("allow exponent 1 explicitly", func(t *testing.T) {
-		jwk.Settings(jwk.WithMinRSAPublicExponent(1))
+		require.NoError(t, jwk.Settings(jwk.WithMinRSAPublicExponent(1)))
 		t.Cleanup(func() {
-			jwk.Settings(jwk.WithMinRSAPublicExponent(3))
+			require.NoError(t, jwk.Settings(jwk.WithMinRSAPublicExponent(3)))
 		})
 
 		payload := rsaPublicJWK(rfc7638RSAModulus, "AQ")


### PR DESCRIPTION
## Summary

- `jwk.Settings(options ...GlobalOption) error` — signature change only, for symmetry with `jwt.Settings` / `jws.Settings` / `jwe.Settings` / `cert.Settings` / `jwx.Settings`.
- Always returns `nil` today; return reserved for future validation (same phrasing as `RegisterKeyImporter` / `RegisterKeyExporter`).
- No bounds added: `0` is a documented disable sentinel for `MinRSAModulusBits` / `MinRSAPublicExponent`, and `e=1` is an intentional compatibility value; adding validation now would be a semantic break.
- MIGRATION.md + Changes-v4.md updated; internal callers (`rsa_validate_test.go`) switched to `require.NoError`.