### PR TITLE
jwk: add WithMaxKeys cap on JWKS entries

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -40,7 +40,7 @@ JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 - **PublicKeyOf(v any) (Key, error)** / **PublicSetOf(v Set, ...PublicSetOption) (Set, error)** — extract public keys. `PublicSetOf` rejects sets containing symmetric (oct) keys by default; pass `WithAllowSymmetric(true)` for legacy pass-through.
 - **AssignKeyID(key Key, ...AssignKeyIDOption) error** — compute and set kid via thumbprint
 - PEM output moved to `jwkbb.EncodePEM(keys ...any)`; unwrap via `jwk.Export[any]` / `jwk.ExportAll[any]` first
-- Global options: `WithStrictKeyUsage(bool)`, `WithMinRSAModulusBits(int)`, `WithMinRSAPublicExponent(int)`
+- Global options: `WithStrictKeyUsage(bool)`, `WithMinRSAModulusBits(int)`, `WithMinRSAPublicExponent(int)`, `WithMaxKeys(int)` (also accepted as a per-call `ParseOption`; caps `"keys"` array + PEM block count at 1000 by default)
 - JWKS caching moved to `github.com/jwx-go/jwkcache` — see [Extension Modules](../../docs/10-extensions.md)
 - Key interfaces: `Key`, `Set`, `RSAPublicKey`, `RSAPrivateKey`, `ECDSAPublicKey`, `ECDSAPrivateKey`, `OKPPublicKey`, `OKPPrivateKey`, `SymmetricKey`, `AKPPublicKey`, `AKPPrivateKey` (post-quantum, used by mldsa/mlkem extensions)
 - Extension: `RegisterCustomField[T]()`, `RegisterCustomDecoder[T]()`, `RegisterKeyParser()`, `RegisterKeyImporter()`, `RegisterKeyExporter()`

--- a/Changes-v4.md
+++ b/Changes-v4.md
@@ -8,6 +8,14 @@ For a step-by-step migration guide with before/after code examples, see [MIGRATI
 
 ## Unreleased
 
+* [jwk] Added `jwk.WithMaxKeys(int)` — caps the number of keys accepted
+  by `jwk.Parse` / `jwk.ParseReader` / `jwk.ParseString` in both the
+  JSON `"keys"` array and the PEM block stream (default **1000**).
+  Usable as a `jwk.Settings()` global or a per-call override.
+  Replaces the hardcoded internal PEM cap of the same value, so the
+  default behavior is unchanged. This is a structural/amplification
+  cap, not a raw-byte cap; see `docs/13-input-size.md`.
+
 * [jws] **Bug fix (RFC compliance, interop):** `jws.Sign()` with
   `jws.WithDetachedPayload()` + `jws.WithJSON()` now correctly omits the
   `"payload"` member from the output, per RFC 7515 Appendix F. Previous

--- a/docs/13-input-size.md
+++ b/docs/13-input-size.md
@@ -90,6 +90,19 @@ A JSON-serialized JWS can carry multiple signatures. `jws.Parse`
 rejects messages with more than `jws.WithMaxSignatures` entries
 (default **100**).
 
+### JWK: number of keys in a set
+
+A JWKS can carry many keys; each entry triggers a probe + unmarshal
++ validation when parsed. `jwk.Parse` rejects inputs with more than
+`jwk.WithMaxKeys` entries (default **1000**). The cap applies to
+both the JSON `"keys"` array and the PEM block stream accepted via
+`jwk.WithX509(true)`.
+
+```go
+jwk.Settings(jwk.WithMaxKeys(500))                    // globally
+jwk.Parse(buf, jwk.WithMaxKeys(100))                  // per call
+```
+
 ## What this means for reviewers
 
 If an audit or review flags "unbounded `io.ReadAll`", "no max input

--- a/jwk/interface.go
+++ b/jwk/interface.go
@@ -133,6 +133,7 @@ type set struct {
 	mu            sync.RWMutex
 	dc            DecodeCtx
 	privateParams map[string]any
+	maxKeys       int // scratch cap consumed by UnmarshalJSON; 0 means use global default
 }
 
 type PublicKeyer interface {

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"reflect"
 	"slices"
+	"sync/atomic"
 
 	"github.com/lestrrat-go/jwx/v4/internal/base64"
 	"github.com/lestrrat-go/jwx/v4/internal/json"
@@ -31,12 +32,16 @@ func bigIntToBytes(n *big.Int) ([]byte, error) {
 	return n.Bytes(), nil
 }
 
-// maxPEMKeys is the maximum number of PEM blocks that Parse() will
-// decode from a single input. This prevents resource exhaustion from
-// inputs containing thousands of small PEM blocks.
-const maxPEMKeys = 1000
+// maxKeys bounds the number of keys accepted by Parse() from a single
+// input. It applies to both the JSON `keys` array and the PEM block
+// stream: each entry triggers a probe + unmarshal + validation, and
+// callers cannot predict that amplification from the raw input size
+// alone. Tunable via WithMaxKeys / Settings(WithMaxKeys(...)).
+var maxKeys atomic.Int64
 
 func init() {
+	maxKeys.Store(1000)
+
 	if err := RegisterProbeField[string]("Kty", "kty"); err != nil {
 		panic(fmt.Errorf("failed to register mandatory probe for 'kty' field: %w", err))
 	}
@@ -458,6 +463,7 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 	var parseX509 bool
 	var localReg *json.Registry
 	var ignoreParseError bool
+	maxK := int(maxKeys.Load())
 	for _, opt := range options {
 		switch opt.Ident() {
 		case identX509{}:
@@ -470,6 +476,12 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 				localReg = json.NewRegistry()
 			}
 			localReg.Register(pair.Name, pair.Value)
+		case identMaxKeys{}:
+			v := option.MustGet[int](opt)
+			if v <= 0 {
+				return nil, parseerr(`WithMaxKeys must be greater than zero, got %d`, v)
+			}
+			maxK = v
 		}
 	}
 
@@ -494,8 +506,8 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 				return nil, parseerr(`failed to add jwk.Key to set: %w`, err)
 			}
 			keyCount++
-			if keyCount > maxPEMKeys {
-				return nil, parseerr(`too many PEM blocks (max %d)`, maxPEMKeys)
+			if keyCount > maxK {
+				return nil, parseerr(`too many keys in PEM input: max %d`, maxK)
 			}
 			src = bytes.TrimSpace(rest)
 		}
@@ -513,6 +525,13 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 		}
 		dcKs.SetDecodeCtx(dc)
 		defer func() { dcKs.SetDecodeCtx(nil) }()
+	}
+
+	// Propagate the resolved cap to Set.UnmarshalJSON. A scratch field
+	// rather than a ParseOption thread-through keeps json.Unmarshal happy.
+	if setter, ok := s.(interface{ setMaxKeys(int) }); ok {
+		setter.setMaxKeys(maxK)
+		defer setter.setMaxKeys(0)
 	}
 
 	if err := json.Unmarshal(src, s); err != nil {
@@ -705,11 +724,23 @@ func IsKeyValidationError(err error) bool {
 
 // Settings is used to configure global behavior of the jwk package.
 //
-// The error return is reserved for future validation. The current
-// implementation always returns nil, but callers — especially extension
-// modules calling this from init() — must check the return value and panic
-// on failure to stay forward-compatible.
+// Returns a non-nil error and applies no changes if any option fails
+// validation (for example, a non-positive [WithMaxKeys]). Extension
+// modules calling this from init() must check the return value and
+// panic on failure.
 func Settings(options ...GlobalOption) error {
+	var newMaxKeys int64
+	for _, opt := range options {
+		switch opt.Ident() {
+		case identMaxKeys{}:
+			v := option.MustGet[int](opt)
+			if v <= 0 {
+				return fmt.Errorf(`jwk.Settings: WithMaxKeys must be greater than zero, got %d`, v)
+			}
+			newMaxKeys = int64(v)
+		}
+	}
+
 	for _, opt := range options {
 		switch opt.Ident() {
 		case identMinRSAModulusBits{}:
@@ -719,6 +750,10 @@ func Settings(options ...GlobalOption) error {
 		case identStrictKeyUsage{}:
 			strictKeyUsage.Store(option.MustGet[bool](opt))
 		}
+	}
+
+	if newMaxKeys > 0 {
+		maxKeys.Store(newMaxKeys)
 	}
 	return nil
 }

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -2656,7 +2656,9 @@ func TestMaxKeys(t *testing.T) {
 		rsaKey, err := jwxtest.GenerateRsaKey()
 		require.NoError(t, err, `jwxtest.GenerateRsaKey should succeed`)
 
-		pemBlock := mustRSAPublicPEM(t, &rsaKey.PublicKey)
+		der, err := x509.MarshalPKIXPublicKey(&rsaKey.PublicKey)
+		require.NoError(t, err, `x509.MarshalPKIXPublicKey should succeed`)
+		pemBlock := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
 
 		buildPEM := func(n int) []byte {
 			var buf bytes.Buffer

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -2552,3 +2552,126 @@ func TestGH1529(t *testing.T) {
 		require.Equal(t, "baz", v2, `set2.Field("foo") should return "baz"`)
 	})
 }
+
+func TestMaxKeys(t *testing.T) {
+	// Build a minimal valid symmetric JWK once; duplicating this entry N
+	// times yields a parseable {"keys":[...]} with a cheap probe path.
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+	keyJSON, err := json.Marshal(key)
+	require.NoError(t, err, `json.Marshal should succeed`)
+	keyStr := string(keyJSON)
+
+	makeJWKS := func(n int) []byte {
+		entries := make([]string, n)
+		for i := range entries {
+			entries[i] = keyStr
+		}
+		return []byte(`{"keys":[` + strings.Join(entries, ",") + `]}`)
+	}
+
+	t.Run("parse accepts within default limit", func(t *testing.T) {
+		set, err := jwk.Parse(makeJWKS(1000))
+		require.NoError(t, err, `jwk.Parse should succeed at the default limit`)
+		require.Equal(t, 1000, set.Len())
+	})
+
+	t.Run("parse rejects over default limit", func(t *testing.T) {
+		_, err := jwk.Parse(makeJWKS(1001))
+		require.Error(t, err, `jwk.Parse should fail beyond the default limit`)
+		require.Contains(t, err.Error(), `too many keys`)
+	})
+
+	t.Run("per-call parse override tightens", func(t *testing.T) {
+		_, err := jwk.Parse(makeJWKS(6), jwk.WithMaxKeys(5))
+		require.Error(t, err, `jwk.Parse should fail with per-call limit of 5`)
+		require.Contains(t, err.Error(), `too many keys`)
+
+		set, err := jwk.Parse(makeJWKS(5), jwk.WithMaxKeys(5))
+		require.NoError(t, err, `jwk.Parse should accept exactly the per-call limit`)
+		require.Equal(t, 5, set.Len())
+	})
+
+	t.Run("global settings override", func(t *testing.T) {
+		require.NoError(t, jwk.Settings(jwk.WithMaxKeys(5)))
+		defer func() {
+			require.NoError(t, jwk.Settings(jwk.WithMaxKeys(1000)))
+		}()
+
+		_, err := jwk.Parse(makeJWKS(6))
+		require.Error(t, err, `jwk.Parse should fail with the lowered global limit`)
+		require.Contains(t, err.Error(), `too many keys`)
+
+		set, err := jwk.Parse(makeJWKS(5))
+		require.NoError(t, err, `jwk.Parse should succeed at the lowered global limit`)
+		require.Equal(t, 5, set.Len())
+	})
+
+	t.Run("per-call override defeats lowered global", func(t *testing.T) {
+		require.NoError(t, jwk.Settings(jwk.WithMaxKeys(5)))
+		defer func() {
+			require.NoError(t, jwk.Settings(jwk.WithMaxKeys(1000)))
+		}()
+
+		set, err := jwk.Parse(makeJWKS(10), jwk.WithMaxKeys(10))
+		require.NoError(t, err, `per-call WithMaxKeys(10) should override global 5`)
+		require.Equal(t, 10, set.Len())
+	})
+
+	t.Run("parse rejects non-positive values", func(t *testing.T) {
+		_, err := jwk.Parse(makeJWKS(1), jwk.WithMaxKeys(0))
+		require.Error(t, err, `jwk.Parse should reject WithMaxKeys(0)`)
+		require.Contains(t, err.Error(), `WithMaxKeys`)
+
+		_, err = jwk.Parse(makeJWKS(1), jwk.WithMaxKeys(-1))
+		require.Error(t, err, `jwk.Parse should reject WithMaxKeys(-1)`)
+		require.Contains(t, err.Error(), `WithMaxKeys`)
+	})
+
+	t.Run("Settings rejects non-positive values", func(t *testing.T) {
+		require.Error(t, jwk.Settings(jwk.WithMaxKeys(0)),
+			`jwk.Settings should reject WithMaxKeys(0)`)
+		require.Error(t, jwk.Settings(jwk.WithMaxKeys(-1)),
+			`jwk.Settings should reject WithMaxKeys(-1)`)
+	})
+
+	t.Run("rejects before decoding entries", func(t *testing.T) {
+		// Structurally valid JWKS with many tiny stubs. If the cap
+		// were enforced only after every entry had been probed and
+		// unmarshaled, this would allocate hundreds of thousands of
+		// Key objects before rejection.
+		const n = 200000
+		parts := make([]string, n)
+		for i := range parts {
+			parts[i] = `{"kty":"oct","k":"AAAA"}`
+		}
+		body := []byte(`{"keys":[` + strings.Join(parts, ",") + `]}`)
+
+		_, err := jwk.Parse(body, jwk.WithMaxKeys(16))
+		require.Error(t, err, `jwk.Parse should reject oversized keys array`)
+		require.Contains(t, err.Error(), `too many keys`)
+	})
+
+	t.Run("PEM path honors WithMaxKeys", func(t *testing.T) {
+		rsaKey, err := jwxtest.GenerateRsaKey()
+		require.NoError(t, err, `jwxtest.GenerateRsaKey should succeed`)
+
+		pemBlock := mustRSAPublicPEM(t, &rsaKey.PublicKey)
+
+		buildPEM := func(n int) []byte {
+			var buf bytes.Buffer
+			for range n {
+				buf.Write(pemBlock)
+			}
+			return buf.Bytes()
+		}
+
+		_, err = jwk.Parse(buildPEM(6), jwk.WithX509(true), jwk.WithMaxKeys(5))
+		require.Error(t, err, `jwk.Parse should reject PEM input beyond WithMaxKeys(5)`)
+		require.Contains(t, err.Error(), `too many keys`)
+
+		set, err := jwk.Parse(buildPEM(5), jwk.WithX509(true), jwk.WithMaxKeys(5))
+		require.NoError(t, err, `jwk.Parse should accept exactly the per-call PEM limit`)
+		require.Equal(t, 5, set.Len())
+	})
+}

--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -9,6 +9,15 @@ interfaces:
     comment: |
       GlobalOption is a type of Option that can be passed to `jwk.Settings()` to
       change the global configuration of the jwk package.
+  - name: GlobalParseOption
+    methods:
+      - globalOption
+      - parseOption
+    comment: |
+      GlobalParseOption describes an Option that can be passed to both
+      `jwk.Settings()` (to change the default globally) and
+      `jwk.Parse()` / `jwk.ParseReader()` / `jwk.ParseString()` (to
+      override per call).
   - name: PublicSetOption
     comment: |
       PublicSetOption is a type of Option that can be passed to `jwk.PublicSetOf()`
@@ -94,6 +103,25 @@ options:
       The default is 3. The exponent must still be odd and fit in a Go `int`.
       Lower this only for legacy interoperability. A value of 0 disables the
       minimum-exponent floor.
+  - ident: MaxKeys
+    interface: GlobalParseOption
+    argument_type: int
+    comment: |
+      WithMaxKeys specifies the maximum number of keys allowed in a JWK
+      set passed to `jwk.Parse()` / `jwk.ParseReader()` / `jwk.ParseString()`.
+      If the "keys" array of a JSON-encoded JWKS, or the number of PEM
+      blocks in an X.509-encoded input, exceeds this value, parsing
+      returns an error. The default is 1000.
+
+      This option can be passed to `jwk.Settings()` to change the default
+      globally, or to `jwk.Parse()` / `jwk.ParseReader()` /
+      `jwk.ParseString()` for a per-call override. A non-positive value
+      is rejected.
+
+      The cap defends against amplification: each entry triggers a
+      probe + unmarshal + validation, each of which allocates. Bounding
+      raw input bytes remains the caller's responsibility — see
+      docs/13-input-size.md.
   - ident: AllowSymmetric
     interface: PublicSetOption
     argument_type: bool

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -35,6 +35,24 @@ type globalOption struct {
 
 func (*globalOption) globalOption() {}
 
+// GlobalParseOption describes an Option that can be passed to both
+// `jwk.Settings()` (to change the default globally) and
+// `jwk.Parse()` / `jwk.ParseReader()` / `jwk.ParseString()` (to
+// override per call).
+type GlobalParseOption interface {
+	Option
+	globalOption()
+	parseOption()
+}
+
+type globalParseOption struct {
+	Option
+}
+
+func (*globalParseOption) globalOption() {}
+
+func (*globalParseOption) parseOption() {}
+
 // ParseOption is a type of Option that can be passed to `jwk.Parse()`
 type ParseOption interface {
 	Option
@@ -63,6 +81,7 @@ type identAllowSymmetric struct{}
 type identForceAssign struct{}
 type identIgnoreParseError struct{}
 type identLocalRegistry struct{}
+type identMaxKeys struct{}
 type identMinRSAModulusBits struct{}
 type identMinRSAPublicExponent struct{}
 type identStrictKeyUsage struct{}
@@ -83,6 +102,10 @@ func (identIgnoreParseError) String() string {
 
 func (identLocalRegistry) String() string {
 	return "withLocalRegistry"
+}
+
+func (identMaxKeys) String() string {
+	return "WithMaxKeys"
 }
 
 func (identMinRSAModulusBits) String() string {
@@ -157,6 +180,25 @@ func WithIgnoreParseError(v bool) ParseOption {
 // This option is only available for internal code. Users don't get to play with it
 func withLocalRegistry(v *json.Registry) ParseOption {
 	return &parseOption{option.New(identLocalRegistry{}, v)}
+}
+
+// WithMaxKeys specifies the maximum number of keys allowed in a JWK
+// set passed to `jwk.Parse()` / `jwk.ParseReader()` / `jwk.ParseString()`.
+// If the "keys" array of a JSON-encoded JWKS, or the number of PEM
+// blocks in an X.509-encoded input, exceeds this value, parsing
+// returns an error. The default is 1000.
+//
+// This option can be passed to `jwk.Settings()` to change the default
+// globally, or to `jwk.Parse()` / `jwk.ParseReader()` /
+// `jwk.ParseString()` for a per-call override. A non-positive value
+// is rejected.
+//
+// The cap defends against amplification: each entry triggers a
+// probe + unmarshal + validation, each of which allocates. Bounding
+// raw input bytes remains the caller's responsibility — see
+// docs/13-input-size.md.
+func WithMaxKeys(v int) GlobalParseOption {
+	return &globalParseOption{option.New(identMaxKeys{}, v)}
 }
 
 // WithMinRSAModulusBits specifies the minimum RSA modulus size, in bits,

--- a/jwk/options_gen_test.go
+++ b/jwk/options_gen_test.go
@@ -13,6 +13,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithForceAssign", identForceAssign{}.String())
 	require.Equal(t, "WithIgnoreParseError", identIgnoreParseError{}.String())
 	require.Equal(t, "withLocalRegistry", identLocalRegistry{}.String())
+	require.Equal(t, "WithMaxKeys", identMaxKeys{}.String())
 	require.Equal(t, "WithMinRSAModulusBits", identMinRSAModulusBits{}.String())
 	require.Equal(t, "WithMinRSAPublicExponent", identMinRSAPublicExponent{}.String())
 	require.Equal(t, "WithStrictKeyUsage", identStrictKeyUsage{}.String())

--- a/jwk/set.go
+++ b/jwk/set.go
@@ -205,6 +205,10 @@ func (s *set) MarshalJSON() ([]byte, error) {
 	return ret, nil
 }
 
+func (s *set) setMaxKeys(n int) {
+	s.maxKeys = n
+}
+
 func (s *set) UnmarshalJSON(data []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -219,6 +223,11 @@ func (s *set) UnmarshalJSON(data []byte) error {
 			options = append(options, withLocalRegistry(localReg))
 		}
 		ignoreParseError = dc.IgnoreParseError()
+	}
+
+	maxK := s.maxKeys
+	if maxK <= 0 {
+		maxK = int(maxKeys.Load())
 	}
 
 	var sawKeysField bool
@@ -242,6 +251,10 @@ func (s *set) UnmarshalJSON(data []byte) error {
 			var list []json.RawMessage
 			if err := json.UnmarshalDecode(dec, &list); err != nil {
 				return fmt.Errorf(`failed to decode "keys": %w`, err)
+			}
+
+			if len(list) > maxK {
+				return fmt.Errorf(`too many keys in "keys" array: got %d, max %d`, len(list), maxK)
 			}
 
 			for i, keysrc := range list {


### PR DESCRIPTION
## Summary
- New `jwk.WithMaxKeys(int)` (default 1000) — caps JSON `"keys"` array + PEM block count on `jwk.Parse`/`ParseReader`/`ParseString`; usable as `jwk.Settings()` global or per-call override
- JSON path rejects before the per-entry probe/unmarshal/validate loop; PEM path replaces the hardcoded `maxPEMKeys = 1000`
- Addresses review finding `JWK-20260418172456-006` (amplification half; raw-byte half remains caller's job per `docs/13-input-size.md`)