### PR TITLE
jws: move streaming option-combo checks into ProcessOptions

### DIFF
--- a/jws/sign_context.go
+++ b/jws/sign_context.go
@@ -127,6 +127,14 @@ func (sc *signContext) ProcessOptions(options []SignOption) error {
 			return makeSignError(prefixJwsSign, `invalid jws.SignOption %q passed`, `With`+strings.TrimPrefix(fmt.Sprintf(`%T`, opt.Ident()), `jws.ident`))
 		}
 	}
+
+	// Streaming sign rejects WithInsecureNoSignature up-front so the
+	// caller's payload Reader is not touched. The narrower streaming
+	// signer used to catch this after touching the reader.
+	if sc.payloadReader != nil && sc.none != nil {
+		return makeSignError(prefixJwsSign, `jws.WithInsecureNoSignature() cannot be combined with jws.WithDetachedPayloadReader(); use jws.Sign with jws.WithInsecureNoSignature() if you really need an unsecured in-memory JWS`)
+	}
+
 	return nil
 }
 

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -140,6 +140,20 @@ func (vc *verifyContext) ProcessOptions(options []VerifyOption) error {
 		return makeVerifyError(`no verifiers available. Specify an algorithm and a key using jws.WithKey() (or jws.WithKeySet(), jws.WithKeyProvider(), or jws.WithVerifyAuto())`)
 	}
 
+	// Streaming verify has a narrower option surface than the full
+	// jws.Verify. The check used to fire deep inside verifyStreaming
+	// after Parse; hoist it here so a malformed option combination
+	// rejects before the caller's payload Reader is touched and
+	// before any parse work is done.
+	if vc.payloadReader != nil {
+		if len(vc.keyProviders) != 1 {
+			return makeVerifyError(`jws.WithDetachedPayloadReader() requires exactly one jws.WithKey(); jws.WithKeySet(), jws.WithKeyProvider() and jws.WithVerifyAuto() are not supported on the streaming path`)
+		}
+		if _, ok := vc.keyProviders[0].(*staticKeyProvider); !ok {
+			return makeVerifyError(`jws.WithDetachedPayloadReader() requires exactly one jws.WithKey(); jws.WithKeySet(), jws.WithKeyProvider() and jws.WithVerifyAuto() are not supported on the streaming path`)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Illegal option combos for `jws.WithDetachedPayloadReader` were rejected deep inside `verifyStreaming` / `signStreaming` — after Parse and after the caller's payload Reader had been touched. Hoist the checks to `ProcessOptions` in `verify_context` and `sign_context` so the rejection fires before any parse or reader I/O.

v4-only. The deep-path checks in `streaming_detached.go` remain as defensive fallbacks.