### PR TITLE
jws: drop double-wrap on compact parse errors

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -424,9 +424,9 @@ func SplitCompactReader(rdr io.Reader) ([]byte, []byte, []byte, error) {
 }
 
 func parseCompact(data []byte) (m *Message, err error) {
-	protected, payload, signature, err := SplitCompact(data)
+	protected, payload, signature, err := jwsbb.SplitCompact(data)
 	if err != nil {
-		return nil, fmt.Errorf(`invalid compact serialization format: %w`, err)
+		return nil, makeParseError(`jws.Parse`, `invalid compact serialization format: %w`, err)
 	}
 	return parse(protected, payload, signature)
 }


### PR DESCRIPTION
parseCompact wrapped the SplitCompact error twice — first via the deprecated top-level `SplitCompact` (`makeParseError`), then again via `fmt.Errorf` — producing `invalid compact serialization format: jws.Parse: …` with the `jws.Parse:` prefix mid-sentence. Route through `jwsbb.SplitCompact` directly with a single `makeParseError`. v3 backport of #2003.