### PR TITLE
jwt: guard Validate against nil token

### DIFF
--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -52,6 +52,10 @@ func timeClaim(t Token, clock Clock, c string) time.Time {
 // See the various `WithXXX` functions for optional parameters
 // that can control the behavior of this method.
 func Validate(t Token, options ...ValidateOption) error {
+	if t == nil {
+		return validateErrorf(`jwt.Validate: token is nil`)
+	}
+
 	// Fast path: no options means default validation (iat, exp, nbf)
 	// with no skew, default truncation, and time.Now as clock.
 	// This avoids context allocation, validator struct creation, and option iteration.

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -965,6 +965,7 @@ func TestValidateNilToken(t *testing.T) {
 	t.Parallel()
 
 	t.Run("fast path (no options)", func(t *testing.T) {
+		t.Parallel()
 		err := jwt.Validate(nil)
 		require.Error(t, err, `jwt.Validate(nil) should return an error, not panic`)
 		require.ErrorIs(t, err, jwt.ValidationError{},
@@ -972,6 +973,7 @@ func TestValidateNilToken(t *testing.T) {
 	})
 
 	t.Run("slow path (with options)", func(t *testing.T) {
+		t.Parallel()
 		err := jwt.Validate(nil, jwt.WithAcceptableSkew(time.Second))
 		require.Error(t, err, `jwt.Validate(nil, ...) should return an error, not panic`)
 		require.ErrorIs(t, err, jwt.ValidationError{},

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -960,3 +960,21 @@ func TestValidateClockSnapshottedOnce(t *testing.T) {
 		`jwt.Validate should call clock.Now() exactly once per call`,
 	)
 }
+
+func TestValidateNilToken(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fast path (no options)", func(t *testing.T) {
+		err := jwt.Validate(nil)
+		require.Error(t, err, `jwt.Validate(nil) should return an error, not panic`)
+		require.ErrorIs(t, err, jwt.ValidationError{},
+			`nil-token error should be a ValidationError`)
+	})
+
+	t.Run("slow path (with options)", func(t *testing.T) {
+		err := jwt.Validate(nil, jwt.WithAcceptableSkew(time.Second))
+		require.Error(t, err, `jwt.Validate(nil, ...) should return an error, not panic`)
+		require.ErrorIs(t, err, jwt.ValidationError{},
+			`nil-token error should be a ValidationError`)
+	})
+}


### PR DESCRIPTION
`jwt.Validate(nil)` panicked in `validateDefault` on `t.Expiration()`. Added an explicit nil-guard returning a `ValidationError`, matching the pattern already in `jwt.Equal`. Covers fast (no options) and slow paths.