### PR TITLE
jws: fail loudly when WithKey and WithProtectedHeaders carry different kids

### DIFF
--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -2208,3 +2208,39 @@ func TestVerifyCompactFastHeaderAlgCrossCheck(t *testing.T) {
 		require.Contains(t, err.Error(), `"alg"`)
 	})
 }
+
+func TestSignKidConflict(t *testing.T) {
+	t.Parallel()
+
+	key, err := jwxtest.GenerateRsaJwk()
+	require.NoError(t, err)
+	require.NoError(t, key.Set(jwk.KeyIDKey, "key-kid"), `set kid on key`)
+
+	hdr := jws.NewHeaders()
+	require.NoError(t, hdr.Set(jws.KeyIDKey, "header-kid"))
+
+	_, err = jws.Sign([]byte("payload"),
+		jws.WithKey(jwa.RS256(), key, jws.WithProtectedHeaders(hdr)))
+	require.Error(t, err, `Sign should fail on kid mismatch`)
+	require.Contains(t, err.Error(), `header-kid`, `error should name both kids`)
+	require.Contains(t, err.Error(), `key-kid`, `error should name both kids`)
+	require.Contains(t, err.Error(), `conflicting "kid" values`)
+}
+
+func TestSignKidMatch(t *testing.T) {
+	// Sign still succeeds when the caller-supplied kid agrees with the
+	// key's kid — this is a legitimate pattern (e.g. echoing the kid
+	// through a template Headers) and must stay working.
+	t.Parallel()
+
+	key, err := jwxtest.GenerateRsaJwk()
+	require.NoError(t, err)
+	require.NoError(t, key.Set(jwk.KeyIDKey, "same-kid"))
+
+	hdr := jws.NewHeaders()
+	require.NoError(t, hdr.Set(jws.KeyIDKey, "same-kid"))
+
+	_, err = jws.Sign([]byte("payload"),
+		jws.WithKey(jwa.RS256(), key, jws.WithProtectedHeaders(hdr)))
+	require.NoError(t, err, `matching kids should sign cleanly`)
+}

--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -294,6 +294,13 @@ options:
 
       It has no effect if used when `jws.WithKey()` is passed to `jws.Verify()`.
 
+      kid precedence: if the supplied headers include a non-empty "kid"
+      and the `jwk.Key` passed to `jws.WithKey()` also carries a non-empty
+      but different kid, `jws.Sign()` fails with an explicit mismatch
+      error rather than silently letting one win. To force a specific kid
+      from the headers, strip it from the key (e.g. via `key.Remove(jwk.KeyIDKey)`)
+      or the other way around; matching kids on both sides still work.
+
       Note that `jwe.WithProtectedHeaders()` exists as well, but it is a top-level
       `jwe.EncryptOption` passed directly to `jwe.Encrypt()`, not a `jwe.WithKey()`
       suboption. The two serve different roles and have different types; the Go

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -509,6 +509,13 @@ func WithPretty(v bool) WithJSONSuboption {
 //
 // It has no effect if used when `jws.WithKey()` is passed to `jws.Verify()`.
 //
+// kid precedence: if the supplied headers include a non-empty "kid"
+// and the `jwk.Key` passed to `jws.WithKey()` also carries a non-empty
+// but different kid, `jws.Sign()` fails with an explicit mismatch
+// error rather than silently letting one win. To force a specific kid
+// from the headers, strip it from the key (e.g. via `key.Remove(jwk.KeyIDKey)`)
+// or the other way around; matching kids on both sides still work.
+//
 // Note that `jwe.WithProtectedHeaders()` exists as well, but it is a top-level
 // `jwe.EncryptOption` passed directly to `jwe.Encrypt()`, not a `jwe.WithKey()`
 // suboption. The two serve different roles and have different types; the Go

--- a/jws/signature_builder.go
+++ b/jws/signature_builder.go
@@ -127,6 +127,17 @@ func (sb *signatureBuilder) Build(sc *signContext, payload []byte) (buildResult,
 
 	if key, ok := sb.key.(jwk.Key); ok {
 		if kid, ok := key.KeyID(); ok && kid != "" {
+			// If the caller already placed a kid into the protected
+			// header via WithProtectedHeaders and it disagrees with
+			// the jwk.Key's kid, fail loudly. Silently preferring
+			// one is a footgun in multi-kid routing setups; callers
+			// who want the override should strip kid from the key or
+			// omit it from the custom headers.
+			if existing, ok := protected.KeyID(); ok && existing != "" && existing != kid {
+				return br, makeSignError(prefixJwsSign,
+					`conflicting "kid" values: jws.WithProtectedHeaders carries %q but jws.WithKey's jwk.Key carries %q — remove one`,
+					existing, kid)
+			}
 			if err := protected.Set(KeyIDKey, kid); err != nil {
 				return br, makeSignError(prefixJwsSign, `failed to set "kid" header: %w`, err)
 			}


### PR DESCRIPTION
`signatureBuilder.Build` silently overwrote the caller's protected kid with the `jwk.Key`'s kid when both were set. Callers who use `WithProtectedHeaders` for per-call kid routing lost their setting with no signal.

Detect the conflict up-front: error with `conflicting "kid" values` naming both. Matching kids still pass through. Option godoc on `WithProtectedHeaders` documents the rule.