### PR TITLE
jws: surface use=enc mismatch as explicit error

### DIFF
--- a/jws/key_provider.go
+++ b/jws/key_provider.go
@@ -118,7 +118,8 @@ func (kp *keySetProvider) selectKey(sink KeySink, key jwk.Key, sig *Signature, _
 	if usage, ok := key.KeyUsage(); ok {
 		// it's okay if use: "". we'll assume it's "sig"
 		if usage != "" && usage != jwk.ForSignature.String() {
-			return false, nil
+			kid, _ := key.KeyID()
+			return false, fmt.Errorf(`key with kid %q is marked use=%q, not usable for signature verification (expected %q)`, kid, usage, jwk.ForSignature.String())
 		}
 	}
 

--- a/jws/key_provider_test.go
+++ b/jws/key_provider_test.go
@@ -92,3 +92,35 @@ func TestKeySetProviderFetchAllKeysAlgPrefilter(t *testing.T) {
 		require.GreaterOrEqual(t, len(sink.pairs), 2, "both keys should be sunk when header has no alg")
 	})
 }
+
+// TestKeySetProviderUseEncSurfacesError pins that a JWKS entry marked
+// use="enc" raises a structured error instead of a silent skip —
+// previously users who dropped an encryption key into their sig JWKS
+// saw only the generic "could not be verified with any of the keys"
+// message.
+func TestKeySetProviderUseEncSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	rsaRaw, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	rsaKey, err := jwk.Import(rsaRaw)
+	require.NoError(t, err)
+	require.NoError(t, rsaKey.Set(jwk.KeyIDKey, "signer-kid"))
+	require.NoError(t, rsaKey.Set(jwk.KeyUsageKey, "enc"))
+
+	kp := &keySetProvider{
+		requireKid: false,
+	}
+
+	sig := NewSignature()
+	hdr := NewHeaders()
+	require.NoError(t, hdr.Set(AlgorithmKey, jwa.RS256()))
+	sig.SetProtectedHeaders(hdr)
+
+	_, err = kp.selectKey(&countingKeySink{}, rsaKey, sig, &Message{})
+	require.Error(t, err, `selectKey should error on use=enc`)
+	require.Contains(t, err.Error(), `signer-kid`, `error should name the kid`)
+	require.Contains(t, err.Error(), `use="enc"`, `error should quote the usage`)
+	require.Contains(t, err.Error(), `not usable for signature verification`,
+		`error should explain the mismatch`)
+}


### PR DESCRIPTION
v3 backport of #2012. `selectKey` now returns an error naming the kid and offending `use` value instead of silently skipping.