### PR TITLE
jwt: guard Validate against nil token

### DIFF
--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -52,6 +52,10 @@ func timeClaim(t Token, clock Clock, c string) time.Time {
 // See the various `WithXXX` functions for optional parameters
 // that can control the behavior of this method.
 func Validate(t Token, options ...ValidateOption) error {
+	if t == nil {
+		return jwterrs.ValidateErrorf(`jwt.Validate: token is nil`)
+	}
+
 	ctx := context.Background()
 	trunc := getDefaultTruncation()
 

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -914,3 +914,21 @@ func TestClaimValueIsNonComparable(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateNilToken(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no options", func(t *testing.T) {
+		err := jwt.Validate(nil)
+		require.Error(t, err, `jwt.Validate(nil) should return an error, not panic`)
+		require.ErrorIs(t, err, jwt.ValidateError(),
+			`nil-token error should be a ValidateError`)
+	})
+
+	t.Run("with options", func(t *testing.T) {
+		err := jwt.Validate(nil, jwt.WithAcceptableSkew(time.Second))
+		require.Error(t, err, `jwt.Validate(nil, ...) should return an error, not panic`)
+		require.ErrorIs(t, err, jwt.ValidateError(),
+			`nil-token error should be a ValidateError`)
+	})
+}

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -919,6 +919,7 @@ func TestValidateNilToken(t *testing.T) {
 	t.Parallel()
 
 	t.Run("no options", func(t *testing.T) {
+		t.Parallel()
 		err := jwt.Validate(nil)
 		require.Error(t, err, `jwt.Validate(nil) should return an error, not panic`)
 		require.ErrorIs(t, err, jwt.ValidateError(),
@@ -926,6 +927,7 @@ func TestValidateNilToken(t *testing.T) {
 	})
 
 	t.Run("with options", func(t *testing.T) {
+		t.Parallel()
 		err := jwt.Validate(nil, jwt.WithAcceptableSkew(time.Second))
 		require.Error(t, err, `jwt.Validate(nil, ...) should return an error, not panic`)
 		require.ErrorIs(t, err, jwt.ValidateError(),


### PR DESCRIPTION
`jwt.Validate(nil)` panicked on `t.Expiration()`. Added an explicit nil-guard returning a `ValidateError`. v3 backport of #2006.