### PR TITLE
jws: explain RFC 8032 EdDSA streaming incompatibility in error message

### DIFF
--- a/jws/streaming_detached.go
+++ b/jws/streaming_detached.go
@@ -316,9 +316,9 @@ func resolveStreamingAlgorithm(alg jwa.SignatureAlgorithm) (streamingAlgorithmIn
 	}
 	switch info.Family {
 	case dsig.EdDSAFamily:
-		return streamingAlgorithmInfo{}, fmt.Errorf(`algorithm %q is incompatible with streaming detached payloads: RFC 8032 EdDSA signs the full message, not a pre-computed digest, so the payload cannot be streamed. If the payload fits in memory, use jws.WithDetachedPayload(). If it does not, use a digest-based algorithm such as HS256, RS256, or ES256.`, alg)
+		return streamingAlgorithmInfo{}, fmt.Errorf(`algorithm %q is incompatible with streaming detached payloads: RFC 8032 EdDSA signs the full message, not a pre-computed digest, so the payload cannot be streamed; use jws.WithDetachedPayload() if the payload fits in memory, or a digest-based algorithm such as HS256, RS256, or ES256`, alg)
 	case dsig.Custom:
-		return streamingAlgorithmInfo{}, fmt.Errorf(`algorithm %q is a custom-family algorithm and does not support streaming because the library cannot know whether the algorithm pre-hashes the payload. Use jws.WithDetachedPayload() if the payload fits in memory.`, alg)
+		return streamingAlgorithmInfo{}, fmt.Errorf(`algorithm %q is a custom-family algorithm and does not support streaming because the library cannot know whether the algorithm pre-hashes the payload; use jws.WithDetachedPayload() if the payload fits in memory`, alg)
 	}
 	return streamingAlgorithmInfo{AlgorithmInfo: info, Name: dsigAlg}, nil
 }

--- a/jws/streaming_detached.go
+++ b/jws/streaming_detached.go
@@ -316,9 +316,9 @@ func resolveStreamingAlgorithm(alg jwa.SignatureAlgorithm) (streamingAlgorithmIn
 	}
 	switch info.Family {
 	case dsig.EdDSAFamily:
-		return streamingAlgorithmInfo{}, fmt.Errorf(`algorithm %q does not support streaming because it requires the full payload; use jws.WithDetachedPayload() if the payload fits in memory`, alg)
+		return streamingAlgorithmInfo{}, fmt.Errorf(`algorithm %q is incompatible with streaming detached payloads: RFC 8032 EdDSA signs the full message, not a pre-computed digest, so the payload cannot be streamed. If the payload fits in memory, use jws.WithDetachedPayload(). If it does not, use a digest-based algorithm such as HS256, RS256, or ES256.`, alg)
 	case dsig.Custom:
-		return streamingAlgorithmInfo{}, fmt.Errorf(`algorithm %q is a custom-family algorithm and does not support streaming; use jws.WithDetachedPayload() if the payload fits in memory`, alg)
+		return streamingAlgorithmInfo{}, fmt.Errorf(`algorithm %q is a custom-family algorithm and does not support streaming because the library cannot know whether the algorithm pre-hashes the payload. Use jws.WithDetachedPayload() if the payload fits in memory.`, alg)
 	}
 	return streamingAlgorithmInfo{AlgorithmInfo: info, Name: dsigAlg}, nil
 }

--- a/jws/streaming_detached_test.go
+++ b/jws/streaming_detached_test.go
@@ -341,7 +341,7 @@ func TestStreamingDetachedEdDSARejected(t *testing.T) {
 		jws.WithDetachedPayloadReader(bytes.NewReader(payload)),
 	)
 	require.Error(t, err)
-	require.ErrorContains(t, err, `does not support streaming`)
+	require.ErrorContains(t, err, `RFC 8032 EdDSA signs the full message`)
 
 	signed, err := jws.Sign(nil, jws.WithKey(jwa.EdDSA(), edKey), jws.WithDetachedPayload(payload))
 	require.NoError(t, err)
@@ -351,7 +351,7 @@ func TestStreamingDetachedEdDSARejected(t *testing.T) {
 		jws.WithDetachedPayloadReader(bytes.NewReader(payload)),
 	)
 	require.Error(t, err)
-	require.ErrorContains(t, err, `does not support streaming`)
+	require.ErrorContains(t, err, `RFC 8032 EdDSA signs the full message`)
 }
 
 func TestStreamingDetachedB64False(t *testing.T) {


### PR DESCRIPTION
Rewrite the EdDSA streaming-rejection error to cite the RFC 8032 constraint (EdDSA signs the full message, not a pre-computed digest) and name concrete digest-based alternatives (HS256/RS256/ES256). The parallel custom-family rejection is also tightened to state why the library cannot stream.