### PR TITLE
jws: honor WithContext on streaming verify

### DIFF
--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -127,6 +127,12 @@ options:
       calls unless the Reader is itself goroutine-safe and positioned
       independently for each call.
 
+      On verify, cancellation and deadline expiry from a context
+      supplied via `jws.WithContext()` propagate between Reads on the
+      supplied Reader, so a long-running payload stream from an
+      untrusted source can be interrupted. Supplying a context is
+      recommended whenever the Reader's cost is not strictly bounded.
+
       Only the HMAC, RSA (PKCS#1 v1.5 and PSS), and ECDSA algorithm
       families are supported by this option; EdDSA and custom-family
       algorithms require the full payload in memory and will be rejected

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -373,6 +373,12 @@ func WithDetachedPayload(v []byte) SignVerifyOption {
 // calls unless the Reader is itself goroutine-safe and positioned
 // independently for each call.
 //
+// On verify, cancellation and deadline expiry from a context
+// supplied via `jws.WithContext()` propagate between Reads on the
+// supplied Reader, so a long-running payload stream from an
+// untrusted source can be interrupted. Supplying a context is
+// recommended whenever the Reader's cost is not strictly bounded.
+//
 // Only the HMAC, RSA (PKCS#1 v1.5 and PSS), and ECDSA algorithm
 // families are supported by this option; EdDSA and custom-family
 // algorithms require the full payload in memory and will be rejected

--- a/jws/streaming_detached.go
+++ b/jws/streaming_detached.go
@@ -25,6 +25,8 @@ import (
 // as the ctx.Err() value, short-circuiting the outer io.Copy loop.
 // A zero-length Read is still delivered to the underlying reader so
 // that an empty-payload verify completes normally.
+//
+//nolint:containedctx // narrow, request-scoped wrapper that the caller owns for the lifetime of a single Verify call; storing the ctx is the point.
 type ctxReader struct {
 	ctx context.Context
 	r   io.Reader

--- a/jws/streaming_detached.go
+++ b/jws/streaming_detached.go
@@ -1,6 +1,7 @@
 package jws
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/hmac"
 	"crypto/rsa"
@@ -18,6 +19,33 @@ import (
 	"github.com/lestrrat-go/jwx/v4/jwk"
 	"github.com/lestrrat-go/jwx/v4/jws/jwsbb"
 )
+
+// ctxReader wraps an io.Reader so that ctx.Err() is checked between
+// reads. Any cancellation or deadline expiry propagates out of Read
+// as the ctx.Err() value, short-circuiting the outer io.Copy loop.
+// A zero-length Read is still delivered to the underlying reader so
+// that an empty-payload verify completes normally.
+type ctxReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (c *ctxReader) Read(p []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return c.r.Read(p)
+}
+
+// wrapReaderWithContext returns a Reader that surfaces ctx.Err()
+// between underlying Reads. If ctx is nil or context.Background(),
+// r is returned unchanged to avoid the indirection.
+func wrapReaderWithContext(ctx context.Context, r io.Reader) io.Reader {
+	if ctx == nil || ctx == context.Background() {
+		return r
+	}
+	return &ctxReader{ctx: ctx, r: r}
+}
 
 // This file implements the streaming detached-payload variant of jws.Sign()
 // and jws.Verify(), reached via the jws.WithDetachedPayloadReader() option.
@@ -270,7 +298,13 @@ func (vc *verifyContext) verifyStreaming(buf []byte) ([]byte, error) {
 	if _, err := hasher.Write([]byte{tokens.Period}); err != nil {
 		return nil, makeVerifyError(`failed to write signing prefix: %w`, err)
 	}
-	if err := streamPayloadIntoHashers([]hash.Hash{hasher}, vc.payloadReader, msg.b64, streamEncoder); err != nil {
+	// When the caller supplied a context via WithContext, surface
+	// cancellation and deadline expiry between Reads on the payload
+	// reader. Without this the streaming verify path would ignore ctx
+	// entirely and keep draining an attacker-controlled reader long
+	// after the caller cancelled.
+	payloadReader := wrapReaderWithContext(vc.ctx, vc.payloadReader)
+	if err := streamPayloadIntoHashers([]hash.Hash{hasher}, payloadReader, msg.b64, streamEncoder); err != nil {
 		return nil, makeVerifyError(`failed to stream payload: %w`, err)
 	}
 

--- a/jws/streaming_detached_test.go
+++ b/jws/streaming_detached_test.go
@@ -2,11 +2,13 @@ package jws_test
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	stdbase64 "encoding/base64"
 	stdjson "encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -454,6 +456,58 @@ func TestStreamingDetachedIOErrorMidStream(t *testing.T) {
 		)
 		require.Error(t, err)
 	})
+}
+
+func TestStreamingDetachedVerifyContextCancel(t *testing.T) {
+	t.Parallel()
+
+	payload := make([]byte, 4096)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	privkey, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err)
+
+	signed, err := jws.Sign(nil,
+		jws.WithKey(jwa.RS256(), privkey),
+		jws.WithDetachedPayload(payload),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel immediately
+
+	// A reader that yields one byte per call; without context
+	// plumbing the verifier would drain it to EOF regardless.
+	r := &slowReader{data: payload}
+
+	_, err = jws.Verify(signed,
+		jws.WithKey(jwa.RS256(), &privkey.PublicKey),
+		jws.WithDetachedPayloadReader(r),
+		jws.WithContext(ctx),
+	)
+	require.Error(t, err, `Verify should surface ctx.Err()`)
+	require.ErrorIs(t, err, context.Canceled,
+		`cancellation should propagate as context.Canceled`)
+}
+
+// slowReader returns one byte per Read until data is exhausted, then
+// io.EOF. Forces the streaming verify loop to issue many small Reads.
+type slowReader struct {
+	data []byte
+	i    int
+}
+
+func (s *slowReader) Read(p []byte) (int, error) {
+	if s.i >= len(s.data) {
+		return 0, io.EOF
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	p[0] = s.data[s.i]
+	s.i++
+	return 1, nil
 }
 
 func TestStreamingDetachedWrongKey(t *testing.T) {


### PR DESCRIPTION
`verifyStreaming` drained `vc.payloadReader` to EOF before any signature check, ignoring `vc.ctx` entirely. Callers who passed `WithContext(ctx)` to cancel a long-running verify against an untrusted stream had no recourse.

Wrap the payload reader in a small context-aware `Reader` so `ctx.Err()` is checked between Reads. Option godoc now documents the guarantee. Covered by `TestStreamingDetachedVerifyContextCancel`.