### PR TITLE
jws/jwe/jwk/jwt: add error return to Unregister* API surface

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -1246,6 +1246,14 @@ func RegisterCustomDecoder[T any](name string, dec CustomDecodeFunc[T]) error {
 }
 
 // UnregisterCustomField removes the registration for a custom field.
-func UnregisterCustomField(name string) {
+//
+// The error return is reserved for future validation (for example,
+// refusing to unregister a built-in field) and is always nil today.
+// Callers — especially extension modules scripting Register/Unregister
+// cycles from init() — should check the returned value and propagate
+// on failure to stay forward-compatible, matching the convention on
+// [RegisterCustomField] / [RegisterCustomDecoder].
+func UnregisterCustomField(name string) error {
 	registry.Unregister(name)
+	return nil
 }

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -659,8 +659,16 @@ func RegisterCustomDecoder[T any](name string, dec CustomDecodeFunc[T]) error {
 }
 
 // UnregisterCustomField removes the registration for a custom field.
-func UnregisterCustomField(name string) {
+//
+// The error return is reserved for future validation (for example,
+// refusing to unregister a built-in field) and is always nil today.
+// Callers — especially extension modules scripting Register/Unregister
+// cycles from init() — should check the returned value and propagate
+// on failure to stay forward-compatible, matching the convention on
+// [RegisterCustomField] / [RegisterCustomDecoder].
+func UnregisterCustomField(name string) error {
 	fieldRegistry.Unregister(name)
+	return nil
 }
 
 // Equal compares two keys and returns true if they are equal. The comparison

--- a/jwk/jwkbb/x509_registry.go
+++ b/jwk/jwkbb/x509_registry.go
@@ -242,10 +242,17 @@ func RegisterX509Decoder[T any](blockType string, decoder X509Decoder[T]) error 
 
 // UnregisterX509Decoder removes the decoder registered for blockType.
 // A no-op if no decoder is registered for blockType.
-func UnregisterX509Decoder(blockType string) {
+//
+// The error return is reserved for future validation (for example,
+// refusing to unregister a built-in block type) and is always nil
+// today. Callers scripting Register/Unregister cycles should check
+// the returned value and propagate on failure to stay forward-
+// compatible, matching the convention on [RegisterX509Decoder].
+func UnregisterX509Decoder(blockType string) error {
 	muX509.Lock()
 	defer muX509.Unlock()
 	delete(x509Decoders, blockType)
+	return nil
 }
 
 // DecodeX509 dispatches block to the decoder registered for
@@ -283,12 +290,19 @@ func RegisterX509Encoder[T any](encoder X509Encoder[T]) error {
 	return nil
 }
 
-// UnregisterX509Encoder removes the encoder registered for type T. A
-// no-op if no encoder is registered for T.
-func UnregisterX509Encoder[T any]() {
+// UnregisterX509Encoder removes the encoder registered for type T.
+// A no-op if no encoder is registered for T.
+//
+// The error return is reserved for future validation (for example,
+// refusing to unregister a built-in type) and is always nil today.
+// Callers scripting Register/Unregister cycles should check the
+// returned value and propagate on failure to stay forward-
+// compatible, matching the convention on [RegisterX509Encoder].
+func UnregisterX509Encoder[T any]() error {
 	muX509.Lock()
 	defer muX509.Unlock()
 	delete(x509Encoders, reflect.TypeFor[T]())
+	return nil
 }
 
 // EncodePEM encodes each key into a PEM block and returns the

--- a/jwk/usage.go
+++ b/jwk/usage.go
@@ -32,10 +32,18 @@ func RegisterKeyUsage(v string) error {
 	return nil
 }
 
-func UnregisterKeyUsage(v string) {
+// UnregisterKeyUsage removes v from the allowlist maintained by
+// [RegisterKeyUsage]. The error return is reserved for future
+// validation (for example, refusing to unregister a built-in usage
+// value like "sig" or "enc") and is always nil today. Callers
+// scripting Register/Unregister cycles should check the returned
+// value and propagate on failure to stay forward-compatible,
+// matching the convention on [RegisterKeyUsage].
+func UnregisterKeyUsage(v string) error {
 	muKeyUsageName.Lock()
 	defer muKeyUsageName.Unlock()
 	delete(keyUsageNames, v)
+	return nil
 }
 
 func init() {

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -478,8 +478,16 @@ func RegisterCustomDecoder[T any](name string, dec CustomDecodeFunc[T]) error {
 }
 
 // UnregisterCustomField removes the registration for a custom field.
-func UnregisterCustomField(name string) {
+//
+// The error return is reserved for future validation (for example,
+// refusing to unregister a built-in field) and is always nil today.
+// Callers — especially extension modules scripting Register/Unregister
+// cycles from init() — should check the returned value and propagate
+// on failure to stay forward-compatible, matching the convention on
+// [RegisterCustomField] / [RegisterCustomDecoder].
+func UnregisterCustomField(name string) error {
 	registry.Unregister(name)
+	return nil
 }
 
 // Helpers for signature verification

--- a/jws/signer.go
+++ b/jws/signer.go
@@ -81,8 +81,16 @@ func RegisterSigner(alg jwa.SignatureAlgorithm, s Signer) error {
 // some other operation (however unlikely, it is still possible).
 // Therefore, in order to completely remove the algorithm, you must
 // call jwa.UnregisterSignatureAlgorithm yourself.
-func UnregisterSigner(alg jwa.SignatureAlgorithm) {
+//
+// The error return is reserved for future validation (for example,
+// refusing to unregister a built-in algorithm) and is always nil
+// today. Callers — especially those scripting
+// Register/Unregister cycles from init() — should check the
+// returned value and propagate on failure to stay
+// forward-compatible, matching the convention on [RegisterSigner].
+func UnregisterSigner(alg jwa.SignatureAlgorithm) error {
 	signerDB.Delete(alg)
+	return nil
 }
 
 type noneSigner struct{}

--- a/jws/verifier.go
+++ b/jws/verifier.go
@@ -70,6 +70,14 @@ func RegisterVerifier(alg jwa.SignatureAlgorithm, v Verifier) error {
 // some other operation (however unlikely, it is still possible).
 // Therefore, in order to completely remove the algorithm, you must
 // call jwa.UnregisterSignatureAlgorithm yourself.
-func UnregisterVerifier(alg jwa.SignatureAlgorithm) {
+//
+// The error return is reserved for future validation (for example,
+// refusing to unregister a built-in algorithm) and is always nil
+// today. Callers — especially those scripting
+// Register/Unregister cycles from init() — should check the
+// returned value and propagate on failure to stay
+// forward-compatible, matching the convention on [RegisterVerifier].
+func UnregisterVerifier(alg jwa.SignatureAlgorithm) error {
 	verifierDB.Delete(alg)
+	return nil
 }

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -610,8 +610,16 @@ func RegisterCustomDecoder[T any](name string, dec CustomDecodeFunc[T]) error {
 }
 
 // UnregisterCustomField removes the registration for a custom field.
-func UnregisterCustomField(name string) {
+//
+// The error return is reserved for future validation (for example,
+// refusing to unregister a built-in field) and is always nil today.
+// Callers — especially extension modules scripting Register/Unregister
+// cycles from init() — should check the returned value and propagate
+// on failure to stay forward-compatible, matching the convention on
+// [RegisterCustomField] / [RegisterCustomDecoder].
+func UnregisterCustomField(name string) error {
 	registry.Unregister(name)
+	return nil
 }
 
 func getDefaultTruncation() time.Duration {

--- a/jwt/openid/openid.go
+++ b/jwt/openid/openid.go
@@ -47,6 +47,14 @@ func RegisterCustomDecoder[T any](name string, dec json.CustomDecodeFunc[T]) err
 }
 
 // UnregisterCustomField removes the registration for a custom field.
-func UnregisterCustomField(name string) {
+//
+// The error return is reserved for future validation (for example,
+// refusing to unregister a built-in field) and is always nil today.
+// Callers — especially extension modules scripting Register/Unregister
+// cycles from init() — should check the returned value and propagate
+// on failure to stay forward-compatible, matching the convention on
+// [RegisterCustomField] / [RegisterCustomDecoder].
+func UnregisterCustomField(name string) error {
 	registry.Unregister(name)
+	return nil
 }


### PR DESCRIPTION
`Register*` functions return `error`; `Unregister*` counterparts were void. That asymmetry leaves no room for future validation (e.g. refusing to unregister a built-in).

Add an `error` return to `UnregisterSigner`, `UnregisterVerifier`, `UnregisterCustomField` (jws/jwe/jwk/jwt/openid), `UnregisterKeyUsage`, and `jwkbb.UnregisterX509Decoder` / `jwkbb.UnregisterX509Encoder`. All return nil today; the return is reserved for future validation.

The `jwa.Unregister*Algorithm` family is generator-produced and out of scope here; a follow-up will update the jwa generator. v4-only.