### PR TITLE
changes: add jwk.WithRejectDuplicateKID entry

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,12 @@ v3 has many incompatibilities with v2. To see the full list of differences betwe
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
 v3.1.0 UNRELEASED
+  * [jwk] Add `jwk.WithRejectDuplicateKID(bool)` — when enabled, `jwk.Parse` /
+    `jwk.ParseReader` / `jwk.ParseString` return an error if the input JWKS
+    contains more than one key sharing the same non-empty `kid`. Usable as a
+    `jwk.Configure()` global or a per-call override. Default behavior
+    (first-match-wins) is unchanged.
+
   * [jwk] Add `jwk.WithMaxKeys(int)` — caps the number of keys accepted
     by `jwk.Parse` / `jwk.ParseReader` / `jwk.ParseString` in both the
     JSON `"keys"` array and the PEM/X.509 block stream (default 1000).


### PR DESCRIPTION
## Summary
- Add missed Changes entry for `jwk.WithRejectDuplicateKID` (feature merged in #2027); v3 Changes only listed `WithMaxKeys`