### PR TITLE
jwa: unify SignatureAlgorithm/KeyEncryption/ContentEncryption into one registry

### DIFF
--- a/internal/jwxcodegen/cmd/jwxcodegen/genjwa.go
+++ b/internal/jwxcodegen/cmd/jwxcodegen/genjwa.go
@@ -14,6 +14,36 @@ import (
 	"github.com/lestrrat-go/codegen"
 )
 
+// isKeyAlgorithmKind reports whether the given algorithm type
+// implements jwa.KeyAlgorithm and therefore lives in the shared
+// algRegistry hand-written in jwa.go. The three KeyAlgorithm kinds
+// share one namespace so KeyAlgorithmFrom can resolve a string to
+// exactly one typed value; everything else (KeyType,
+// EllipticCurveAlgorithm, CompressionAlgorithm) keeps its own
+// per-kind storage emitted by this generator.
+func isKeyAlgorithmKind(name string) bool {
+	switch name {
+	case "SignatureAlgorithm", "KeyEncryptionAlgorithm", "ContentEncryptionAlgorithm":
+		return true
+	}
+	return false
+}
+
+// algKindEnumSuffix maps an algorithm type name to the suffix used in
+// its algorithmKind constant in jwa.go (e.g. "SignatureAlgorithm" ->
+// "Signature", which combines into algKindSignature).
+func algKindEnumSuffix(name string) string {
+	switch name {
+	case "SignatureAlgorithm":
+		return "Signature"
+	case "KeyEncryptionAlgorithm":
+		return "KeyEncryption"
+	case "ContentEncryptionAlgorithm":
+		return "ContentEncryption"
+	}
+	return ""
+}
+
 // Define the structs with exported fields for proper YAML unmarshaling
 type AlgYAML struct {
 	Algorithms []Algorithm `yaml:"algorithms"`
@@ -142,6 +172,12 @@ func generateAlgImports(o *codegen.Output, t Algorithm) {
 }
 
 func generateAlgGlobalState(o *codegen.Output, t Algorithm) {
+	if isKeyAlgorithmKind(t.Name) {
+		// KeyAlgorithm-implementing kinds dispatch through the shared
+		// algRegistry (hand-written in jwa.go); no per-kind state is
+		// emitted here.
+		return
+	}
 	o.LL("var muAll%s sync.RWMutex", t.Name)
 	o.L("var all%[1]s = map[string]%[1]s{}", t.Name)
 	o.L("var muList%s sync.RWMutex", t.Name)
@@ -186,7 +222,11 @@ func generateAlgInit(o *codegen.Output, t Algorithm) {
 	o.L("panic(fmt.Sprintf(%q, err))", fmt.Sprintf("jwa: failed to register builtin %s: %%s", t.Name))
 	o.L("}")
 	o.L("for _, alg := range algorithms {")
-	o.L("builtin%s[alg.String()] = struct{}{}", t.Name)
+	if isKeyAlgorithmKind(t.Name) {
+		o.L("markBuiltin(alg.String())")
+	} else {
+		o.L("builtin%s[alg.String()] = struct{}{}", t.Name)
+	}
 	o.L("}")
 	o.L("}") // end init
 }
@@ -223,13 +263,21 @@ func generateAlgAccessors(o *codegen.Output, t Algorithm) error {
 	}
 
 	o.LL("func lookupBuiltin%s(name string) %s {", t.Name, t.Name)
-	o.L("muAll%s.RLock()", t.Name)
-	o.L("v, ok := all%s[name]", t.Name)
-	o.L("muAll%s.RUnlock()", t.Name)
-	o.L("if !ok {")
-	o.L("panic(fmt.Sprintf(`jwa: %s %%q not registered`, name))", t.Name)
-	o.L("}")
-	o.L("return v")
+	if isKeyAlgorithmKind(t.Name) {
+		o.L("v, ok := lookupAlgorithm(algKind%s, name)", algKindEnumSuffix(t.Name))
+		o.L("if !ok {")
+		o.L("panic(fmt.Sprintf(`jwa: %s %%q not registered`, name))", t.Name)
+		o.L("}")
+		o.L("return v.(%s)", t.Name)
+	} else {
+		o.L("muAll%s.RLock()", t.Name)
+		o.L("v, ok := all%s[name]", t.Name)
+		o.L("muAll%s.RUnlock()", t.Name)
+		o.L("if !ok {")
+		o.L("panic(fmt.Sprintf(`jwa: %s %%q not registered`, name))", t.Name)
+		o.L("}")
+		o.L("return v")
+	}
 	o.L("}")
 	return nil
 }
@@ -299,6 +347,11 @@ func generateAlgConstructorAndEmpty(o *codegen.Output, t Algorithm) {
 }
 
 func generateAlgRegistration(o *codegen.Output, t Algorithm) {
+	if isKeyAlgorithmKind(t.Name) {
+		generateAlgRegistrationKeyAlgorithm(o, t)
+		return
+	}
+
 	o.LL("// Lookup%[1]s returns the %[1]s object for the given name.", t.Name)
 	o.L("func Lookup%[1]s(name string) (%[1]s, bool) {", t.Name)
 	o.L("muAll%[1]s.RLock()", t.Name)
@@ -365,6 +418,63 @@ func generateAlgRegistration(o *codegen.Output, t Algorithm) {
 	o.L("muList%[1]s.RLock()", t.Name)
 	o.L("defer muList%[1]s.RUnlock()", t.Name)
 	o.L("return list%[1]s", t.Name)
+	o.L("}")
+}
+
+// generateAlgRegistrationKeyAlgorithm emits the per-kind public
+// surface for the three KeyAlgorithm-implementing kinds. Each of
+// Lookup/Register/Unregister/<Kind>s becomes a thin wrapper around
+// the shared algRegistry helpers in jwa.go, so cross-kind name
+// collisions are caught at registration time.
+func generateAlgRegistrationKeyAlgorithm(o *codegen.Output, t Algorithm) {
+	suffix := algKindEnumSuffix(t.Name)
+
+	o.LL("// Lookup%[1]s returns the %[1]s object for the given name.", t.Name)
+	o.L("func Lookup%[1]s(name string) (%[1]s, bool) {", t.Name)
+	o.L("if v, ok := lookupAlgorithm(algKind%s, name); ok {", suffix)
+	o.L("return v.(%s), true", t.Name)
+	o.L("}")
+	o.L("var zero %s", t.Name)
+	o.L("return zero, false")
+	o.L("}")
+
+	o.LL("// Register%[1]s registers a new %[1]s. The signature value must be immutable", t.Name)
+	o.L("// and safe to be used by multiple goroutines, as it is going to be shared with all other users of this library.")
+	o.L("//")
+	o.L("// Registration is process-global. Built-in identifiers such as RS256 are")
+	o.L("// reserved and cannot be replaced by callers after init has completed; use a")
+	o.L("// distinct name for third-party algorithms.")
+	o.L("//")
+	o.L("// SignatureAlgorithm, KeyEncryptionAlgorithm, and ContentEncryptionAlgorithm")
+	o.L("// share a single algorithm-name namespace so that KeyAlgorithmFrom can")
+	o.L("// resolve unambiguously. Registering a name that is already registered as a")
+	o.L("// different kind returns an error naming both the existing and the requested")
+	o.L("// kind.")
+	o.L("func Register%[1]s(algorithms ...%[1]s) error {", t.Name)
+	o.L("for _, alg := range algorithms {")
+	o.L("if err := registerAlgorithm(algKind%s, alg); err != nil {", suffix)
+	o.L("return err")
+	o.L("}")
+	o.L("}")
+	o.L("return nil")
+	o.L("}")
+
+	o.LL("// Unregister%[1]s unregisters a %[1]s from its known database.", t.Name)
+	o.L("// Non-existent entries, as well as built-in algorithms will silently be ignored.")
+	o.L("func Unregister%[1]s(algorithms ...%[1]s) {", t.Name)
+	o.L("for _, alg := range algorithms {")
+	o.L("unregisterAlgorithm(algKind%s, alg.String())", suffix)
+	o.L("}")
+	o.L("}")
+
+	o.LL("// %[1]ss returns a list of all available values for %[1]s.", t.Name)
+	o.L("func %[1]ss() []%[1]s {", t.Name)
+	o.L("raw := listAlgorithmsByKind(algKind%s)", suffix)
+	o.L("out := make([]%s, len(raw))", t.Name)
+	o.L("for i, alg := range raw {")
+	o.L("out[i] = alg.(%s)", t.Name)
+	o.L("}")
+	o.L("return out")
 	o.L("}")
 }
 

--- a/jwa/content_encryption_gen.go
+++ b/jwa/content_encryption_gen.go
@@ -3,21 +3,12 @@
 package jwa
 
 import (
-	"cmp"
 	"encoding/json"
 	"fmt"
-	"slices"
-	"sync"
 
 	"github.com/lestrrat-go/jwx/v4/internal/tokens"
 	"github.com/lestrrat-go/option/v3"
 )
-
-var muAllContentEncryptionAlgorithm sync.RWMutex
-var allContentEncryptionAlgorithm = map[string]ContentEncryptionAlgorithm{}
-var muListContentEncryptionAlgorithm sync.RWMutex
-var listContentEncryptionAlgorithm []ContentEncryptionAlgorithm
-var builtinContentEncryptionAlgorithm = map[string]struct{}{}
 
 func init() {
 	// builtin values for ContentEncryptionAlgorithm
@@ -33,7 +24,7 @@ func init() {
 		panic(fmt.Sprintf("jwa: failed to register builtin ContentEncryptionAlgorithm: %s", err))
 	}
 	for _, alg := range algorithms {
-		builtinContentEncryptionAlgorithm[alg.String()] = struct{}{}
+		markBuiltin(alg.String())
 	}
 }
 
@@ -68,13 +59,11 @@ func A256GCM() ContentEncryptionAlgorithm {
 }
 
 func lookupBuiltinContentEncryptionAlgorithm(name string) ContentEncryptionAlgorithm {
-	muAllContentEncryptionAlgorithm.RLock()
-	v, ok := allContentEncryptionAlgorithm[name]
-	muAllContentEncryptionAlgorithm.RUnlock()
+	v, ok := lookupAlgorithm(algKindContentEncryption, name)
 	if !ok {
 		panic(fmt.Sprintf(`jwa: ContentEncryptionAlgorithm %q not registered`, name))
 	}
-	return v
+	return v.(ContentEncryptionAlgorithm)
 }
 
 // ContentEncryptionAlgorithm represents the various encryption algorithms as described in https://tools.ietf.org/html/rfc7518#section-5
@@ -111,10 +100,11 @@ func NewContentEncryptionAlgorithm(name string, options ...NewAlgorithmOption) C
 
 // LookupContentEncryptionAlgorithm returns the ContentEncryptionAlgorithm object for the given name.
 func LookupContentEncryptionAlgorithm(name string) (ContentEncryptionAlgorithm, bool) {
-	muAllContentEncryptionAlgorithm.RLock()
-	v, ok := allContentEncryptionAlgorithm[name]
-	muAllContentEncryptionAlgorithm.RUnlock()
-	return v, ok
+	if v, ok := lookupAlgorithm(algKindContentEncryption, name); ok {
+		return v.(ContentEncryptionAlgorithm), true
+	}
+	var zero ContentEncryptionAlgorithm
+	return zero, false
 }
 
 // RegisterContentEncryptionAlgorithm registers a new ContentEncryptionAlgorithm. The signature value must be immutable
@@ -123,58 +113,37 @@ func LookupContentEncryptionAlgorithm(name string) (ContentEncryptionAlgorithm, 
 // Registration is process-global. Built-in identifiers such as RS256 are
 // reserved and cannot be replaced by callers after init has completed; use a
 // distinct name for third-party algorithms.
+//
+// SignatureAlgorithm, KeyEncryptionAlgorithm, and ContentEncryptionAlgorithm
+// share a single algorithm-name namespace so that KeyAlgorithmFrom can
+// resolve unambiguously. Registering a name that is already registered as a
+// different kind returns an error naming both the existing and the requested
+// kind.
 func RegisterContentEncryptionAlgorithm(algorithms ...ContentEncryptionAlgorithm) error {
-	muAllContentEncryptionAlgorithm.Lock()
-	defer muAllContentEncryptionAlgorithm.Unlock()
 	for _, alg := range algorithms {
-		if _, ok := builtinContentEncryptionAlgorithm[alg.String()]; ok {
-			if existing, ok := allContentEncryptionAlgorithm[alg.String()]; ok && existing != alg {
-				return fmt.Errorf(`jwa: ContentEncryptionAlgorithm %q is reserved for a built-in value`, alg.String())
-			}
+		if err := registerAlgorithm(algKindContentEncryption, alg); err != nil {
+			return err
 		}
 	}
-	for _, alg := range algorithms {
-		if _, ok := builtinContentEncryptionAlgorithm[alg.String()]; ok {
-			continue
-		}
-		allContentEncryptionAlgorithm[alg.String()] = alg
-	}
-	rebuildContentEncryptionAlgorithmLocked()
 	return nil
 }
 
 // UnregisterContentEncryptionAlgorithm unregisters a ContentEncryptionAlgorithm from its known database.
 // Non-existent entries, as well as built-in algorithms will silently be ignored.
 func UnregisterContentEncryptionAlgorithm(algorithms ...ContentEncryptionAlgorithm) {
-	muAllContentEncryptionAlgorithm.Lock()
-	defer muAllContentEncryptionAlgorithm.Unlock()
 	for _, alg := range algorithms {
-		if _, ok := builtinContentEncryptionAlgorithm[alg.String()]; ok {
-			continue
-		}
-		delete(allContentEncryptionAlgorithm, alg.String())
+		unregisterAlgorithm(algKindContentEncryption, alg.String())
 	}
-	rebuildContentEncryptionAlgorithmLocked()
-}
-
-func rebuildContentEncryptionAlgorithmLocked() {
-	list := make([]ContentEncryptionAlgorithm, 0, len(allContentEncryptionAlgorithm))
-	for _, v := range allContentEncryptionAlgorithm {
-		list = append(list, v)
-	}
-	slices.SortFunc(list, func(a, b ContentEncryptionAlgorithm) int {
-		return cmp.Compare(a.String(), b.String())
-	})
-	muListContentEncryptionAlgorithm.Lock()
-	listContentEncryptionAlgorithm = list
-	muListContentEncryptionAlgorithm.Unlock()
 }
 
 // ContentEncryptionAlgorithms returns a list of all available values for ContentEncryptionAlgorithm.
 func ContentEncryptionAlgorithms() []ContentEncryptionAlgorithm {
-	muListContentEncryptionAlgorithm.RLock()
-	defer muListContentEncryptionAlgorithm.RUnlock()
-	return listContentEncryptionAlgorithm
+	raw := listAlgorithmsByKind(algKindContentEncryption)
+	out := make([]ContentEncryptionAlgorithm, len(raw))
+	for i, alg := range raw {
+		out[i] = alg.(ContentEncryptionAlgorithm)
+	}
+	return out
 }
 
 // MarshalJSON serializes the ContentEncryptionAlgorithm object to a JSON string.

--- a/jwa/cross_kind_test.go
+++ b/jwa/cross_kind_test.go
@@ -1,0 +1,127 @@
+package jwa_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisterCrossKindCollision pins JWA-001: registering an
+// algorithm name that is already owned by a different kind must
+// return a structured error naming both kinds. Before unification,
+// the three Register* functions kept independent maps and would
+// happily accept the same string in two of them, after which
+// KeyAlgorithmFrom would silently resolve via fixed precedence.
+func TestRegisterCrossKindCollision(t *testing.T) {
+	const name = "TESTALG-XKIND"
+
+	t.Run("Sig then KeyEncryption", func(t *testing.T) {
+		sig := jwa.NewSignatureAlgorithm(name)
+		require.NoError(t, jwa.RegisterSignatureAlgorithm(sig))
+		t.Cleanup(func() { jwa.UnregisterSignatureAlgorithm(sig) })
+
+		kenc := jwa.NewKeyEncryptionAlgorithm(name)
+		err := jwa.RegisterKeyEncryptionAlgorithm(kenc)
+		require.Error(t, err, `cross-kind registration should be refused`)
+		require.Contains(t, err.Error(), name, `error should name the algorithm`)
+		require.Contains(t, err.Error(), "SignatureAlgorithm",
+			`error should name the existing kind`)
+		require.Contains(t, err.Error(), "KeyEncryptionAlgorithm",
+			`error should name the requested kind`)
+	})
+
+	t.Run("Sig then ContentEncryption", func(t *testing.T) {
+		// Use a distinct name so this subtest is independent of the
+		// one above.
+		const name = "TESTALG-XKIND-CE"
+		sig := jwa.NewSignatureAlgorithm(name)
+		require.NoError(t, jwa.RegisterSignatureAlgorithm(sig))
+		t.Cleanup(func() { jwa.UnregisterSignatureAlgorithm(sig) })
+
+		cenc := jwa.NewContentEncryptionAlgorithm(name)
+		err := jwa.RegisterContentEncryptionAlgorithm(cenc)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), name)
+		require.Contains(t, err.Error(), "SignatureAlgorithm")
+		require.Contains(t, err.Error(), "ContentEncryptionAlgorithm")
+	})
+
+	t.Run("KeyEncryption then Sig", func(t *testing.T) {
+		// Inverse direction: confirm the check is symmetric.
+		const name = "TESTALG-XKIND-KS"
+		kenc := jwa.NewKeyEncryptionAlgorithm(name)
+		require.NoError(t, jwa.RegisterKeyEncryptionAlgorithm(kenc))
+		t.Cleanup(func() { jwa.UnregisterKeyEncryptionAlgorithm(kenc) })
+
+		sig := jwa.NewSignatureAlgorithm(name)
+		err := jwa.RegisterSignatureAlgorithm(sig)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "KeyEncryptionAlgorithm")
+		require.Contains(t, err.Error(), "SignatureAlgorithm")
+	})
+}
+
+// TestKeyAlgorithmFromUnambiguous pins that KeyAlgorithmFrom resolves
+// via the shared registry, returning the registered typed value
+// without any precedence rule between kinds. Before unification,
+// KeyAlgorithmFrom("X") would prefer SignatureAlgorithm even when
+// the caller registered "X" only as KeyEncryptionAlgorithm.
+func TestKeyAlgorithmFromUnambiguous(t *testing.T) {
+	const name = "TESTALG-UNAMBIG"
+	kenc := jwa.NewKeyEncryptionAlgorithm(name)
+	require.NoError(t, jwa.RegisterKeyEncryptionAlgorithm(kenc))
+	t.Cleanup(func() { jwa.UnregisterKeyEncryptionAlgorithm(kenc) })
+
+	got, err := jwa.KeyAlgorithmFrom(name)
+	require.NoError(t, err)
+	_, ok := got.(jwa.KeyEncryptionAlgorithm)
+	require.True(t, ok,
+		`KeyAlgorithmFrom should return the registered KeyEncryptionAlgorithm typed value, got %T`, got)
+}
+
+// TestKeyAlgorithmFromZeroValueRejected pins JWA-002: a zero-value
+// typed algorithm has String() == "" and cannot resolve through any
+// registry. Before this check, the typed arms accepted such inputs
+// and the failure surfaced far from the call site (deep inside
+// jws.Sign etc.) with confusing messages.
+func TestKeyAlgorithmFromZeroValueRejected(t *testing.T) {
+	t.Run("zero SignatureAlgorithm", func(t *testing.T) {
+		var sa jwa.SignatureAlgorithm
+		_, err := jwa.KeyAlgorithmFrom(sa)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jwa.ErrInvalidKeyAlgorithm()),
+			`zero-value typed alg should wrap ErrInvalidKeyAlgorithm, got %v`, err)
+	})
+
+	t.Run("zero KeyEncryptionAlgorithm", func(t *testing.T) {
+		var ka jwa.KeyEncryptionAlgorithm
+		_, err := jwa.KeyAlgorithmFrom(ka)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jwa.ErrInvalidKeyAlgorithm()))
+	})
+
+	t.Run("zero ContentEncryptionAlgorithm", func(t *testing.T) {
+		var ca jwa.ContentEncryptionAlgorithm
+		_, err := jwa.KeyAlgorithmFrom(ca)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jwa.ErrInvalidKeyAlgorithm()))
+	})
+
+	t.Run("EmptySignatureAlgorithm() helper", func(t *testing.T) {
+		_, err := jwa.KeyAlgorithmFrom(jwa.EmptySignatureAlgorithm())
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jwa.ErrInvalidKeyAlgorithm()))
+	})
+}
+
+// TestRegisterIdempotent pins that re-registering the exact same
+// value is a no-op, regardless of whether it's a builtin. This
+// preserves the pre-unification behavior; some companion init()
+// paths can be re-entered in tests, and breaking idempotence here
+// would surface as random test failures.
+func TestRegisterIdempotent(t *testing.T) {
+	require.NoError(t, jwa.RegisterSignatureAlgorithm(jwa.ES256()))
+	require.NoError(t, jwa.RegisterSignatureAlgorithm(jwa.ES256()))
+}

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -6,6 +6,8 @@ package jwa
 import (
 	"errors"
 	"fmt"
+	"sort"
+	"sync"
 )
 
 const maxKeyAlgorithmErrorPreview = 64
@@ -41,38 +43,182 @@ func formatInvalidKeyAlgorithmValue(v string) string {
 	return fmt.Sprintf("%q", string(runes[:maxKeyAlgorithmErrorPreview])+`...`)
 }
 
+// algorithmKind tags entries in the shared algRegistry so the
+// per-kind public Register/Lookup/Unregister/<Kind>s functions can
+// dispatch through one map without losing the typed identity of each
+// algorithm.
+type algorithmKind uint8
+
+const (
+	algKindUnknown algorithmKind = iota
+	algKindSignature
+	algKindKeyEncryption
+	algKindContentEncryption
+)
+
+func (k algorithmKind) String() string {
+	switch k {
+	case algKindSignature:
+		return "SignatureAlgorithm"
+	case algKindKeyEncryption:
+		return "KeyEncryptionAlgorithm"
+	case algKindContentEncryption:
+		return "ContentEncryptionAlgorithm"
+	default:
+		return "unknown algorithm kind"
+	}
+}
+
+type algRegistryEntry struct {
+	kind    algorithmKind
+	alg     KeyAlgorithm
+	builtin bool
+}
+
+// algRegistry is the single shared namespace for the three
+// KeyAlgorithm-implementing kinds. Independent per-kind maps would
+// let an extension register the same name as both (say) a
+// SignatureAlgorithm and a KeyEncryptionAlgorithm, after which
+// KeyAlgorithmFrom("X") would resolve to whichever kind was tried
+// first — silently flipping with import order. Funnelling all three
+// through one map turns that collision into a loud Register* error
+// at the conflicting init() call site.
+var (
+	muAlgRegistry sync.RWMutex
+	algRegistry   = map[string]algRegistryEntry{}
+)
+
+// registerAlgorithm is the shared backend for the three public
+// Register{Signature,KeyEncryption,ContentEncryption}Algorithm
+// functions.
+//
+// Behavior:
+//   - Re-registering the exact same value (same kind, same alg) is a
+//     no-op. Mirrors the pre-unification behavior where calling
+//     RegisterSignatureAlgorithm(ES256()) twice was harmless.
+//   - Cross-kind collision is rejected with a structured error
+//     naming both the existing kind and the requested kind.
+//   - Replacing a built-in is rejected with the existing
+//     "reserved for a built-in value" error.
+//   - Same-kind, non-builtin re-registration with a different value
+//     silently overwrites. This preserves the pre-unification
+//     behavior of the per-kind Register* functions; tightening this
+//     is a separate UX concern.
+func registerAlgorithm(kind algorithmKind, alg KeyAlgorithm) error {
+	name := alg.String()
+	muAlgRegistry.Lock()
+	defer muAlgRegistry.Unlock()
+	if existing, ok := algRegistry[name]; ok {
+		if existing.kind == kind && existing.alg == alg {
+			return nil
+		}
+		if existing.kind != kind {
+			return fmt.Errorf(`jwa: %q is already registered as %s; cannot register as %s`, name, existing.kind, kind)
+		}
+		if existing.builtin {
+			return fmt.Errorf(`jwa: %s %q is reserved for a built-in value`, kind, name)
+		}
+	}
+	algRegistry[name] = algRegistryEntry{kind: kind, alg: alg}
+	return nil
+}
+
+// markBuiltin flips the builtin flag on an already-registered name.
+// Called by the per-kind generated init() after the bulk Register*
+// pass, preserving the existing two-phase init pattern.
+func markBuiltin(name string) {
+	muAlgRegistry.Lock()
+	defer muAlgRegistry.Unlock()
+	if entry, ok := algRegistry[name]; ok {
+		entry.builtin = true
+		algRegistry[name] = entry
+	}
+}
+
+// unregisterAlgorithm is the shared backend for the three public
+// Unregister*Algorithm functions. No-op for built-ins, no-op for a
+// kind mismatch, no-op for unknown names — same surface contract as
+// the pre-unification per-kind Unregister*.
+func unregisterAlgorithm(kind algorithmKind, name string) {
+	muAlgRegistry.Lock()
+	defer muAlgRegistry.Unlock()
+	if entry, ok := algRegistry[name]; ok && entry.kind == kind && !entry.builtin {
+		delete(algRegistry, name)
+	}
+}
+
+// lookupAlgorithm returns the registered KeyAlgorithm for name iff it
+// is registered as the requested kind. Used by the per-kind
+// generated Lookup* wrappers.
+func lookupAlgorithm(kind algorithmKind, name string) (KeyAlgorithm, bool) {
+	muAlgRegistry.RLock()
+	defer muAlgRegistry.RUnlock()
+	if entry, ok := algRegistry[name]; ok && entry.kind == kind {
+		return entry.alg, true
+	}
+	return nil, false
+}
+
+// listAlgorithmsByKind returns every registered algorithm of the
+// given kind, sorted by name. Used by the per-kind generated
+// <Kind>s() functions. The pre-unification implementation kept a
+// dedicated cached slice rebuilt on each Register/Unregister; here
+// we just iterate the shared map and sort, which is cheap for the
+// <50-entry registries jwa exposes.
+func listAlgorithmsByKind(kind algorithmKind) []KeyAlgorithm {
+	muAlgRegistry.RLock()
+	defer muAlgRegistry.RUnlock()
+	out := make([]KeyAlgorithm, 0, len(algRegistry))
+	for _, entry := range algRegistry {
+		if entry.kind == kind {
+			out = append(out, entry.alg)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	return out
+}
+
 // KeyAlgorithmFrom takes either a string, `jwa.SignatureAlgorithm`,
-// `jwa.KeyEncryptionAlgorithm`, or `jwa.ContentEncryptionAlgorithm`.
+// `jwa.KeyEncryptionAlgorithm`, or `jwa.ContentEncryptionAlgorithm`,
 // and returns a `jwa.KeyAlgorithm`.
 //
-// If the value cannot be handled, it returns an `jwa.InvalidKeyAlgorithm`
-// object instead of returning an error. This design choice was made to allow
-// users to directly pass the return value to functions such as `jws.Sign()`
+// String inputs resolve through the shared algorithm registry: the
+// returned KeyAlgorithm holds the concrete typed value (Signature,
+// KeyEncryption, or ContentEncryption) for whichever kind owns the
+// name. Cross-kind name reuse is structurally impossible — the
+// registry refuses it at registration time — so KeyAlgorithmFrom no
+// longer needs precedence rules.
+//
+// Typed inputs whose String() is empty (for example a zero-value
+// `var sa jwa.SignatureAlgorithm`) are rejected with
+// ErrInvalidKeyAlgorithm. Without this check the typed arms accepted
+// names that would never resolve through any registry, surfacing as
+// confusing failures far from the call site.
 func KeyAlgorithmFrom(v any) (KeyAlgorithm, error) {
 	switch v := v.(type) {
 	case SignatureAlgorithm:
+		if v.String() == "" {
+			return nil, fmt.Errorf(`invalid key value: zero-value %T: %w`, v, errInvalidKeyAlgorithm)
+		}
 		return v, nil
 	case KeyEncryptionAlgorithm:
+		if v.String() == "" {
+			return nil, fmt.Errorf(`invalid key value: zero-value %T: %w`, v, errInvalidKeyAlgorithm)
+		}
 		return v, nil
 	case ContentEncryptionAlgorithm:
+		if v.String() == "" {
+			return nil, fmt.Errorf(`invalid key value: zero-value %T: %w`, v, errInvalidKeyAlgorithm)
+		}
 		return v, nil
 	case string:
-		salg, ok := LookupSignatureAlgorithm(v)
-		if ok {
-			return salg, nil
+		muAlgRegistry.RLock()
+		entry, ok := algRegistry[v]
+		muAlgRegistry.RUnlock()
+		if !ok {
+			return nil, fmt.Errorf(`invalid key value: %s: %w`, formatInvalidKeyAlgorithmValue(v), errInvalidKeyAlgorithm)
 		}
-
-		kalg, ok := LookupKeyEncryptionAlgorithm(v)
-		if ok {
-			return kalg, nil
-		}
-
-		calg, ok := LookupContentEncryptionAlgorithm(v)
-		if ok {
-			return calg, nil
-		}
-
-		return nil, fmt.Errorf(`invalid key value: %s: %w`, formatInvalidKeyAlgorithmValue(v), errInvalidKeyAlgorithm)
+		return entry.alg, nil
 	default:
 		return nil, fmt.Errorf(`invalid key type: %T: %w`, v, errInvalidKeyAlgorithm)
 	}

--- a/jwa/key_encryption_gen.go
+++ b/jwa/key_encryption_gen.go
@@ -3,21 +3,12 @@
 package jwa
 
 import (
-	"cmp"
 	"encoding/json"
 	"fmt"
-	"slices"
-	"sync"
 
 	"github.com/lestrrat-go/jwx/v4/internal/tokens"
 	"github.com/lestrrat-go/option/v3"
 )
-
-var muAllKeyEncryptionAlgorithm sync.RWMutex
-var allKeyEncryptionAlgorithm = map[string]KeyEncryptionAlgorithm{}
-var muListKeyEncryptionAlgorithm sync.RWMutex
-var listKeyEncryptionAlgorithm []KeyEncryptionAlgorithm
-var builtinKeyEncryptionAlgorithm = map[string]struct{}{}
 
 func init() {
 	// builtin values for KeyEncryptionAlgorithm
@@ -52,7 +43,7 @@ func init() {
 		panic(fmt.Sprintf("jwa: failed to register builtin KeyEncryptionAlgorithm: %s", err))
 	}
 	for _, alg := range algorithms {
-		builtinKeyEncryptionAlgorithm[alg.String()] = struct{}{}
+		markBuiltin(alg.String())
 	}
 }
 
@@ -182,13 +173,11 @@ func RSA_OAEP_512() KeyEncryptionAlgorithm {
 }
 
 func lookupBuiltinKeyEncryptionAlgorithm(name string) KeyEncryptionAlgorithm {
-	muAllKeyEncryptionAlgorithm.RLock()
-	v, ok := allKeyEncryptionAlgorithm[name]
-	muAllKeyEncryptionAlgorithm.RUnlock()
+	v, ok := lookupAlgorithm(algKindKeyEncryption, name)
 	if !ok {
 		panic(fmt.Sprintf(`jwa: KeyEncryptionAlgorithm %q not registered`, name))
 	}
-	return v
+	return v.(KeyEncryptionAlgorithm)
 }
 
 // KeyEncryptionAlgorithm represents the various encryption algorithms as described in https://tools.ietf.org/html/rfc7518#section-4.1
@@ -234,10 +223,11 @@ func NewKeyEncryptionAlgorithm(name string, options ...NewKeyEncryptionAlgorithm
 
 // LookupKeyEncryptionAlgorithm returns the KeyEncryptionAlgorithm object for the given name.
 func LookupKeyEncryptionAlgorithm(name string) (KeyEncryptionAlgorithm, bool) {
-	muAllKeyEncryptionAlgorithm.RLock()
-	v, ok := allKeyEncryptionAlgorithm[name]
-	muAllKeyEncryptionAlgorithm.RUnlock()
-	return v, ok
+	if v, ok := lookupAlgorithm(algKindKeyEncryption, name); ok {
+		return v.(KeyEncryptionAlgorithm), true
+	}
+	var zero KeyEncryptionAlgorithm
+	return zero, false
 }
 
 // RegisterKeyEncryptionAlgorithm registers a new KeyEncryptionAlgorithm. The signature value must be immutable
@@ -246,58 +236,37 @@ func LookupKeyEncryptionAlgorithm(name string) (KeyEncryptionAlgorithm, bool) {
 // Registration is process-global. Built-in identifiers such as RS256 are
 // reserved and cannot be replaced by callers after init has completed; use a
 // distinct name for third-party algorithms.
+//
+// SignatureAlgorithm, KeyEncryptionAlgorithm, and ContentEncryptionAlgorithm
+// share a single algorithm-name namespace so that KeyAlgorithmFrom can
+// resolve unambiguously. Registering a name that is already registered as a
+// different kind returns an error naming both the existing and the requested
+// kind.
 func RegisterKeyEncryptionAlgorithm(algorithms ...KeyEncryptionAlgorithm) error {
-	muAllKeyEncryptionAlgorithm.Lock()
-	defer muAllKeyEncryptionAlgorithm.Unlock()
 	for _, alg := range algorithms {
-		if _, ok := builtinKeyEncryptionAlgorithm[alg.String()]; ok {
-			if existing, ok := allKeyEncryptionAlgorithm[alg.String()]; ok && existing != alg {
-				return fmt.Errorf(`jwa: KeyEncryptionAlgorithm %q is reserved for a built-in value`, alg.String())
-			}
+		if err := registerAlgorithm(algKindKeyEncryption, alg); err != nil {
+			return err
 		}
 	}
-	for _, alg := range algorithms {
-		if _, ok := builtinKeyEncryptionAlgorithm[alg.String()]; ok {
-			continue
-		}
-		allKeyEncryptionAlgorithm[alg.String()] = alg
-	}
-	rebuildKeyEncryptionAlgorithmLocked()
 	return nil
 }
 
 // UnregisterKeyEncryptionAlgorithm unregisters a KeyEncryptionAlgorithm from its known database.
 // Non-existent entries, as well as built-in algorithms will silently be ignored.
 func UnregisterKeyEncryptionAlgorithm(algorithms ...KeyEncryptionAlgorithm) {
-	muAllKeyEncryptionAlgorithm.Lock()
-	defer muAllKeyEncryptionAlgorithm.Unlock()
 	for _, alg := range algorithms {
-		if _, ok := builtinKeyEncryptionAlgorithm[alg.String()]; ok {
-			continue
-		}
-		delete(allKeyEncryptionAlgorithm, alg.String())
+		unregisterAlgorithm(algKindKeyEncryption, alg.String())
 	}
-	rebuildKeyEncryptionAlgorithmLocked()
-}
-
-func rebuildKeyEncryptionAlgorithmLocked() {
-	list := make([]KeyEncryptionAlgorithm, 0, len(allKeyEncryptionAlgorithm))
-	for _, v := range allKeyEncryptionAlgorithm {
-		list = append(list, v)
-	}
-	slices.SortFunc(list, func(a, b KeyEncryptionAlgorithm) int {
-		return cmp.Compare(a.String(), b.String())
-	})
-	muListKeyEncryptionAlgorithm.Lock()
-	listKeyEncryptionAlgorithm = list
-	muListKeyEncryptionAlgorithm.Unlock()
 }
 
 // KeyEncryptionAlgorithms returns a list of all available values for KeyEncryptionAlgorithm.
 func KeyEncryptionAlgorithms() []KeyEncryptionAlgorithm {
-	muListKeyEncryptionAlgorithm.RLock()
-	defer muListKeyEncryptionAlgorithm.RUnlock()
-	return listKeyEncryptionAlgorithm
+	raw := listAlgorithmsByKind(algKindKeyEncryption)
+	out := make([]KeyEncryptionAlgorithm, len(raw))
+	for i, alg := range raw {
+		out[i] = alg.(KeyEncryptionAlgorithm)
+	}
+	return out
 }
 
 // MarshalJSON serializes the KeyEncryptionAlgorithm object to a JSON string.

--- a/jwa/signature_gen.go
+++ b/jwa/signature_gen.go
@@ -3,20 +3,11 @@
 package jwa
 
 import (
-	"cmp"
 	"encoding/json"
 	"fmt"
-	"slices"
-	"sync"
 
 	"github.com/lestrrat-go/option/v3"
 )
-
-var muAllSignatureAlgorithm sync.RWMutex
-var allSignatureAlgorithm = map[string]SignatureAlgorithm{}
-var muListSignatureAlgorithm sync.RWMutex
-var listSignatureAlgorithm []SignatureAlgorithm
-var builtinSignatureAlgorithm = map[string]struct{}{}
 
 func init() {
 	// builtin values for SignatureAlgorithm
@@ -41,7 +32,7 @@ func init() {
 		panic(fmt.Sprintf("jwa: failed to register builtin SignatureAlgorithm: %s", err))
 	}
 	for _, alg := range algorithms {
-		builtinSignatureAlgorithm[alg.String()] = struct{}{}
+		markBuiltin(alg.String())
 	}
 }
 
@@ -121,13 +112,11 @@ func RS512() SignatureAlgorithm {
 }
 
 func lookupBuiltinSignatureAlgorithm(name string) SignatureAlgorithm {
-	muAllSignatureAlgorithm.RLock()
-	v, ok := allSignatureAlgorithm[name]
-	muAllSignatureAlgorithm.RUnlock()
+	v, ok := lookupAlgorithm(algKindSignature, name)
 	if !ok {
 		panic(fmt.Sprintf(`jwa: SignatureAlgorithm %q not registered`, name))
 	}
-	return v
+	return v.(SignatureAlgorithm)
 }
 
 // SignatureAlgorithm represents the various signature algorithms as described in https://tools.ietf.org/html/rfc7518#section-3.1
@@ -173,10 +162,11 @@ func NewSignatureAlgorithm(name string, options ...NewSignatureAlgorithmOption) 
 
 // LookupSignatureAlgorithm returns the SignatureAlgorithm object for the given name.
 func LookupSignatureAlgorithm(name string) (SignatureAlgorithm, bool) {
-	muAllSignatureAlgorithm.RLock()
-	v, ok := allSignatureAlgorithm[name]
-	muAllSignatureAlgorithm.RUnlock()
-	return v, ok
+	if v, ok := lookupAlgorithm(algKindSignature, name); ok {
+		return v.(SignatureAlgorithm), true
+	}
+	var zero SignatureAlgorithm
+	return zero, false
 }
 
 // RegisterSignatureAlgorithm registers a new SignatureAlgorithm. The signature value must be immutable
@@ -185,58 +175,37 @@ func LookupSignatureAlgorithm(name string) (SignatureAlgorithm, bool) {
 // Registration is process-global. Built-in identifiers such as RS256 are
 // reserved and cannot be replaced by callers after init has completed; use a
 // distinct name for third-party algorithms.
+//
+// SignatureAlgorithm, KeyEncryptionAlgorithm, and ContentEncryptionAlgorithm
+// share a single algorithm-name namespace so that KeyAlgorithmFrom can
+// resolve unambiguously. Registering a name that is already registered as a
+// different kind returns an error naming both the existing and the requested
+// kind.
 func RegisterSignatureAlgorithm(algorithms ...SignatureAlgorithm) error {
-	muAllSignatureAlgorithm.Lock()
-	defer muAllSignatureAlgorithm.Unlock()
 	for _, alg := range algorithms {
-		if _, ok := builtinSignatureAlgorithm[alg.String()]; ok {
-			if existing, ok := allSignatureAlgorithm[alg.String()]; ok && existing != alg {
-				return fmt.Errorf(`jwa: SignatureAlgorithm %q is reserved for a built-in value`, alg.String())
-			}
+		if err := registerAlgorithm(algKindSignature, alg); err != nil {
+			return err
 		}
 	}
-	for _, alg := range algorithms {
-		if _, ok := builtinSignatureAlgorithm[alg.String()]; ok {
-			continue
-		}
-		allSignatureAlgorithm[alg.String()] = alg
-	}
-	rebuildSignatureAlgorithmLocked()
 	return nil
 }
 
 // UnregisterSignatureAlgorithm unregisters a SignatureAlgorithm from its known database.
 // Non-existent entries, as well as built-in algorithms will silently be ignored.
 func UnregisterSignatureAlgorithm(algorithms ...SignatureAlgorithm) {
-	muAllSignatureAlgorithm.Lock()
-	defer muAllSignatureAlgorithm.Unlock()
 	for _, alg := range algorithms {
-		if _, ok := builtinSignatureAlgorithm[alg.String()]; ok {
-			continue
-		}
-		delete(allSignatureAlgorithm, alg.String())
+		unregisterAlgorithm(algKindSignature, alg.String())
 	}
-	rebuildSignatureAlgorithmLocked()
-}
-
-func rebuildSignatureAlgorithmLocked() {
-	list := make([]SignatureAlgorithm, 0, len(allSignatureAlgorithm))
-	for _, v := range allSignatureAlgorithm {
-		list = append(list, v)
-	}
-	slices.SortFunc(list, func(a, b SignatureAlgorithm) int {
-		return cmp.Compare(a.String(), b.String())
-	})
-	muListSignatureAlgorithm.Lock()
-	listSignatureAlgorithm = list
-	muListSignatureAlgorithm.Unlock()
 }
 
 // SignatureAlgorithms returns a list of all available values for SignatureAlgorithm.
 func SignatureAlgorithms() []SignatureAlgorithm {
-	muListSignatureAlgorithm.RLock()
-	defer muListSignatureAlgorithm.RUnlock()
-	return listSignatureAlgorithm
+	raw := listAlgorithmsByKind(algKindSignature)
+	out := make([]SignatureAlgorithm, len(raw))
+	for i, alg := range raw {
+		out[i] = alg.(SignatureAlgorithm)
+	}
+	return out
 }
 
 // MarshalJSON serializes the SignatureAlgorithm object to a JSON string.


### PR DESCRIPTION
`KeyAlgorithmFrom("X")` used to walk three independent registries — `SignatureAlgorithm` → `KeyEncryptionAlgorithm` → `ContentEncryptionAlgorithm` — and return the first hit. There was no cross-registry uniqueness, so an extension could register the same name in two kinds and `KeyAlgorithmFrom` would silently flip resolution with import order. Failure landed deep in `jws.Sign` / `jwe.Encrypt` with confusing messages far from the misconfiguration.

This change funnels all three KeyAlgorithm-implementing kinds through a single shared `algRegistry` (hand-written in `jwa/jwa.go`). Per-kind `Register*` / `Lookup*` / `Unregister*` / `<Kind>s()` become thin wrappers around five private helpers (`registerAlgorithm`, `markBuiltin`, `unregisterAlgorithm`, `lookupAlgorithm`, `listAlgorithmsByKind`) emitted by the generator. Cross-kind name reuse becomes a structured error from `Register*` at the conflicting init() call site, which existing `panicOnRegistrationError` wrappers turn into a startup crash.

Bundles JWA-002: `KeyAlgorithmFrom` typed arms now reject zero-value typed algorithms (`String() == ""`) with `ErrInvalidKeyAlgorithm`.

Preserved:
- Same-kind idempotent re-registration (`RegisterSignatureAlgorithm(ES256())` twice is a no-op).
- Per-kind built-in protection ("reserved for a built-in value").
- Same-kind, non-builtin overwrite (separate UX concern, not flagged).

Out of scope:
- `KeyType`, `EllipticCurveAlgorithm`, `CompressionAlgorithm` — they don't dispatch through `KeyAlgorithmFrom` and don't have JWA-001's collision shape.
- v3 backport — separate follow-up via the older `tools/cmd/genjwa/` generator.

Tests added at `jwa/cross_kind_test.go`: cross-kind collision (3 directions), unambiguous lookup, zero-value rejection (3 typed kinds + `EmptySignatureAlgorithm()`), idempotent re-register. mldsa companion smoke against the unified registry passes.