### PR TITLE
jws: return non-nil empty []byte from streaming Verify

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -238,6 +238,13 @@ func Sign(payload []byte, options ...SignOption) ([]byte, error) {
 // when the verification process itself fails (e.g. invalid signature, wrong key),
 // while the former is returned when any other part of the `jws.Verify()`
 // function fails.
+//
+// When `jws.WithDetachedPayloadReader()` is used, the payload is streamed
+// from the caller's `io.Reader` and is not extracted from the JWS envelope.
+// In that case, the returned `[]byte` is a non-nil zero-length slice on
+// success; the verified bytes are whatever the caller read from the Reader.
+// Do not treat the returned slice as "the payload is empty" — callers that
+// need the payload bytes must retain their own copy.
 func Verify(buf []byte, options ...VerifyOption) ([]byte, error) {
 	vc := verifyContextPool.Get()
 	defer verifyContextPool.Put(vc)

--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -145,9 +145,12 @@ options:
       with `jws.WithDetachedPayload()` and a buffered copy of the
       payload.
 
-      On verify, the first return value of `jws.Verify()` is nil when this
-      option is used, because the payload was streamed from the caller
-      rather than extracted from the JWS envelope.
+      On verify, `jws.Verify()` returns a non-nil zero-length `[]byte` on
+      success when this option is used, because the payload was streamed
+      from the caller rather than extracted from the JWS envelope. Do not
+      read that slice as "the payload is empty" — the verified bytes are
+      whatever the caller read from the Reader, and callers that need
+      them must retain their own copy.
 
       `jws.WithBase64Encoder()` is honored as long as the supplied encoder
       implements `jws.Base64StreamEncoder` (i.e. provides a

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -396,9 +396,12 @@ func WithDetachedPayload(v []byte) SignVerifyOption {
 // with `jws.WithDetachedPayload()` and a buffered copy of the
 // payload.
 //
-// On verify, the first return value of `jws.Verify()` is nil when this
-// option is used, because the payload was streamed from the caller
-// rather than extracted from the JWS envelope.
+// On verify, `jws.Verify()` returns a non-nil zero-length `[]byte` on
+// success when this option is used, because the payload was streamed
+// from the caller rather than extracted from the JWS envelope. Do not
+// read that slice as "the payload is empty" — the verified bytes are
+// whatever the caller read from the Reader, and callers that need
+// them must retain their own copy.
 //
 // `jws.WithBase64Encoder()` is honored as long as the supplied encoder
 // implements `jws.Base64StreamEncoder` (i.e. provides a

--- a/jws/streaming_detached.go
+++ b/jws/streaming_detached.go
@@ -285,7 +285,11 @@ func (vc *verifyContext) verifyStreaming(buf []byte) ([]byte, error) {
 	if vc.dst != nil {
 		*vc.dst = *msg
 	}
-	return nil, nil
+	// Non-nil zero-length slice is the sentinel: the payload was streamed
+	// from the caller so there are no bytes to hand back, but returning
+	// nil would be indistinguishable from "ignored return" and invite
+	// `len(payload) == 0` silent-logic bugs in callers.
+	return []byte{}, nil
 }
 
 // streamingAlgorithmInfo carries the resolved dsig metadata plus the dsig

--- a/jws/streaming_detached_test.go
+++ b/jws/streaming_detached_test.go
@@ -95,6 +95,35 @@ func TestStreamingDetachedJSONRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestStreamingDetachedVerifyReturnsNonNilEmptyPayload locks in the
+// sentinel contract that jws.Verify with WithDetachedPayloadReader returns
+// a non-nil, zero-length []byte on success. The payload was streamed from
+// the caller, not extracted from the envelope — so there are no bytes to
+// return — but returning a nil slice would be indistinguishable from
+// "ignored return value" and set up silent-logic bugs in callers that
+// check len(payload)==0.
+func TestStreamingDetachedVerifyReturnsNonNilEmptyPayload(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`sentinel-return-payload`)
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err)
+
+	signed, err := jws.Sign(nil,
+		jws.WithKey(jwa.HS256(), key),
+		jws.WithDetachedPayloadReader(bytes.NewReader(payload)),
+	)
+	require.NoError(t, err)
+
+	got, err := jws.Verify(signed,
+		jws.WithKey(jwa.HS256(), key),
+		jws.WithDetachedPayloadReader(bytes.NewReader(payload)),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, got, "streaming Verify must return a non-nil []byte on success so callers can distinguish it from an ignored return value")
+	require.Empty(t, got, "streaming Verify has no payload bytes to hand back")
+}
+
 func TestStreamingDetachedKeyUsed(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- `jws.Verify(..., jws.WithDetachedPayloadReader(r))` now returns a non-nil zero-length `[]byte` on success instead of `nil`, so callers can distinguish it from an ignored return value
- documented the sentinel contract on `jws.Verify` and `WithDetachedPayloadReader` godoc
- regression test pins the contract