### PR TITLE
jwt: point caller at WithStrictBase64Encoding on fast-path base64 errors

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -5,6 +5,7 @@ package jwt
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -321,6 +322,19 @@ func verifyJWS(ctx *parseCtx, payload []byte) ([]byte, int, error) {
 			// that sentinel, fall through to jws.Verify below so
 			// the full validateCritical rule set applies.
 			if !errors.Is(err, jws.ErrCritPresent()) {
+				// The fast path uses strict base64url (RFC 7515).
+				// A caller whose issuer emits padded/standard
+				// base64 can re-run with jwt.WithStrictBase64Encoding(false)
+				// to fall back to jws.Verify's lenient decoder.
+				// The error message itself doesn't point at that
+				// escape hatch, so surface the hint here.
+				var corrupt base64.CorruptInputError
+				if errors.As(err, &corrupt) {
+					return nil, _JwsVerifyDone, fmt.Errorf(
+						`jwt.Parse: base64 decode failed; if the issuer emits padded/standard base64, set jwt.WithStrictBase64Encoding(false): %w`,
+						err,
+					)
+				}
 				return nil, _JwsVerifyDone, err
 			}
 		}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -185,6 +185,9 @@ func TestStrictBase64Encoding(t *testing.T) {
 		t.Parallel()
 		_, err := jwt.Parse(paddedCompact, jwt.WithKey(alg, key))
 		require.Error(t, err, `jwt.Parse should fail: padded payload not decodable with strict base64`)
+		// The error should point the caller at the escape hatch.
+		require.Contains(t, err.Error(), `WithStrictBase64Encoding(false)`,
+			`error should name the option that flips to lenient base64`)
 	})
 
 	// Lenient mode with no verification: auto-detection handles padded base64.

--- a/jwt/parse_fast.go
+++ b/jwt/parse_fast.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -80,6 +81,17 @@ func parseCompactFast(data []byte, ctx *fastParseCtx) (Token, error) {
 		// the default-strict (empty) WithCritExtension allowlist.
 		if errors.Is(err, jws.ErrCritPresent()) {
 			return parseCompactCritFallback(data, ctx)
+		}
+		// The fast path uses strict base64url (RFC 7515). A caller
+		// whose issuer emits padded/standard base64 can re-parse with
+		// jwt.WithStrictBase64Encoding(false) to fall back to the
+		// lenient decoder used by jws.Verify. The underlying error
+		// doesn't point at that escape hatch, so surface the hint
+		// before wrapping.
+		var corrupt base64.CorruptInputError
+		if errors.As(err, &corrupt) {
+			return nil, parseErrorf(`jwt.Parse`,
+				`base64 decode failed; if the issuer emits padded/standard base64, set jwt.WithStrictBase64Encoding(false): %w`, err)
 		}
 		return nil, parseErrorf(`jwt.Parse`, `%w`, err)
 	}


### PR DESCRIPTION
Fast paths (`parseCompactFast` and `verifyJWS`) use `jws.VerifyCompactFast` which decodes with strict RFC 7515 base64url. Callers hitting a padded/standard-base64 token had no obvious hint at the escape hatch. Recognize `base64.CorruptInputError` in the chain and rewrap with a hint pointing at `jwt.WithStrictBase64Encoding(false)`.