### PR TITLE
jws: align streaming HMAC key-type error with non-streaming path

### DIFF
--- a/jws/streaming_detached.go
+++ b/jws/streaming_detached.go
@@ -337,7 +337,13 @@ func newStreamingHasher(info streamingAlgorithmInfo, key any) (hash.Hash, error)
 		}
 		keyBytes, ok := key.([]byte)
 		if !ok {
-			return nil, fmt.Errorf(`HMAC key must be []byte, got %T`, key)
+			// Route through keyconv so the error matches the non-streaming
+			// HMAC path (e.g., passing a string secret surfaces
+			// `keyconv: expected []byte, got string`) instead of the
+			// terser type-assertion failure.
+			if err := keyconv.ByteSliceKey(&keyBytes, key); err != nil {
+				return nil, fmt.Errorf(`failed to convert HMAC key to []byte (streaming path): %w`, err)
+			}
 		}
 		return hmac.New(meta.HashFunc, keyBytes), nil
 	case dsig.RSA:

--- a/jws/streaming_detached_test.go
+++ b/jws/streaming_detached_test.go
@@ -944,6 +944,43 @@ func TestStreamingDetachedJSONGeneralSingleSignature(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestStreamingDetachedHMACStringKeyErrorMatchesNonStreaming asserts that
+// passing a raw string as the HMAC secret (the common "secret-as-string"
+// footgun) on the streaming path produces an actionable error that
+// identifies the offending key type, matching the non-streaming path's
+// behaviour. The option-layer validation in jws.Verify currently
+// short-circuits before newStreamingHasher is reached, so the observable
+// error comes from jws.AlgorithmsForKey and reads "unknown key type
+// string". If that gate is ever relaxed for HMAC, the streaming branch
+// in newStreamingHasher now routes through keyconv.ByteSliceKey — which
+// surfaces "keyconv:" — so the streaming and non-streaming paths stay
+// aligned either way.
+func TestStreamingDetachedHMACStringKeyErrorMatchesNonStreaming(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`hmac-string-key-payload`)
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err)
+
+	signed, err := jws.Sign(nil,
+		jws.WithKey(jwa.HS256(), key),
+		jws.WithDetachedPayloadReader(bytes.NewReader(payload)),
+	)
+	require.NoError(t, err)
+
+	_, err = jws.Verify(signed,
+		jws.WithKey(jwa.HS256(), "secret-as-string"),
+		jws.WithDetachedPayloadReader(bytes.NewReader(payload)),
+	)
+	require.Error(t, err)
+	msg := err.Error()
+	require.True(t,
+		strings.Contains(msg, "keyconv") ||
+			strings.Contains(msg, "convertible to []byte") ||
+			strings.Contains(msg, "unknown key type string"),
+		"expected error to name the offending key type; got %q", msg)
+}
+
 // failingReader returns data up to failAt bytes, then fails with failErr.
 type failingReader struct {
 	data    []byte


### PR DESCRIPTION
The streaming HMAC branch in newStreamingHasher now falls back to keyconv.ByteSliceKey when the key is not already []byte, matching the wrapping done by convertStreamingVerifyKey. This keeps the streaming and non-streaming HMAC conversion paths structurally consistent so callers never dead-end on a terse "HMAC key must be []byte" message if the upstream algorithm/key gate is ever relaxed.