### PR TITLE
jws: improve v4 WithDetachedPayloadReader nil-payload error wording

### DIFF
--- a/jws/sign_context.go
+++ b/jws/sign_context.go
@@ -115,7 +115,7 @@ func (sc *signContext) ProcessOptions(options []SignOption) error {
 				return makeSignError(prefixJwsSign, `jws.WithDetachedPayload() and jws.WithDetachedPayloadReader() are mutually exclusive`)
 			}
 			if sc.payload != nil {
-				return makeSignError(prefixJwsSign, `payload must be nil when jws.WithDetachedPayloadReader() is specified`)
+				return makeSignError(prefixJwsSign, `the first argument to jws.Sign() must be nil when jws.WithDetachedPayloadReader() is used`)
 			}
 			sc.payloadReader = option.MustGet[io.Reader](opt)
 			sc.detached = true

--- a/jws/streaming_detached_test.go
+++ b/jws/streaming_detached_test.go
@@ -275,6 +275,17 @@ func TestStreamingDetachedRejectsConflictingOptions(t *testing.T) {
 		require.ErrorContains(t, err, `mutually exclusive`)
 	})
 
+	t.Run("Sign rejects non-nil payload with reader", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := jws.Sign(payload,
+			jws.WithKey(jwa.HS256(), key),
+			jws.WithDetachedPayloadReader(bytes.NewReader(payload)),
+		)
+		require.Error(t, err)
+		require.ErrorContains(t, err, `first argument to jws.Sign() must be nil`)
+	})
+
 	t.Run("Sign rejects insecure no-signature", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Align the v4 error text with v3: when a caller passes a non-nil first argument to jws.Sign() together with jws.WithDetachedPayloadReader(), the returned error now explicitly names the first argument instead of the ambiguous 'payload must be nil' phrasing.