### PR TITLE
fix v3.1.0 changelog inaccuracies and add missing entries

### DIFF
--- a/Changes
+++ b/Changes
@@ -127,7 +127,21 @@ v3.1.0 UNRELEASED
     empty "crit" array, standard JOSE header names in "crit", or "crit"-listed
     extensions not present in the protected header are now rejected. To disable
     this validation on a per-call basis, pass
-    `jws.WithStrictCriticalHeaders(false)` to `jws.Verify()`.
+    `jws.WithCritValidation(false)` to `jws.Verify()`.
+
+  * [jwe] `jwe.Decrypt()` now validates the "crit" (Critical) header parameter
+    per RFC 7516 Section 4.1.13, matching the jws behavior above. Messages with
+    an empty "crit" array, standard JOSE header names in "crit", or "crit"-listed
+    extensions not present in the protected header are now rejected. Declare
+    extensions with `jwe.WithCritExtension()`, or disable validation on a
+    per-call basis with `jwe.WithCritValidation(false)`. (#1735)
+
+  * [jwk] BREAKING (extension modules): `jwk.RegisterKeyExporter` now takes a
+    `jwk.KeyKind` instead of `jwa.KeyType`. Call sites migrate with
+    `jwk.KeyKind(kty.String())`; for curve-specific exporters, use a compound
+    identity like `jwk.KeyKind("OKP:Ed448")`. Only affects extension-module
+    authors registering custom exporters; library users calling `jwk.Export`
+    are unaffected.
 
   * [jwk] Fixed inverted rlocker condition in RSA key export. (#1576)
 


### PR DESCRIPTION
## Summary
- Fix jws crit entry: `WithStrictCriticalHeaders(false)` → `WithCritValidation(false)` (actual option name)
- Add missing entry for jwe crit validation (#1735)
- Add BREAKING entry for `jwk.RegisterKeyExporter` signature change (`jwa.KeyType` → `jwk.KeyKind`), relevant to extension-module authors