### PR TITLE
fix AddressClaim.MarshalJSON for non-printable bytes

### DIFF
--- a/jwt/openid/address.go
+++ b/jwt/openid/address.go
@@ -2,7 +2,6 @@ package openid
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/lestrrat-go/jwx/v4/internal/json"
 	"github.com/lestrrat-go/jwx/v4/internal/pool"
@@ -208,53 +207,49 @@ func (t AddressClaim) MarshalJSON() ([]byte, error) {
 
 	buf.WriteByte(tokens.OpenCurlyBracket)
 	prev := buf.Len()
-	if v := t.country; v != nil {
-		buf.WriteString(`"country":`)
-		buf.WriteString(strconv.Quote(*v))
-	}
-
-	if v := t.formatted; v != nil {
+	// String values go through json.Marshal, not strconv.Quote.
+	// strconv.Quote produces Go source-form escaping (\xNN, invalid
+	// for JSON; control bytes 0x00–0x1F and 0x7F must be \u00NN).
+	// Routing through json.Marshal also handles invalid UTF-8 the
+	// way the rest of the package's encoders do.
+	writeStringField := func(name string, v *string) error {
+		if v == nil {
+			return nil
+		}
 		if buf.Len() > prev {
 			buf.WriteByte(tokens.Comma)
 		}
 		prev = buf.Len()
-		buf.WriteString(`"formatted":`)
-		buf.WriteString(strconv.Quote(*v))
+		buf.WriteByte('"')
+		buf.WriteString(name)
+		buf.WriteString(`":`)
+		encoded, err := json.Marshal(*v)
+		if err != nil {
+			return fmt.Errorf(`failed to marshal %q field: %w`, name, err)
+		}
+		buf.Write(encoded)
+		return nil
 	}
 
-	if v := t.locality; v != nil {
-		if buf.Len() > prev {
-			buf.WriteByte(tokens.Comma)
-		}
-		prev = buf.Len()
-		buf.WriteString(`"locality":`)
-		buf.WriteString(strconv.Quote(*v))
+	// Field order preserved from the historical implementation so the
+	// MarshalJSON output is byte-stable for callers that compare it.
+	if err := writeStringField("country", t.country); err != nil {
+		return nil, err
 	}
-
-	if v := t.postalCode; v != nil {
-		if buf.Len() > prev {
-			buf.WriteByte(tokens.Comma)
-		}
-		prev = buf.Len()
-		buf.WriteString(`"postal_code":`)
-		buf.WriteString(strconv.Quote(*v))
+	if err := writeStringField("formatted", t.formatted); err != nil {
+		return nil, err
 	}
-
-	if v := t.region; v != nil {
-		if buf.Len() > prev {
-			buf.WriteByte(tokens.Comma)
-		}
-		prev = buf.Len()
-		buf.WriteString(`"region":`)
-		buf.WriteString(strconv.Quote(*v))
+	if err := writeStringField("locality", t.locality); err != nil {
+		return nil, err
 	}
-
-	if v := t.streetAddress; v != nil {
-		if buf.Len() > prev {
-			buf.WriteByte(tokens.Comma)
-		}
-		buf.WriteString(`"street_address":`)
-		buf.WriteString(strconv.Quote(*v))
+	if err := writeStringField("postal_code", t.postalCode); err != nil {
+		return nil, err
+	}
+	if err := writeStringField("region", t.region); err != nil {
+		return nil, err
+	}
+	if err := writeStringField("street_address", t.streetAddress); err != nil {
+		return nil, err
 	}
 
 	buf.WriteByte(tokens.CloseCurlyBracket)

--- a/jwt/openid/openid_test.go
+++ b/jwt/openid/openid_test.go
@@ -86,6 +86,61 @@ func testStockAddressClaim(t *testing.T, x *openid.AddressClaim) {
 	}
 }
 
+// TestAddressClaimRoundTripsAwkwardStrings pins that AddressClaim
+// MarshalJSON produces output that the same package's UnmarshalJSON
+// accepts, even when the field values contain bytes that JSON requires
+// to be escaped as \u00NN (control bytes 0x00–0x1F, 0x7F) or invalid
+// UTF-8.
+//
+// Regression for: AddressClaim.MarshalJSON used strconv.Quote, which
+// is Go-source-form escaping (emits \xNN for control bytes and invalid
+// UTF-8). \xNN is illegal in JSON — RFC 8259 §7 only permits the
+// two-character \" \\ \/ \b \f \n \r \t escapes plus the six-character
+// \uXXXX form. The strconv.Quote output therefore parsed in some
+// permissive consumers and was rejected by strict ones; either way it
+// failed to round-trip through the same package's own UnmarshalJSON.
+func TestAddressClaimRoundTripsAwkwardStrings(t *testing.T) {
+	// Each entry exercises a different path:
+	//  * control bytes (\x01) that strconv.Quote emits as \xNN
+	//  * DEL (\x7F) which Go-source escaping treats as printable but
+	//    JSON requires escaped
+	//  * a literal Unicode line separator (U+2028) which Go encodes
+	//    happily but some JSON consumers also escape
+	cases := map[string]string{
+		"control_byte":    "line1\x01line2",
+		"delete_byte":     "before\x7fafter",
+		"line_separator":  "first second",
+		"interior_quote":  `key "value" pair`,
+		"backslash":       `path\to\file`,
+		"normal_japanese": "東京都港区芝公園",
+	}
+
+	for name, value := range cases {
+		t.Run(name, func(t *testing.T) {
+			var src openid.AddressClaim
+			require.NoError(t, src.Set(openid.AddressFormattedKey, value),
+				`Set should succeed for any well-formed string value`)
+
+			buf, err := json.Marshal(&src)
+			require.NoError(t, err, `MarshalJSON should succeed`)
+
+			// The output must be syntactically valid JSON.
+			var parseProbe map[string]any
+			require.NoError(t, json.Unmarshal(buf, &parseProbe),
+				`MarshalJSON output must be valid JSON; got %s`, buf)
+
+			// And the package's own UnmarshalJSON must accept it.
+			var dst openid.AddressClaim
+			require.NoError(t, json.Unmarshal(buf, &dst),
+				`AddressClaim.UnmarshalJSON must accept its own MarshalJSON output; got %s`, buf)
+
+			got, ok := dst.Get(openid.AddressFormattedKey)
+			require.True(t, ok, `formatted field must round-trip`)
+			require.Equal(t, value, got, `value must survive the round-trip byte-for-byte`)
+		})
+	}
+}
+
 func TestAdressClaim(t *testing.T) {
 	const src = `{
     "formatted": "〒105-0011 東京都港区芝公園４丁目２−８",


### PR DESCRIPTION
- `openid.AddressClaim.MarshalJSON` used `strconv.Quote` for each string field. `strconv.Quote` produces Go source-form escaping (`\xNN` for control bytes, `\xFF` for invalid UTF-8) — none of which are valid JSON per RFC 8259 §7. The output failed to round-trip through the package's own `UnmarshalJSON`.
- Replaced the `strconv.Quote` calls with `internal/json.Marshal` per field, which produces valid JSON for any string. Field order is preserved so output stays byte-stable for callers comparing it.
- New regression test `TestAddressClaimRoundTripsAwkwardStrings` exercises control bytes, DEL (0x7F), interior quotes, backslashes, and Japanese text. Each must round-trip Marshal → Unmarshal byte-for-byte.