### PR TITLE
jws: expand WithDetachedPayloadReader encoder-missing error with install hint

### DIFF
--- a/jws/streaming_detached.go
+++ b/jws/streaming_detached.go
@@ -56,7 +56,7 @@ func (sc *signContext) signStreaming() ([]byte, error) {
 
 	streamEncoder, ok := base64.AsStreamEncoder(sc.encoder)
 	if !ok {
-		return nil, makeSignError(prefixJwsSign, `the configured base64 encoder (%T) does not support streaming; jws.WithDetachedPayloadReader() requires an encoder that implements jws.Base64StreamEncoder (the default encoder does)`, sc.encoder)
+		return nil, makeSignError(prefixJwsSign, `jws.WithDetachedPayloadReader() requires a base64 encoder with a NewEncoder(io.Writer) io.WriteCloser method (interface jws.Base64StreamEncoder). The configured encoder %T does not provide one. Install a stream-capable encoder via jwx.Settings(jwx.WithBase64Encoder(...)) or jws.WithBase64Encoder(...); the default encoding/base64.RawURLEncoding satisfies this automatically.`, sc.encoder)
 	}
 
 	signers := make([]streamingSigner, 0, len(sc.sigbuilders))
@@ -213,7 +213,7 @@ func (vc *verifyContext) verifyStreaming(buf []byte) ([]byte, error) {
 
 	streamEncoder, ok := base64.AsStreamEncoder(vc.encoder)
 	if !ok {
-		return nil, makeVerifyError(`the configured base64 encoder (%T) does not support streaming; jws.WithDetachedPayloadReader() requires an encoder that implements jws.Base64StreamEncoder (the default encoder does)`, vc.encoder)
+		return nil, makeVerifyError(`jws.WithDetachedPayloadReader() requires a base64 encoder with a NewEncoder(io.Writer) io.WriteCloser method (interface jws.Base64StreamEncoder). The configured encoder %T does not provide one. Install a stream-capable encoder via jwx.Settings(jwx.WithBase64Encoder(...)) or jws.WithBase64Encoder(...); the default encoding/base64.RawURLEncoding satisfies this automatically.`, vc.encoder)
 	}
 
 	msg, err := Parse(buf, vc.parseOptions...)

--- a/jws/streaming_detached_test.go
+++ b/jws/streaming_detached_test.go
@@ -226,7 +226,8 @@ func TestStreamingDetachedRejectsNonStreamEncoder(t *testing.T) {
 		jws.WithBase64Encoder(encoder),
 	)
 	require.Error(t, err)
-	require.ErrorContains(t, err, `does not support streaming`)
+	require.ErrorContains(t, err, `jws.WithBase64Encoder`)
+	require.ErrorContains(t, err, `Install a stream-capable encoder`)
 
 	// Sign a compact JWS normally so we have something to feed Verify.
 	signed, err := jws.Sign(payload, jws.WithKey(jwa.HS256(), key))
@@ -238,7 +239,8 @@ func TestStreamingDetachedRejectsNonStreamEncoder(t *testing.T) {
 		jws.WithBase64Encoder(encoder),
 	)
 	require.Error(t, err)
-	require.ErrorContains(t, err, `does not support streaming`)
+	require.ErrorContains(t, err, `jws.WithBase64Encoder`)
+	require.ErrorContains(t, err, `Install a stream-capable encoder`)
 }
 
 func TestStreamingDetachedRejectsConflictingOptions(t *testing.T) {


### PR DESCRIPTION
The error now names the required NewEncoder(io.Writer) io.WriteCloser method and points callers at jwx.Settings(jwx.WithBase64Encoder(...)) and jws.WithBase64Encoder(...) as install points. The default encoding/base64.RawURLEncoding already satisfies the interface.