### PR TITLE
jwk: refuse RegisterKeyImporter for built-in raw key types

### DIFF
--- a/jwk/convert.go
+++ b/jwk/convert.go
@@ -24,6 +24,13 @@ import (
 
 var keyImporters = make(map[reflect.Type]KeyImporter)
 
+// builtinImporterTypes is the set of raw key types whose importers
+// are owned by the jwk package and cannot be overridden by callers.
+// [RegisterKeyImporter] for these types returns an error;
+// [UnregisterKeyImporter] for them is a silent no-op. Populated by
+// init() via [registerBuiltinImporter].
+var builtinImporterTypes = make(map[reflect.Type]struct{})
+
 // KeyKind identifies a key for exporter dispatch. Built-in key types
 // use the key type string (e.g. "RSA", "EC", "OKP", "oct"). Keys that
 // implement [KeyKinder] can return a more specific identity
@@ -75,12 +82,24 @@ var muKeyExporters sync.RWMutex
 // chain; importer dispatch is a single-value map keyed by Go type,
 // with no equivalent dimension to try next.
 //
+// The importers for stdlib raw key types — both value and pointer
+// forms of rsa.PrivateKey / rsa.PublicKey / ecdsa.PrivateKey /
+// ecdsa.PublicKey / ecdh.PrivateKey / ecdh.PublicKey, plus
+// ed25519.PrivateKey, ed25519.PublicKey, and []byte — are owned by
+// jwk and cannot be overridden. RegisterKeyImporter for any of these
+// types returns an error; [UnregisterKeyImporter] for them is a
+// silent no-op. Use a wrapper type if you need to apply additional
+// validation.
+//
 // Extension modules calling this from init() must check the returned
 // error and panic on failure.
 func RegisterKeyImporter[T any](fn func(T) (Key, error)) error {
 	muKeyImporters.Lock()
 	defer muKeyImporters.Unlock()
 	t := reflect.TypeFor[T]()
+	if _, ok := builtinImporterTypes[t]; ok {
+		return fmt.Errorf(`jwk.RegisterKeyImporter: %s is a built-in raw key type; built-in importers cannot be overridden`, t)
+	}
 	if _, exists := keyImporters[t]; exists {
 		return fmt.Errorf(`jwk.RegisterKeyImporter: an importer for %s is already registered; call jwk.UnregisterKeyImporter[%s]() first if you need to replace it`, t, t)
 	}
@@ -90,7 +109,9 @@ func RegisterKeyImporter[T any](fn func(T) (Key, error)) error {
 
 // UnregisterKeyImporter removes the importer previously registered
 // for type T. Returns true if an importer was removed, false if none
-// was registered for T.
+// was registered for T or if T is one of the built-in raw key types
+// (see [RegisterKeyImporter] for the list); built-in importers cannot
+// be unregistered.
 //
 // This is primarily useful for tests or for extension modules that
 // need to replace a previously installed importer. In steady-state
@@ -101,6 +122,9 @@ func UnregisterKeyImporter[T any]() bool {
 	muKeyImporters.Lock()
 	defer muKeyImporters.Unlock()
 	t := reflect.TypeFor[T]()
+	if _, ok := builtinImporterTypes[t]; ok {
+		return false
+	}
 	if _, ok := keyImporters[t]; !ok {
 		return false
 	}
@@ -220,21 +244,32 @@ func init() {
 	normalizedOKP = KeyKind(jwa.OKP().String()).normalize()
 	normalizedOCT = KeyKind(jwa.OctetSeq().String()).normalize()
 
-	panicOnRegistrationError(RegisterKeyImporter(importRSAPrivateKey))
-	panicOnRegistrationError(RegisterKeyImporter(importRSAPrivateKeyPtr))
-	panicOnRegistrationError(RegisterKeyImporter(importRSAPublicKey))
-	panicOnRegistrationError(RegisterKeyImporter(importRSAPublicKeyPtr))
-	panicOnRegistrationError(RegisterKeyImporter(importECDSAPrivateKey))
-	panicOnRegistrationError(RegisterKeyImporter(importECDSAPrivateKeyPtr))
-	panicOnRegistrationError(RegisterKeyImporter(importECDSAPublicKey))
-	panicOnRegistrationError(RegisterKeyImporter(importECDSAPublicKeyPtr))
-	panicOnRegistrationError(RegisterKeyImporter(importEd25519PrivateKey))
-	panicOnRegistrationError(RegisterKeyImporter(importECDHPrivateKey))
-	panicOnRegistrationError(RegisterKeyImporter(importECDHPrivateKeyPtr))
-	panicOnRegistrationError(RegisterKeyImporter(importEd25519PublicKey))
-	panicOnRegistrationError(RegisterKeyImporter(importECDHPublicKey))
-	panicOnRegistrationError(RegisterKeyImporter(importECDHPublicKeyPtr))
-	panicOnRegistrationError(RegisterKeyImporter(importSymmetricKey))
+	registerBuiltinKeyImporter(importRSAPrivateKey)
+	registerBuiltinKeyImporter(importRSAPrivateKeyPtr)
+	registerBuiltinKeyImporter(importRSAPublicKey)
+	registerBuiltinKeyImporter(importRSAPublicKeyPtr)
+	registerBuiltinKeyImporter(importECDSAPrivateKey)
+	registerBuiltinKeyImporter(importECDSAPrivateKeyPtr)
+	registerBuiltinKeyImporter(importECDSAPublicKey)
+	registerBuiltinKeyImporter(importECDSAPublicKeyPtr)
+	registerBuiltinKeyImporter(importEd25519PrivateKey)
+	registerBuiltinKeyImporter(importECDHPrivateKey)
+	registerBuiltinKeyImporter(importECDHPrivateKeyPtr)
+	registerBuiltinKeyImporter(importEd25519PublicKey)
+	registerBuiltinKeyImporter(importECDHPublicKey)
+	registerBuiltinKeyImporter(importECDHPublicKeyPtr)
+	registerBuiltinKeyImporter(importSymmetricKey)
+}
+
+// registerBuiltinKeyImporter installs an importer that the public
+// [RegisterKeyImporter] / [UnregisterKeyImporter] APIs are not allowed
+// to touch. Intended for jwk's own init() — runs single-threaded
+// before any goroutine could observe partially-populated state, so
+// the muKeyImporters lock is not taken.
+func registerBuiltinKeyImporter[T any](fn func(T) (Key, error)) {
+	t := reflect.TypeFor[T]()
+	builtinImporterTypes[t] = struct{}{}
+	keyImporters[t] = &keyImportAdapter[T]{fn: fn}
 }
 
 // panicOnRegistrationError converts a non-nil error returned by a Register*

--- a/jwk/convert_test.go
+++ b/jwk/convert_test.go
@@ -1,6 +1,12 @@
 package jwk_test
 
 import (
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
 	"errors"
 	"testing"
 
@@ -118,5 +124,107 @@ func TestRegisterKeyImporterRejectsDuplicate(t *testing.T) {
 	t.Run("Unregister on unknown type returns false", func(t *testing.T) {
 		require.False(t, jwk.UnregisterKeyImporter[dupImporterKey](),
 			`Unregister should return false when no importer was registered`)
+	})
+}
+
+// TestRegisterKeyImporterRejectsBuiltinTypes pins that the public
+// Register/Unregister APIs refuse to touch the importers jwk owns for
+// stdlib raw key types. Allowing a caller to swap the *rsa.PrivateKey
+// (etc.) importer would let an extension silently change how every
+// downstream caller's RSA private key parses — exactly the kind of
+// "registered = effective" footgun the report (JWK-001) flagged.
+//
+// The stub importer returns a non-nil error so the test does not
+// resemble a (nil, nil) sentinel.
+func TestRegisterKeyImporterRejectsBuiltinTypes(t *testing.T) {
+	stubErr := errors.New("stub importer must not be invoked: built-in types are reserved")
+
+	t.Run("RegisterKeyImporter[*rsa.PrivateKey]", func(t *testing.T) {
+		err := jwk.RegisterKeyImporter(func(*rsa.PrivateKey) (jwk.Key, error) {
+			return nil, stubErr
+		})
+		require.Error(t, err, `RegisterKeyImporter should refuse a built-in raw key type`)
+		require.Contains(t, err.Error(), `built-in`,
+			`error should explain that built-in importers cannot be overridden`)
+		require.Contains(t, err.Error(), `*rsa.PrivateKey`,
+			`error should name the rejected type`)
+	})
+
+	builtins := []struct {
+		name string
+		fn   func() error
+	}{
+		{"rsa.PrivateKey", func() error {
+			return jwk.RegisterKeyImporter(func(rsa.PrivateKey) (jwk.Key, error) { return nil, stubErr })
+		}},
+		{"*rsa.PublicKey", func() error {
+			return jwk.RegisterKeyImporter(func(*rsa.PublicKey) (jwk.Key, error) { return nil, stubErr })
+		}},
+		{"rsa.PublicKey", func() error {
+			return jwk.RegisterKeyImporter(func(rsa.PublicKey) (jwk.Key, error) { return nil, stubErr })
+		}},
+		{"*ecdsa.PrivateKey", func() error {
+			return jwk.RegisterKeyImporter(func(*ecdsa.PrivateKey) (jwk.Key, error) { return nil, stubErr })
+		}},
+		{"ecdsa.PrivateKey", func() error {
+			return jwk.RegisterKeyImporter(func(ecdsa.PrivateKey) (jwk.Key, error) { return nil, stubErr })
+		}},
+		{"*ecdsa.PublicKey", func() error {
+			return jwk.RegisterKeyImporter(func(*ecdsa.PublicKey) (jwk.Key, error) { return nil, stubErr })
+		}},
+		{"ecdsa.PublicKey", func() error {
+			return jwk.RegisterKeyImporter(func(ecdsa.PublicKey) (jwk.Key, error) { return nil, stubErr })
+		}},
+		{"ed25519.PrivateKey", func() error {
+			return jwk.RegisterKeyImporter(func(ed25519.PrivateKey) (jwk.Key, error) { return nil, stubErr })
+		}},
+		{"ed25519.PublicKey", func() error {
+			return jwk.RegisterKeyImporter(func(ed25519.PublicKey) (jwk.Key, error) { return nil, stubErr })
+		}},
+		{"*ecdh.PrivateKey", func() error {
+			return jwk.RegisterKeyImporter(func(*ecdh.PrivateKey) (jwk.Key, error) { return nil, stubErr })
+		}},
+		{"ecdh.PrivateKey", func() error {
+			return jwk.RegisterKeyImporter(func(ecdh.PrivateKey) (jwk.Key, error) { return nil, stubErr })
+		}},
+		{"*ecdh.PublicKey", func() error {
+			return jwk.RegisterKeyImporter(func(*ecdh.PublicKey) (jwk.Key, error) { return nil, stubErr })
+		}},
+		{"ecdh.PublicKey", func() error {
+			return jwk.RegisterKeyImporter(func(ecdh.PublicKey) (jwk.Key, error) { return nil, stubErr })
+		}},
+		{"[]byte", func() error {
+			return jwk.RegisterKeyImporter(func([]byte) (jwk.Key, error) { return nil, stubErr })
+		}},
+	}
+	for _, tc := range builtins {
+		t.Run("RegisterKeyImporter["+tc.name+"]", func(t *testing.T) {
+			err := tc.fn()
+			require.Error(t, err, `RegisterKeyImporter for %s should be refused`, tc.name)
+			require.Contains(t, err.Error(), `built-in`,
+				`error should explain that built-in importers cannot be overridden`)
+		})
+	}
+
+	t.Run("UnregisterKeyImporter[*rsa.PrivateKey] is a silent no-op", func(t *testing.T) {
+		require.False(t, jwk.UnregisterKeyImporter[*rsa.PrivateKey](),
+			`UnregisterKeyImporter for a built-in must report no removal`)
+
+		// Built-in importer must still be functional after the
+		// attempted unregister: importing a real *rsa.PrivateKey should
+		// continue to succeed.
+		raw, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err, `rsa.GenerateKey should succeed`)
+		_, err = jwk.Import[jwk.Key](raw)
+		require.NoError(t, err, `built-in *rsa.PrivateKey importer must remain functional`)
+	})
+
+	t.Run("UnregisterKeyImporter[*ecdsa.PrivateKey] is a silent no-op", func(t *testing.T) {
+		require.False(t, jwk.UnregisterKeyImporter[*ecdsa.PrivateKey]())
+
+		raw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		_, err = jwk.Import[jwk.Key](raw)
+		require.NoError(t, err, `built-in *ecdsa.PrivateKey importer must remain functional`)
 	})
 }


### PR DESCRIPTION
The built-in importers for stdlib raw key types (rsa, ecdsa, ed25519, ecdh — value and pointer forms — plus \`[]byte\`) are claimed by jwk and dispatched through the \`importBuiltinKey\` fast path before the user-extensible \`keyImporters\` map is consulted. A caller passing one of those types to \`RegisterKeyImporter\` previously hit the generic "already registered; call UnregisterKeyImporter first" message — misleading because even after Unregister + Register, the fast-path switch would still shadow the registration.

This change tracks the built-in set explicitly:

- \`RegisterKeyImporter\` returns \`built-in importers cannot be overridden\` for those types.
- \`UnregisterKeyImporter\` is a silent no-op for them; the importer remains functional after the call.
- Godoc on \`RegisterKeyImporter\` and \`UnregisterKeyImporter\` spells out the off-limits list and points at wrapper types as the supported extension path.

Test added at \`jwk/convert_test.go:TestRegisterKeyImporterRejectsBuiltinTypes\`.