### PR TITLE
jwt: stop using dynamic fmt.Errorf format string in ParseRequest

### DIFF
--- a/jwt/http.go
+++ b/jwt/http.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -227,21 +228,36 @@ func ParseRequest(req *http.Request, options ...ParseOption) (Token, error) {
 	lmhdrs := len(mhdrs)
 	lmfrms := len(mfrms)
 	lmcookies := len(mcookies)
-	var errors []any
+	// Render display text without fmt verbs. A dynamic fmt.Errorf format
+	// string would be brittle: caller-supplied keys flow through
+	// strconv.Quote, but strconv.Quote does not escape '%', so a key
+	// containing '%s' would otherwise turn into a format verb and mangle
+	// output. We instead write the error texts directly and propagate
+	// the underlying errors via errors.Join so errors.Is / errors.As
+	// still traverse them.
+	var errs []error
 	if lmhdrs > 0 || lmfrms > 0 || lmcookies > 0 {
 		b.WriteString(". Additionally, errors were encountered during attempts to verify using:")
 
 		if lmhdrs > 0 {
 			b.WriteString(" headers: (")
 			count := 0
-			for hdrkey, err := range mhdrs {
+			// Iterate the ordered key slices so rendering is
+			// deterministic (map iteration would reorder per run).
+			for _, hdrkey := range hdrkeys {
+				err, ok := mhdrs[hdrkey]
+				if !ok {
+					continue
+				}
 				if count > 0 {
 					b.WriteString(", ")
 				}
 				b.WriteString("[header key: ")
 				b.WriteString(strconv.Quote(hdrkey))
-				b.WriteString(", error: %w]")
-				errors = append(errors, err)
+				b.WriteString(", error: ")
+				b.WriteString(err.Error())
+				b.WriteByte(tokens.CloseSquareBracket)
+				errs = append(errs, err)
 				count++
 			}
 			b.WriteString(")")
@@ -250,32 +266,49 @@ func ParseRequest(req *http.Request, options ...ParseOption) (Token, error) {
 		if lmcookies > 0 {
 			count := 0
 			b.WriteString(" cookies: (")
-			for cookiekey, err := range mcookies {
+			for _, cookiekey := range cookiekeys {
+				err, ok := mcookies[cookiekey]
+				if !ok {
+					continue
+				}
 				if count > 0 {
 					b.WriteString(", ")
 				}
 				b.WriteString("[cookie key: ")
 				b.WriteString(strconv.Quote(cookiekey))
-				b.WriteString(", error: %w]")
-				errors = append(errors, err)
+				b.WriteString(", error: ")
+				b.WriteString(err.Error())
+				b.WriteByte(tokens.CloseSquareBracket)
+				errs = append(errs, err)
 				count++
 			}
+			b.WriteString(")")
 		}
 
 		if lmfrms > 0 {
 			count := 0
 			b.WriteString(" forms: (")
-			for formkey, err := range mfrms {
+			for _, formkey := range formkeys {
+				err, ok := mfrms[formkey]
+				if !ok {
+					continue
+				}
 				if count > 0 {
 					b.WriteString(", ")
 				}
 				b.WriteString("[form key: ")
 				b.WriteString(strconv.Quote(formkey))
-				b.WriteString(", error: %w]")
-				errors = append(errors, err)
+				b.WriteString(", error: ")
+				b.WriteString(err.Error())
+				b.WriteByte(tokens.CloseSquareBracket)
+				errs = append(errs, err)
 				count++
 			}
+			b.WriteString(")")
 		}
 	}
-	return nil, fmt.Errorf(b.String(), errors...)
+	if len(errs) == 0 {
+		return nil, errors.New(b.String())
+	}
+	return nil, fmt.Errorf("%s: %w", b.String(), errors.Join(errs...))
 }

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1118,6 +1118,31 @@ func TestParseRequest(t *testing.T) {
 		require.ErrorIs(t, err, jwt.TokenExpiredError{}, `error should report token expiration, not missing cookie`)
 		require.NotErrorIs(t, err, http.ErrNoCookie, `error must not masquerade as missing cookie`)
 	})
+
+	t.Run("Key names containing %-verbs do not corrupt the error", func(t *testing.T) {
+		// Regression test: ParseRequest used to build a dynamic format
+		// string (b.String() + "%w" placeholders) fed to fmt.Errorf.
+		// strconv.Quote escapes control bytes but not '%', so a header
+		// key such as "X-With-%s-Verb" would turn into a format verb
+		// and mangle the output with "%!s(MISSING)".
+		privkey, _ := jwxtest.GenerateEcdsaJwk()
+		require.NoError(t, privkey.Set(jwk.AlgorithmKey, jwa.ES256()))
+		pub, err := jwk.PublicKeyOf(privkey)
+		require.NoError(t, err)
+
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, u, nil)
+		req.Header.Set("X-With-%s-Verb", "not-a-jwt")
+		_, err = jwt.ParseRequest(req,
+			jwt.WithHeaderKey("X-With-%s-Verb"),
+			jwt.WithKey(jwa.ES256(), pub))
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), `%!s(MISSING)`,
+			`error must not run percent verbs from caller-supplied keys`)
+		require.NotContains(t, err.Error(), `%!(EXTRA `,
+			`error must not carry an extra-args banner`)
+		require.Contains(t, err.Error(), `X-With-%s-Verb`,
+			`error should still include the offending header key verbatim`)
+	})
 }
 
 func TestGHIssue368(t *testing.T) {


### PR DESCRIPTION
The aggregate error built a format string at runtime by appending `, error: %w]` between caller-supplied keys quoted with `strconv.Quote`, then fed the whole thing to `fmt.Errorf`. `strconv.Quote` does not escape `%`, so a key like `X-With-%s-Verb` turned into a format verb. Write the display text without verbs and wrap the per-attempt errors via `errors.Join`. Also iterate the ordered key slices for deterministic output.