### PR TITLE
jwk: reject duplicate RegisterKeyImporter; add UnregisterKeyImporter

### DIFF
--- a/jwk/convert.go
+++ b/jwk/convert.go
@@ -57,22 +57,55 @@ var keyExporters = make(map[KeyKind][]KeyExporter)
 var muKeyImporters sync.RWMutex
 var muKeyExporters sync.RWMutex
 
-// RegisterKeyImporter registers a typed import function for converting raw keys of
-// type T to jwk.Key. The type is derived from the type parameter, eliminating the
-// need to pass a zero value.
+// RegisterKeyImporter registers a typed import function for converting
+// raw keys of type T to jwk.Key. The type is derived from the type
+// parameter, eliminating the need to pass a zero value.
 //
-// When `jwk.Import()` is called, the library will look up the appropriate importer
-// for the given raw key type (via `reflect`) and execute it.
+// When `jwk.Import()` is called, the library looks up the appropriate
+// importer for the given raw key type (via `reflect`) and executes it.
 //
-// The error return is reserved for future validation. The current
-// implementation always returns nil, but callers — especially extension
-// modules calling this from init() — must check the return value and panic
-// on failure to stay forward-compatible.
+// Importer dispatch is single-valued per Go type T: there is exactly
+// one importer per reflect.Type. Subsequent registrations for the same
+// T return an error ("already registered") and do not replace the
+// previous entry. Callers (e.g. tests) that need to swap an existing
+// importer must first call [UnregisterKeyImporter] for the same T.
+// This intentionally differs from the stacking behavior of
+// [RegisterKeyExporter] and [RegisterKeyParser], which dispatch by
+// [KeyKind] / untyped JSON and therefore have a meaningful fallback
+// chain; importer dispatch is a single-value map keyed by Go type,
+// with no equivalent dimension to try next.
+//
+// Extension modules calling this from init() must check the returned
+// error and panic on failure.
 func RegisterKeyImporter[T any](fn func(T) (Key, error)) error {
 	muKeyImporters.Lock()
 	defer muKeyImporters.Unlock()
-	keyImporters[reflect.TypeFor[T]()] = &keyImportAdapter[T]{fn: fn}
+	t := reflect.TypeFor[T]()
+	if _, exists := keyImporters[t]; exists {
+		return fmt.Errorf(`jwk.RegisterKeyImporter: an importer for %s is already registered; call jwk.UnregisterKeyImporter[%s]() first if you need to replace it`, t, t)
+	}
+	keyImporters[t] = &keyImportAdapter[T]{fn: fn}
 	return nil
+}
+
+// UnregisterKeyImporter removes the importer previously registered
+// for type T. Returns true if an importer was removed, false if none
+// was registered for T.
+//
+// This is primarily useful for tests or for extension modules that
+// need to replace a previously installed importer. In steady-state
+// code, prefer letting [RegisterKeyImporter] fail with the
+// already-registered error; that loud failure catches accidental
+// collisions between unrelated extension modules at import time.
+func UnregisterKeyImporter[T any]() bool {
+	muKeyImporters.Lock()
+	defer muKeyImporters.Unlock()
+	t := reflect.TypeFor[T]()
+	if _, ok := keyImporters[t]; !ok {
+		return false
+	}
+	delete(keyImporters, t)
+	return true
 }
 
 // RegisterKeyExporter registers a [KeyExporter] for the given [KeyKind] identity.

--- a/jwk/convert_test.go
+++ b/jwk/convert_test.go
@@ -1,6 +1,7 @@
 package jwk_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v4/jwa"
@@ -79,10 +80,16 @@ func TestMigrationRecipe10KeyImporterSyntax(t *testing.T) {
 // dupImporterKey is a fake raw key type used by TestRegisterKeyImporterRejectsDuplicate.
 // It is intentionally package-local so it does not collide with any
 // built-in importer.
-type dupImporterKey struct{ body string }
+type dupImporterKey struct{}
 
 func TestRegisterKeyImporterRejectsDuplicate(t *testing.T) {
-	fn := func(dupImporterKey) (jwk.Key, error) { return nil, nil }
+	// Importer body isn't exercised — the test only asserts that the
+	// Register/Unregister bookkeeping is correct. Return a non-nil
+	// error so the function doesn't look like a (nil, nil) sentinel
+	// that nilnil flags.
+	fn := func(dupImporterKey) (jwk.Key, error) {
+		return nil, errors.New("dupImporterKey: importer body not exercised by this test")
+	}
 
 	t.Run("first registration succeeds", func(t *testing.T) {
 		require.NoError(t, jwk.RegisterKeyImporter(fn))

--- a/jwk/convert_test.go
+++ b/jwk/convert_test.go
@@ -75,3 +75,41 @@ func TestMigrationRecipe10KeyImporterSyntax(t *testing.T) {
 	require.True(t, ok, "imported key should carry the KID set by the importer")
 	require.Equal(t, "recipe10", kid, "KID should match the value set by the importer")
 }
+
+// dupImporterKey is a fake raw key type used by TestRegisterKeyImporterRejectsDuplicate.
+// It is intentionally package-local so it does not collide with any
+// built-in importer.
+type dupImporterKey struct{ body string }
+
+func TestRegisterKeyImporterRejectsDuplicate(t *testing.T) {
+	fn := func(dupImporterKey) (jwk.Key, error) { return nil, nil }
+
+	t.Run("first registration succeeds", func(t *testing.T) {
+		require.NoError(t, jwk.RegisterKeyImporter(fn))
+		defer jwk.UnregisterKeyImporter[dupImporterKey]()
+	})
+
+	t.Run("duplicate registration is rejected", func(t *testing.T) {
+		require.NoError(t, jwk.RegisterKeyImporter(fn))
+		defer jwk.UnregisterKeyImporter[dupImporterKey]()
+
+		err := jwk.RegisterKeyImporter(fn)
+		require.Error(t, err, `second RegisterKeyImporter should error`)
+		require.Contains(t, err.Error(), `already registered`,
+			`error should say the type is already registered`)
+	})
+
+	t.Run("Unregister + Register allows replacement", func(t *testing.T) {
+		require.NoError(t, jwk.RegisterKeyImporter(fn))
+		require.True(t, jwk.UnregisterKeyImporter[dupImporterKey](),
+			`UnregisterKeyImporter should report removal`)
+		require.NoError(t, jwk.RegisterKeyImporter(fn),
+			`RegisterKeyImporter should succeed after Unregister`)
+		defer jwk.UnregisterKeyImporter[dupImporterKey]()
+	})
+
+	t.Run("Unregister on unknown type returns false", func(t *testing.T) {
+		require.False(t, jwk.UnregisterKeyImporter[dupImporterKey](),
+			`Unregister should return false when no importer was registered`)
+	})
+}


### PR DESCRIPTION
`RegisterKeyImporter[T]` silently overwrote previous importers for the same `T`. Extensions or tests colliding with built-ins had no signal. Change to return an error on duplicate registration; add `UnregisterKeyImporter[T]()` for callers that need to swap (tests, deliberate replacements).

Godoc explains why importer dispatch is single-valued per Go type (no `ContinueError` chain exists) and why this differs from `RegisterKeyExporter` / `RegisterKeyParser`. Covered by `TestRegisterKeyImporterRejectsDuplicate`.