### PR TITLE
jwk: add WithRejectDuplicateKID parse option

### DIFF
--- a/jwk/interface.go
+++ b/jwk/interface.go
@@ -119,11 +119,12 @@ type Set interface {
 }
 
 type set struct {
-	keys          []Key
-	mu            sync.RWMutex
-	dc            DecodeCtx
-	privateParams map[string]any
-	maxKeys       int // scratch cap consumed by UnmarshalJSON; 0 means use global default
+	keys               []Key
+	mu                 sync.RWMutex
+	dc                 DecodeCtx
+	privateParams      map[string]any
+	maxKeys            int  // scratch cap consumed by UnmarshalJSON; 0 means use global default
+	rejectDuplicateKID bool // scratch flag consumed by UnmarshalJSON; false falls back to global
 }
 
 type PublicKeyer interface {

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -37,6 +37,12 @@ func bigIntToBytes(n *big.Int) ([]byte, error) {
 // size alone. Tunable via WithMaxKeys / Configure(WithMaxKeys(...)).
 var maxKeys atomic.Int64
 
+// rejectDuplicateKID makes Parse/UnmarshalJSON fail when the JWKS
+// carries two or more keys with the same non-empty "kid". Default is
+// false (RFC 7517 allows duplicates; LookupKeyID returns the first).
+// Tunable via WithRejectDuplicateKID / Configure(WithRejectDuplicateKID(...)).
+var rejectDuplicateKID atomic.Bool
+
 func init() {
 	maxKeys.Store(1000)
 
@@ -340,6 +346,7 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 	var ignoreParseError bool
 	var pemDecoder PEMDecoder
 	maxK := int(maxKeys.Load())
+	rejectDupKid := rejectDuplicateKID.Load()
 	for _, option := range options {
 		switch option.Ident() {
 		case identPEM{}:
@@ -367,6 +374,10 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 				return nil, parseerr(`WithMaxKeys must be greater than zero, got %d`, v)
 			}
 			maxK = v
+		case identRejectDuplicateKID{}:
+			if err := option.Value(&rejectDupKid); err != nil {
+				return nil, parseerr(`failed to retrieve RejectDuplicateKID option value: %w`, err)
+			}
 		case identTypedField{}:
 			var pair typedFieldPair // temporary var needed for typed field
 			if err := option.Value(&pair); err != nil {
@@ -405,6 +416,11 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 			}
 			src = bytes.TrimSpace(rest)
 		}
+		if rejectDupKid {
+			if kid, dup := firstDuplicateKID(s); dup {
+				return nil, parseerr(`duplicate "kid" %q in PEM input`, kid)
+			}
+		}
 		return s, nil
 	}
 
@@ -427,12 +443,34 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 		setter.setMaxKeys(maxK)
 		defer setter.setMaxKeys(0)
 	}
+	if setter, ok := s.(interface{ setRejectDuplicateKID(bool) }); ok && rejectDupKid {
+		setter.setRejectDuplicateKID(true)
+		defer setter.setRejectDuplicateKID(false)
+	}
 
 	if err := json.Unmarshal(src, s); err != nil {
 		return nil, parseerr(`failed to unmarshal JWK set: %w`, err)
 	}
 
 	return s, nil
+}
+
+// firstDuplicateKID returns the first non-empty kid that appears more
+// than once in s, or ("", false) if every non-empty kid is unique.
+func firstDuplicateKID(s Set) (string, bool) {
+	seen := make(map[string]struct{}, s.Len())
+	for i := range s.Len() {
+		key, _ := s.Key(i)
+		kid, ok := key.KeyID()
+		if !ok || kid == "" {
+			continue
+		}
+		if _, dup := seen[kid]; dup {
+			return kid, true
+		}
+		seen[kid] = struct{}{}
+	}
+	return "", false
 }
 
 // ParseReader parses a JWK set from the incoming byte buffer.
@@ -767,6 +805,12 @@ func Configure(options ...GlobalOption) {
 			}
 			v64 := int64(v)
 			minRSAPublicExponentPtr = &v64
+		case identRejectDuplicateKID{}:
+			var v bool
+			if err := option.Value(&v); err != nil {
+				continue
+			}
+			rejectDuplicateKID.Store(v)
 		}
 	}
 

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -2980,3 +2980,55 @@ func TestMaxKeys(t *testing.T) {
 		require.Equal(t, 5, set.Len())
 	})
 }
+
+func TestRejectDuplicateKID(t *testing.T) {
+	keyA, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err)
+	require.NoError(t, keyA.Set(jwk.KeyIDKey, "same-kid"))
+	keyB, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err)
+	require.NoError(t, keyB.Set(jwk.KeyIDKey, "same-kid"))
+
+	aJSON, err := json.Marshal(keyA)
+	require.NoError(t, err)
+	bJSON, err := json.Marshal(keyB)
+	require.NoError(t, err)
+
+	dupPayload := []byte(`{"keys":[` + string(aJSON) + `,` + string(bJSON) + `]}`)
+
+	t.Run("default accepts duplicate kid", func(t *testing.T) {
+		set, err := jwk.Parse(dupPayload)
+		require.NoError(t, err, `default parse should tolerate duplicate kids`)
+		require.Equal(t, 2, set.Len())
+	})
+
+	t.Run("per-call rejects duplicate kid", func(t *testing.T) {
+		_, err := jwk.Parse(dupPayload, jwk.WithRejectDuplicateKID(true))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `same-kid`)
+		require.Contains(t, err.Error(), `duplicate`)
+	})
+
+	t.Run("global setting rejects duplicate kid", func(t *testing.T) {
+		jwk.Configure(jwk.WithRejectDuplicateKID(true))
+		defer jwk.Configure(jwk.WithRejectDuplicateKID(false))
+		_, err := jwk.Parse(dupPayload)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `same-kid`)
+	})
+
+	t.Run("empty kid entries are ignored", func(t *testing.T) {
+		noKidA, err := jwxtest.GenerateSymmetricJwk()
+		require.NoError(t, err)
+		noKidB, err := jwxtest.GenerateSymmetricJwk()
+		require.NoError(t, err)
+		aJSON, err := json.Marshal(noKidA)
+		require.NoError(t, err)
+		bJSON, err := json.Marshal(noKidB)
+		require.NoError(t, err)
+		payload := []byte(`{"keys":[` + string(aJSON) + `,` + string(bJSON) + `]}`)
+		set, err := jwk.Parse(payload, jwk.WithRejectDuplicateKID(true))
+		require.NoError(t, err)
+		require.Equal(t, 2, set.Len())
+	})
+}

--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -257,6 +257,29 @@ options:
       The cap defends against amplification: each entry triggers a
       probe + unmarshal + validation, each of which allocates.
       Bounding raw input bytes remains the caller's responsibility.
+  - ident: RejectDuplicateKID
+    interface: GlobalParseOption
+    argument_type: bool
+    comment: |
+      WithRejectDuplicateKID instructs `jwk.Parse()` /
+      `jwk.ParseReader()` / `jwk.ParseString()` and
+      `Set.UnmarshalJSON()` to return an error when the JWKS contains
+      two or more keys with the same non-empty `kid`. Keys without a
+      kid are not considered.
+
+      Default is false — first-match-wins is retained for
+      compatibility with RFC 7517 (which permits, but does not
+      mandate, unique kids) and with existing callers that rely on
+      `(jwk.Set).LookupKeyID` returning the first entry. Use this
+      option when your issuer should guarantee kid uniqueness and a
+      duplicate is a sign of misconfiguration worth surfacing at
+      parse time rather than at verify time.
+
+      Can be set globally via `jwk.Configure()` or per-call on
+      `jwk.Parse()` / `jwk.ParseReader()` / `jwk.ParseString()`.
+
+      This does not affect `(*Set).AddKey` — programmatic additions
+      remain permissive (AddKey dedupes only by pointer identity).
   - ident: AllowSymmetric
     interface: PublicSetOption
     argument_type: bool

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -215,6 +215,7 @@ type identMinRSAModulusBits struct{}
 type identMinRSAPublicExponent struct{}
 type identPEM struct{}
 type identPEMDecoder struct{}
+type identRejectDuplicateKID struct{}
 type identStrictKeyUsage struct{}
 type identThumbprintHash struct{}
 type identWaitReady struct{}
@@ -270,6 +271,10 @@ func (identPEM) String() string {
 
 func (identPEMDecoder) String() string {
 	return "WithPEMDecoder"
+}
+
+func (identRejectDuplicateKID) String() string {
+	return "WithRejectDuplicateKID"
 }
 
 func (identStrictKeyUsage) String() string {
@@ -458,6 +463,29 @@ func WithPEM(v bool) ParseOption {
 // use `jwk.RegisterX509Decoder()` to register a custom X.509 decoder globally.
 func WithPEMDecoder(v PEMDecoder) ParseOption {
 	return &parseOption{option.New(identPEMDecoder{}, v)}
+}
+
+// WithRejectDuplicateKID instructs `jwk.Parse()` /
+// `jwk.ParseReader()` / `jwk.ParseString()` and
+// `Set.UnmarshalJSON()` to return an error when the JWKS contains
+// two or more keys with the same non-empty `kid`. Keys without a
+// kid are not considered.
+//
+// Default is false — first-match-wins is retained for
+// compatibility with RFC 7517 (which permits, but does not
+// mandate, unique kids) and with existing callers that rely on
+// `(jwk.Set).LookupKeyID` returning the first entry. Use this
+// option when your issuer should guarantee kid uniqueness and a
+// duplicate is a sign of misconfiguration worth surfacing at
+// parse time rather than at verify time.
+//
+// Can be set globally via `jwk.Configure()` or per-call on
+// `jwk.Parse()` / `jwk.ParseReader()` / `jwk.ParseString()`.
+//
+// This does not affect `(*Set).AddKey` — programmatic additions
+// remain permissive (AddKey dedupes only by pointer identity).
+func WithRejectDuplicateKID(v bool) GlobalParseOption {
+	return &globalParseOption{option.New(identRejectDuplicateKID{}, v)}
 }
 
 // WithStrictKeyUsage specifies if during JWK parsing, the "use" field

--- a/jwk/options_gen_test.go
+++ b/jwk/options_gen_test.go
@@ -22,6 +22,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithMinRSAPublicExponent", identMinRSAPublicExponent{}.String())
 	require.Equal(t, "WithPEM", identPEM{}.String())
 	require.Equal(t, "WithPEMDecoder", identPEMDecoder{}.String())
+	require.Equal(t, "WithRejectDuplicateKID", identRejectDuplicateKID{}.String())
 	require.Equal(t, "WithStrictKeyUsage", identStrictKeyUsage{}.String())
 	require.Equal(t, "WithThumbprintHash", identThumbprintHash{}.String())
 	require.Equal(t, "WithWaitReady", identWaitReady{}.String())

--- a/jwk/set.go
+++ b/jwk/set.go
@@ -211,6 +211,10 @@ func (s *set) setMaxKeys(n int) {
 	s.maxKeys = n
 }
 
+func (s *set) setRejectDuplicateKID(v bool) {
+	s.rejectDuplicateKID = v
+}
+
 func (s *set) UnmarshalJSON(data []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -231,6 +235,7 @@ func (s *set) UnmarshalJSON(data []byte) error {
 	if maxK <= 0 {
 		maxK = int(maxKeys.Load())
 	}
+	rejectDupKid := s.rejectDuplicateKID || rejectDuplicateKID.Load()
 
 	var sawKeysField bool
 	dec := json.NewDecoder(bytes.NewReader(data))
@@ -263,6 +268,10 @@ LOOP:
 					return fmt.Errorf(`too many keys in "keys" array: got %d, max %d`, len(list), maxK)
 				}
 
+				var seenKIDs map[string]struct{}
+				if rejectDupKid {
+					seenKIDs = make(map[string]struct{}, len(list))
+				}
 				for i, keysrc := range list {
 					key, err := ParseKey(keysrc, options...)
 					if err != nil {
@@ -270,6 +279,14 @@ LOOP:
 							return fmt.Errorf(`failed to decode key #%d in "keys": %w`, i, err)
 						}
 						continue
+					}
+					if seenKIDs != nil {
+						if kid, ok := key.KeyID(); ok && kid != "" {
+							if _, dup := seenKIDs[kid]; dup {
+								return fmt.Errorf(`duplicate "kid" %q in "keys" array`, kid)
+							}
+							seenKIDs[kid] = struct{}{}
+						}
 					}
 					s.keys = append(s.keys, key)
 				}


### PR DESCRIPTION
v3 backport of #2026. Additive option; default unchanged. Covered by `TestRejectDuplicateKID`.