### PR TITLE
reject jwe with conflicting alg in protected vs per-recipient

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -613,9 +613,34 @@ func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgo
 		Tag(msg.tag).
 		CEK(dc.cek)
 
-	// The "alg" header can be in either protected/unprotected headers.
-	// prefer per-recipient headers (as it might be the case that the algorithm differs
-	// by each recipient), then look at protected headers.
+	// RFC 7516 §7.2.1 requires header parameter names to be disjoint
+	// across the protected, shared-unprotected, and per-recipient
+	// header locations. For "alg" specifically, allowing protected
+	// and per-recipient headers to declare conflicting values is an
+	// algorithm-confusion vector: an attacker who can rewrite the
+	// per-recipient (unprotected) location can claim a different alg
+	// than the integrity-protected one, and the alg-match loop below
+	// would silently break on whichever it sees first.
+	//
+	// Compact-form JWE legitimately has the same alg value in both
+	// places — parseCompact synthesizes a per-recipient header by
+	// cloning the protected header (minus enc), so a strict-disjoint
+	// check would reject every compact JWE. We therefore allow the
+	// duplication when the values agree, and reject only when they
+	// disagree.
+	if rh := recipient.Headers(); rh != nil {
+		if recipAlg, recipHas := rh.Algorithm(); recipHas {
+			if protectedAlg, protectedHas := protectedHeaders.Algorithm(); protectedHas && protectedAlg != recipAlg {
+				return nil, makeDecryptError(`malformed JWE — "alg" header value differs between protected (%q) and per-recipient (%q) headers (RFC 7516 §7.2.1)`, protectedAlg, recipAlg)
+			}
+		}
+	}
+
+	// The "alg" header can be in either protected or per-recipient
+	// headers. With disjointness enforced above, only one location can
+	// have it, so iteration order does not affect security; we keep
+	// per-recipient first to match the historical preference for
+	// recipient-specific algs in multi-recipient JWE.
 	var algMatched bool
 	for _, hdr := range []Headers{recipient.Headers(), protectedHeaders} {
 		v, ok := hdr.Algorithm()

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1669,3 +1669,52 @@ func TestDecryptIgnoresUnprotectedHeader(t *testing.T) {
 	require.NoError(t, err, `jwe.Decrypt must ignore unprotected-header overrides`)
 	require.Equal(t, []byte(payload), decrypted, `plaintext should still round-trip through the tampered JWE`)
 }
+
+// TestDecryptRejectsAlgConflictBetweenProtectedAndPerRecipient pins
+// RFC 7516 §7.2.1's header-disjointness requirement for the
+// algorithm-confusion case: when the integrity-protected `alg` and
+// the per-recipient (unprotected) `alg` declare DIFFERENT values, the
+// recipient's alg-match loop would silently break on whichever it sees
+// first. An on-path attacker who rewrites the per-recipient header
+// can therefore steer dispatch even though the integrity-protected
+// header says something else. Decrypt must reject the message rather
+// than pick a winner.
+//
+// Compact JWE legitimately carries the same alg in both locations
+// (parseCompact synthesizes the per-recipient header by cloning
+// protected), so the check is "values must agree if both are present"
+// rather than strict disjointness.
+func TestDecryptRejectsAlgConflictBetweenProtectedAndPerRecipient(t *testing.T) {
+	privkey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, `rsa.GenerateKey should succeed`)
+
+	const payload = `lorem ipsum dolor sit amet`
+	encrypted, err := jwe.Encrypt(
+		[]byte(payload),
+		jwe.WithKey(jwa.RSA_OAEP(), &privkey.PublicKey),
+		jwe.WithContentEncryption(jwa.A128GCM()),
+		jwe.WithJSON(),
+	)
+	require.NoError(t, err, `jwe.Encrypt should succeed`)
+
+	decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.RSA_OAEP(), privkey))
+	require.NoError(t, err, `baseline jwe.Decrypt should succeed`)
+	require.Equal(t, []byte(payload), decrypted, `baseline plaintext should round-trip`)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(encrypted, &parsed))
+
+	// Inject a conflicting per-recipient `alg`. Protected still claims
+	// RSA-OAEP; per-recipient now says RSA1_5.
+	parsed["header"] = map[string]any{
+		"alg": jwa.RSA1_5().String(),
+	}
+
+	tampered, err := json.Marshal(parsed)
+	require.NoError(t, err)
+
+	_, err = jwe.Decrypt(tampered, jwe.WithKey(jwa.RSA_OAEP(), privkey))
+	require.Error(t, err, `Decrypt must reject a JWE whose alg differs between protected and per-recipient headers`)
+	require.ErrorIs(t, err, jwe.DecryptError())
+	require.Contains(t, err.Error(), "differs between protected", `error should name the conflict`)
+}


### PR DESCRIPTION
- `decryptContent` now rejects a JWE whose `alg` declares different values in the integrity-protected header and a per-recipient (unprotected) header. Per RFC 7516 §7.2.1 these locations are disjoint by parameter name; a conflict is malformed input.
- Fixes the algorithm-confusion vector where an on-path attacker rewrites the per-recipient `alg` to a value compatible with the recipient's key, while the integrity-protected location says something else. Without the check, the alg-match loop walked per-recipient first and silently picked it.
- Compact-form JWE legitimately has the same `alg` in both places (`parseCompact` synthesizes the per-recipient header by cloning protected), so the check is "values must agree if both are present" rather than strict disjointness. All compact paths still decrypt.
- New regression: `TestDecryptRejectsAlgConflictBetweenProtectedAndPerRecipient`. Mirrors the v4 PR (#2051).