### PR TITLE
jwk/jws/jwe: add FieldNotFoundError and FieldTypeMismatchError

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -43,6 +43,15 @@ Only `jwt.UnknownPayloadTypeError()` remains a sentinel function (no struct type
 | Type | Structured Fields | Meaning |
 |------|------------------|---------|
 | `KeyTypeMismatchError` | `Got`, `Want` (both `reflect.Type`) | Generic type parameter on `Import[T]` / `ParseKeyAs[T]` does not match the resolved key type |
+| `FieldNotFoundError` | `Name` | Field not present (`jwk.Get` miss) |
+| `FieldTypeMismatchError` | `Name`, `Got`, `Want` | Field present but wrong type (`jwk.Get` type assertion failed) |
+
+## Exported Error Types (jws)
+
+| Type | Structured Fields | Meaning |
+|------|------------------|---------|
+| `FieldNotFoundError` | `Name` | Header field not present (`jws.Get` miss) |
+| `FieldTypeMismatchError` | `Name`, `Got`, `Want` | Header field present but wrong type (`jws.Get` type assertion failed) |
 
 ## Exported Error Types (jwe)
 
@@ -50,6 +59,8 @@ Only `jwt.UnknownPayloadTypeError()` remains a sentinel function (no struct type
 |------|------------------|---------|
 | `MissingContentEncryptionError` | *(none)* | `enc` missing from protected headers during `Decrypt` |
 | `AlgorithmMismatchError` | `Expected`, `Got` (both `jwa.KeyEncryptionAlgorithm`) | Per-recipient/protected `alg` does not match the key's algorithm |
+| `FieldNotFoundError` | `Name` | Header field not present (`jwe.Get` miss) |
+| `FieldTypeMismatchError` | `Name`, `Got`, `Want` | Header field present but wrong type (`jwe.Get` type assertion failed) |
 
 ## Sentinel Function Registry
 

--- a/jwe/accessors.go
+++ b/jwe/accessors.go
@@ -1,7 +1,5 @@
 package jwe
 
-import "fmt"
-
 // Get is a type-safe generic accessor that retrieves a header field value.
 // It returns the value and an error if the field does not exist or cannot be
 // converted to type T.
@@ -10,15 +8,20 @@ import "fmt"
 //
 //	kid, err := jwe.Get[string](headers, jwe.KeyIDKey)
 //	custom, err := jwe.Get[MyType](headers, "my-custom-field")
+//
+// Callers that need to distinguish "field missing" from "field present
+// but wrong type" should use [errors.Is] with [FieldNotFoundError]{} /
+// [FieldTypeMismatchError]{}, or [errors.AsType] to recover the Name,
+// Got, and Want fields.
 func Get[T any](headers Headers, name string) (T, error) {
 	var zero T
 	v, ok := headers.Field(name)
 	if !ok {
-		return zero, fmt.Errorf(`jwe.Get: field %q not found`, name)
+		return zero, FieldNotFoundError{Name: name}
 	}
 	result, ok := v.(T)
 	if !ok {
-		return zero, fmt.Errorf(`jwe.Get: field %q is %T, not %T`, name, v, zero)
+		return zero, FieldTypeMismatchError{Name: name, Got: v, Want: zero}
 	}
 	return result, nil
 }

--- a/jwe/accessors_test.go
+++ b/jwe/accessors_test.go
@@ -1,0 +1,38 @@
+package jwe_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwe"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTypedErrors(t *testing.T) {
+	t.Parallel()
+
+	hdr := jwe.NewHeaders()
+	require.NoError(t, hdr.Set(jwe.KeyIDKey, "my-kid"))
+
+	t.Run("missing field returns FieldNotFoundError", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwe.Get[string](hdr, "nonexistent-field")
+		require.Error(t, err)
+		require.ErrorIs(t, err, jwe.FieldNotFoundError{})
+
+		nf, ok := errors.AsType[jwe.FieldNotFoundError](err)
+		require.True(t, ok)
+		require.Equal(t, "nonexistent-field", nf.Name)
+	})
+
+	t.Run("type mismatch returns FieldTypeMismatchError", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwe.Get[int](hdr, jwe.KeyIDKey)
+		require.Error(t, err)
+		require.ErrorIs(t, err, jwe.FieldTypeMismatchError{})
+
+		mm, ok := errors.AsType[jwe.FieldTypeMismatchError](err)
+		require.True(t, ok)
+		require.Equal(t, jwe.KeyIDKey, mm.Name)
+	})
+}

--- a/jwe/errors.go
+++ b/jwe/errors.go
@@ -195,3 +195,54 @@ func (AlgorithmMismatchError) Is(target error) bool {
 	_, ok := target.(AlgorithmMismatchError)
 	return ok
 }
+
+//-------------------------------------------------------------------
+// FieldNotFoundError
+//-------------------------------------------------------------------
+
+// FieldNotFoundError is returned when jwe.Get fails to find the
+// requested field on a jwe.Headers.
+type FieldNotFoundError struct {
+	// Name is the name of the field that was not found.
+	Name string
+}
+
+func (e FieldNotFoundError) Error() string {
+	return fmt.Sprintf(`field %q not found`, e.Name)
+}
+
+func (e FieldNotFoundError) Is(target error) bool {
+	_, ok := target.(FieldNotFoundError)
+	return ok
+}
+
+//-------------------------------------------------------------------
+// FieldTypeMismatchError
+//-------------------------------------------------------------------
+
+// FieldTypeMismatchError is returned when jwe.Get finds the requested
+// field but the stored value cannot be converted to the requested type.
+//
+// Callers that need to distinguish "field missing" from "field present
+// but wrong type" should use errors.Is with FieldNotFoundError{} /
+// FieldTypeMismatchError{}, or errors.AsType to recover Name, Got, and
+// Want fields.
+type FieldTypeMismatchError struct {
+	// Name is the name of the field whose value could not be converted.
+	Name string
+	// Got is the value currently stored under the field. Use %T to
+	// inspect its concrete type.
+	Got any
+	// Want is a zero value of the requested type T. Use %T to inspect
+	// its concrete type.
+	Want any
+}
+
+func (e FieldTypeMismatchError) Error() string {
+	return fmt.Sprintf(`field %q is %T, not %T`, e.Name, e.Got, e.Want)
+}
+
+func (e FieldTypeMismatchError) Is(target error) bool {
+	_, ok := target.(FieldTypeMismatchError)
+	return ok
+}

--- a/jwk/accessors.go
+++ b/jwk/accessors.go
@@ -1,7 +1,5 @@
 package jwk
 
-import "fmt"
-
 // Get is a type-safe generic accessor that retrieves a field value from a key.
 // It returns the value and an error if the field does not exist or cannot be
 // converted to type T.
@@ -10,15 +8,20 @@ import "fmt"
 //
 //	kid, err := jwk.Get[string](key, jwk.KeyIDKey)
 //	custom, err := jwk.Get[MyType](key, "my-custom-field")
+//
+// Callers that need to distinguish "field missing" from "field present
+// but wrong type" should use [errors.Is] with [FieldNotFoundError]{} /
+// [FieldTypeMismatchError]{}, or [errors.AsType] to recover the Name,
+// Got, and Want fields.
 func Get[T any](key Key, name string) (T, error) {
 	var zero T
 	v, ok := key.Field(name)
 	if !ok {
-		return zero, fmt.Errorf(`jwk.Get: field %q not found`, name)
+		return zero, FieldNotFoundError{Name: name}
 	}
 	result, ok := v.(T)
 	if !ok {
-		return zero, fmt.Errorf(`jwk.Get: field %q is %T, not %T`, name, v, zero)
+		return zero, FieldTypeMismatchError{Name: name, Got: v, Want: zero}
 	}
 	return result, nil
 }

--- a/jwk/accessors_test.go
+++ b/jwk/accessors_test.go
@@ -1,0 +1,42 @@
+package jwk_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/internal/jwxtest"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTypedErrors(t *testing.T) {
+	t.Parallel()
+
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err)
+	require.NoError(t, key.Set(jwk.KeyIDKey, "my-kid"))
+
+	t.Run("missing field returns FieldNotFoundError", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwk.Get[string](key, "nonexistent-field")
+		require.Error(t, err)
+		require.ErrorIs(t, err, jwk.FieldNotFoundError{}, `type check via errors.Is should match`)
+
+		nf, ok := errors.AsType[jwk.FieldNotFoundError](err)
+		require.True(t, ok, `errors.AsType should recover FieldNotFoundError`)
+		require.Equal(t, "nonexistent-field", nf.Name)
+	})
+
+	t.Run("type mismatch returns FieldTypeMismatchError", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwk.Get[int](key, jwk.KeyIDKey)
+		require.Error(t, err)
+		require.ErrorIs(t, err, jwk.FieldTypeMismatchError{})
+
+		mm, ok := errors.AsType[jwk.FieldTypeMismatchError](err)
+		require.True(t, ok, `errors.AsType should recover FieldTypeMismatchError`)
+		require.Equal(t, jwk.KeyIDKey, mm.Name)
+		require.IsType(t, "", mm.Got, `Got should be the stored string`)
+		require.IsType(t, 0, mm.Want, `Want should be int zero`)
+	})
+}

--- a/jwk/errors.go
+++ b/jwk/errors.go
@@ -116,3 +116,55 @@ func typeName(t reflect.Type) string {
 	}
 	return t.String()
 }
+
+//-------------------------------------------------------------------
+// FieldNotFoundError
+//-------------------------------------------------------------------
+
+// FieldNotFoundError is returned when jwk.Get fails to find the
+// requested field on a jwk.Key.
+type FieldNotFoundError struct {
+	// Name is the name of the field that was not found.
+	Name string
+}
+
+func (e FieldNotFoundError) Error() string {
+	return fmt.Sprintf(`field %q not found`, e.Name)
+}
+
+func (e FieldNotFoundError) Is(target error) bool {
+	_, ok := target.(FieldNotFoundError)
+	return ok
+}
+
+//-------------------------------------------------------------------
+// FieldTypeMismatchError
+//-------------------------------------------------------------------
+
+// FieldTypeMismatchError is returned when jwk.Get finds the
+// requested field but the stored value cannot be converted to the
+// requested type.
+//
+// Callers that need to distinguish "field missing" from "field present
+// but wrong type" should use errors.Is with FieldNotFoundError{} /
+// FieldTypeMismatchError{}, or errors.AsType to recover Name, Got,
+// and Want fields.
+type FieldTypeMismatchError struct {
+	// Name is the name of the field whose value could not be converted.
+	Name string
+	// Got is the value currently stored under the field. Use %T to
+	// inspect its concrete type.
+	Got any
+	// Want is a zero value of the requested type T. Use %T to inspect
+	// its concrete type.
+	Want any
+}
+
+func (e FieldTypeMismatchError) Error() string {
+	return fmt.Sprintf(`field %q is %T, not %T`, e.Name, e.Got, e.Want)
+}
+
+func (e FieldTypeMismatchError) Is(target error) bool {
+	_, ok := target.(FieldTypeMismatchError)
+	return ok
+}

--- a/jws/accessors.go
+++ b/jws/accessors.go
@@ -1,7 +1,5 @@
 package jws
 
-import "fmt"
-
 // Get is a type-safe generic accessor that retrieves a header field value.
 // It returns the value and an error if the field does not exist or cannot be
 // converted to type T.
@@ -10,15 +8,20 @@ import "fmt"
 //
 //	kid, err := jws.Get[string](headers, jws.KeyIDKey)
 //	custom, err := jws.Get[MyType](headers, "my-custom-field")
+//
+// Callers that need to distinguish "field missing" from "field present
+// but wrong type" should use [errors.Is] with [FieldNotFoundError]{} /
+// [FieldTypeMismatchError]{}, or [errors.AsType] to recover the Name,
+// Got, and Want fields.
 func Get[T any](headers Headers, name string) (T, error) {
 	var zero T
 	v, ok := headers.Field(name)
 	if !ok {
-		return zero, fmt.Errorf(`jws.Get: field %q not found`, name)
+		return zero, FieldNotFoundError{Name: name}
 	}
 	result, ok := v.(T)
 	if !ok {
-		return zero, fmt.Errorf(`jws.Get: field %q is %T, not %T`, name, v, zero)
+		return zero, FieldTypeMismatchError{Name: name, Got: v, Want: zero}
 	}
 	return result, nil
 }

--- a/jws/accessors_test.go
+++ b/jws/accessors_test.go
@@ -1,0 +1,38 @@
+package jws_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jws"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTypedErrors(t *testing.T) {
+	t.Parallel()
+
+	hdr := jws.NewHeaders()
+	require.NoError(t, hdr.Set(jws.KeyIDKey, "my-kid"))
+
+	t.Run("missing field returns FieldNotFoundError", func(t *testing.T) {
+		t.Parallel()
+		_, err := jws.Get[string](hdr, "nonexistent-field")
+		require.Error(t, err)
+		require.ErrorIs(t, err, jws.FieldNotFoundError{})
+
+		nf, ok := errors.AsType[jws.FieldNotFoundError](err)
+		require.True(t, ok)
+		require.Equal(t, "nonexistent-field", nf.Name)
+	})
+
+	t.Run("type mismatch returns FieldTypeMismatchError", func(t *testing.T) {
+		t.Parallel()
+		_, err := jws.Get[int](hdr, jws.KeyIDKey)
+		require.Error(t, err)
+		require.ErrorIs(t, err, jws.FieldTypeMismatchError{})
+
+		mm, ok := errors.AsType[jws.FieldTypeMismatchError](err)
+		require.True(t, ok)
+		require.Equal(t, jws.KeyIDKey, mm.Name)
+	})
+}

--- a/jws/errors.go
+++ b/jws/errors.go
@@ -120,3 +120,54 @@ func (parseError) Is(err error) bool {
 func makeParseError(prefix string, f string, args ...any) error {
 	return parseError{fmt.Errorf(prefix+": "+f, args...)}
 }
+
+//-------------------------------------------------------------------
+// FieldNotFoundError
+//-------------------------------------------------------------------
+
+// FieldNotFoundError is returned when jws.Get fails to find the
+// requested field on a jws.Headers.
+type FieldNotFoundError struct {
+	// Name is the name of the field that was not found.
+	Name string
+}
+
+func (e FieldNotFoundError) Error() string {
+	return fmt.Sprintf(`field %q not found`, e.Name)
+}
+
+func (e FieldNotFoundError) Is(target error) bool {
+	_, ok := target.(FieldNotFoundError)
+	return ok
+}
+
+//-------------------------------------------------------------------
+// FieldTypeMismatchError
+//-------------------------------------------------------------------
+
+// FieldTypeMismatchError is returned when jws.Get finds the requested
+// field but the stored value cannot be converted to the requested type.
+//
+// Callers that need to distinguish "field missing" from "field present
+// but wrong type" should use errors.Is with FieldNotFoundError{} /
+// FieldTypeMismatchError{}, or errors.AsType to recover Name, Got, and
+// Want fields.
+type FieldTypeMismatchError struct {
+	// Name is the name of the field whose value could not be converted.
+	Name string
+	// Got is the value currently stored under the field. Use %T to
+	// inspect its concrete type.
+	Got any
+	// Want is a zero value of the requested type T. Use %T to inspect
+	// its concrete type.
+	Want any
+}
+
+func (e FieldTypeMismatchError) Error() string {
+	return fmt.Sprintf(`field %q is %T, not %T`, e.Name, e.Got, e.Want)
+}
+
+func (e FieldTypeMismatchError) Is(target error) bool {
+	_, ok := target.(FieldTypeMismatchError)
+	return ok
+}


### PR DESCRIPTION
`jwk.Get[T]`, `jws.Get[T]`, and `jwe.Get[T]` returned `fmt.Errorf` messages for 'field missing' and 'type mismatch'. Callers had to string-match. jwt already had structured `ClaimNotFoundError` / `ClaimTypeMismatchError`.

Add `FieldNotFoundError{Name}` and `FieldTypeMismatchError{Name, Got, Want}` to each of jwk, jws, and jwe; update `Get[T]` to return them. Existing `err.Error()` text is equivalent (prefix is dropped since the typed struct carries the context). `.claude/docs/error-formatting.md` updated. Covered by `TestGetTypedErrors` per package.