### PR TITLE
jws: rename mutating Protected getter to SetProtectedDefault

### DIFF
--- a/jws/options.go
+++ b/jws/options.go
@@ -75,11 +75,22 @@ type withKey struct {
 	keyPrevalidated bool   // true if algorithm-key validation was done at construction time
 }
 
-// Protected returns the protected headers. If w.protected is nil and v is
-// non-nil, v is stored as the protected headers before returning. This allows
-// callers to provide a default Headers that is used only when none was
-// explicitly configured via WithProtectedHeaders.
-func (w *withKey) Protected(v Headers) Headers {
+// SetProtectedDefault returns the protected headers, installing the
+// supplied default when none was configured via WithProtectedHeaders.
+//
+// Semantics:
+//   - If the caller already configured protected headers via
+//     WithProtectedHeaders, those are returned unchanged; the default
+//     is ignored.
+//   - If none were configured and the default is non-nil, the default
+//     is stored on the option and returned (making the call a side
+//     effect — hence the explicit "Set" prefix).
+//   - If none were configured and the default is nil, nil is returned.
+//
+// The method is both a getter and a conditional setter. The explicit
+// name reflects the side effect so callers reviewing code do not
+// mistake the call for a pure accessor.
+func (w *withKey) SetProtectedDefault(v Headers) Headers {
 	if w.protected == nil && v != nil {
 		w.protected = v
 		// Invalidate the precomputed header JSON because the caller
@@ -301,11 +312,10 @@ type withInsecureNoSignature struct {
 	protected Headers
 }
 
-// Protected returns the protected headers. If w.protected is nil and v is
-// non-nil, v is stored as the protected headers before returning. This allows
-// callers to provide a default Headers that is used only when none was
-// explicitly configured via WithProtectedHeaders.
-func (w *withInsecureNoSignature) Protected(v Headers) Headers {
+// SetProtectedDefault returns the protected headers, installing the
+// supplied default when none was configured via WithProtectedHeaders.
+// See (*withKey).SetProtectedDefault for the full semantics.
+func (w *withInsecureNoSignature) SetProtectedDefault(v Headers) Headers {
 	if w.protected == nil && v != nil {
 		w.protected = v
 	}

--- a/jwt/serialize.go
+++ b/jwt/serialize.go
@@ -140,11 +140,13 @@ func (s *jwsSerializer) Serialize(ctx SerializeCtx, v any) (any, error) {
 	}
 
 	for _, opt := range s.options {
-		pc, ok := option.Get[interface{ Protected(jws.Headers) jws.Headers }](opt)
+		pc, ok := option.Get[interface {
+			SetProtectedDefault(jws.Headers) jws.Headers
+		}](opt)
 		if !ok {
 			continue
 		}
-		hdrs := pc.Protected(jws.NewHeaders())
+		hdrs := pc.SetProtectedDefault(jws.NewHeaders())
 		if err := setTypeOrCty(ctx, hdrs); err != nil {
 			return nil, err // this is already wrapped
 		}


### PR DESCRIPTION
`(*withKey).Protected` looks like a pure accessor but writes to `w.protected` on first call. Rename to `SetProtectedDefault` so the side effect is explicit; applies to `(*withInsecureNoSignature).Protected` as well and the single caller in `jwt/serialize.go`.

Both types are unexported; the method is reachable only via `option.Get[interface{…}](opt)`, so the rename doesn't affect external callers. v4-only.