### PR TITLE
jws: jkuProvider rejects fetched keys marked use=enc

### DIFF
--- a/jws/key_provider.go
+++ b/jws/key_provider.go
@@ -310,6 +310,12 @@ func (kp jkuProvider) FetchKeys(ctx context.Context, sink KeySink, sig *Signatur
 		return fmt.Errorf(`jku: key with "kid" %q not found in JWKS fetched from %q`, kid, u)
 	}
 
+	if usage, ok := key.KeyUsage(); ok {
+		if usage != "" && usage != jwk.ForSignature.String() {
+			return fmt.Errorf(`key with kid %q is marked use=%q, not usable for signature verification (expected %q)`, kid, usage, jwk.ForSignature.String())
+		}
+	}
+
 	algs, err := AlgorithmsForKey(key)
 	if err != nil {
 		return fmt.Errorf(`failed to get a list of signature methods for key type %s: %w`, key.KeyType(), err)

--- a/jws/key_provider_test.go
+++ b/jws/key_provider_test.go
@@ -125,3 +125,46 @@ func TestKeySetProviderUseEncSurfacesError(t *testing.T) {
 	require.Contains(t, err.Error(), `not usable for signature verification`,
 		`error should explain the mismatch`)
 }
+
+// fixedFetcher is a jwk.Fetcher that returns the same JWK Set for any URL.
+type fixedFetcher struct {
+	set jwk.Set
+}
+
+func (f fixedFetcher) Fetch(_ context.Context, _ string) (jwk.Set, error) {
+	return f.set, nil
+}
+
+// TestJKUProviderUseEncSurfacesError pins that jkuProvider mirrors the
+// keySetProvider use-check: a JWKS entry with use="enc" that matches
+// the JWS "kid" is rejected with a structured error rather than
+// silently passed through to AlgorithmsForKey.
+func TestJKUProviderUseEncSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	rsaRaw, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	pub, err := jwk.Import[jwk.Key](&rsaRaw.PublicKey)
+	require.NoError(t, err)
+	require.NoError(t, pub.Set(jwk.KeyIDKey, "signer-kid"))
+	require.NoError(t, pub.Set(jwk.KeyUsageKey, "enc"))
+
+	set := jwk.NewSet()
+	require.NoError(t, set.AddKey(pub))
+
+	kp := jkuProvider{fetcher: fixedFetcher{set: set}}
+
+	sig := NewSignature()
+	hdr := NewHeaders()
+	require.NoError(t, hdr.Set(AlgorithmKey, jwa.RS256()))
+	require.NoError(t, hdr.Set(KeyIDKey, "signer-kid"))
+	require.NoError(t, hdr.Set(JWKSetURLKey, "https://example.test/jwks"))
+	sig.SetProtectedHeaders(hdr)
+
+	err = kp.FetchKeys(context.Background(), &countingKeySink{}, sig, &Message{})
+	require.Error(t, err, `jkuProvider.FetchKeys should error on use=enc`)
+	require.Contains(t, err.Error(), `signer-kid`, `error should name the kid`)
+	require.Contains(t, err.Error(), `use="enc"`, `error should quote the usage`)
+	require.Contains(t, err.Error(), `not usable for signature verification`,
+		`error should explain the mismatch`)
+}


### PR DESCRIPTION
The `keySetProvider` already rejects JWKS entries marked `use="enc"` with a structured error (`signer-kid` use="enc" not usable for signature verification...). The `jkuProvider` skipped that check, so a `jku`-resolved JWKS entry mismarked as a decryption key would fall through to `AlgorithmsForKey` and surface as a generic "could not be verified with any of the keys".

This mirrors the `selectKey` check inside `jkuProvider.FetchKeys` immediately after the `kid` lookup. Behavior change is limited to what was already a verification failure — operators just get a clearer error.

Test added at `jws/key_provider_test.go:TestJKUProviderUseEncSurfacesError`.