### PR TITLE
guard ecdsa coordinates against oversized big.Int

### DIFF
--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -172,6 +172,20 @@ func validateECDSAPoint(crv elliptic.Curve, x, y *big.Int) error {
 		return fmt.Errorf(`invalid ECDSA public key: identity point is not a valid public key`)
 	}
 
+	// Coordinates must fit in the curve's field. The NIST P-curve
+	// branch below pads x and y into a fixed-size SEC1 buffer via
+	// big.Int.FillBytes, which panics on oversized input. Bounding
+	// here makes the function safe by construction for every caller,
+	// including jwk.Import handed a hand-built *ecdsa.PublicKey from
+	// raw bytes.
+	bits := crv.Params().BitSize
+	if x.BitLen() > bits {
+		return fmt.Errorf(`invalid ECDSA public key: x coordinate is %d bits, exceeds curve %q field size of %d bits`, x.BitLen(), crv.Params().Name, bits)
+	}
+	if y.BitLen() > bits {
+		return fmt.Errorf(`invalid ECDSA public key: y coordinate is %d bits, exceeds curve %q field size of %d bits`, y.BitLen(), crv.Params().Name, bits)
+	}
+
 	if ecdhCrv, ok := stdlibECDHCurve(crv); ok {
 		size := (crv.Params().BitSize + 7) / 8
 		buf := make([]byte, 1+2*size)

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -74,6 +74,54 @@ func TestECDSAInvalidPointsRejectedOnParse(t *testing.T) {
 	})
 }
 
+// TestECDSAImportRejectsOversizedCoordinates asserts that
+// validateECDSAPoint rejects (X, Y) whose minimal byte representation
+// exceeds the curve's field size, instead of letting the call panic
+// inside math/big.Int.FillBytes. The NIST P-curve branch in
+// validateECDSAPoint pads X and Y into a fixed-size SEC1 buffer via
+// FillBytes; an oversized BigInt previously triggered
+// "math/big: buffer too small to fit value" deep inside math/big.
+func TestECDSAImportRejectsOversizedCoordinates(t *testing.T) {
+	// 33 bytes with a non-zero leading byte → BitLen() > 256, larger
+	// than the P-256 field. FillBytes(buf[1:33]) would panic.
+	oversize := make([]byte, 33)
+	oversize[0] = 0xff
+	bigVal := new(big.Int).SetBytes(oversize)
+
+	t.Run("oversized X on public key", func(t *testing.T) {
+		bad := &ecdsa.PublicKey{
+			Curve: elliptic.P256(),
+			X:     bigVal,
+			Y:     big.NewInt(1),
+		}
+		_, err := jwk.Import(bad)
+		require.Error(t, err, `jwk.Import must reject an oversized X without panicking`)
+	})
+
+	t.Run("oversized Y on public key", func(t *testing.T) {
+		bad := &ecdsa.PublicKey{
+			Curve: elliptic.P256(),
+			X:     big.NewInt(1),
+			Y:     bigVal,
+		}
+		_, err := jwk.Import(bad)
+		require.Error(t, err, `jwk.Import must reject an oversized Y without panicking`)
+	})
+
+	t.Run("oversized public coordinate on private key", func(t *testing.T) {
+		bad := &ecdsa.PrivateKey{
+			PublicKey: ecdsa.PublicKey{
+				Curve: elliptic.P256(),
+				X:     bigVal,
+				Y:     big.NewInt(1),
+			},
+			D: big.NewInt(2),
+		}
+		_, err := jwk.Import(bad)
+		require.Error(t, err, `jwk.Import must reject an oversized X on a private key without panicking`)
+	})
+}
+
 // TestECDSAImportRejectsInvalidPoints covers the Import(*ecdsa.PublicKey)
 // entry point, which previously accepted any non-nil X/Y without curve
 // membership checks.


### PR DESCRIPTION
- `validateECDSAPoint` rejects `x.BitLen() > crv.Params().BitSize` (and same for `y`) before either branch (NIST stdlib-ecdh path or custom-curve `IsOnCurve` path)
- precaution, not an exploitable bug: the parse path is already length-checked in `ecdsaValidateKey`. Only `jwk.Import` of a hand-built `*ecdsa.PublicKey`/`*ecdsa.PrivateKey` with an oversized `X` or `Y` could reach the panic
- mirrors the same fix on `develop/v4` (#2049)