### PR TITLE
bump actions/cache to v5.0.5 in companion templates

### DIFF
--- a/.companions/templates/ci.yml
+++ b/.companions/templates/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Test"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/go/pkg/mod

--- a/.companions/templates/fuzz.yml
+++ b/.companions/templates/fuzz.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build/fuzz
           key: fuzz-${{ hashFiles('go.mod') }}-${{ github.ref }}


### PR DESCRIPTION
- `ci.yml`, `fuzz.yml`: `actions/cache` v5.0.4 → v5.0.5 (SHA `27d5ce7f`)
- Picked newest version seen across companion `.github/workflows/*.yml`