### PR TITLE
jws: surface per-key selectKey errors in keySetProvider

### DIFF
--- a/jws/key_provider.go
+++ b/jws/key_provider.go
@@ -2,6 +2,7 @@ package jws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"slices"
@@ -189,6 +190,7 @@ func (kp *keySetProvider) FetchKeys(_ context.Context, sink KeySink, sig *Signat
 		// if multipleKeysPerKeyID is true, we attempt all keys whose key ID matches
 		// the wantedKey
 		found := false
+		var errs []error
 		for i := range kp.set.Len() {
 			key, _ := kp.set.Key(i)
 			if kid, ok := key.KeyID(); !ok || kid != wantedKid {
@@ -196,12 +198,16 @@ func (kp *keySetProvider) FetchKeys(_ context.Context, sink KeySink, sig *Signat
 			}
 
 			if err := kp.selectKey(sink, key, sig, msg); err != nil {
+				errs = append(errs, fmt.Errorf(`key #%d: %w`, i, err))
 				continue
 			}
 			found = true
 			// continue processing so that we try all keys with the same key ID
 		}
 		if !found {
+			if len(errs) > 0 {
+				return fmt.Errorf(`failed to select any key with key ID %q: %w`, wantedKid, errors.Join(errs...))
+			}
 			return fmt.Errorf(`failed to find key with key ID %q in key set`, wantedKid)
 		}
 		return nil
@@ -227,6 +233,8 @@ func (kp *keySetProvider) FetchKeys(_ context.Context, sink KeySink, sig *Signat
 	if hdrAlg, ok := sig.ProtectedHeaders().Algorithm(); ok {
 		allowedKtys = keyTypesForAlgorithm(hdrAlg)
 	}
+	found := false
+	var errs []error
 	for i := range kp.set.Len() {
 		key, ok := kp.set.Key(i)
 		if !ok {
@@ -236,8 +244,13 @@ func (kp *keySetProvider) FetchKeys(_ context.Context, sink KeySink, sig *Signat
 			continue
 		}
 		if err := kp.selectKey(sink, key, sig, msg); err != nil {
+			errs = append(errs, fmt.Errorf(`key #%d: %w`, i, err))
 			continue
 		}
+		found = true
+	}
+	if !found && len(errs) > 0 {
+		return fmt.Errorf(`no key in the key set was usable: %w`, errors.Join(errs...))
 	}
 	return nil
 }


### PR DESCRIPTION
Multi-key iteration paths in `keySetProvider.FetchKeys` silently dropped `selectKey` errors via `continue`. When every candidate failed, the outer loop reported the generic 'could not be verified with any of the keys' error with no hint at the root cause.

Accumulate per-key errors and, on zero hits, return `errors.Join` of the reasons. Happy paths unchanged.