### PR TITLE
clarify jwe decrypt unprotected-header scope

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -494,13 +494,17 @@ func (dc *decryptContext) DecryptMessage(buf []byte) ([]byte, error) {
 		}
 	}
 
-	// Process things that are common to the message. We deliberately do
-	// NOT merge msg.unprotectedHeaders into h: per RFC 7516 §5.3 only the
-	// protected header is integrity-checked, so algorithm parameters
-	// (alg, enc, epk, p2s, p2c, iv, tag, …) must come from the protected
-	// and per-recipient headers only. Merging unprotected headers here
-	// would let an attacker contribute or override parameters that the
-	// AEAD tag never covered.
+	// Clone the shared (top-level) protected header as our working copy.
+	// We deliberately do NOT merge msg.unprotectedHeaders (the shared,
+	// top-level *unprotected* header) here: it is never covered by the
+	// AEAD tag, so it must not contribute algorithm parameters.
+	//
+	// Per-recipient unprotected headers are a separate case — RFC 7516
+	// §5.3 explicitly permits them to carry recipient-specific algorithm
+	// parameters (alg, epk, p2s, p2c, iv, tag, apu, apv, …), and
+	// decryptContent merges recipient.Headers() onto this base below.
+	// That merge is bounded by WithMaxRecipients and, for PBES2, by
+	// WithMaxPBES2Count (applied per recipient).
 	h, err := msg.protectedHeaders.Clone()
 	if err != nil {
 		return nil, fmt.Errorf(`jwe.Decrypt: failed to copy protected headers: %w`, err)

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -173,6 +173,14 @@ options:
       accordingly. Use this option to clamp the cap lower if your
       deployment cannot tolerate the default worst case.
 
+      The cap is applied per recipient. RFC 7516 §5.3 allows each
+      recipient of a JSON-serialized JWE to carry its own "p2c" iteration
+      count in its per-recipient unprotected header, and jwe.Decrypt
+      honors that. For a JWE with N recipients, the worst-case PBKDF2
+      cost is therefore on the order of N * MaxPBES2Count iterations per
+      decrypt attempt. When accepting multi-recipient JSON JWEs from
+      untrusted senders, also clamp jwe.WithMaxRecipients.
+
       This option can be used for `jwe.Settings()`, which changes the behavior
       globally, or for `jwe.Decrypt()`, which changes the behavior for that
       specific call.

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -395,6 +395,14 @@ func WithMaxDecompressBufferSize(v int64) GlobalDecryptOption {
 // accordingly. Use this option to clamp the cap lower if your
 // deployment cannot tolerate the default worst case.
 //
+// The cap is applied per recipient. RFC 7516 §5.3 allows each
+// recipient of a JSON-serialized JWE to carry its own "p2c" iteration
+// count in its per-recipient unprotected header, and jwe.Decrypt
+// honors that. For a JWE with N recipients, the worst-case PBKDF2
+// cost is therefore on the order of N * MaxPBES2Count iterations per
+// decrypt attempt. When accepting multi-recipient JSON JWEs from
+// untrusted senders, also clamp jwe.WithMaxRecipients.
+//
 // This option can be used for `jwe.Settings()`, which changes the behavior
 // globally, or for `jwe.Decrypt()`, which changes the behavior for that
 // specific call.


### PR DESCRIPTION
## Summary
- rewrite `jwe/jwe.go` comment at the protected-header clone to distinguish shared unprotected (excluded) from per-recipient unprotected (merged later per RFC 7516 §5.3)
- document on `WithMaxPBES2Count` that the cap is per-recipient and point at `WithMaxRecipients` for multi-recipient JSON JWEs