### PR TITLE
jwe: enforce WithMaxParseInputSize in Decrypt

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -324,6 +324,7 @@ type decryptContext struct {
 	dst                     *Message
 	maxRecipients           int
 	maxDecompressBufferSize int64
+	maxParseInputSize       int64
 	maxPBES2Count           int
 	minPBES2Count           int
 	critValidation          bool
@@ -348,6 +349,7 @@ func freeDecryptContext(dc *decryptContext) *decryptContext {
 	dc.dst = nil
 	dc.maxRecipients = 0
 	dc.maxDecompressBufferSize = 0
+	dc.maxParseInputSize = 0
 	dc.maxPBES2Count = 0
 	dc.minPBES2Count = 0
 	dc.critValidation = true
@@ -359,6 +361,7 @@ func freeDecryptContext(dc *decryptContext) *decryptContext {
 func (dc *decryptContext) ProcessOptions(options []DecryptOption) error {
 	dc.maxRecipients = int(maxRecipients.Load())
 	dc.maxDecompressBufferSize = maxDecompressBufferSize.Load()
+	dc.maxParseInputSize = maxParseInputSize.Load()
 	dc.maxPBES2Count = int(maxPBES2Count.Load())
 	dc.minPBES2Count = int(minPBES2Count.Load())
 
@@ -384,6 +387,12 @@ func (dc *decryptContext) ProcessOptions(options []DecryptOption) error {
 			dc.maxRecipients = option.MustGet[int](opt)
 		case identMaxDecompressBufferSize{}:
 			dc.maxDecompressBufferSize = option.MustGet[int64](opt)
+		case identMaxParseInputSize{}:
+			v := option.MustGet[int64](opt)
+			if v <= 0 {
+				return fmt.Errorf(`jwe.Decrypt: WithMaxParseInputSize must be greater than zero, got %d`, v)
+			}
+			dc.maxParseInputSize = v
 		case identMaxPBES2Count{}:
 			dc.maxPBES2Count = option.MustGet[int](opt)
 		case identMinPBES2Count{}:
@@ -1050,12 +1059,22 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 //
 //	jwe.Settings(jwe.WithMaxDecompressBufferSize(10*1024*1024)) // changes value globally
 //	jwe.Decrypt(..., jwe.WithMaxDecompressBufferSize(250*1024)) // changes just for this call
+//
+// Decrypt also enforces the `WithMaxParseInputSize` cap on the length of
+// buf before any JSON/compact parsing or cryptographic work, mirroring
+// the behavior of `jwe.Parse*`. The default is 10MB; override globally
+// with `jwe.Settings(jwe.WithMaxParseInputSize(...))` or per-call by
+// passing `jwe.WithMaxParseInputSize(...)` to `jwe.Decrypt`.
 func Decrypt(buf []byte, options ...DecryptOption) ([]byte, error) {
 	dc := decryptContextPool.Get()
 	defer decryptContextPool.Put(dc)
 
 	if err := dc.ProcessOptions(options); err != nil {
 		return nil, makeDecryptError(`failed to process options: %w`, err)
+	}
+
+	if dc.maxParseInputSize > 0 && int64(len(buf)) > dc.maxParseInputSize {
+		return nil, makeDecryptError(`input exceeded max size of %d bytes`, dc.maxParseInputSize)
 	}
 
 	ret, err := dc.DecryptMessage(buf)

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1842,6 +1842,69 @@ func TestMaxParseInputSize(t *testing.T) {
 	})
 }
 
+func TestDecryptMaxParseInputSize(t *testing.T) {
+	// A valid key provider is required for jwe.Decrypt to reach the
+	// size check; use a symmetric direct key throughout. The concrete
+	// alg does not matter — we never exercise a full decrypt on the
+	// rejection path.
+	key := make([]byte, 32)
+
+	// Produce a small valid JWE so the "per-call override can raise
+	// above global" subtest can pass the size gate and surface a
+	// non-size error.
+	validJWE, err := jwe.Encrypt(
+		[]byte("hello"),
+		jwe.WithKey(jwa.DIRECT(), key),
+		jwe.WithContentEncryption(jwa.A256GCM()),
+	)
+	require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+	t.Run("default rejects oversized input", func(t *testing.T) {
+		data := make([]byte, 10*1024*1024+1)
+		_, err := jwe.Decrypt(data, jwe.WithKey(jwa.DIRECT(), key))
+		require.Error(t, err, `jwe.Decrypt should reject input exceeding default max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("per-call option overrides default", func(t *testing.T) {
+		data := make([]byte, 200)
+		_, err := jwe.Decrypt(data, jwe.WithKey(jwa.DIRECT(), key), jwe.WithMaxParseInputSize(100))
+		require.Error(t, err, `jwe.Decrypt should reject input exceeding per-call max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("global setting changes default", func(t *testing.T) {
+		require.NoError(t, jwe.Settings(jwe.WithMaxParseInputSize(50)))
+		defer jwe.Settings(jwe.WithMaxParseInputSize(10 * 1024 * 1024)) // restore
+
+		data := make([]byte, 100)
+		_, err := jwe.Decrypt(data, jwe.WithKey(jwa.DIRECT(), key))
+		require.Error(t, err, `jwe.Decrypt should reject input exceeding global max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("per-call option overrides global setting", func(t *testing.T) {
+		require.NoError(t, jwe.Settings(jwe.WithMaxParseInputSize(50)))
+		defer jwe.Settings(jwe.WithMaxParseInputSize(10 * 1024 * 1024)) // restore
+
+		_, err := jwe.Decrypt(validJWE, jwe.WithKey(jwa.DIRECT(), key), jwe.WithMaxParseInputSize(int64(len(validJWE)+1024)))
+		require.NoError(t, err, `jwe.Decrypt should succeed when per-call cap is above input size`)
+	})
+	t.Run("negative per-call value returns error", func(t *testing.T) {
+		_, err := jwe.Decrypt([]byte(`test`), jwe.WithKey(jwa.DIRECT(), key), jwe.WithMaxParseInputSize(-1))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `greater than zero`)
+	})
+	t.Run("size gate fires before JSON unmarshal", func(t *testing.T) {
+		// Construct a payload that would blow up inside json.Unmarshal
+		// if it were allowed through. `{` is the JSON-flavor marker;
+		// without the gate parseJSONOrCompact would attempt to parse
+		// this as JSON and fail with a parse error rather than a
+		// size error.
+		data := append([]byte(`{`), make([]byte, 10*1024*1024)...)
+		_, err := jwe.Decrypt(data, jwe.WithKey(jwa.DIRECT(), key))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+}
+
 func TestMaxRecipients(t *testing.T) {
 	privkey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, `rsa.GenerateKey should succeed`)

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -48,6 +48,14 @@ interfaces:
     comment: |
       GlobalParseOption describes an Option that can be passed to `jwe.Settings()`
       and `jwe.Parse()`.
+  - name: GlobalParseDecryptOption
+    methods:
+      - globalOption
+      - parseOption
+      - decryptOption
+    comment: |
+      GlobalParseDecryptOption describes an Option that can be passed to
+      `jwe.Settings()`, `jwe.Parse*()`, and `jwe.Decrypt()`.
 options:
   - ident: Key
     skip_option: true
@@ -239,16 +247,17 @@ options:
 
       This option has a global effect.
   - ident: MaxParseInputSize
-    interface: GlobalParseOption
+    interface: GlobalParseDecryptOption
     argument_type: int64
     comment: |
       WithMaxParseInputSize specifies the maximum byte length of input
       accepted by every `jwe.Parse*` entry point (`jwe.Parse`,
-      `jwe.ParseString`, and `jwe.ParseReader`). Inputs exceeding this
-      size are rejected before decoding. The default value is 10MB.
+      `jwe.ParseString`, `jwe.ParseReader`) and by `jwe.Decrypt`.
+      Inputs exceeding this size are rejected before any JSON/compact
+      decoding or cryptographic work. The default value is 10MB.
 
       This option can be passed to `jwe.Settings()` to change the default
-      globally, or to any `jwe.Parse*` call / `jwe.ParseFS()` for a
+      globally, or to any `jwe.Parse*` / `jwe.Decrypt` call for a
       per-call override.
   - ident: CritValidation
     interface: DecryptOption

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -104,6 +104,25 @@ type globalOption struct {
 
 func (*globalOption) globalOption() {}
 
+// GlobalParseDecryptOption describes an Option that can be passed to
+// `jwe.Settings()`, `jwe.Parse*()`, and `jwe.Decrypt()`.
+type GlobalParseDecryptOption interface {
+	Option
+	globalOption()
+	parseOption()
+	decryptOption()
+}
+
+type globalParseDecryptOption struct {
+	Option
+}
+
+func (*globalParseDecryptOption) globalOption() {}
+
+func (*globalParseDecryptOption) parseOption() {}
+
+func (*globalParseDecryptOption) decryptOption() {}
+
 // GlobalParseOption describes an Option that can be passed to `jwe.Settings()`
 // and `jwe.Parse()`.
 type GlobalParseOption interface {
@@ -404,14 +423,15 @@ func WithMaxPBES2Count(v int) GlobalDecryptOption {
 
 // WithMaxParseInputSize specifies the maximum byte length of input
 // accepted by every `jwe.Parse*` entry point (`jwe.Parse`,
-// `jwe.ParseString`, and `jwe.ParseReader`). Inputs exceeding this
-// size are rejected before decoding. The default value is 10MB.
+// `jwe.ParseString`, `jwe.ParseReader`) and by `jwe.Decrypt`.
+// Inputs exceeding this size are rejected before any JSON/compact
+// decoding or cryptographic work. The default value is 10MB.
 //
 // This option can be passed to `jwe.Settings()` to change the default
-// globally, or to any `jwe.Parse*` call / `jwe.ParseFS()` for a
+// globally, or to any `jwe.Parse*` / `jwe.Decrypt` call for a
 // per-call override.
-func WithMaxParseInputSize(v int64) GlobalParseOption {
-	return &globalParseOption{option.New(identMaxParseInputSize{}, v)}
+func WithMaxParseInputSize(v int64) GlobalParseDecryptOption {
+	return &globalParseDecryptOption{option.New(identMaxParseInputSize{}, v)}
 }
 
 // WithMaxRecipients specifies the maximum number of recipients allowed


### PR DESCRIPTION
## Summary
- `jwe.Decrypt` now rejects `buf` exceeding `WithMaxParseInputSize` (default 10MB) before any JSON/compact parsing or crypto, matching `jwe.Parse*`
- `WithMaxParseInputSize` is accepted on `DecryptOption` for per-call override via new `GlobalParseDecryptOption` interface
- Closes the DoS gap where `json.Unmarshal` ran on attacker-sized input before `maxRecipients` was checked

## Test plan
- [x] `go test -race ./jwe/...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./jwe/...`