### PR TITLE
jwt: wrap unsupported-time-claim error as ValidateError

### DIFF
--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -25,7 +25,7 @@ func isSupportedTimeClaim(c string) error {
 	case ExpirationKey, IssuedAtKey, NotBeforeKey:
 		return nil
 	}
-	return fmt.Errorf(`unsupported time claim %s`, strconv.Quote(c))
+	return jwterrs.ValidateErrorf(`unsupported time claim %s in jwt.WithMaxDelta/jwt.WithMinDelta`, strconv.Quote(c))
 }
 
 func timeClaim(t Token, clock Clock, c string) time.Time {

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -915,22 +915,14 @@ func TestClaimValueIsNonComparable(t *testing.T) {
 	}
 }
 
-func TestValidateNilToken(t *testing.T) {
+func TestValidateUnsupportedTimeClaimIsValidateError(t *testing.T) {
 	t.Parallel()
 
-	t.Run("no options", func(t *testing.T) {
-		t.Parallel()
-		err := jwt.Validate(nil)
-		require.Error(t, err, `jwt.Validate(nil) should return an error, not panic`)
-		require.ErrorIs(t, err, jwt.ValidateError(),
-			`nil-token error should be a ValidateError`)
-	})
-
-	t.Run("with options", func(t *testing.T) {
-		t.Parallel()
-		err := jwt.Validate(nil, jwt.WithAcceptableSkew(time.Second))
-		require.Error(t, err, `jwt.Validate(nil, ...) should return an error, not panic`)
-		require.ErrorIs(t, err, jwt.ValidateError(),
-			`nil-token error should be a ValidateError`)
-	})
+	tok := jwt.New()
+	err := jwt.Validate(tok, jwt.WithMaxDelta(time.Minute, "custom_claim", jwt.IssuedAtKey))
+	require.Error(t, err, `WithMaxDelta with unsupported claim should error`)
+	require.ErrorIs(t, err, jwt.ValidateError(),
+		`unsupported time claim error should wrap as ValidateError`)
+	require.Contains(t, err.Error(), `custom_claim`,
+		`error should name the offending claim`)
 }


### PR DESCRIPTION
v3 backport of #2014. Route `isSupportedTimeClaim` through `jwterrs.ValidateErrorf` so the error participates in the `errors.Is(err, jwt.ValidateError())` chain.