### PR TITLE
jws: make jkuProvider surface missing-alg error

### DIFF
--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1348,6 +1348,31 @@ func TestJKU(t *testing.T) {
 		require.Contains(t, err.Error(), `signer-kid`, `error should name the missing kid`)
 		require.Contains(t, err.Error(), `not found`, `error should say the kid was not found`)
 	})
+	t.Run("ProtectedHeaderHasNoAlg", func(t *testing.T) {
+		// Craft a compact JWS whose protected header carries "jku" and
+		// "kid" but no "alg". jkuProvider used to return nil-no-error
+		// here — hiding the root cause — and now returns an explicit
+		// error naming the missing alg field.
+		protected := map[string]any{
+			"jku": srv.URL,
+			"kid": `my-awesome-key`,
+		}
+		phdr, err := json.Marshal(protected)
+		require.NoError(t, err, `json.Marshal should succeed`)
+		b64hdr := base64.EncodeToString(phdr)
+		b64payload := base64.EncodeToString(payload)
+		// Signature bytes do not matter — rejection happens before
+		// signature math.
+		signed := strings.Join([]string{b64hdr, b64payload, "AAAA"}, ".")
+
+		_, err = jws.Verify([]byte(signed), jws.WithVerifyAuto(nil,
+			jwk.WithFetchWhitelist(jwk.InsecureWhitelist{}),
+			jwk.WithHTTPClient(srv.Client()),
+		))
+		require.Error(t, err, `jws.Verify should fail when jku JWS has no alg`)
+		require.Contains(t, err.Error(), `"alg"`,
+			`error should name the missing alg field`)
+	})
 }
 
 func TestAlgorithmsForKey(t *testing.T) {

--- a/jws/key_provider.go
+++ b/jws/key_provider.go
@@ -319,9 +319,13 @@ func (kp jkuProvider) FetchKeys(ctx context.Context, sink KeySink, sig *Signatur
 
 	hdrAlg, ok := sig.ProtectedHeaders().Algorithm()
 	if !ok {
-		// No algorithm in the JWS header. The jku provider requires both
-		// kid and alg to match, so we don't send any keys without alg.
-		return nil
+		// The jku provider routes a key by matching both "kid" and
+		// "alg" against the JWS protected header. With no alg in the
+		// header there's nothing to pin the signature algorithm to,
+		// so reject explicitly rather than returning no keys and
+		// letting the outer verify loop surface a generic "could not
+		// be verified with any of the keys" message.
+		return fmt.Errorf(`use of "jku" requires that the protected header contain an "alg" field`)
 	}
 
 	for _, alg := range algs {


### PR DESCRIPTION
Backport of #2008. jku provider used to return `(nil, nil)` when the protected header had no `alg`; now returns an explicit error naming the missing field.