### PR TITLE
jwt: only call ParseForm when WithFormKey is supplied

### DIFF
--- a/jwt/http.go
+++ b/jwt/http.go
@@ -100,6 +100,13 @@ func ParseForm(values url.Values, name string, options ...ParseOption) (Token, e
 // cookies with the same name, and you want to search for a specific one that
 // (http.Request).Cookie() would not return, you will need to implement your
 // own logic to extract the cookie and use jwt.ParseString().
+//
+// When (and only when) at least one WithFormKey() option is supplied,
+// ParseRequest will call (*http.Request).ParseForm() to read form fields
+// from the request body. Callers that accept untrusted requests should
+// wrap req.Body with http.MaxBytesReader before calling ParseRequest so
+// that an oversized body does not exhaust memory during form parsing.
+// Without WithFormKey() the request body is left untouched.
 func ParseRequest(req *http.Request, options ...ParseOption) (Token, error) {
 	var hdrkeys []string
 	var formkeys []string
@@ -168,7 +175,13 @@ func ParseRequest(req *http.Request, options ...ParseOption) (Token, error) {
 		return tok, nil
 	}
 
-	if cl := req.ContentLength; cl > 0 {
+	// Only touch the request body when the caller actually asked us
+	// to look at form fields. Without this guard ParseRequest would
+	// call req.ParseForm() on every request with a non-zero
+	// ContentLength — for form-encoded bodies that drains the body,
+	// leaving downstream handlers with an empty io.Reader; for other
+	// Content-Types it is still wasted work on the URL query.
+	if len(formkeys) > 0 && req.ContentLength > 0 {
 		if err := req.ParseForm(); err != nil {
 			return nil, fmt.Errorf(`failed to parse form: %w`, err)
 		}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -983,6 +984,52 @@ func TestParseRequest(t *testing.T) {
 		_, err := jwt.ParseRequest(req, jwt.WithCookieKey("cookie"), jwt.WithCookie(&dst), jwt.WithKey(jwa.ES256(), pubkey))
 		require.NoError(t, err, `jwt.ParseRequest should succeed`)
 		require.NotNil(t, dst, `cookie should be extracted`)
+	})
+
+	// Regression: ParseRequest used to call req.ParseForm() whenever the
+	// request had a non-zero ContentLength, even when the caller never
+	// passed WithFormKey. The bug is reachable when the header/cookie
+	// lookup falls through without returning a token: ParseRequest then
+	// tries the form path, but with no form keys the call is pure waste.
+	// The body must only be touched when at least one WithFormKey was
+	// supplied.
+	//
+	// JSON-body case: stdlib ParseForm bails on non-form Content-Types
+	// without reading the body, so the body survives either way; what
+	// we can observe is that req.Form is left nil because the guarded
+	// code path never runs ParseForm at all.
+	t.Run("ParseForm is not called when no WithFormKey is supplied (json body)", func(t *testing.T) {
+		body := `{"hello":"world"}`
+		req := httptest.NewRequest(http.MethodPost, u, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		// No Authorization header on purpose: forces ParseRequest past
+		// the header path so the form-handling code is reached.
+
+		_, err := jwt.ParseRequest(req, jwt.WithKey(jwa.ES256(), pubkey))
+		require.Error(t, err, `jwt.ParseRequest should fail (no token in request)`)
+
+		require.Nil(t, req.Form, `req.Form must remain nil when no WithFormKey is supplied`)
+
+		got, err := io.ReadAll(req.Body)
+		require.NoError(t, err, `req.Body should still be readable after ParseRequest`)
+		require.Equal(t, body, string(got), `req.Body must be intact`)
+	})
+
+	// Companion case: form-encoded body. stdlib ParseForm DOES drain
+	// the body on form Content-Types, so without the guard the handler
+	// downstream of ParseRequest would see an empty body.
+	t.Run("body is not consumed when no WithFormKey is supplied (form body)", func(t *testing.T) {
+		body := `payload=hello&other=world`
+		req := httptest.NewRequest(http.MethodPost, u, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		// No Authorization header: see note above.
+
+		_, err := jwt.ParseRequest(req, jwt.WithKey(jwa.ES256(), pubkey))
+		require.Error(t, err, `jwt.ParseRequest should fail (no token in request)`)
+
+		got, err := io.ReadAll(req.Body)
+		require.NoError(t, err, `req.Body should still be readable after ParseRequest`)
+		require.Equal(t, body, string(got), `req.Body must be intact when no WithFormKey is supplied`)
 	})
 }
 


### PR DESCRIPTION
v3 backport of #2057.

ParseRequest used to call (*http.Request).ParseForm() whenever the request had a non-zero ContentLength, even when no WithFormKey() was supplied. For form-encoded bodies that drained the body, leaving downstream handlers with an empty io.Reader; for other Content-Types it was wasted work on the URL query.

Guard the call on len(formkeys) > 0 && req.ContentLength > 0. Two regression subtests added: a json-body case asserting req.Form stays nil, and a form-body case asserting req.Body is not drained. Godoc on ParseRequest now also recommends wrapping the body with http.MaxBytesReader when WithFormKey() is in play, since untrusted form bodies are read fully into memory by ParseForm.