### PR TITLE
jws: surface use=enc mismatch as explicit error

### DIFF
--- a/jws/key_provider.go
+++ b/jws/key_provider.go
@@ -114,7 +114,8 @@ func (kp *keySetProvider) selectKey(sink KeySink, key jwk.Key, sig *Signature, _
 	if usage, ok := key.KeyUsage(); ok {
 		// it's okay if use: "". we'll assume it's "sig"
 		if usage != "" && usage != jwk.ForSignature.String() {
-			return nil
+			kid, _ := key.KeyID()
+			return fmt.Errorf(`key with kid %q is marked use=%q, not usable for signature verification (expected %q)`, kid, usage, jwk.ForSignature.String())
 		}
 	}
 

--- a/jws/key_provider_test.go
+++ b/jws/key_provider_test.go
@@ -92,3 +92,36 @@ func TestKeySetProviderFetchAllKeysAlgPrefilter(t *testing.T) {
 		require.GreaterOrEqual(t, len(sink.pairs), 2, "both keys should be sunk when header has no alg")
 	})
 }
+
+// TestKeySetProviderUseEncSurfacesError pins the behavior that a JWKS
+// entry with use="enc" is reported as a structured error instead of a
+// silent skip. The common footgun is a consumer who dropped a
+// decryption key into the sig JWKS by mistake; with the silent-skip
+// behavior, Verify used to fail with a generic "could not be verified
+// with any of the keys" message.
+func TestKeySetProviderUseEncSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	rsaRaw, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	rsaKey, err := jwk.Import[jwk.Key](rsaRaw)
+	require.NoError(t, err)
+	require.NoError(t, rsaKey.Set(jwk.KeyIDKey, "signer-kid"))
+	require.NoError(t, rsaKey.Set(jwk.KeyUsageKey, "enc"))
+
+	kp := &keySetProvider{
+		requireKid: false,
+	}
+
+	sig := NewSignature()
+	hdr := NewHeaders()
+	require.NoError(t, hdr.Set(AlgorithmKey, jwa.RS256()))
+	sig.SetProtectedHeaders(hdr)
+
+	err = kp.selectKey(&countingKeySink{}, rsaKey, sig, &Message{})
+	require.Error(t, err, `selectKey should error on use=enc`)
+	require.Contains(t, err.Error(), `signer-kid`, `error should name the kid`)
+	require.Contains(t, err.Error(), `use="enc"`, `error should quote the usage`)
+	require.Contains(t, err.Error(), `not usable for signature verification`,
+		`error should explain the mismatch`)
+}


### PR DESCRIPTION
`keySetProvider.selectKey` silently returned nil when a JWK's `use` was anything other than `sig`. The outer loop then reported the generic 'could not be verified with any of the keys' error with no hint that the selected kid was marked for encryption.

Return an error naming the kid and the offending `use` value. Multi-key iteration paths keep their try-next-key posture through the existing `continue` (now surfaced via `errors.Join` in #2010 when every candidate fails).