### PR TITLE
jwk: add WithMaxKeys cap on JWKS entries

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -38,7 +38,7 @@ JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 - **NewCache(ctx, client) (*Cache, error)** — auto-refreshing JWKS cache
 - **AssignKeyID(key Key, ...AssignKeyIDOption) error** — compute and set kid via thumbprint
 - **Pem(v any) ([]byte, error)** — PEM encode
-- Global options: `WithStrictKeyUsage(bool)`, `WithHTTPClient(HTTPClient)`, `WithMaxFetchBodySize(int64)`, `WithMinRSAModulusBits(int)`, `WithMinRSAPublicExponent(int)`
+- Global options: `WithStrictKeyUsage(bool)`, `WithHTTPClient(HTTPClient)`, `WithMaxFetchBodySize(int64)`, `WithMinRSAModulusBits(int)`, `WithMinRSAPublicExponent(int)`, `WithMaxKeys(int)` (also accepted as a per-call `ParseOption`; caps `"keys"` array + PEM block count at 1000 by default)
 - Key interfaces: `Key`, `Set`, `RSAPublicKey`, `RSAPrivateKey`, `ECDSAPublicKey`, `ECDSAPrivateKey`, `OKPPublicKey`, `OKPPrivateKey`, `SymmetricKey`
 - Extension: `RegisterCustomField()`, `RegisterKeyParser()`, `RegisterKeyImporter()`, `RegisterKeyExporter()`
 - Error sentinels: `ImportError()`, `ParseError()`, `WhitelistError()`, `ContinueError()`

--- a/Changes
+++ b/Changes
@@ -5,6 +5,15 @@ v3 has many incompatibilities with v2. To see the full list of differences betwe
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
 v3.1.0 UNRELEASED
+  * [jwk] Add `jwk.WithMaxKeys(int)` — caps the number of keys accepted
+    by `jwk.Parse` / `jwk.ParseReader` / `jwk.ParseString` in both the
+    JSON `"keys"` array and the PEM/X.509 block stream (default 1000).
+    Usable as a `jwk.Configure()` global or a per-call override.
+    Replaces the hardcoded internal PEM cap of the same value, so the
+    default behavior is unchanged. Backport of the v4 amplification
+    cap that mirrors `jws.WithMaxSignatures` and
+    `jwe.WithMaxRecipients`.
+
   * [jws] Add `jws.WithDetachedPayloadReader(io.Reader)` — a streaming
     variant of `jws.WithDetachedPayload([]byte)` that consumes the
     payload from an `io.Reader` instead of a byte slice, so the payload

--- a/jwk/interface.go
+++ b/jwk/interface.go
@@ -123,6 +123,7 @@ type set struct {
 	mu            sync.RWMutex
 	dc            DecodeCtx
 	privateParams map[string]any
+	maxKeys       int // scratch cap consumed by UnmarshalJSON; 0 means use global default
 }
 
 type PublicKeyer interface {

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -14,6 +14,7 @@ import (
 	"math/big"
 	"reflect"
 	"slices"
+	"sync/atomic"
 
 	"github.com/lestrrat-go/jwx/v3/internal/base64"
 	"github.com/lestrrat-go/jwx/v3/internal/json"
@@ -29,12 +30,16 @@ func bigIntToBytes(n *big.Int) ([]byte, error) {
 	return n.Bytes(), nil
 }
 
-// maxPEMKeys is the maximum number of PEM blocks that Parse() will
-// decode from a single input. This prevents resource exhaustion from
-// inputs containing thousands of small PEM blocks.
-const maxPEMKeys = 1000
+// maxKeys bounds the number of keys accepted by Parse() from a single
+// input. It applies to both the JSON `keys` array and the PEM/X.509
+// block stream: each entry triggers a probe + unmarshal + validation,
+// and callers cannot predict that amplification from the raw input
+// size alone. Tunable via WithMaxKeys / Configure(WithMaxKeys(...)).
+var maxKeys atomic.Int64
 
 func init() {
+	maxKeys.Store(1000)
+
 	if err := RegisterProbeField(reflect.StructField{
 		Name: "Kty",
 		Type: reflect.TypeFor[string](),
@@ -334,6 +339,7 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 	var localReg *json.Registry
 	var ignoreParseError bool
 	var pemDecoder PEMDecoder
+	maxK := int(maxKeys.Load())
 	for _, option := range options {
 		switch option.Ident() {
 		case identPEM{}:
@@ -352,6 +358,15 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 			if err := option.Value(&ignoreParseError); err != nil {
 				return nil, parseerr(`failed to retrieve IgnoreParseError option value: %w`, err)
 			}
+		case identMaxKeys{}:
+			var v int
+			if err := option.Value(&v); err != nil {
+				return nil, parseerr(`failed to retrieve MaxKeys option value: %w`, err)
+			}
+			if v <= 0 {
+				return nil, parseerr(`WithMaxKeys must be greater than zero, got %d`, v)
+			}
+			maxK = v
 		case identTypedField{}:
 			var pair typedFieldPair // temporary var needed for typed field
 			if err := option.Value(&pair); err != nil {
@@ -385,8 +400,8 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 				return nil, parseerr(`failed to add jwk.Key to set: %w`, err)
 			}
 			keyCount++
-			if keyCount > maxPEMKeys {
-				return nil, parseerr(`too many PEM blocks (max %d)`, maxPEMKeys)
+			if keyCount > maxK {
+				return nil, parseerr(`too many keys in PEM input: max %d`, maxK)
 			}
 			src = bytes.TrimSpace(rest)
 		}
@@ -404,6 +419,13 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 		}
 		dcKs.SetDecodeCtx(dc)
 		defer func() { dcKs.SetDecodeCtx(nil) }()
+	}
+
+	// Propagate the resolved cap to Set.UnmarshalJSON. A scratch field
+	// rather than a ParseOption thread-through keeps json.Unmarshal happy.
+	if setter, ok := s.(interface{ setMaxKeys(int) }); ok {
+		setter.setMaxKeys(maxK)
+		defer setter.setMaxKeys(0)
 	}
 
 	if err := json.Unmarshal(src, s); err != nil {
@@ -694,6 +716,7 @@ func IsKeyValidationError(err error) bool {
 func Configure(options ...GlobalOption) {
 	var strictKeyUsagePtr *bool
 	var maxFetchBodySizePtr *int64
+	var maxKeysPtr *int64
 	var httpClientPtr *HTTPClient
 	var minRSAModulusBitsPtr *int64
 	var minRSAPublicExponentPtr *int64
@@ -714,6 +737,16 @@ func Configure(options ...GlobalOption) {
 				continue
 			}
 			maxFetchBodySizePtr = &v
+		case identMaxKeys{}:
+			var v int
+			if err := option.Value(&v); err != nil {
+				continue
+			}
+			if v <= 0 {
+				continue
+			}
+			v64 := int64(v)
+			maxKeysPtr = &v64
 		case identHTTPClient{}:
 			var v HTTPClient
 			if err := option.Value(&v); err != nil {
@@ -743,6 +776,10 @@ func Configure(options ...GlobalOption) {
 
 	if maxFetchBodySizePtr != nil {
 		maxFetchBodySize.Store(*maxFetchBodySizePtr)
+	}
+
+	if maxKeysPtr != nil {
+		maxKeys.Store(*maxKeysPtr)
 	}
 
 	if httpClientPtr != nil {

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -2869,5 +2870,113 @@ func TestGH1529(t *testing.T) {
 		require.NoError(t, set2.Get("foo", &v2), `set2.Get should succeed`)
 		require.Equal(t, "bar", v1, `set1.Get("foo") should still return "bar"`)
 		require.Equal(t, "baz", v2, `set2.Get("foo") should return "baz"`)
+	})
+}
+
+func TestMaxKeys(t *testing.T) {
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+	keyJSON, err := json.Marshal(key)
+	require.NoError(t, err, `json.Marshal should succeed`)
+	keyStr := string(keyJSON)
+
+	makeJWKS := func(n int) []byte {
+		entries := make([]string, n)
+		for i := range entries {
+			entries[i] = keyStr
+		}
+		return []byte(`{"keys":[` + strings.Join(entries, ",") + `]}`)
+	}
+
+	t.Run("parse accepts within default limit", func(t *testing.T) {
+		set, err := jwk.Parse(makeJWKS(1000))
+		require.NoError(t, err, `jwk.Parse should succeed at the default limit`)
+		require.Equal(t, 1000, set.Len())
+	})
+
+	t.Run("parse rejects over default limit", func(t *testing.T) {
+		_, err := jwk.Parse(makeJWKS(1001))
+		require.Error(t, err, `jwk.Parse should fail beyond the default limit`)
+		require.Contains(t, err.Error(), `too many keys`)
+	})
+
+	t.Run("per-call parse override tightens", func(t *testing.T) {
+		_, err := jwk.Parse(makeJWKS(6), jwk.WithMaxKeys(5))
+		require.Error(t, err, `jwk.Parse should fail with per-call limit of 5`)
+		require.Contains(t, err.Error(), `too many keys`)
+
+		set, err := jwk.Parse(makeJWKS(5), jwk.WithMaxKeys(5))
+		require.NoError(t, err, `jwk.Parse should accept exactly the per-call limit`)
+		require.Equal(t, 5, set.Len())
+	})
+
+	t.Run("Configure global override", func(t *testing.T) {
+		jwk.Configure(jwk.WithMaxKeys(5))
+		defer jwk.Configure(jwk.WithMaxKeys(1000))
+
+		_, err := jwk.Parse(makeJWKS(6))
+		require.Error(t, err, `jwk.Parse should fail with the lowered global limit`)
+		require.Contains(t, err.Error(), `too many keys`)
+
+		set, err := jwk.Parse(makeJWKS(5))
+		require.NoError(t, err, `jwk.Parse should succeed at the lowered global limit`)
+		require.Equal(t, 5, set.Len())
+	})
+
+	t.Run("per-call override defeats lowered global", func(t *testing.T) {
+		jwk.Configure(jwk.WithMaxKeys(5))
+		defer jwk.Configure(jwk.WithMaxKeys(1000))
+
+		set, err := jwk.Parse(makeJWKS(10), jwk.WithMaxKeys(10))
+		require.NoError(t, err, `per-call WithMaxKeys(10) should override global 5`)
+		require.Equal(t, 10, set.Len())
+	})
+
+	t.Run("parse rejects non-positive values", func(t *testing.T) {
+		_, err := jwk.Parse(makeJWKS(1), jwk.WithMaxKeys(0))
+		require.Error(t, err, `jwk.Parse should reject WithMaxKeys(0)`)
+		require.Contains(t, err.Error(), `WithMaxKeys`)
+
+		_, err = jwk.Parse(makeJWKS(1), jwk.WithMaxKeys(-1))
+		require.Error(t, err, `jwk.Parse should reject WithMaxKeys(-1)`)
+		require.Contains(t, err.Error(), `WithMaxKeys`)
+	})
+
+	t.Run("rejects before decoding entries", func(t *testing.T) {
+		const n = 200000
+		parts := make([]string, n)
+		for i := range parts {
+			parts[i] = `{"kty":"oct","k":"AAAA"}`
+		}
+		body := []byte(`{"keys":[` + strings.Join(parts, ",") + `]}`)
+
+		_, err := jwk.Parse(body, jwk.WithMaxKeys(16))
+		require.Error(t, err, `jwk.Parse should reject oversized keys array`)
+		require.Contains(t, err.Error(), `too many keys`)
+	})
+
+	t.Run("PEM path honors WithMaxKeys", func(t *testing.T) {
+		rsaKey, err := jwxtest.GenerateRsaKey()
+		require.NoError(t, err, `jwxtest.GenerateRsaKey should succeed`)
+
+		der, err := x509.MarshalPKIXPublicKey(&rsaKey.PublicKey)
+		require.NoError(t, err, `x509.MarshalPKIXPublicKey should succeed`)
+		pemBlock := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+
+		buildPEM := func(n int) []byte {
+			var buf bytes.Buffer
+			for range n {
+				buf.Write(pemBlock)
+			}
+			return buf.Bytes()
+		}
+
+		_, err = jwk.Parse(buildPEM(6), jwk.WithPEM(true), jwk.WithMaxKeys(5))
+		require.Error(t, err, `jwk.Parse should reject PEM input beyond WithMaxKeys(5)`)
+		require.Contains(t, err.Error(), `too many keys`)
+
+		set, err := jwk.Parse(buildPEM(5), jwk.WithPEM(true), jwk.WithMaxKeys(5))
+		require.NoError(t, err, `jwk.Parse should accept exactly the per-call PEM limit`)
+		require.Equal(t, 5, set.Len())
 	})
 }

--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -45,6 +45,17 @@ interfaces:
     comment: |
       GlobalOption is a type of Option that can be passed to the `jwk.Configure()` to
       change the global configuration of the jwk package.
+  - name: GlobalParseOption
+    methods:
+      - globalOption
+      - fetchOption
+      - registerOption
+      - readFileOption
+    comment: |
+      GlobalParseOption describes an Option that can be passed to both
+      `jwk.Configure()` (to change the default globally) and
+      `jwk.Parse()` / `jwk.ParseReader()` / `jwk.ParseString()` (to
+      override per call).
   - name: PublicSetOption
     comment: |
       PublicSetOption is a type of Option that can be passed to `jwk.PublicSetOf()`
@@ -228,6 +239,24 @@ options:
       The default is 3. The exponent must still be odd and fit in a Go `int`.
       Lower this only for legacy interoperability. A value of 0 disables the
       minimum-exponent floor.
+  - ident: MaxKeys
+    interface: GlobalParseOption
+    argument_type: int
+    comment: |
+      WithMaxKeys specifies the maximum number of keys allowed in a JWK
+      set passed to `jwk.Parse()` / `jwk.ParseReader()` / `jwk.ParseString()`.
+      If the "keys" array of a JSON-encoded JWKS, or the number of PEM
+      blocks in a PEM/X.509-encoded input, exceeds this value, parsing
+      returns an error. The default is 1000.
+
+      This option can be passed to `jwk.Configure()` to change the
+      default globally, or to `jwk.Parse()` / `jwk.ParseReader()` /
+      `jwk.ParseString()` for a per-call override. A non-positive
+      value is rejected.
+
+      The cap defends against amplification: each entry triggers a
+      probe + unmarshal + validation, each of which allocates.
+      Bounding raw input bytes remains the caller's responsibility.
   - ident: AllowSymmetric
     interface: PublicSetOption
     argument_type: bool

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -91,6 +91,30 @@ type globalOption struct {
 
 func (*globalOption) globalOption() {}
 
+// GlobalParseOption describes an Option that can be passed to both
+// `jwk.Configure()` (to change the default globally) and
+// `jwk.Parse()` / `jwk.ParseReader()` / `jwk.ParseString()` (to
+// override per call).
+type GlobalParseOption interface {
+	Option
+	globalOption()
+	fetchOption()
+	registerOption()
+	readFileOption()
+}
+
+type globalParseOption struct {
+	Option
+}
+
+func (*globalParseOption) globalOption() {}
+
+func (*globalParseOption) fetchOption() {}
+
+func (*globalParseOption) registerOption() {}
+
+func (*globalParseOption) readFileOption() {}
+
 // ParseOption is a type of Option that can be passed to `jwk.Parse()`
 // ParseOption also implements the `ReadFileOption` and `NewCacheOption`,
 // and thus safely be passed to `jwk.ReadFile` and `(*jwk.Cache).Configure()`
@@ -186,6 +210,7 @@ type identHTTPClient struct{}
 type identIgnoreParseError struct{}
 type identLocalRegistry struct{}
 type identMaxFetchBodySize struct{}
+type identMaxKeys struct{}
 type identMinRSAModulusBits struct{}
 type identMinRSAPublicExponent struct{}
 type identPEM struct{}
@@ -225,6 +250,10 @@ func (identLocalRegistry) String() string {
 
 func (identMaxFetchBodySize) String() string {
 	return "WithMaxFetchBodySize"
+}
+
+func (identMaxKeys) String() string {
+	return "WithMaxKeys"
 }
 
 func (identMinRSAModulusBits) String() string {
@@ -375,6 +404,24 @@ func withLocalRegistry(v *json.Registry) ParseOption {
 // override.
 func WithMaxFetchBodySize(v int64) GlobalFetchOption {
 	return &globalFetchOption{option.New(identMaxFetchBodySize{}, v)}
+}
+
+// WithMaxKeys specifies the maximum number of keys allowed in a JWK
+// set passed to `jwk.Parse()` / `jwk.ParseReader()` / `jwk.ParseString()`.
+// If the "keys" array of a JSON-encoded JWKS, or the number of PEM
+// blocks in a PEM/X.509-encoded input, exceeds this value, parsing
+// returns an error. The default is 1000.
+//
+// This option can be passed to `jwk.Configure()` to change the
+// default globally, or to `jwk.Parse()` / `jwk.ParseReader()` /
+// `jwk.ParseString()` for a per-call override. A non-positive
+// value is rejected.
+//
+// The cap defends against amplification: each entry triggers a
+// probe + unmarshal + validation, each of which allocates.
+// Bounding raw input bytes remains the caller's responsibility.
+func WithMaxKeys(v int) GlobalParseOption {
+	return &globalParseOption{option.New(identMaxKeys{}, v)}
 }
 
 // WithMinRSAModulusBits specifies the minimum RSA modulus size, in bits,

--- a/jwk/options_gen_test.go
+++ b/jwk/options_gen_test.go
@@ -17,6 +17,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithIgnoreParseError", identIgnoreParseError{}.String())
 	require.Equal(t, "withLocalRegistry", identLocalRegistry{}.String())
 	require.Equal(t, "WithMaxFetchBodySize", identMaxFetchBodySize{}.String())
+	require.Equal(t, "WithMaxKeys", identMaxKeys{}.String())
 	require.Equal(t, "WithMinRSAModulusBits", identMinRSAModulusBits{}.String())
 	require.Equal(t, "WithMinRSAPublicExponent", identMinRSAPublicExponent{}.String())
 	require.Equal(t, "WithPEM", identPEM{}.String())

--- a/jwk/set.go
+++ b/jwk/set.go
@@ -207,6 +207,10 @@ func (s *set) MarshalJSON() ([]byte, error) {
 	return ret, nil
 }
 
+func (s *set) setMaxKeys(n int) {
+	s.maxKeys = n
+}
+
 func (s *set) UnmarshalJSON(data []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -221,6 +225,11 @@ func (s *set) UnmarshalJSON(data []byte) error {
 			options = append(options, withLocalRegistry(localReg))
 		}
 		ignoreParseError = dc.IgnoreParseError()
+	}
+
+	maxK := s.maxKeys
+	if maxK <= 0 {
+		maxK = int(maxKeys.Load())
 	}
 
 	var sawKeysField bool
@@ -248,6 +257,10 @@ LOOP:
 				var list []json.RawMessage
 				if err := dec.Decode(&list); err != nil {
 					return fmt.Errorf(`failed to decode "keys": %w`, err)
+				}
+
+				if len(list) > maxK {
+					return fmt.Errorf(`too many keys in "keys" array: got %d, max %d`, len(list), maxK)
 				}
 
 				for i, keysrc := range list {


### PR DESCRIPTION
## Summary
- Backport of #1988 (v4 → v3): new `jwk.WithMaxKeys(int)` (default 1000) caps JSON `"keys"` array + PEM block count on `jwk.Parse`/`ParseReader`/`ParseString`; usable as `jwk.Configure()` global or per-call override
- JSON path rejects before the per-entry probe/unmarshal/validate loop; PEM path replaces the hardcoded `maxPEMKeys = 1000`
- Mirrors existing `jws.WithMaxSignatures` / `jwe.WithMaxRecipients` amplification caps