### PR TITLE
clarify EncryptStatic CEK for direct-CEK algs

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -264,6 +264,16 @@ func Encrypt(payload []byte, options ...EncryptOption) ([]byte, error) {
 // `EncryptStatic` validates the final CEK length before payload encryption
 // and returns an error if it does not match the selected `enc` algorithm.
 //
+// NOTE: when the chosen key-encryption algorithm derives the CEK rather than
+// wrapping it — specifically `jwa.DIRECT()` and bare `jwa.ECDH_ES()` (without
+// a key-wrap suffix) — the `cek` argument supplied here is ignored for
+// content encryption. In those modes the effective CEK is the shared/derived
+// key produced by the `jwe.WithKey()` input, and the byte-length check
+// described above is enforced against that derived CEK, not against the
+// value passed as `cek`. To pin the CEK deterministically, pair
+// `EncryptStatic` only with key-wrapping algorithms such as
+// `jwa.RSA_OAEP()`, `jwa.A256KW()`, or `jwa.ECDH_ES_A256KW()`.
+//
 // DO NOT attempt to use this function unless you completely understand the
 // security implications to using static CEKs. You have been warned.
 //


### PR DESCRIPTION
- v3 backport of #1989.
- Adds godoc paragraph on `jwe.EncryptStatic` noting the `cek` argument is ignored when the key-encryption algorithm is `jwa.DIRECT()` or bare `jwa.ECDH_ES()` (the effective CEK comes from the `WithKey()` input).
- Pre-existing and tested behavior; doc-only.