### PR TITLE
jws: document goroutine-safety for WithDetachedPayloadReader

### DIFF
--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -122,6 +122,11 @@ options:
       failure the Reader cannot be rewound; callers that need retry
       semantics must buffer the payload themselves.
 
+      The Reader is accessed from the calling goroutine only; do not
+      share a single Reader between concurrent `jws.Sign` / `jws.Verify`
+      calls unless the Reader is itself goroutine-safe and positioned
+      independently for each call.
+
       Only the HMAC, RSA (PKCS#1 v1.5 and PSS), and ECDSA algorithm
       families are supported by this option; EdDSA and custom-family
       algorithms require the full payload in memory and will be rejected

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -368,6 +368,11 @@ func WithDetachedPayload(v []byte) SignVerifyOption {
 // failure the Reader cannot be rewound; callers that need retry
 // semantics must buffer the payload themselves.
 //
+// The Reader is accessed from the calling goroutine only; do not
+// share a single Reader between concurrent `jws.Sign` / `jws.Verify`
+// calls unless the Reader is itself goroutine-safe and positioned
+// independently for each call.
+//
 // Only the HMAC, RSA (PKCS#1 v1.5 and PSS), and ECDSA algorithm
 // families are supported by this option; EdDSA and custom-family
 // algorithms require the full payload in memory and will be rejected


### PR DESCRIPTION
WithDetachedPayloadReader godoc now notes that the Reader is accessed from the calling goroutine only; callers must not share a single Reader across concurrent jws.Sign / jws.Verify invocations unless the Reader is itself goroutine-safe and positioned independently per call.