### PR TITLE
jwk: fix data race in RegisterProbeField vs KeyProbe.Field

### DIFF
--- a/jwk/parser.go
+++ b/jwk/parser.go
@@ -162,7 +162,17 @@ func (kp *keyProber) addField(name string, def probeFieldDef) error {
 
 	def.index = len(kp.fields)
 	kp.fields = append(kp.fields, def)
-	kp.names[name] = def.index
+
+	// Replace kp.names with a fresh map. KeyProbe instances created by
+	// earlier Probe calls keep their reference to the old map, which is
+	// never mutated again — so KeyProbe.Field reads stay safe even while
+	// a concurrent RegisterProbeField runs.
+	names := make(map[string]int, len(kp.fields))
+	for k, v := range kp.names {
+		names[k] = v
+	}
+	names[name] = def.index
+	kp.names = names
 
 	// Rebuild jsonKeys lookup
 	kp.jsonKeys = make(map[string]*probeFieldDef, len(kp.fields))

--- a/jwk/parser.go
+++ b/jwk/parser.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json/jsontext"
 	jsonv2 "encoding/json/v2"
 	"fmt"
+	"maps"
 	"sync"
 
 	"github.com/lestrrat-go/jwx/v4/internal/json"
@@ -168,9 +169,7 @@ func (kp *keyProber) addField(name string, def probeFieldDef) error {
 	// never mutated again — so KeyProbe.Field reads stay safe even while
 	// a concurrent RegisterProbeField runs.
 	names := make(map[string]int, len(kp.fields))
-	for k, v := range kp.names {
-		names[k] = v
-	}
+	maps.Copy(names, kp.names)
 	names[name] = def.index
 	kp.names = names
 

--- a/jwk/probe_test.go
+++ b/jwk/probe_test.go
@@ -1,0 +1,49 @@
+package jwk
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestProbeFieldRegistrationConcurrent exercises the race between
+// RegisterProbeField (mutating the prober's field/name maps) and
+// concurrent KeyProbe.Field reads on a KeyProbe captured from an
+// earlier Probe call. Must pass under `go test -race`.
+func TestProbeFieldRegistrationConcurrent(t *testing.T) {
+	probe, err := keyProbe.Probe(rsaPrivateKeyJSON)
+	require.NoError(t, err, `Probe should succeed`)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Reader: hammer KeyProbe.Field on the captured probe.
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_, _ = probe.Field("Kty")
+					_, _ = probe.Field("D")
+				}
+			}
+		}()
+	}
+
+	// Writer: register a batch of fresh fields. Each Register call
+	// mutates the prober's internal state that the Reader goroutines
+	// also reach via the captured KeyProbe.
+	for i := range 16 {
+		name := "__jwktest_probe_" + string(rune('a'+i%26)) + string(rune('a'+i/26))
+		jsonKey := "__jwktest_jsonkey_" + string(rune('a'+i%26)) + string(rune('a'+i/26))
+		require.NoError(t, RegisterProbeField[string](name, jsonKey))
+	}
+
+	close(stop)
+	wg.Wait()
+}

--- a/jwk/probe_test.go
+++ b/jwk/probe_test.go
@@ -20,9 +20,7 @@ func TestProbeFieldRegistrationConcurrent(t *testing.T) {
 
 	// Reader: hammer KeyProbe.Field on the captured probe.
 	for range 4 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for {
 				select {
 				case <-stop:
@@ -32,7 +30,7 @@ func TestProbeFieldRegistrationConcurrent(t *testing.T) {
 					_, _ = probe.Field("D")
 				}
 			}
-		}()
+		})
 	}
 
 	// Writer: register a batch of fresh fields. Each Register call


### PR DESCRIPTION
`keyProber.addField` mutated `kp.names` in place; `Probe()` hands out `*KeyProbe` values that retain that map reference, and `KeyProbe.Field` reads it without any lock. A concurrent `RegisterProbeField` triggers the race detector and can panic with 'concurrent map read and map write'.

Replace `kp.names` with a freshly allocated map each time `addField` runs. Previously handed-out `KeyProbe` instances keep pointing at the old (frozen) map. Added `TestProbeFieldRegistrationConcurrent` to lock the invariant under `-race`.