### PR TITLE
fix ClaimValueIs panic on non-comparable values

### DIFF
--- a/jwt/options.go
+++ b/jwt/options.go
@@ -206,7 +206,10 @@ func WithAudience(s string) ValidateOption {
 	return WithValidator(audienceClaimContainsString(s))
 }
 
-// WithClaimValue specifies the expected value for a given claim
+// WithClaimValue specifies the expected value for a given claim.
+// The stored and expected values are compared with reflect.DeepEqual,
+// so slice-, map-, and struct-valued claims are supported in addition
+// to scalars. See [ClaimValueIs] for edge-case semantics.
 func WithClaimValue(name string, v any) ValidateOption {
 	return WithValidator(ClaimValueIs(name, v))
 }

--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -3,6 +3,7 @@ package jwt
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"slices"
 	"strconv"
 	"time"
@@ -474,9 +475,11 @@ type claimValueIs struct {
 }
 
 // ClaimValueIs creates a Validator that checks if the value of claim `name`
-// matches `value`. The comparison is done using a simple `==` comparison,
-// and therefore complex comparisons may fail using this code. If you
-// need to do more, use a custom Validator.
+// matches `value`. The comparison is done with reflect.DeepEqual, so
+// slice-, map-, and struct-valued claims are supported in addition to
+// scalars. Function-valued claims follow reflect.DeepEqual semantics
+// (equal only when both sides are nil). If you need finer-grained
+// matching than DeepEqual provides, use a custom Validator.
 func ClaimValueIs(name string, value any) Validator {
 	return &claimValueIs{
 		name:  name,
@@ -493,7 +496,7 @@ func (cv *claimValueIs) Validate(_ context.Context, t Token) error {
 		return newClaimValidationError(cv.name, cv.value, nil,
 			fmt.Sprintf(`claim %q does not exist`, cv.name))
 	}
-	if v != cv.value {
+	if !reflect.DeepEqual(v, cv.value) {
 		if cv.makeErr != nil {
 			return cv.makeErr(`claim %[1]q does not have the expected value`, cv.name)
 		}

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -853,6 +853,69 @@ func TestClaimValidator(t *testing.T) {
 	}
 }
 
+func TestClaimValueIsNonComparable(t *testing.T) {
+	t.Parallel()
+
+	const claimName = "non-comparable"
+
+	testcases := []struct {
+		Name     string
+		Stored   any
+		Expected any
+		WantPass bool
+	}{
+		{
+			Name:     "equal maps",
+			Stored:   map[string]any{"k": "v"},
+			Expected: map[string]any{"k": "v"},
+			WantPass: true,
+		},
+		{
+			Name:     "different maps",
+			Stored:   map[string]any{"k": "v"},
+			Expected: map[string]any{"k": "other"},
+			WantPass: false,
+		},
+		{
+			Name:     "equal slices",
+			Stored:   []string{"a", "b"},
+			Expected: []string{"a", "b"},
+			WantPass: true,
+		},
+		{
+			Name:     "different slices",
+			Stored:   []string{"a", "b"},
+			Expected: []string{"a", "c"},
+			WantPass: false,
+		},
+		{
+			Name:     "stored non-comparable, expected string",
+			Stored:   map[string]any{"k": "v"},
+			Expected: "scalar",
+			WantPass: false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			tok := jwt.New()
+			require.NoError(t, tok.Set(claimName, tc.Stored))
+
+			var err error
+			require.NotPanics(t, func() {
+				err = jwt.Validate(tok, jwt.WithClaimValue(claimName, tc.Expected))
+			}, "Validate must not panic on non-comparable claim values")
+
+			if tc.WantPass {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.ErrorIs(t, err, jwt.ClaimValidationError{})
+		})
+	}
+}
+
 // countingClock returns successive samples from a fixed sequence and
 // records how many times Now was called. Used to lock in the invariant
 // that jwt.Validate samples the clock exactly once per call, so that


### PR DESCRIPTION
- `jwt.ClaimValueIs` / `WithClaimValue` now uses `reflect.DeepEqual` instead of `==`, so slice/map/struct claim values no longer panic.
- Godoc on `ClaimValueIs` and `WithClaimValue` updated to reflect the new semantics.
- Test locks in no-panic behavior for maps, slices, and mixed comparable/non-comparable inputs.

Addresses review item JWT-20260418172456-007.