### PR TITLE
jwe: enforce WithMaxParseInputSize in Decrypt

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -304,6 +304,7 @@ type decryptContext struct {
 	dst                     *Message
 	maxRecipients           int
 	maxDecompressBufferSize int64
+	maxParseInputSize       int64
 	maxPBES2Count           int
 	minPBES2Count           int
 	critValidation          bool
@@ -327,6 +328,7 @@ func freeDecryptContext(dc *decryptContext) *decryptContext {
 	dc.dst = nil
 	dc.maxRecipients = 0
 	dc.maxDecompressBufferSize = 0
+	dc.maxParseInputSize = 0
 	dc.maxPBES2Count = 0
 	dc.minPBES2Count = 0
 	dc.critValidation = false
@@ -338,6 +340,7 @@ func freeDecryptContext(dc *decryptContext) *decryptContext {
 func (dc *decryptContext) ProcessOptions(options []DecryptOption) error {
 	dc.maxRecipients = int(maxRecipients.Load())
 	dc.maxDecompressBufferSize = maxDecompressBufferSize.Load()
+	dc.maxParseInputSize = maxParseInputSize.Load()
 	dc.maxPBES2Count = int(maxPBES2Count.Load())
 	dc.minPBES2Count = int(minPBES2Count.Load())
 
@@ -379,6 +382,15 @@ func (dc *decryptContext) ProcessOptions(options []DecryptOption) error {
 			if err := option.Value(&dc.maxDecompressBufferSize); err != nil {
 				return fmt.Errorf("jwe.decrypt: WithMaxDecompressBufferSize must be int64: %w", err)
 			}
+		case identMaxParseInputSize{}:
+			var v int64
+			if err := option.Value(&v); err != nil {
+				return fmt.Errorf("jwe.decrypt: WithMaxParseInputSize must be int64: %w", err)
+			}
+			if v <= 0 {
+				return fmt.Errorf(`jwe.Decrypt: WithMaxParseInputSize must be greater than zero, got %d`, v)
+			}
+			dc.maxParseInputSize = v
 		case identMaxPBES2Count{}:
 			if err := option.Value(&dc.maxPBES2Count); err != nil {
 				return fmt.Errorf("jwe.decrypt: WithMaxPBES2Count must be int: %w", err)
@@ -1153,12 +1165,22 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 //
 //	jwe.Settings(jwe.WithMaxDecompressBufferSize(10*1024*1024)) // changes value globally
 //	jwe.Decrypt(..., jwe.WithMaxDecompressBufferSize(250*1024)) // changes just for this call
+//
+// Decrypt also enforces the `WithMaxParseInputSize` cap on the length of
+// buf before any JSON/compact parsing or cryptographic work, mirroring
+// the behavior of `jwe.Parse*`. The default is 10MB; override globally
+// with `jwe.Settings(jwe.WithMaxParseInputSize(...))` or per-call by
+// passing `jwe.WithMaxParseInputSize(...)` to `jwe.Decrypt`.
 func Decrypt(buf []byte, options ...DecryptOption) ([]byte, error) {
 	dc := decryptContextPool.Get()
 	defer decryptContextPool.Put(dc)
 
 	if err := dc.ProcessOptions(options); err != nil {
 		return nil, makeDecryptError(`failed to process options: %w`, err)
+	}
+
+	if dc.maxParseInputSize > 0 && int64(len(buf)) > dc.maxParseInputSize {
+		return nil, makeDecryptError(`input exceeded max size of %d bytes`, dc.maxParseInputSize)
 	}
 
 	ret, err := dc.DecryptMessage(buf)

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1606,6 +1606,69 @@ func TestMaxParseInputSize(t *testing.T) {
 	})
 }
 
+func TestDecryptMaxParseInputSize(t *testing.T) {
+	// A valid key provider is required for jwe.Decrypt to reach the
+	// size check; use a symmetric direct key throughout. The concrete
+	// alg does not matter — we never exercise a full decrypt on the
+	// rejection path.
+	key := make([]byte, 32)
+
+	// Produce a small valid JWE so the "per-call override can raise
+	// above global" subtest can pass the size gate and surface a
+	// non-size error.
+	validJWE, err := jwe.Encrypt(
+		[]byte("hello"),
+		jwe.WithKey(jwa.DIRECT(), key),
+		jwe.WithContentEncryption(jwa.A256GCM()),
+	)
+	require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+	t.Run("default rejects oversized input", func(t *testing.T) {
+		data := make([]byte, 10*1024*1024+1)
+		_, err := jwe.Decrypt(data, jwe.WithKey(jwa.DIRECT(), key))
+		require.Error(t, err, `jwe.Decrypt should reject input exceeding default max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("per-call option overrides default", func(t *testing.T) {
+		data := make([]byte, 200)
+		_, err := jwe.Decrypt(data, jwe.WithKey(jwa.DIRECT(), key), jwe.WithMaxParseInputSize(100))
+		require.Error(t, err, `jwe.Decrypt should reject input exceeding per-call max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("global setting changes default", func(t *testing.T) {
+		jwe.Settings(jwe.WithMaxParseInputSize(50))
+		defer jwe.Settings(jwe.WithMaxParseInputSize(10 * 1024 * 1024)) // restore
+
+		data := make([]byte, 100)
+		_, err := jwe.Decrypt(data, jwe.WithKey(jwa.DIRECT(), key))
+		require.Error(t, err, `jwe.Decrypt should reject input exceeding global max size`)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+	t.Run("per-call option overrides global setting", func(t *testing.T) {
+		jwe.Settings(jwe.WithMaxParseInputSize(50))
+		defer jwe.Settings(jwe.WithMaxParseInputSize(10 * 1024 * 1024)) // restore
+
+		_, err := jwe.Decrypt(validJWE, jwe.WithKey(jwa.DIRECT(), key), jwe.WithMaxParseInputSize(int64(len(validJWE)+1024)))
+		require.NoError(t, err, `jwe.Decrypt should succeed when per-call cap is above input size`)
+	})
+	t.Run("negative per-call value returns error", func(t *testing.T) {
+		_, err := jwe.Decrypt([]byte(`test`), jwe.WithKey(jwa.DIRECT(), key), jwe.WithMaxParseInputSize(-1))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `greater than zero`)
+	})
+	t.Run("size gate fires before JSON unmarshal", func(t *testing.T) {
+		// Construct a payload that would blow up inside json.Unmarshal
+		// if it were allowed through. `{` is the JSON-flavor marker;
+		// without the gate parseJSONOrCompact would attempt to parse
+		// this as JSON and fail with a parse error rather than a
+		// size error.
+		data := append([]byte(`{`), make([]byte, 10*1024*1024)...)
+		_, err := jwe.Decrypt(data, jwe.WithKey(jwa.DIRECT(), key))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `exceeded max size`)
+	})
+}
+
 func TestMaxRecipients(t *testing.T) {
 	privkey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, `rsa.GenerateKey should succeed`)

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -50,6 +50,14 @@ interfaces:
     comment: |
       GlobalParseOption describes an Option that can be passed to `jwe.Settings()`
       and `jwe.ReadFile()`.
+  - name: GlobalParseDecryptOption
+    methods:
+      - globalOption
+      - readFileOption
+      - decryptOption
+    comment: |
+      GlobalParseDecryptOption describes an Option that can be passed to
+      `jwe.Settings()`, `jwe.Parse*()` / `jwe.ReadFile()`, and `jwe.Decrypt()`.
   - name: ReadFileOption
     comment: |
       ReadFileOption is a type of `Option` that can be passed to `jwe.ReadFile`
@@ -236,17 +244,18 @@ options:
 
       This option has a global effect.
   - ident: MaxParseInputSize
-    interface: GlobalParseOption
+    interface: GlobalParseDecryptOption
     argument_type: int64
     comment: |
       WithMaxParseInputSize specifies the maximum byte length of input
       accepted by every `jwe.Parse*` entry point (`jwe.Parse`,
-      `jwe.ParseString`, and `jwe.ParseReader`). Inputs exceeding this
-      size are rejected before decoding. The default value is 10MB.
+      `jwe.ParseString`, `jwe.ParseReader`) and by `jwe.Decrypt`.
+      Inputs exceeding this size are rejected before any JSON/compact
+      decoding or cryptographic work. The default value is 10MB.
 
       This option can be passed to `jwe.Settings()` to change the default
-      globally, or to any `jwe.Parse*` call / `jwe.ReadFile()` for a
-      per-call override.
+      globally, or to any `jwe.Parse*` / `jwe.Decrypt` / `jwe.ReadFile()`
+      call for a per-call override.
   - ident: CritValidation
     interface: DecryptOption
     argument_type: bool

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -105,6 +105,25 @@ type globalOption struct {
 
 func (*globalOption) globalOption() {}
 
+// GlobalParseDecryptOption describes an Option that can be passed to
+// `jwe.Settings()`, `jwe.Parse*()` / `jwe.ReadFile()`, and `jwe.Decrypt()`.
+type GlobalParseDecryptOption interface {
+	Option
+	globalOption()
+	readFileOption()
+	decryptOption()
+}
+
+type globalParseDecryptOption struct {
+	Option
+}
+
+func (*globalParseDecryptOption) globalOption() {}
+
+func (*globalParseDecryptOption) readFileOption() {}
+
+func (*globalParseDecryptOption) decryptOption() {}
+
 // GlobalParseOption describes an Option that can be passed to `jwe.Settings()`
 // and `jwe.ReadFile()`.
 type GlobalParseOption interface {
@@ -459,14 +478,15 @@ func WithMaxPBES2Count(v int) GlobalDecryptOption {
 
 // WithMaxParseInputSize specifies the maximum byte length of input
 // accepted by every `jwe.Parse*` entry point (`jwe.Parse`,
-// `jwe.ParseString`, and `jwe.ParseReader`). Inputs exceeding this
-// size are rejected before decoding. The default value is 10MB.
+// `jwe.ParseString`, `jwe.ParseReader`) and by `jwe.Decrypt`.
+// Inputs exceeding this size are rejected before any JSON/compact
+// decoding or cryptographic work. The default value is 10MB.
 //
 // This option can be passed to `jwe.Settings()` to change the default
-// globally, or to any `jwe.Parse*` call / `jwe.ReadFile()` for a
-// per-call override.
-func WithMaxParseInputSize(v int64) GlobalParseOption {
-	return &globalParseOption{option.New(identMaxParseInputSize{}, v)}
+// globally, or to any `jwe.Parse*` / `jwe.Decrypt` / `jwe.ReadFile()`
+// call for a per-call override.
+func WithMaxParseInputSize(v int64) GlobalParseDecryptOption {
+	return &globalParseDecryptOption{option.New(identMaxParseInputSize{}, v)}
 }
 
 // WithMaxRecipients specifies the maximum number of recipients allowed


### PR DESCRIPTION
## Summary
- Backport of #1980 to v3
- `jwe.Decrypt` now rejects `buf` exceeding `WithMaxParseInputSize` (default 10MB) before JSON/compact parsing, matching `jwe.Parse*`
- `WithMaxParseInputSize` is accepted on `DecryptOption` for per-call override via new `GlobalParseDecryptOption` interface

## Test plan
- [x] `go test -race ./jwe/...`
- [x] `go vet ./...`