### PR TITLE
jwk: add WithRejectDuplicateKID parse option

### DIFF
--- a/jwk/interface.go
+++ b/jwk/interface.go
@@ -129,11 +129,12 @@ type Set interface {
 }
 
 type set struct {
-	keys          []Key
-	mu            sync.RWMutex
-	dc            DecodeCtx
-	privateParams map[string]any
-	maxKeys       int // scratch cap consumed by UnmarshalJSON; 0 means use global default
+	keys               []Key
+	mu                 sync.RWMutex
+	dc                 DecodeCtx
+	privateParams      map[string]any
+	maxKeys            int  // scratch cap consumed by UnmarshalJSON; 0 means use global default
+	rejectDuplicateKID bool // scratch flag consumed by UnmarshalJSON; false falls back to global
 }
 
 type PublicKeyer interface {

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -39,6 +39,12 @@ func bigIntToBytes(n *big.Int) ([]byte, error) {
 // alone. Tunable via WithMaxKeys / Settings(WithMaxKeys(...)).
 var maxKeys atomic.Int64
 
+// rejectDuplicateKID makes Parse/UnmarshalJSON fail when the JWKS
+// carries two or more keys with the same non-empty "kid". Default is
+// false (RFC 7517 allows duplicates; LookupKeyID returns the first).
+// Tunable via WithRejectDuplicateKID / Settings(WithRejectDuplicateKID(...)).
+var rejectDuplicateKID atomic.Bool
+
 func init() {
 	maxKeys.Store(1000)
 
@@ -464,6 +470,7 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 	var localReg *json.Registry
 	var ignoreParseError bool
 	maxK := int(maxKeys.Load())
+	rejectDupKid := rejectDuplicateKID.Load()
 	for _, opt := range options {
 		switch opt.Ident() {
 		case identX509{}:
@@ -482,6 +489,8 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 				return nil, parseerr(`WithMaxKeys must be greater than zero, got %d`, v)
 			}
 			maxK = v
+		case identRejectDuplicateKID{}:
+			rejectDupKid = option.MustGet[bool](opt)
 		}
 	}
 
@@ -511,6 +520,11 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 			}
 			src = bytes.TrimSpace(rest)
 		}
+		if rejectDupKid {
+			if kid, dup := firstDuplicateKID(s); dup {
+				return nil, parseerr(`duplicate "kid" %q in PEM input`, kid)
+			}
+		}
 		return s, nil
 	}
 
@@ -533,12 +547,34 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 		setter.setMaxKeys(maxK)
 		defer setter.setMaxKeys(0)
 	}
+	if setter, ok := s.(interface{ setRejectDuplicateKID(bool) }); ok && rejectDupKid {
+		setter.setRejectDuplicateKID(true)
+		defer setter.setRejectDuplicateKID(false)
+	}
 
 	if err := json.Unmarshal(src, s); err != nil {
 		return nil, parseerr(`failed to unmarshal JWK set: %w`, err)
 	}
 
 	return s, nil
+}
+
+// firstDuplicateKID returns the first non-empty kid that appears more
+// than once in s, or ("", false) if every non-empty kid is unique.
+func firstDuplicateKID(s Set) (string, bool) {
+	seen := make(map[string]struct{}, s.Len())
+	for i := range s.Len() {
+		key, _ := s.Key(i)
+		kid, ok := key.KeyID()
+		if !ok || kid == "" {
+			continue
+		}
+		if _, dup := seen[kid]; dup {
+			return kid, true
+		}
+		seen[kid] = struct{}{}
+	}
+	return "", false
 }
 
 // ParseReader parses a JWK set from the incoming byte buffer.
@@ -749,6 +785,8 @@ func Settings(options ...GlobalOption) error {
 			setMinRSAPublicExponent(option.MustGet[int](opt))
 		case identStrictKeyUsage{}:
 			strictKeyUsage.Store(option.MustGet[bool](opt))
+		case identRejectDuplicateKID{}:
+			rejectDuplicateKID.Store(option.MustGet[bool](opt))
 		}
 	}
 

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -2677,3 +2677,61 @@ func TestMaxKeys(t *testing.T) {
 		require.Equal(t, 5, set.Len())
 	})
 }
+
+func TestRejectDuplicateKID(t *testing.T) {
+	keyA, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err)
+	require.NoError(t, keyA.Set(jwk.KeyIDKey, "same-kid"))
+	keyB, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err)
+	require.NoError(t, keyB.Set(jwk.KeyIDKey, "same-kid"))
+
+	aJSON, err := json.Marshal(keyA)
+	require.NoError(t, err)
+	bJSON, err := json.Marshal(keyB)
+	require.NoError(t, err)
+
+	dupPayload := []byte(`{"keys":[` + string(aJSON) + `,` + string(bJSON) + `]}`)
+
+	t.Run("default accepts duplicate kid", func(t *testing.T) {
+		set, err := jwk.Parse(dupPayload)
+		require.NoError(t, err, `default parse should tolerate duplicate kids (RFC 7517 allows)`)
+		require.Equal(t, 2, set.Len(), `both keys should be in the set`)
+	})
+
+	t.Run("per-call rejects duplicate kid", func(t *testing.T) {
+		_, err := jwk.Parse(dupPayload, jwk.WithRejectDuplicateKID(true))
+		require.Error(t, err, `WithRejectDuplicateKID(true) should fail on duplicate kid`)
+		require.Contains(t, err.Error(), `same-kid`, `error should name the duplicate kid`)
+		require.Contains(t, err.Error(), `duplicate`, `error should say "duplicate"`)
+	})
+
+	t.Run("global setting rejects duplicate kid", func(t *testing.T) {
+		require.NoError(t, jwk.Settings(jwk.WithRejectDuplicateKID(true)))
+		defer func() {
+			require.NoError(t, jwk.Settings(jwk.WithRejectDuplicateKID(false)))
+		}()
+		_, err := jwk.Parse(dupPayload)
+		require.Error(t, err, `global WithRejectDuplicateKID should fail on duplicate kid`)
+		require.Contains(t, err.Error(), `same-kid`)
+	})
+
+	t.Run("empty kid entries are ignored", func(t *testing.T) {
+		// Two keys, neither carrying a kid. Reject-duplicates should
+		// still accept — the setting targets explicit duplicates, not
+		// the absence of a kid on multiple keys.
+		noKidA, err := jwxtest.GenerateSymmetricJwk()
+		require.NoError(t, err)
+		noKidB, err := jwxtest.GenerateSymmetricJwk()
+		require.NoError(t, err)
+		aJSON, err := json.Marshal(noKidA)
+		require.NoError(t, err)
+		bJSON, err := json.Marshal(noKidB)
+		require.NoError(t, err)
+		payload := []byte(`{"keys":[` + string(aJSON) + `,` + string(bJSON) + `]}`)
+
+		set, err := jwk.Parse(payload, jwk.WithRejectDuplicateKID(true))
+		require.NoError(t, err, `keyless kids should not trip the duplicate check`)
+		require.Equal(t, 2, set.Len())
+	})
+}

--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -122,6 +122,29 @@ options:
       probe + unmarshal + validation, each of which allocates. Bounding
       raw input bytes remains the caller's responsibility — see
       docs/13-input-size.md.
+  - ident: RejectDuplicateKID
+    interface: GlobalParseOption
+    argument_type: bool
+    comment: |
+      WithRejectDuplicateKID instructs `jwk.Parse()` /
+      `jwk.ParseReader()` / `jwk.ParseString()` and the companion
+      `Set.UnmarshalJSON()` to return an error when the JWKS contains
+      two or more keys with the same non-empty `kid`. Keys without a
+      kid are not considered.
+
+      Default is false — first-match-wins is retained for
+      compatibility with RFC 7517 (which permits, but does not
+      mandate, unique kids) and with existing callers that rely on
+      `(jwk.Set).LookupKeyID` returning the first entry. Use this
+      option when your issuer should guarantee kid uniqueness and a
+      duplicate is a sign of misconfiguration worth surfacing at
+      parse time rather than at verify time.
+
+      Can be set globally via `jwk.Settings()` or per-call on
+      `jwk.Parse()` / `jwk.ParseReader()` / `jwk.ParseString()`.
+
+      This does not affect `(*Set).AddKey` — programmatic additions
+      remain permissive (AddKey dedupes only by pointer identity).
   - ident: AllowSymmetric
     interface: PublicSetOption
     argument_type: bool

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -84,6 +84,7 @@ type identLocalRegistry struct{}
 type identMaxKeys struct{}
 type identMinRSAModulusBits struct{}
 type identMinRSAPublicExponent struct{}
+type identRejectDuplicateKID struct{}
 type identStrictKeyUsage struct{}
 type identThumbprintHash struct{}
 type identX509 struct{}
@@ -114,6 +115,10 @@ func (identMinRSAModulusBits) String() string {
 
 func (identMinRSAPublicExponent) String() string {
 	return "WithMinRSAPublicExponent"
+}
+
+func (identRejectDuplicateKID) String() string {
+	return "WithRejectDuplicateKID"
 }
 
 func (identStrictKeyUsage) String() string {
@@ -218,6 +223,29 @@ func WithMinRSAModulusBits(v int) GlobalOption {
 // minimum-exponent floor.
 func WithMinRSAPublicExponent(v int) GlobalOption {
 	return &globalOption{option.New(identMinRSAPublicExponent{}, v)}
+}
+
+// WithRejectDuplicateKID instructs `jwk.Parse()` /
+// `jwk.ParseReader()` / `jwk.ParseString()` and the companion
+// `Set.UnmarshalJSON()` to return an error when the JWKS contains
+// two or more keys with the same non-empty `kid`. Keys without a
+// kid are not considered.
+//
+// Default is false — first-match-wins is retained for
+// compatibility with RFC 7517 (which permits, but does not
+// mandate, unique kids) and with existing callers that rely on
+// `(jwk.Set).LookupKeyID` returning the first entry. Use this
+// option when your issuer should guarantee kid uniqueness and a
+// duplicate is a sign of misconfiguration worth surfacing at
+// parse time rather than at verify time.
+//
+// Can be set globally via `jwk.Settings()` or per-call on
+// `jwk.Parse()` / `jwk.ParseReader()` / `jwk.ParseString()`.
+//
+// This does not affect `(*Set).AddKey` — programmatic additions
+// remain permissive (AddKey dedupes only by pointer identity).
+func WithRejectDuplicateKID(v bool) GlobalParseOption {
+	return &globalParseOption{option.New(identRejectDuplicateKID{}, v)}
 }
 
 // WithStrictKeyUsage specifies if during JWK parsing, the "use" field

--- a/jwk/options_gen_test.go
+++ b/jwk/options_gen_test.go
@@ -16,6 +16,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithMaxKeys", identMaxKeys{}.String())
 	require.Equal(t, "WithMinRSAModulusBits", identMinRSAModulusBits{}.String())
 	require.Equal(t, "WithMinRSAPublicExponent", identMinRSAPublicExponent{}.String())
+	require.Equal(t, "WithRejectDuplicateKID", identRejectDuplicateKID{}.String())
 	require.Equal(t, "WithStrictKeyUsage", identStrictKeyUsage{}.String())
 	require.Equal(t, "WithThumbprintHash", identThumbprintHash{}.String())
 	require.Equal(t, "WithX509", identX509{}.String())

--- a/jwk/set.go
+++ b/jwk/set.go
@@ -209,6 +209,10 @@ func (s *set) setMaxKeys(n int) {
 	s.maxKeys = n
 }
 
+func (s *set) setRejectDuplicateKID(v bool) {
+	s.rejectDuplicateKID = v
+}
+
 func (s *set) UnmarshalJSON(data []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -229,6 +233,7 @@ func (s *set) UnmarshalJSON(data []byte) error {
 	if maxK <= 0 {
 		maxK = int(maxKeys.Load())
 	}
+	rejectDupKid := s.rejectDuplicateKID || rejectDuplicateKID.Load()
 
 	var sawKeysField bool
 	dec := json.NewDecoder(bytes.NewReader(data))
@@ -257,6 +262,10 @@ func (s *set) UnmarshalJSON(data []byte) error {
 				return fmt.Errorf(`too many keys in "keys" array: got %d, max %d`, len(list), maxK)
 			}
 
+			var seenKIDs map[string]struct{}
+			if rejectDupKid {
+				seenKIDs = make(map[string]struct{}, len(list))
+			}
 			for i, keysrc := range list {
 				key, err := doParseKey(keysrc, options...)
 				if err != nil {
@@ -264,6 +273,14 @@ func (s *set) UnmarshalJSON(data []byte) error {
 						return fmt.Errorf(`failed to decode key #%d in "keys": %w`, i, err)
 					}
 					continue
+				}
+				if seenKIDs != nil {
+					if kid, ok := key.KeyID(); ok && kid != "" {
+						if _, dup := seenKIDs[kid]; dup {
+							return fmt.Errorf(`duplicate "kid" %q in "keys" array`, kid)
+						}
+						seenKIDs[kid] = struct{}{}
+					}
 				}
 				s.keys = append(s.keys, key)
 			}


### PR DESCRIPTION
JWKS sets permit, but do not require, unique `kid` values (RFC 7517). jwx accepts duplicates silently and `LookupKeyID` returns the first match, shadowing the rest.

Add `jwk.WithRejectDuplicateKID` as a `GlobalParseOption`: pass it to `jwk.Settings()` globally or per-call on `jwk.Parse` / `jwk.ParseReader` / `jwk.ParseString`. When true, parser errors on the first duplicate non-empty kid. Default stays false — existing callers see no change.