### PR TITLE
jwt: wrap unsupported-time-claim error as ValidationError

### DIFF
--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -25,7 +25,7 @@ func isSupportedTimeClaim(c string) error {
 	case ExpirationKey, IssuedAtKey, NotBeforeKey:
 		return nil
 	}
-	return fmt.Errorf(`unsupported time claim %s`, strconv.Quote(c))
+	return validateErrorf(`unsupported time claim %s in jwt.WithMaxDelta/jwt.WithMinDelta`, strconv.Quote(c))
 }
 
 func timeClaim(t Token, clock Clock, c string) time.Time {

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -961,22 +961,14 @@ func TestValidateClockSnapshottedOnce(t *testing.T) {
 	)
 }
 
-func TestValidateNilToken(t *testing.T) {
+func TestValidateUnsupportedTimeClaimIsValidationError(t *testing.T) {
 	t.Parallel()
 
-	t.Run("fast path (no options)", func(t *testing.T) {
-		t.Parallel()
-		err := jwt.Validate(nil)
-		require.Error(t, err, `jwt.Validate(nil) should return an error, not panic`)
-		require.ErrorIs(t, err, jwt.ValidationError{},
-			`nil-token error should be a ValidationError`)
-	})
-
-	t.Run("slow path (with options)", func(t *testing.T) {
-		t.Parallel()
-		err := jwt.Validate(nil, jwt.WithAcceptableSkew(time.Second))
-		require.Error(t, err, `jwt.Validate(nil, ...) should return an error, not panic`)
-		require.ErrorIs(t, err, jwt.ValidationError{},
-			`nil-token error should be a ValidationError`)
-	})
+	tok := jwt.New()
+	err := jwt.Validate(tok, jwt.WithMaxDelta(time.Minute, "custom_claim", jwt.IssuedAtKey))
+	require.Error(t, err, `WithMaxDelta with unsupported claim should error`)
+	require.ErrorIs(t, err, jwt.ValidationError{},
+		`unsupported time claim error should wrap as ValidationError`)
+	require.Contains(t, err.Error(), `custom_claim`,
+		`error should name the offending claim`)
 }


### PR DESCRIPTION
`isSupportedTimeClaim` returned a bare `fmt.Errorf`. Callers using `errors.Is(err, jwt.ValidationError{})` to classify outcomes missed this branch. Wrap via `validateErrorf` and mention the options that can trip it.