### PR TITLE
docs: document PrivateClaims concurrency contract

### DIFF
--- a/internal/jwxcodegen/cmd/jwxcodegen/genjwt.go
+++ b/internal/jwxcodegen/cmd/jwxcodegen/genjwt.go
@@ -332,7 +332,18 @@ func generateTokenGetters(o *codegen.Output, obj *codegen.Object) {
 }
 
 func generateTokenPrivateClaims(o *codegen.Output, obj *codegen.Object) {
-	o.LL("func (t *%s) PrivateClaims() map[string]any {", obj.Name(false))
+	o.LL("// PrivateClaims returns the underlying map of non-standard claims held by")
+	o.L("// the token. The returned map is the live map used by the token, not a copy:")
+	o.L("// callers must not mutate it, and must not read from it concurrently with")
+	o.L("// Set/Remove or with unmarshaling on the same token. If you need a stable")
+	o.L("// snapshot for concurrent use, copy the map (for example via maps.Clone)")
+	o.L("// before iterating.")
+	o.L("//")
+	o.L("// To obtain a fresh token containing only the non-standard claims, use the")
+	o.L("// jwxfilter companion module: jwtfilter.Standard().Reject(token) from")
+	o.L("// github.com/jwx-go/jwxfilter/v4/jwtfilter (or openidfilter.Standard().Reject")
+	o.L("// for openid.Token).")
+	o.L("func (t *%s) PrivateClaims() map[string]any {", obj.Name(false))
 	o.L("t.mu.RLock()")
 	o.L("defer t.mu.RUnlock()")
 	o.L("return t.privateClaims")

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -892,6 +892,17 @@ func (t *stdToken) Zoneinfo() (string, bool) {
 	return "", false
 }
 
+// PrivateClaims returns the underlying map of non-standard claims held by
+// the token. The returned map is the live map used by the token, not a copy:
+// callers must not mutate it, and must not read from it concurrently with
+// Set/Remove or with unmarshaling on the same token. If you need a stable
+// snapshot for concurrent use, copy the map (for example via maps.Clone)
+// before iterating.
+//
+// To obtain a fresh token containing only the non-standard claims, use the
+// jwxfilter companion module: jwtfilter.Standard().Reject(token) from
+// github.com/jwx-go/jwxfilter/v4/jwtfilter (or openidfilter.Standard().Reject
+// for openid.Token).
 func (t *stdToken) PrivateClaims() map[string]any {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -349,6 +349,17 @@ func (t *stdToken) Subject() (string, bool) {
 	return "", false
 }
 
+// PrivateClaims returns the underlying map of non-standard claims held by
+// the token. The returned map is the live map used by the token, not a copy:
+// callers must not mutate it, and must not read from it concurrently with
+// Set/Remove or with unmarshaling on the same token. If you need a stable
+// snapshot for concurrent use, copy the map (for example via maps.Clone)
+// before iterating.
+//
+// To obtain a fresh token containing only the non-standard claims, use the
+// jwxfilter companion module: jwtfilter.Standard().Reject(token) from
+// github.com/jwx-go/jwxfilter/v4/jwtfilter (or openidfilter.Standard().Reject
+// for openid.Token).
 func (t *stdToken) PrivateClaims() map[string]any {
 	t.mu.RLock()
 	defer t.mu.RUnlock()


### PR DESCRIPTION
PrivateClaims returns the live map, not a snapshot. Document that callers must not mutate it or read it concurrently with Set/Remove/unmarshal, and point them at maps.Clone for a snapshot or at jwxfilter (jwtfilter.Standard().Reject / openidfilter.Standard().Reject) for a fresh token of just the non-standard claims.

Generator-side change in internal/jwxcodegen/cmd/jwxcodegen/genjwt.go; jwt/token_gen.go and jwt/openid/token_gen.go regenerated.