### PR TITLE
guard ecdsa coordinates against oversized big.Int

### DIFF
--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -173,6 +173,22 @@ func validateECDSAPoint(crv elliptic.Curve, x, y *big.Int) error {
 		return fmt.Errorf(`invalid ECDSA public key: identity point is not a valid public key`)
 	}
 
+	// Coordinates must fit in the curve's field. PointValidator
+	// implementations commonly write x and y into a fixed-size buffer
+	// (jwk's own ecdhPointValidator uses big.Int.FillBytes; third-party
+	// validators registered via jwk/ecdsa.RegisterCurve, e.g. secp256k1
+	// in jwx-go/es256k, follow the same pattern). FillBytes panics on
+	// oversized input. Bounding here makes the PointValidator contract
+	// safe by construction for every registered curve, including any
+	// custom curve a downstream extension may add.
+	bits := crv.Params().BitSize
+	if x.BitLen() > bits {
+		return fmt.Errorf(`invalid ECDSA public key: x coordinate is %d bits, exceeds curve %q field size of %d bits`, x.BitLen(), crv.Params().Name, bits)
+	}
+	if y.BitLen() > bits {
+		return fmt.Errorf(`invalid ECDSA public key: y coordinate is %d bits, exceeds curve %q field size of %d bits`, y.BitLen(), crv.Params().Name, bits)
+	}
+
 	alg, err := ourecdsa.AlgorithmFromCurve(crv)
 	if err != nil {
 		return fmt.Errorf(`invalid ECDSA public key: %w`, err)

--- a/jwk/ecdsa/ecdsa.go
+++ b/jwk/ecdsa/ecdsa.go
@@ -24,6 +24,11 @@ import (
 // protects downstream crypto/ecdsa and crypto/ecdh consumers from
 // invalid-curve attacks.
 //
+// jwk guarantees that x and y fit in the curve's field (BitLen() is at
+// most crv.Params().BitSize) before invoking ValidatePoint. Validators
+// that write coordinates into a fixed-size buffer via big.Int.FillBytes
+// can rely on this precondition.
+//
 // Extension modules that register a non-stdlib curve (for example
 // secp256k1 via jwx-go/es256k) MUST provide a correct PointValidator;
 // it is the mechanism that replaces the deprecated

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -75,6 +75,60 @@ func TestECDSAInvalidPointsRejectedOnParse(t *testing.T) {
 	})
 }
 
+// TestECDSAImportRejectsOversizedCoordinates covers the panic-prevention
+// guarantee on the validateECDSAPoint trust boundary: any caller-supplied
+// (X, Y) whose minimal byte representation exceeds the curve's field size
+// must be rejected with a typed error rather than reaching the registered
+// PointValidator. The stdlib NIST validators use big.Int.FillBytes into a
+// fixed-size buffer (jwk/ecdsa.go ecdhPointValidator) and would panic on
+// oversized input; third-party PointValidators registered via
+// jwk/ecdsa.RegisterCurve (e.g. secp256k1 in jwx-go/es256k) use the same
+// pattern. Bounding inside validateECDSAPoint makes the PointValidator
+// contract safe by construction for every registered curve.
+func TestECDSAImportRejectsOversizedCoordinates(t *testing.T) {
+	// 33 bytes with a non-zero leading byte → BitLen() > 256, larger than
+	// the P-256 field. FillBytes(buf[1:33]) would panic.
+	oversize := make([]byte, 33)
+	oversize[0] = 0xff
+	bigVal := new(big.Int).SetBytes(oversize)
+
+	t.Run("oversized X on public key", func(t *testing.T) {
+		bad := &ecdsa.PublicKey{
+			Curve: elliptic.P256(),
+			X:     bigVal,
+			Y:     big.NewInt(1),
+		}
+		_, err := jwk.Import[jwk.Key](bad)
+		require.Error(t, err, `jwk.Import must reject an oversized X without panicking`)
+		require.ErrorIs(t, err, jwk.ImportError(), `Import error should be classified as jwk.ImportError`)
+	})
+
+	t.Run("oversized Y on public key", func(t *testing.T) {
+		bad := &ecdsa.PublicKey{
+			Curve: elliptic.P256(),
+			X:     big.NewInt(1),
+			Y:     bigVal,
+		}
+		_, err := jwk.Import[jwk.Key](bad)
+		require.Error(t, err, `jwk.Import must reject an oversized Y without panicking`)
+		require.ErrorIs(t, err, jwk.ImportError(), `Import error should be classified as jwk.ImportError`)
+	})
+
+	t.Run("oversized public coordinate on private key", func(t *testing.T) {
+		bad := &ecdsa.PrivateKey{
+			PublicKey: ecdsa.PublicKey{
+				Curve: elliptic.P256(),
+				X:     bigVal,
+				Y:     big.NewInt(1),
+			},
+			D: big.NewInt(2),
+		}
+		_, err := jwk.Import[jwk.Key](bad)
+		require.Error(t, err, `jwk.Import must reject an oversized X on a private key without panicking`)
+		require.ErrorIs(t, err, jwk.ImportError(), `Import error should be classified as jwk.ImportError`)
+	})
+}
+
 // TestECDSAImportRejectsInvalidPoints covers the Import(*ecdsa.PublicKey)
 // entry point, which previously accepted any non-nil X/Y without curve
 // membership checks.


### PR DESCRIPTION
- `validateECDSAPoint` rejects `x.BitLen() > crv.Params().BitSize` (and same for `y`) before dispatching to the registered `PointValidator`
- `PointValidator` godoc now pins the precondition; implementations using `FillBytes` into a fixed-size buffer can rely on it
- precaution, not an exploitable bug: the parse path is already length-checked in `ecdsaValidateKey`. Only `jwk.Import` of a hand-built `*ecdsa.PublicKey`/`*ecdsa.PrivateKey` with an oversized `X` or `Y` could reach the panic