### PR TITLE
jwa: unify SignatureAlgorithm/KeyEncryption/ContentEncryption into one registry

### DIFF
--- a/jwa/content_encryption_gen.go
+++ b/jwa/content_encryption_gen.go
@@ -5,17 +5,9 @@ package jwa
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
-	"sync"
 
 	"github.com/lestrrat-go/jwx/v3/internal/tokens"
 )
-
-var muAllContentEncryptionAlgorithm sync.RWMutex
-var allContentEncryptionAlgorithm = map[string]ContentEncryptionAlgorithm{}
-var muListContentEncryptionAlgorithm sync.RWMutex
-var listContentEncryptionAlgorithm []ContentEncryptionAlgorithm
-var builtinContentEncryptionAlgorithm = map[string]struct{}{}
 
 func init() {
 	// builtin values for ContentEncryptionAlgorithm
@@ -29,7 +21,7 @@ func init() {
 
 	RegisterContentEncryptionAlgorithm(algorithms...)
 	for _, alg := range algorithms {
-		builtinContentEncryptionAlgorithm[alg.String()] = struct{}{}
+		markBuiltin(alg.String())
 	}
 }
 
@@ -64,13 +56,11 @@ func A256GCM() ContentEncryptionAlgorithm {
 }
 
 func lookupBuiltinContentEncryptionAlgorithm(name string) ContentEncryptionAlgorithm {
-	muAllContentEncryptionAlgorithm.RLock()
-	v, ok := allContentEncryptionAlgorithm[name]
-	muAllContentEncryptionAlgorithm.RUnlock()
+	v, ok := lookupAlgorithm(algKindContentEncryption, name)
 	if !ok {
 		panic(fmt.Sprintf(`jwa: ContentEncryptionAlgorithm %q not registered`, name))
 	}
-	return v
+	return v.(ContentEncryptionAlgorithm)
 }
 
 // ContentEncryptionAlgorithm represents the various encryption algorithms as described in https://tools.ietf.org/html/rfc7518#section-5
@@ -109,10 +99,11 @@ func NewContentEncryptionAlgorithm(name string, options ...NewAlgorithmOption) C
 
 // LookupContentEncryptionAlgorithm returns the ContentEncryptionAlgorithm object for the given name.
 func LookupContentEncryptionAlgorithm(name string) (ContentEncryptionAlgorithm, bool) {
-	muAllContentEncryptionAlgorithm.RLock()
-	v, ok := allContentEncryptionAlgorithm[name]
-	muAllContentEncryptionAlgorithm.RUnlock()
-	return v, ok
+	if v, ok := lookupAlgorithm(algKindContentEncryption, name); ok {
+		return v.(ContentEncryptionAlgorithm), true
+	}
+	var zero ContentEncryptionAlgorithm
+	return zero, false
 }
 
 // RegisterContentEncryptionAlgorithm registers a new ContentEncryptionAlgorithm. The signature value must be immutable
@@ -121,53 +112,33 @@ func LookupContentEncryptionAlgorithm(name string) (ContentEncryptionAlgorithm, 
 // Registration is process-global. Built-in identifiers such as RS256 are
 // reserved and cannot be replaced by callers after init has completed; use a
 // distinct name for third-party algorithms.
+//
+// SignatureAlgorithm, KeyEncryptionAlgorithm, and ContentEncryptionAlgorithm
+// share a single algorithm-name namespace so that KeyAlgorithmFrom can
+// resolve unambiguously. Registering a name that is already registered as a
+// different kind is a silent no-op (the first Register* call wins).
 func RegisterContentEncryptionAlgorithm(algorithms ...ContentEncryptionAlgorithm) {
-	muAllContentEncryptionAlgorithm.Lock()
-	defer muAllContentEncryptionAlgorithm.Unlock()
 	for _, alg := range algorithms {
-		if _, ok := builtinContentEncryptionAlgorithm[alg.String()]; ok {
-			if existing, ok := allContentEncryptionAlgorithm[alg.String()]; ok && existing != alg {
-				continue
-			}
-			continue
-		}
-		allContentEncryptionAlgorithm[alg.String()] = alg
+		registerAlgorithm(algKindContentEncryption, alg)
 	}
-	rebuildContentEncryptionAlgorithmLocked()
 }
 
 // UnregisterContentEncryptionAlgorithm unregisters a ContentEncryptionAlgorithm from its known database.
 // Non-existent entries, as well as built-in algorithms will silently be ignored.
 func UnregisterContentEncryptionAlgorithm(algorithms ...ContentEncryptionAlgorithm) {
-	muAllContentEncryptionAlgorithm.Lock()
-	defer muAllContentEncryptionAlgorithm.Unlock()
 	for _, alg := range algorithms {
-		if _, ok := builtinContentEncryptionAlgorithm[alg.String()]; ok {
-			continue
-		}
-		delete(allContentEncryptionAlgorithm, alg.String())
+		unregisterAlgorithm(algKindContentEncryption, alg.String())
 	}
-	rebuildContentEncryptionAlgorithmLocked()
-}
-
-func rebuildContentEncryptionAlgorithmLocked() {
-	list := make([]ContentEncryptionAlgorithm, 0, len(allContentEncryptionAlgorithm))
-	for _, v := range allContentEncryptionAlgorithm {
-		list = append(list, v)
-	}
-	sort.Slice(list, func(i, j int) bool {
-		return list[i].String() < list[j].String()
-	})
-	muListContentEncryptionAlgorithm.Lock()
-	listContentEncryptionAlgorithm = list
-	muListContentEncryptionAlgorithm.Unlock()
 }
 
 // ContentEncryptionAlgorithms returns a list of all available values for ContentEncryptionAlgorithm.
 func ContentEncryptionAlgorithms() []ContentEncryptionAlgorithm {
-	muListContentEncryptionAlgorithm.RLock()
-	defer muListContentEncryptionAlgorithm.RUnlock()
-	return listContentEncryptionAlgorithm
+	raw := listAlgorithmsByKind(algKindContentEncryption)
+	out := make([]ContentEncryptionAlgorithm, len(raw))
+	for i, alg := range raw {
+		out[i] = alg.(ContentEncryptionAlgorithm)
+	}
+	return out
 }
 
 // MarshalJSON serializes the ContentEncryptionAlgorithm object to a JSON string.

--- a/jwa/cross_kind_test.go
+++ b/jwa/cross_kind_test.go
@@ -1,0 +1,138 @@
+package jwa_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisterCrossKindSilentNoop pins JWA-001 in v3: registering an
+// algorithm name that is already owned by a different kind is a
+// silent no-op (the first Register* call wins). v3's pre-existing
+// Register* signature returns nothing and v3 does not change
+// observable error/panic behavior, so the cross-kind path can't
+// surface as a returned error or a panic — it just doesn't take.
+//
+// The point of this test is to pin the post-unification observable:
+// after Register Sig "X" + Register KeyEnc "X", Lookup for the
+// second kind returns false and KeyAlgorithmFrom resolves to the
+// first kind. Pre-unification both Lookups would have returned
+// their entries and KeyAlgorithmFrom would have resolved Sig-first
+// by fixed precedence.
+func TestRegisterCrossKindSilentNoop(t *testing.T) {
+	t.Run("Sig wins, KeyEncryption registration silently dropped", func(t *testing.T) {
+		const name = "TESTALG-XKIND"
+		sig := jwa.NewSignatureAlgorithm(name)
+		jwa.RegisterSignatureAlgorithm(sig)
+		t.Cleanup(func() { jwa.UnregisterSignatureAlgorithm(sig) })
+
+		kenc := jwa.NewKeyEncryptionAlgorithm(name)
+		require.NotPanics(t, func() {
+			jwa.RegisterKeyEncryptionAlgorithm(kenc)
+		}, `cross-kind registration must NOT panic — v3 keeps observable error/panic behavior`)
+
+		gotSig, ok := jwa.LookupSignatureAlgorithm(name)
+		require.True(t, ok, `LookupSignatureAlgorithm should still find the first-registered Sig entry`)
+		require.Equal(t, sig, gotSig)
+
+		_, ok = jwa.LookupKeyEncryptionAlgorithm(name)
+		require.False(t, ok, `LookupKeyEncryptionAlgorithm must not see the dropped second registration`)
+
+		got, err := jwa.KeyAlgorithmFrom(name)
+		require.NoError(t, err)
+		_, isSig := got.(jwa.SignatureAlgorithm)
+		require.True(t, isSig, `KeyAlgorithmFrom should resolve to the first-registered SignatureAlgorithm, got %T`, got)
+	})
+
+	t.Run("KeyEncryption wins, Sig registration silently dropped", func(t *testing.T) {
+		// Inverse direction: confirm the silent-no-op is symmetric.
+		const name = "TESTALG-XKIND-KS"
+		kenc := jwa.NewKeyEncryptionAlgorithm(name)
+		jwa.RegisterKeyEncryptionAlgorithm(kenc)
+		t.Cleanup(func() { jwa.UnregisterKeyEncryptionAlgorithm(kenc) })
+
+		sig := jwa.NewSignatureAlgorithm(name)
+		require.NotPanics(t, func() {
+			jwa.RegisterSignatureAlgorithm(sig)
+		})
+
+		_, ok := jwa.LookupSignatureAlgorithm(name)
+		require.False(t, ok)
+
+		gotKenc, ok := jwa.LookupKeyEncryptionAlgorithm(name)
+		require.True(t, ok)
+		require.Equal(t, kenc, gotKenc)
+
+		got, err := jwa.KeyAlgorithmFrom(name)
+		require.NoError(t, err)
+		_, isKenc := got.(jwa.KeyEncryptionAlgorithm)
+		require.True(t, isKenc, `KeyAlgorithmFrom should resolve to the first-registered KeyEncryptionAlgorithm, got %T`, got)
+	})
+}
+
+// TestKeyAlgorithmFromUnambiguous pins that KeyAlgorithmFrom resolves
+// via the shared registry, returning the registered typed value
+// without any precedence rule between kinds. Before unification,
+// KeyAlgorithmFrom("X") would prefer SignatureAlgorithm even when
+// the caller registered "X" only as KeyEncryptionAlgorithm.
+func TestKeyAlgorithmFromUnambiguous(t *testing.T) {
+	const name = "TESTALG-UNAMBIG"
+	kenc := jwa.NewKeyEncryptionAlgorithm(name)
+	jwa.RegisterKeyEncryptionAlgorithm(kenc)
+	t.Cleanup(func() { jwa.UnregisterKeyEncryptionAlgorithm(kenc) })
+
+	got, err := jwa.KeyAlgorithmFrom(name)
+	require.NoError(t, err)
+	_, ok := got.(jwa.KeyEncryptionAlgorithm)
+	require.True(t, ok,
+		`KeyAlgorithmFrom should return the registered KeyEncryptionAlgorithm typed value, got %T`, got)
+}
+
+// TestKeyAlgorithmFromZeroValueRejected pins JWA-002: a zero-value
+// typed algorithm has String() == "" and cannot resolve through any
+// registry. Before this check, the typed arms accepted such inputs
+// and the failure surfaced far from the call site (deep inside
+// jws.Sign etc.) with confusing messages.
+func TestKeyAlgorithmFromZeroValueRejected(t *testing.T) {
+	t.Run("zero SignatureAlgorithm", func(t *testing.T) {
+		var sa jwa.SignatureAlgorithm
+		_, err := jwa.KeyAlgorithmFrom(sa)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jwa.ErrInvalidKeyAlgorithm()),
+			`zero-value typed alg should wrap ErrInvalidKeyAlgorithm, got %v`, err)
+	})
+
+	t.Run("zero KeyEncryptionAlgorithm", func(t *testing.T) {
+		var ka jwa.KeyEncryptionAlgorithm
+		_, err := jwa.KeyAlgorithmFrom(ka)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jwa.ErrInvalidKeyAlgorithm()))
+	})
+
+	t.Run("zero ContentEncryptionAlgorithm", func(t *testing.T) {
+		var ca jwa.ContentEncryptionAlgorithm
+		_, err := jwa.KeyAlgorithmFrom(ca)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jwa.ErrInvalidKeyAlgorithm()))
+	})
+
+	t.Run("EmptySignatureAlgorithm() helper", func(t *testing.T) {
+		_, err := jwa.KeyAlgorithmFrom(jwa.EmptySignatureAlgorithm())
+		require.Error(t, err)
+		require.True(t, errors.Is(err, jwa.ErrInvalidKeyAlgorithm()))
+	})
+}
+
+// TestRegisterIdempotent pins that re-registering the exact same
+// value is a no-op (no panic), regardless of whether it's a
+// builtin. This preserves the pre-unification behavior; some
+// extension init() paths can be re-entered in tests, and breaking
+// idempotence here would surface as random failures.
+func TestRegisterIdempotent(t *testing.T) {
+	require.NotPanics(t, func() {
+		jwa.RegisterSignatureAlgorithm(jwa.ES256())
+		jwa.RegisterSignatureAlgorithm(jwa.ES256())
+	})
+}

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -6,6 +6,8 @@ package jwa
 import (
 	"errors"
 	"fmt"
+	"sort"
+	"sync"
 )
 
 const maxKeyAlgorithmErrorPreview = 64
@@ -41,38 +43,180 @@ func formatInvalidKeyAlgorithmValue(v string) string {
 	return fmt.Sprintf("%q", string(runes[:maxKeyAlgorithmErrorPreview])+`...`)
 }
 
+// algorithmKind tags entries in the shared algRegistry so the
+// per-kind public Register/Lookup/Unregister/<Kind>s functions can
+// dispatch through one map without losing the typed identity of each
+// algorithm.
+type algorithmKind uint8
+
+const (
+	algKindUnknown algorithmKind = iota
+	algKindSignature
+	algKindKeyEncryption
+	algKindContentEncryption
+)
+
+func (k algorithmKind) String() string {
+	switch k {
+	case algKindSignature:
+		return "SignatureAlgorithm"
+	case algKindKeyEncryption:
+		return "KeyEncryptionAlgorithm"
+	case algKindContentEncryption:
+		return "ContentEncryptionAlgorithm"
+	default:
+		return "unknown algorithm kind"
+	}
+}
+
+type algRegistryEntry struct {
+	kind    algorithmKind
+	alg     KeyAlgorithm
+	builtin bool
+}
+
+// algRegistry is the single shared namespace for the three
+// KeyAlgorithm-implementing kinds. Independent per-kind maps would
+// let an extension register the same name as both (say) a
+// SignatureAlgorithm and a KeyEncryptionAlgorithm, after which
+// KeyAlgorithmFrom("X") would resolve to whichever kind was tried
+// first — silently flipping with import order. Funnelling all three
+// through one map fixes that ambiguity at registration time.
+var (
+	muAlgRegistry sync.RWMutex
+	algRegistry   = map[string]algRegistryEntry{}
+)
+
+// registerAlgorithm is the shared backend for the three public
+// Register{Signature,KeyEncryption,ContentEncryption}Algorithm
+// functions.
+//
+// Behavior:
+//   - Re-registering the exact same value (same kind, same alg) is a
+//     no-op.
+//   - Cross-kind name reuse is a silent no-op: the first registration
+//     wins and the second Register* call has no effect. v3's
+//     pre-existing Register* signature returns no error and v3 does
+//     not change observable error/panic behavior, so the cross-kind
+//     case is silently skipped — KeyAlgorithmFrom now resolves
+//     unambiguously to the first-registered kind. (v4 escalates this
+//     to a returned error from Register*.)
+//   - Built-in replacement is a silent no-op, preserving the
+//     pre-unification per-kind v3 Register* behavior.
+//   - Same-kind, non-builtin re-registration with a different value
+//     silently overwrites. This preserves the pre-unification
+//     behavior of the per-kind Register* functions.
+func registerAlgorithm(kind algorithmKind, alg KeyAlgorithm) {
+	name := alg.String()
+	muAlgRegistry.Lock()
+	defer muAlgRegistry.Unlock()
+	if existing, ok := algRegistry[name]; ok {
+		if existing.kind == kind && existing.alg == alg {
+			return
+		}
+		if existing.kind != kind {
+			return
+		}
+		if existing.builtin {
+			return
+		}
+	}
+	algRegistry[name] = algRegistryEntry{kind: kind, alg: alg}
+}
+
+// markBuiltin flips the builtin flag on an already-registered name.
+// Called by the per-kind generated init() after the bulk Register*
+// pass, preserving the existing two-phase init pattern.
+func markBuiltin(name string) {
+	muAlgRegistry.Lock()
+	defer muAlgRegistry.Unlock()
+	if entry, ok := algRegistry[name]; ok {
+		entry.builtin = true
+		algRegistry[name] = entry
+	}
+}
+
+// unregisterAlgorithm is the shared backend for the three public
+// Unregister*Algorithm functions. No-op for built-ins, no-op for a
+// kind mismatch, no-op for unknown names — same surface contract as
+// the pre-unification per-kind Unregister*.
+func unregisterAlgorithm(kind algorithmKind, name string) {
+	muAlgRegistry.Lock()
+	defer muAlgRegistry.Unlock()
+	if entry, ok := algRegistry[name]; ok && entry.kind == kind && !entry.builtin {
+		delete(algRegistry, name)
+	}
+}
+
+// lookupAlgorithm returns the registered KeyAlgorithm for name iff it
+// is registered as the requested kind. Used by the per-kind
+// generated Lookup* wrappers.
+func lookupAlgorithm(kind algorithmKind, name string) (KeyAlgorithm, bool) {
+	muAlgRegistry.RLock()
+	defer muAlgRegistry.RUnlock()
+	if entry, ok := algRegistry[name]; ok && entry.kind == kind {
+		return entry.alg, true
+	}
+	return nil, false
+}
+
+// listAlgorithmsByKind returns every registered algorithm of the
+// given kind, sorted by name. Used by the per-kind generated
+// <Kind>s() functions.
+func listAlgorithmsByKind(kind algorithmKind) []KeyAlgorithm {
+	muAlgRegistry.RLock()
+	defer muAlgRegistry.RUnlock()
+	out := make([]KeyAlgorithm, 0, len(algRegistry))
+	for _, entry := range algRegistry {
+		if entry.kind == kind {
+			out = append(out, entry.alg)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	return out
+}
+
 // KeyAlgorithmFrom takes either a string, `jwa.SignatureAlgorithm`,
-// `jwa.KeyEncryptionAlgorithm`, or `jwa.ContentEncryptionAlgorithm`.
+// `jwa.KeyEncryptionAlgorithm`, or `jwa.ContentEncryptionAlgorithm`,
 // and returns a `jwa.KeyAlgorithm`.
 //
-// If the value cannot be handled, it returns an `jwa.InvalidKeyAlgorithm`
-// object instead of returning an error. This design choice was made to allow
-// users to directly pass the return value to functions such as `jws.Sign()`
+// String inputs resolve through the shared algorithm registry: the
+// returned KeyAlgorithm holds the concrete typed value (Signature,
+// KeyEncryption, or ContentEncryption) for whichever kind owns the
+// name. Cross-kind name reuse is structurally avoided — the first
+// Register* wins and subsequent cross-kind registrations are silent
+// no-ops — so KeyAlgorithmFrom no longer needs precedence rules.
+//
+// Typed inputs whose String() is empty (for example a zero-value
+// `var sa jwa.SignatureAlgorithm`) are rejected with
+// ErrInvalidKeyAlgorithm. Without this check the typed arms accepted
+// names that would never resolve through any registry, surfacing as
+// confusing failures far from the call site.
 func KeyAlgorithmFrom(v any) (KeyAlgorithm, error) {
 	switch v := v.(type) {
 	case SignatureAlgorithm:
+		if v.String() == "" {
+			return nil, fmt.Errorf(`invalid key value: zero-value %T: %w`, v, errInvalidKeyAlgorithm)
+		}
 		return v, nil
 	case KeyEncryptionAlgorithm:
+		if v.String() == "" {
+			return nil, fmt.Errorf(`invalid key value: zero-value %T: %w`, v, errInvalidKeyAlgorithm)
+		}
 		return v, nil
 	case ContentEncryptionAlgorithm:
+		if v.String() == "" {
+			return nil, fmt.Errorf(`invalid key value: zero-value %T: %w`, v, errInvalidKeyAlgorithm)
+		}
 		return v, nil
 	case string:
-		salg, ok := LookupSignatureAlgorithm(v)
-		if ok {
-			return salg, nil
+		muAlgRegistry.RLock()
+		entry, ok := algRegistry[v]
+		muAlgRegistry.RUnlock()
+		if !ok {
+			return nil, fmt.Errorf(`invalid key value: %s: %w`, formatInvalidKeyAlgorithmValue(v), errInvalidKeyAlgorithm)
 		}
-
-		kalg, ok := LookupKeyEncryptionAlgorithm(v)
-		if ok {
-			return kalg, nil
-		}
-
-		calg, ok := LookupContentEncryptionAlgorithm(v)
-		if ok {
-			return calg, nil
-		}
-
-		return nil, fmt.Errorf(`invalid key value: %s: %w`, formatInvalidKeyAlgorithmValue(v), errInvalidKeyAlgorithm)
+		return entry.alg, nil
 	default:
 		return nil, fmt.Errorf(`invalid key type: %T: %w`, v, errInvalidKeyAlgorithm)
 	}

--- a/jwa/key_encryption_gen.go
+++ b/jwa/key_encryption_gen.go
@@ -5,17 +5,9 @@ package jwa
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
-	"sync"
 
 	"github.com/lestrrat-go/jwx/v3/internal/tokens"
 )
-
-var muAllKeyEncryptionAlgorithm sync.RWMutex
-var allKeyEncryptionAlgorithm = map[string]KeyEncryptionAlgorithm{}
-var muListKeyEncryptionAlgorithm sync.RWMutex
-var listKeyEncryptionAlgorithm []KeyEncryptionAlgorithm
-var builtinKeyEncryptionAlgorithm = map[string]struct{}{}
 
 func init() {
 	// builtin values for KeyEncryptionAlgorithm
@@ -42,7 +34,7 @@ func init() {
 
 	RegisterKeyEncryptionAlgorithm(algorithms...)
 	for _, alg := range algorithms {
-		builtinKeyEncryptionAlgorithm[alg.String()] = struct{}{}
+		markBuiltin(alg.String())
 	}
 }
 
@@ -142,13 +134,11 @@ func RSA_OAEP_512() KeyEncryptionAlgorithm {
 }
 
 func lookupBuiltinKeyEncryptionAlgorithm(name string) KeyEncryptionAlgorithm {
-	muAllKeyEncryptionAlgorithm.RLock()
-	v, ok := allKeyEncryptionAlgorithm[name]
-	muAllKeyEncryptionAlgorithm.RUnlock()
+	v, ok := lookupAlgorithm(algKindKeyEncryption, name)
 	if !ok {
 		panic(fmt.Sprintf(`jwa: KeyEncryptionAlgorithm %q not registered`, name))
 	}
-	return v
+	return v.(KeyEncryptionAlgorithm)
 }
 
 // KeyEncryptionAlgorithm represents the various encryption algorithms as described in https://tools.ietf.org/html/rfc7518#section-4.1
@@ -198,10 +188,11 @@ func NewKeyEncryptionAlgorithm(name string, options ...NewKeyEncryptionAlgorithm
 
 // LookupKeyEncryptionAlgorithm returns the KeyEncryptionAlgorithm object for the given name.
 func LookupKeyEncryptionAlgorithm(name string) (KeyEncryptionAlgorithm, bool) {
-	muAllKeyEncryptionAlgorithm.RLock()
-	v, ok := allKeyEncryptionAlgorithm[name]
-	muAllKeyEncryptionAlgorithm.RUnlock()
-	return v, ok
+	if v, ok := lookupAlgorithm(algKindKeyEncryption, name); ok {
+		return v.(KeyEncryptionAlgorithm), true
+	}
+	var zero KeyEncryptionAlgorithm
+	return zero, false
 }
 
 // RegisterKeyEncryptionAlgorithm registers a new KeyEncryptionAlgorithm. The signature value must be immutable
@@ -210,53 +201,33 @@ func LookupKeyEncryptionAlgorithm(name string) (KeyEncryptionAlgorithm, bool) {
 // Registration is process-global. Built-in identifiers such as RS256 are
 // reserved and cannot be replaced by callers after init has completed; use a
 // distinct name for third-party algorithms.
+//
+// SignatureAlgorithm, KeyEncryptionAlgorithm, and ContentEncryptionAlgorithm
+// share a single algorithm-name namespace so that KeyAlgorithmFrom can
+// resolve unambiguously. Registering a name that is already registered as a
+// different kind is a silent no-op (the first Register* call wins).
 func RegisterKeyEncryptionAlgorithm(algorithms ...KeyEncryptionAlgorithm) {
-	muAllKeyEncryptionAlgorithm.Lock()
-	defer muAllKeyEncryptionAlgorithm.Unlock()
 	for _, alg := range algorithms {
-		if _, ok := builtinKeyEncryptionAlgorithm[alg.String()]; ok {
-			if existing, ok := allKeyEncryptionAlgorithm[alg.String()]; ok && existing != alg {
-				continue
-			}
-			continue
-		}
-		allKeyEncryptionAlgorithm[alg.String()] = alg
+		registerAlgorithm(algKindKeyEncryption, alg)
 	}
-	rebuildKeyEncryptionAlgorithmLocked()
 }
 
 // UnregisterKeyEncryptionAlgorithm unregisters a KeyEncryptionAlgorithm from its known database.
 // Non-existent entries, as well as built-in algorithms will silently be ignored.
 func UnregisterKeyEncryptionAlgorithm(algorithms ...KeyEncryptionAlgorithm) {
-	muAllKeyEncryptionAlgorithm.Lock()
-	defer muAllKeyEncryptionAlgorithm.Unlock()
 	for _, alg := range algorithms {
-		if _, ok := builtinKeyEncryptionAlgorithm[alg.String()]; ok {
-			continue
-		}
-		delete(allKeyEncryptionAlgorithm, alg.String())
+		unregisterAlgorithm(algKindKeyEncryption, alg.String())
 	}
-	rebuildKeyEncryptionAlgorithmLocked()
-}
-
-func rebuildKeyEncryptionAlgorithmLocked() {
-	list := make([]KeyEncryptionAlgorithm, 0, len(allKeyEncryptionAlgorithm))
-	for _, v := range allKeyEncryptionAlgorithm {
-		list = append(list, v)
-	}
-	sort.Slice(list, func(i, j int) bool {
-		return list[i].String() < list[j].String()
-	})
-	muListKeyEncryptionAlgorithm.Lock()
-	listKeyEncryptionAlgorithm = list
-	muListKeyEncryptionAlgorithm.Unlock()
 }
 
 // KeyEncryptionAlgorithms returns a list of all available values for KeyEncryptionAlgorithm.
 func KeyEncryptionAlgorithms() []KeyEncryptionAlgorithm {
-	muListKeyEncryptionAlgorithm.RLock()
-	defer muListKeyEncryptionAlgorithm.RUnlock()
-	return listKeyEncryptionAlgorithm
+	raw := listAlgorithmsByKind(algKindKeyEncryption)
+	out := make([]KeyEncryptionAlgorithm, len(raw))
+	for i, alg := range raw {
+		out[i] = alg.(KeyEncryptionAlgorithm)
+	}
+	return out
 }
 
 // MarshalJSON serializes the KeyEncryptionAlgorithm object to a JSON string.

--- a/jwa/signature_gen.go
+++ b/jwa/signature_gen.go
@@ -5,15 +5,7 @@ package jwa
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
-	"sync"
 )
-
-var muAllSignatureAlgorithm sync.RWMutex
-var allSignatureAlgorithm = map[string]SignatureAlgorithm{}
-var muListSignatureAlgorithm sync.RWMutex
-var listSignatureAlgorithm []SignatureAlgorithm
-var builtinSignatureAlgorithm = map[string]struct{}{}
 
 func init() {
 	// builtin values for SignatureAlgorithm
@@ -37,7 +29,7 @@ func init() {
 
 	RegisterSignatureAlgorithm(algorithms...)
 	for _, alg := range algorithms {
-		builtinSignatureAlgorithm[alg.String()] = struct{}{}
+		markBuiltin(alg.String())
 	}
 }
 
@@ -122,13 +114,11 @@ func RS512() SignatureAlgorithm {
 }
 
 func lookupBuiltinSignatureAlgorithm(name string) SignatureAlgorithm {
-	muAllSignatureAlgorithm.RLock()
-	v, ok := allSignatureAlgorithm[name]
-	muAllSignatureAlgorithm.RUnlock()
+	v, ok := lookupAlgorithm(algKindSignature, name)
 	if !ok {
 		panic(fmt.Sprintf(`jwa: SignatureAlgorithm %q not registered`, name))
 	}
-	return v
+	return v.(SignatureAlgorithm)
 }
 
 // SignatureAlgorithm represents the various signature algorithms as described in https://tools.ietf.org/html/rfc7518#section-3.1
@@ -178,10 +168,11 @@ func NewSignatureAlgorithm(name string, options ...NewSignatureAlgorithmOption) 
 
 // LookupSignatureAlgorithm returns the SignatureAlgorithm object for the given name.
 func LookupSignatureAlgorithm(name string) (SignatureAlgorithm, bool) {
-	muAllSignatureAlgorithm.RLock()
-	v, ok := allSignatureAlgorithm[name]
-	muAllSignatureAlgorithm.RUnlock()
-	return v, ok
+	if v, ok := lookupAlgorithm(algKindSignature, name); ok {
+		return v.(SignatureAlgorithm), true
+	}
+	var zero SignatureAlgorithm
+	return zero, false
 }
 
 // RegisterSignatureAlgorithm registers a new SignatureAlgorithm. The signature value must be immutable
@@ -190,53 +181,33 @@ func LookupSignatureAlgorithm(name string) (SignatureAlgorithm, bool) {
 // Registration is process-global. Built-in identifiers such as RS256 are
 // reserved and cannot be replaced by callers after init has completed; use a
 // distinct name for third-party algorithms.
+//
+// SignatureAlgorithm, KeyEncryptionAlgorithm, and ContentEncryptionAlgorithm
+// share a single algorithm-name namespace so that KeyAlgorithmFrom can
+// resolve unambiguously. Registering a name that is already registered as a
+// different kind is a silent no-op (the first Register* call wins).
 func RegisterSignatureAlgorithm(algorithms ...SignatureAlgorithm) {
-	muAllSignatureAlgorithm.Lock()
-	defer muAllSignatureAlgorithm.Unlock()
 	for _, alg := range algorithms {
-		if _, ok := builtinSignatureAlgorithm[alg.String()]; ok {
-			if existing, ok := allSignatureAlgorithm[alg.String()]; ok && existing != alg {
-				continue
-			}
-			continue
-		}
-		allSignatureAlgorithm[alg.String()] = alg
+		registerAlgorithm(algKindSignature, alg)
 	}
-	rebuildSignatureAlgorithmLocked()
 }
 
 // UnregisterSignatureAlgorithm unregisters a SignatureAlgorithm from its known database.
 // Non-existent entries, as well as built-in algorithms will silently be ignored.
 func UnregisterSignatureAlgorithm(algorithms ...SignatureAlgorithm) {
-	muAllSignatureAlgorithm.Lock()
-	defer muAllSignatureAlgorithm.Unlock()
 	for _, alg := range algorithms {
-		if _, ok := builtinSignatureAlgorithm[alg.String()]; ok {
-			continue
-		}
-		delete(allSignatureAlgorithm, alg.String())
+		unregisterAlgorithm(algKindSignature, alg.String())
 	}
-	rebuildSignatureAlgorithmLocked()
-}
-
-func rebuildSignatureAlgorithmLocked() {
-	list := make([]SignatureAlgorithm, 0, len(allSignatureAlgorithm))
-	for _, v := range allSignatureAlgorithm {
-		list = append(list, v)
-	}
-	sort.Slice(list, func(i, j int) bool {
-		return list[i].String() < list[j].String()
-	})
-	muListSignatureAlgorithm.Lock()
-	listSignatureAlgorithm = list
-	muListSignatureAlgorithm.Unlock()
 }
 
 // SignatureAlgorithms returns a list of all available values for SignatureAlgorithm.
 func SignatureAlgorithms() []SignatureAlgorithm {
-	muListSignatureAlgorithm.RLock()
-	defer muListSignatureAlgorithm.RUnlock()
-	return listSignatureAlgorithm
+	raw := listAlgorithmsByKind(algKindSignature)
+	out := make([]SignatureAlgorithm, len(raw))
+	for i, alg := range raw {
+		out[i] = alg.(SignatureAlgorithm)
+	}
+	return out
 }
 
 // MarshalJSON serializes the SignatureAlgorithm object to a JSON string.

--- a/tools/cmd/genjwa/main.go
+++ b/tools/cmd/genjwa/main.go
@@ -88,12 +88,45 @@ func _main() error {
 	return nil
 }
 
+// isKeyAlgorithmKind reports whether the given algorithm type
+// implements jwa.KeyAlgorithm and therefore lives in the shared
+// algRegistry hand-written in jwa.go. The three KeyAlgorithm kinds
+// share one namespace so KeyAlgorithmFrom can resolve a string to
+// exactly one typed value; everything else (KeyType,
+// EllipticCurveAlgorithm, CompressionAlgorithm) keeps its own
+// per-kind storage emitted by this generator.
+func isKeyAlgorithmKind(name string) bool {
+	switch name {
+	case "SignatureAlgorithm", "KeyEncryptionAlgorithm", "ContentEncryptionAlgorithm":
+		return true
+	}
+	return false
+}
+
+// algKindEnumSuffix maps an algorithm type name to the suffix used in
+// its algorithmKind constant in jwa.go (e.g. "SignatureAlgorithm" ->
+// "Signature", which combines into algKindSignature).
+func algKindEnumSuffix(name string) string {
+	switch name {
+	case "SignatureAlgorithm":
+		return "Signature"
+	case "KeyEncryptionAlgorithm":
+		return "KeyEncryption"
+	case "ContentEncryptionAlgorithm":
+		return "ContentEncryption"
+	}
+	return ""
+}
+
 func Generate(t Algorithm) error {
 	var buf bytes.Buffer
 
 	if t.Filename == "" {
 		return fmt.Errorf("filename is empty for type %q", t.Name)
 	}
+
+	keyAlg := isKeyAlgorithmKind(t.Name)
+	algKindSuffix := algKindEnumSuffix(t.Name)
 
 	o := codegen.NewOutput(&buf)
 
@@ -126,11 +159,13 @@ func Generate(t Algorithm) error {
 	}
 	o.L(")")
 
-	o.LL("var muAll%s sync.RWMutex", t.Name)
-	o.L("var all%[1]s = map[string]%[1]s{}", t.Name)
-	o.L("var muList%s sync.RWMutex", t.Name)
-	o.L("var list%s []%s", t.Name, t.Name)
-	o.L("var builtin%s = map[string]struct{}{}", t.Name)
+	if !keyAlg {
+		o.LL("var muAll%s sync.RWMutex", t.Name)
+		o.L("var all%[1]s = map[string]%[1]s{}", t.Name)
+		o.L("var muList%s sync.RWMutex", t.Name)
+		o.L("var list%s []%s", t.Name, t.Name)
+		o.L("var builtin%s = map[string]struct{}{}", t.Name)
+	}
 
 	o.LL("func init() {")
 	o.L("// builtin values for %s", t.Name)
@@ -166,7 +201,11 @@ func Generate(t Algorithm) error {
 
 	o.LL("Register%s(algorithms...)", t.Name)
 	o.L("for _, alg := range algorithms {")
-	o.L("builtin%s[alg.String()] = struct{}{}", t.Name)
+	if keyAlg {
+		o.L("markBuiltin(alg.String())")
+	} else {
+		o.L("builtin%s[alg.String()] = struct{}{}", t.Name)
+	}
 	o.L("}")
 	o.L("}") // end init
 
@@ -201,13 +240,21 @@ func Generate(t Algorithm) error {
 	}
 
 	o.LL("func lookupBuiltin%s(name string) %s {", t.Name, t.Name)
-	o.L("muAll%s.RLock()", t.Name)
-	o.L("v, ok := all%s[name]", t.Name)
-	o.L("muAll%s.RUnlock()", t.Name)
-	o.L("if !ok {")
-	o.L("panic(fmt.Sprintf(`jwa: %s %%q not registered`, name))", t.Name)
-	o.L("}")
-	o.L("return v")
+	if keyAlg {
+		o.L("v, ok := lookupAlgorithm(algKind%s, name)", algKindSuffix)
+		o.L("if !ok {")
+		o.L("panic(fmt.Sprintf(`jwa: %s %%q not registered`, name))", t.Name)
+		o.L("}")
+		o.L("return v.(%s)", t.Name)
+	} else {
+		o.L("muAll%s.RLock()", t.Name)
+		o.L("v, ok := all%s[name]", t.Name)
+		o.L("muAll%s.RUnlock()", t.Name)
+		o.L("if !ok {")
+		o.L("panic(fmt.Sprintf(`jwa: %s %%q not registered`, name))", t.Name)
+		o.L("}")
+		o.L("return v")
+	}
 	o.L("}")
 
 	o.LL("// %s", t.Comment)
@@ -274,68 +321,114 @@ func Generate(t Algorithm) error {
 	o.R("}")
 	o.L("}")
 
-	o.LL("// Lookup%[1]s returns the %[1]s object for the given name.", t.Name)
-	o.L("func Lookup%[1]s(name string) (%[1]s, bool) {", t.Name)
-	o.L("muAll%[1]s.RLock()", t.Name)
-	o.L("v, ok := all%[1]s[name]", t.Name)
-	o.L("muAll%[1]s.RUnlock()", t.Name)
-	o.L("return v, ok")
-	o.L("}")
+	if keyAlg {
+		o.LL("// Lookup%[1]s returns the %[1]s object for the given name.", t.Name)
+		o.L("func Lookup%[1]s(name string) (%[1]s, bool) {", t.Name)
+		o.L("if v, ok := lookupAlgorithm(algKind%s, name); ok {", algKindSuffix)
+		o.L("return v.(%s), true", t.Name)
+		o.L("}")
+		o.L("var zero %s", t.Name)
+		o.L("return zero, false")
+		o.L("}")
 
-	o.LL("// Register%[1]s registers a new %[1]s. The signature value must be immutable", t.Name)
-	o.L("// and safe to be used by multiple goroutines, as it is going to be shared with all other users of this library.")
-	o.L("//")
-	o.L("// Registration is process-global. Built-in identifiers such as RS256 are")
-	o.L("// reserved and cannot be replaced by callers after init has completed; use a")
-	o.L("// distinct name for third-party algorithms.")
-	o.L("func Register%[1]s(algorithms ...%[1]s) {", t.Name)
-	o.L("muAll%[1]s.Lock()", t.Name)
-	o.L("defer muAll%[1]s.Unlock()", t.Name)
-	o.L("for _, alg := range algorithms {")
-	o.L("if _, ok := builtin%[1]s[alg.String()]; ok {", t.Name)
-	o.L("if existing, ok := all%[1]s[alg.String()]; ok && existing != alg {", t.Name)
-	o.L("continue")
-	o.L("}")
-	o.L("continue")
-	o.L("}")
-	o.L("all%[1]s[alg.String()] = alg", t.Name)
-	o.L("}")
-	o.L("rebuild%[1]sLocked()", t.Name)
-	o.L("}")
+		o.LL("// Register%[1]s registers a new %[1]s. The signature value must be immutable", t.Name)
+		o.L("// and safe to be used by multiple goroutines, as it is going to be shared with all other users of this library.")
+		o.L("//")
+		o.L("// Registration is process-global. Built-in identifiers such as RS256 are")
+		o.L("// reserved and cannot be replaced by callers after init has completed; use a")
+		o.L("// distinct name for third-party algorithms.")
+		o.L("//")
+		o.L("// SignatureAlgorithm, KeyEncryptionAlgorithm, and ContentEncryptionAlgorithm")
+		o.L("// share a single algorithm-name namespace so that KeyAlgorithmFrom can")
+		o.L("// resolve unambiguously. Registering a name that is already registered as a")
+		o.L("// different kind is a silent no-op (the first Register* call wins).")
+		o.L("func Register%[1]s(algorithms ...%[1]s) {", t.Name)
+		o.L("for _, alg := range algorithms {")
+		o.L("registerAlgorithm(algKind%s, alg)", algKindSuffix)
+		o.L("}")
+		o.L("}")
 
-	o.LL("// Unregister%[1]s unregisters a %[1]s from its known database.", t.Name)
-	o.L("// Non-existent entries, as well as built-in algorithms will silently be ignored.")
-	o.L("func Unregister%[1]s(algorithms ...%[1]s) {", t.Name)
-	o.L("muAll%[1]s.Lock()", t.Name)
-	o.L("defer muAll%[1]s.Unlock()", t.Name)
-	o.L("for _, alg := range algorithms {")
-	o.L("if _, ok := builtin%[1]s[alg.String()]; ok {", t.Name)
-	o.L("continue")
-	o.L("}")
-	o.L("delete(all%[1]s, alg.String())", t.Name)
-	o.L("}")
-	o.L("rebuild%[1]sLocked()", t.Name)
-	o.L("}")
+		o.LL("// Unregister%[1]s unregisters a %[1]s from its known database.", t.Name)
+		o.L("// Non-existent entries, as well as built-in algorithms will silently be ignored.")
+		o.L("func Unregister%[1]s(algorithms ...%[1]s) {", t.Name)
+		o.L("for _, alg := range algorithms {")
+		o.L("unregisterAlgorithm(algKind%s, alg.String())", algKindSuffix)
+		o.L("}")
+		o.L("}")
 
-	o.LL("func rebuild%[1]sLocked() {", t.Name)
-	o.L("list := make([]%[1]s, 0, len(all%[1]s))", t.Name)
-	o.L("for _, v := range all%[1]s {", t.Name)
-	o.L("list = append(list, v)")
-	o.L("}")
-	o.L("sort.Slice(list, func(i, j int) bool {")
-	o.L("return list[i].String() < list[j].String()")
-	o.L("})")
-	o.L("muList%[1]s.Lock()", t.Name)
-	o.L("list%[1]s = list", t.Name)
-	o.L("muList%[1]s.Unlock()", t.Name)
-	o.L("}")
+		o.LL("// %[1]ss returns a list of all available values for %[1]s.", t.Name)
+		o.L("func %[1]ss() []%[1]s {", t.Name)
+		o.L("raw := listAlgorithmsByKind(algKind%s)", algKindSuffix)
+		o.L("out := make([]%s, len(raw))", t.Name)
+		o.L("for i, alg := range raw {")
+		o.L("out[i] = alg.(%s)", t.Name)
+		o.L("}")
+		o.L("return out")
+		o.L("}")
+	} else {
+		o.LL("// Lookup%[1]s returns the %[1]s object for the given name.", t.Name)
+		o.L("func Lookup%[1]s(name string) (%[1]s, bool) {", t.Name)
+		o.L("muAll%[1]s.RLock()", t.Name)
+		o.L("v, ok := all%[1]s[name]", t.Name)
+		o.L("muAll%[1]s.RUnlock()", t.Name)
+		o.L("return v, ok")
+		o.L("}")
 
-	o.LL("// %[1]ss returns a list of all available values for %[1]s.", t.Name)
-	o.L("func %[1]ss() []%[1]s {", t.Name)
-	o.L("muList%[1]s.RLock()", t.Name)
-	o.L("defer muList%[1]s.RUnlock()", t.Name)
-	o.L("return list%[1]s", t.Name)
-	o.L("}")
+		o.LL("// Register%[1]s registers a new %[1]s. The signature value must be immutable", t.Name)
+		o.L("// and safe to be used by multiple goroutines, as it is going to be shared with all other users of this library.")
+		o.L("//")
+		o.L("// Registration is process-global. Built-in identifiers such as RS256 are")
+		o.L("// reserved and cannot be replaced by callers after init has completed; use a")
+		o.L("// distinct name for third-party algorithms.")
+		o.L("func Register%[1]s(algorithms ...%[1]s) {", t.Name)
+		o.L("muAll%[1]s.Lock()", t.Name)
+		o.L("defer muAll%[1]s.Unlock()", t.Name)
+		o.L("for _, alg := range algorithms {")
+		o.L("if _, ok := builtin%[1]s[alg.String()]; ok {", t.Name)
+		o.L("if existing, ok := all%[1]s[alg.String()]; ok && existing != alg {", t.Name)
+		o.L("continue")
+		o.L("}")
+		o.L("continue")
+		o.L("}")
+		o.L("all%[1]s[alg.String()] = alg", t.Name)
+		o.L("}")
+		o.L("rebuild%[1]sLocked()", t.Name)
+		o.L("}")
+
+		o.LL("// Unregister%[1]s unregisters a %[1]s from its known database.", t.Name)
+		o.L("// Non-existent entries, as well as built-in algorithms will silently be ignored.")
+		o.L("func Unregister%[1]s(algorithms ...%[1]s) {", t.Name)
+		o.L("muAll%[1]s.Lock()", t.Name)
+		o.L("defer muAll%[1]s.Unlock()", t.Name)
+		o.L("for _, alg := range algorithms {")
+		o.L("if _, ok := builtin%[1]s[alg.String()]; ok {", t.Name)
+		o.L("continue")
+		o.L("}")
+		o.L("delete(all%[1]s, alg.String())", t.Name)
+		o.L("}")
+		o.L("rebuild%[1]sLocked()", t.Name)
+		o.L("}")
+
+		o.LL("func rebuild%[1]sLocked() {", t.Name)
+		o.L("list := make([]%[1]s, 0, len(all%[1]s))", t.Name)
+		o.L("for _, v := range all%[1]s {", t.Name)
+		o.L("list = append(list, v)")
+		o.L("}")
+		o.L("sort.Slice(list, func(i, j int) bool {")
+		o.L("return list[i].String() < list[j].String()")
+		o.L("})")
+		o.L("muList%[1]s.Lock()", t.Name)
+		o.L("list%[1]s = list", t.Name)
+		o.L("muList%[1]s.Unlock()", t.Name)
+		o.L("}")
+
+		o.LL("// %[1]ss returns a list of all available values for %[1]s.", t.Name)
+		o.L("func %[1]ss() []%[1]s {", t.Name)
+		o.L("muList%[1]s.RLock()", t.Name)
+		o.L("defer muList%[1]s.RUnlock()", t.Name)
+		o.L("return list%[1]s", t.Name)
+		o.L("}")
+	}
 
 	o.LL("// MarshalJSON serializes the %[1]s object to a JSON string.", t.Name)
 	o.L("func (s %[1]s) MarshalJSON() ([]byte, error) {", t.Name)


### PR DESCRIPTION
Backport of #2062, with a v3-compatible behavior choice for the cross-kind collision case.

`KeyAlgorithmFrom("X")` used to walk three independent registries — `SignatureAlgorithm` → `KeyEncryptionAlgorithm` → `ContentEncryptionAlgorithm` — and return the first hit. There was no cross-registry uniqueness, so an extension could register the same name in two kinds and `KeyAlgorithmFrom` would silently flip resolution with import order.

Funnels all three KeyAlgorithm-implementing kinds through a single shared `algRegistry` (hand-written in `jwa/jwa.go`). Per-kind `Register*` / `Lookup*` / `Unregister*` / `<Kind>s()` become thin wrappers around five private helpers emitted by the v3 generator (`tools/cmd/genjwa`).

**v3-specific behavior choice:** cross-kind name reuse is a **silent no-op** — the first `Register*` call wins, the second is dropped. v3's pre-existing `Register*` signature returns nothing and v3 doesn't change observable error/panic behavior, so panicking or escalating to a returned error would break the v3 contract. (v4 escalates this to a returned error.)

Side effect to be aware of: today in v3, two `Lookup<Kind>` calls for cross-kind-registered names both return their entries. After this change, only the first kind's `Lookup` returns; the second's `Lookup` returns false. No known caller exercises this pattern.

Same-kind idempotent re-registration, same-kind builtin replacement, and same-kind non-builtin overwrite are all preserved.

Bundles JWA-002: `KeyAlgorithmFrom` typed arms now reject zero-value typed algorithms (`String() == ""`) with `ErrInvalidKeyAlgorithm`.

Out of scope:
- `KeyType`, `EllipticCurveAlgorithm`, `CompressionAlgorithm` — they don't dispatch through `KeyAlgorithmFrom` and don't have JWA-001's collision shape.

Tests added at `jwa/cross_kind_test.go`: silent-no-op cross-kind (both directions, asserting `Lookup` and `KeyAlgorithmFrom` outcomes), unambiguous lookup, zero-value rejection (3 typed kinds + `EmptySignatureAlgorithm()`), idempotent re-register.