### PR TITLE
jwe: fix grammar in ECDH-ES/DIRECT multi-recipient error

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -784,7 +784,7 @@ func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
 
 	if useRawCEK {
 		if len(ec.builders) != 1 {
-			return fmt.Errorf(`multiple recipients for ECDH-ES/DIRECT mode supported`)
+			return fmt.Errorf(`multiple recipients for ECDH-ES/DIRECT mode are not supported`)
 		}
 	}
 


### PR DESCRIPTION
Error at `jwe/jwe.go:787` read `multiple recipients for ECDH-ES/DIRECT mode supported` (missing negation). Inserted `are not`.