### PR TITLE
cmd/jwx: warn on private-key-to-tty + reject keysize<=0 for oct

### DIFF
--- a/cmd/jwx/go.mod
+++ b/cmd/jwx/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.26.0
 	golang.org/x/crypto v0.49.0
+	golang.org/x/term v0.41.0
 )
 
 require (
@@ -18,6 +19,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/valyala/fastjson v1.6.10 // indirect
 	github.com/xrash/smetrics v0.0.0-20231213231151-1d8dd44e695e // indirect
+	golang.org/x/sys v0.42.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/cmd/jwx/go.sum
+++ b/cmd/jwx/go.sum
@@ -20,6 +20,10 @@ github.com/xrash/smetrics v0.0.0-20231213231151-1d8dd44e695e h1:+SOyEddqYF09QP7v
 github.com/xrash/smetrics v0.0.0-20231213231151-1d8dd44e695e/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
+golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=
+golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/cmd/jwx/jwk.go
+++ b/cmd/jwx/jwk.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/lestrrat-go/jwx/v4/jwa"
 	"github.com/lestrrat-go/jwx/v4/jwk"
@@ -16,6 +17,7 @@ import (
 	"github.com/lestrrat-go/jwx/v4/jwk/jwkbb"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/crypto/ed25519"
+	"golang.org/x/term"
 )
 
 func init() {
@@ -124,7 +126,7 @@ func makeJwkGenerateCmd() *cli.Command {
 		&cli.IntFlag{
 			Name:    "keysize",
 			Aliases: []string{"s"},
-			Usage:   "Integer `SIZE` for RSA and oct key sizes",
+			Usage:   "Integer `SIZE`: bits for RSA (default 2048), bytes for oct. Ignored for EC and OKP keys.",
 			Value:   2048,
 		},
 		publicKeyFlag(),
@@ -168,7 +170,11 @@ func makeJwkGenerateCmd() *cli.Command {
 			}
 			rawkey = v
 		case jwa.OctetSeq():
-			octets := make([]byte, c.Int("keysize"))
+			size := c.Int("keysize")
+			if size <= 0 {
+				return fmt.Errorf(`invalid --keysize %d for oct: must be greater than zero (units for oct are bytes; for RSA they are bits)`, size)
+			}
+			octets := make([]byte, size)
 			if _, err := io.ReadFull(rand.Reader, octets); err != nil {
 				return fmt.Errorf(`failed to generate octet seq key: %w`, err)
 			}
@@ -229,6 +235,19 @@ func makeJwkGenerateCmd() *cli.Command {
 				return fmt.Errorf(`failed to generate public keys: %w`, err)
 			}
 			keyset = pubks
+		}
+
+		// If the caller is about to dump private key material to a
+		// terminal — the default when -o is omitted and --public-key
+		// is not set — emit a stderr warning. The key still goes to
+		// stdout, so pipes (`| jq`, `| tee key.json`) and shell
+		// redirections continue to work; only the interactive
+		// "dump-to-scrollback" footgun gets a signal.
+		if c.String("output") == "-" && !c.Bool("public-key") && term.IsTerminal(int(os.Stdout.Fd())) {
+			fmt.Fprintln(os.Stderr,
+				"warning: writing private key material to a terminal — leaks into scrollback, "+
+					"shell history, and any session recording. Re-run with -o FILE to write to a "+
+					"0600-mode file, or pipe to another command to suppress this warning.")
 		}
 
 		output, err := getOutput(c.String("output"))

--- a/cmd/jwx/jwk_test.go
+++ b/cmd/jwx/jwk_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+// runJwx invokes the CLI app with the given args and captures stdout +
+// stderr. The actual os.Stdout / os.Stderr file descriptors are
+// redirected through os.Pipe so the captured streams reflect what an
+// invoking shell would see — including: term.IsTerminal returns false
+// against a pipe fd, so the isatty-gated warning correctly does NOT
+// fire in tests.
+func runJwx(t *testing.T, args []string) (stdout, stderr string, err error) {
+	t.Helper()
+
+	stdoutR, stdoutW, perr := os.Pipe()
+	require.NoError(t, perr)
+	stderrR, stderrW, perr := os.Pipe()
+	require.NoError(t, perr)
+
+	origStdout, origStderr := os.Stdout, os.Stderr
+	os.Stdout = stdoutW
+	os.Stderr = stderrW
+	t.Cleanup(func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	})
+
+	app := &cli.App{Commands: topLevelCommands}
+	runErr := app.Run(append([]string{"jwx"}, args...))
+
+	// Close the writers so the readers terminate.
+	stdoutW.Close()
+	stderrW.Close()
+
+	stdoutBytes, _ := io.ReadAll(stdoutR)
+	stderrBytes, _ := io.ReadAll(stderrR)
+	return string(stdoutBytes), string(stderrBytes), runErr
+}
+
+// TestJwkGenerateOctRejectsZeroKeysize pins the INTERNAL-002 fix:
+// `jwx jwk generate -t oct --keysize 0` must error instead of
+// silently producing an empty symmetric key. RSA already rejects
+// too-small sizes via stdlib; oct used to accept anything.
+func TestJwkGenerateOctRejectsZeroKeysize(t *testing.T) {
+	t.Run("zero", func(t *testing.T) {
+		_, _, err := runJwx(t, []string{"jwk", "generate", "-t", "oct", "--keysize", "0"})
+		require.Error(t, err, `--keysize 0 must be rejected`)
+		require.Contains(t, err.Error(), "must be greater than zero",
+			`error should explain the constraint`)
+		require.Contains(t, err.Error(), "oct",
+			`error should name the affected key type`)
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		_, _, err := runJwx(t, []string{"jwk", "generate", "-t", "oct", "--keysize", "-1"})
+		require.Error(t, err, `--keysize -1 must be rejected`)
+		require.Contains(t, err.Error(), "must be greater than zero")
+	})
+}
+
+// TestJwkGenerateNoWarningOnNonTTY pins half of the INTERNAL-001 fix:
+// when stdout is not a terminal (a pipe in this test, the typical
+// `| jq` / `> file` case in real use), the "writing private key to
+// terminal" warning must NOT fire. The complementary tty-attached
+// case is verified manually because go test never gives us a real
+// tty.
+func TestJwkGenerateNoWarningOnNonTTY(t *testing.T) {
+	stdout, stderr, err := runJwx(t, []string{"jwk", "generate", "-t", "oct", "--keysize", "16"})
+	require.NoError(t, err)
+	require.NotEmpty(t, stdout, `expected JWK on stdout`)
+	require.NotContains(t, strings.ToLower(stderr), "warning",
+		`no warning should fire when stdout is non-tty (got stderr=%q)`, stderr)
+}
+
+// TestJwkGenerateNoWarningWithPublicKey pins the other half of the
+// INTERNAL-001 fix: even when stdout were a tty, --public-key
+// strips the secret material via PublicSetOf before serialization,
+// so no warning is needed. We assert the gate by setting
+// --public-key and checking stderr stays clean (the non-tty harness
+// would already suppress, but the assertion still pins that the
+// guard treats --public-key as exempt).
+func TestJwkGenerateNoWarningWithPublicKey(t *testing.T) {
+	// 2048-bit RSA: smaller is rejected by jwk's modulus floor.
+	stdout, stderr, err := runJwx(t, []string{
+		"jwk", "generate",
+		"-t", "RSA",
+		"--keysize", "2048",
+		"--public-key",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, stdout)
+	require.NotContains(t, strings.ToLower(stderr), "warning",
+		`--public-key strips secrets; no warning expected`)
+
+	// Sanity: the result really is a public key (no "d", "p", "q" fields).
+	require.NotContains(t, stdout, `"d":`, `public-key result must not contain "d"`)
+}

--- a/cmd/jwx/jwx.go
+++ b/cmd/jwx/jwx.go
@@ -27,7 +27,7 @@ func outputFlag() cli.Flag {
 	return &cli.StringFlag{
 		Name:    "output",
 		Aliases: []string{"o"},
-		Usage:   "Write output to `FILE`",
+		Usage:   "Write output to `FILE` (default \"-\" for stdout). For commands that emit private key material, prefer an explicit -o FILE: file output is created with mode 0600 and truncated on each run, while stdout has no such protection.",
 		Value:   "-",
 	}
 }


### PR DESCRIPTION
Two findings from the adversarial review against `cmd/jwx`:

**INTERNAL-001 — private key to terminal default.** `jwx jwk generate -t RSA` with no `-o` writes a fresh RSA private key to stdout. When stdout is an interactive terminal that puts the secret into scrollback, shell history, and any session recording. The `getOutput` path's 0600/O_TRUNC protection only kicks in for explicit file output.

Fix: stderr warning when stdout is a tty AND `--public-key` is not set. Pipes (`| jq`, `| tee key.json`) and shell redirections (`> key.json`) stay silent. `--public-key` strips the secret via `PublicSetOf` before serialization and is exempt. Hard "require `-o`" was rejected as breaking legitimate pipe workflows.

**INTERNAL-002 — `--keysize 0` silently produces empty oct key.** RSA's stdlib already rejects too-small sizes; oct used to accept anything (negative, zero, ...). Fix: reject `--keysize <= 0` for oct with a friendly message that also clarifies the unit difference (bytes for oct, bits for RSA). Also clarify `--keysize` flag Usage.

Cosmetic: update `outputFlag()` Usage to mention the stdout default and the file-mode protection difference.

Adds `golang.org/x/term` dependency for the isatty check (sibling of the existing `golang.org/x/crypto`).

Tests at `cmd/jwx/jwk_test.go`:
- `TestJwkGenerateOctRejectsZeroKeysize` (zero + negative subtests)
- `TestJwkGenerateNoWarningOnNonTTY` — the typical pipe/redirect case in real use
- `TestJwkGenerateNoWarningWithPublicKey` — pins the `--public-key` exemption

The tty-attached warning case is verified manually since `go test` never gives us a real tty. Manual smoke confirmed: `jwx jwk generate -t RSA` at a terminal emits the warning; `| tee` and `-o FILE` paths suppress.

v3 backport in a follow-up PR.