### PR TITLE
ci: print coverage summary in GitHub Actions run summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,38 @@ jobs:
         if: always()
         run: |
           if [ -f coverage.out ]; then
-            go work init . ./cmd/jwx
             {
               echo "## Coverage"
-              echo '```'
-              go tool cover -func=coverage.out
-              echo '```'
+              echo
+              echo '| Package | Coverage | Covered/Total |'
+              echo '|---------|---------:|--------------:|'
+              awk '
+                NR == 1 { next }
+                {
+                  n = index($1, ".go:")
+                  pkg = substr($1, 1, n + 1)
+                  sub(/\/[^\/]+$/, "", pkg)
+                  sub(/^github\.com\/lestrrat-go\/jwx\/v[0-9]+\/?/, "", pkg)
+                  if (pkg == "") pkg = "(root)"
+                  total[pkg] += $2
+                  if ($3 > 0) covered[pkg] += $2
+                  gt += $2
+                  if ($3 > 0) gc += $2
+                }
+                END {
+                  n = 0
+                  for (p in total) keys[++n] = p
+                  for (i = 1; i <= n; i++)
+                    for (j = i + 1; j <= n; j++)
+                      if (keys[j] < keys[i]) { t = keys[i]; keys[i] = keys[j]; keys[j] = t }
+                  for (i = 1; i <= n; i++) {
+                    p = keys[i]
+                    printf "| %s | %.1f%% | %d/%d |\n", p, 100 * covered[p] / total[p], covered[p], total[p]
+                  }
+                  if (gt > 0) printf "| **TOTAL** | **%.1f%%** | **%d/%d** |\n", 100 * gc / gt, gc, gt
+                }
+              ' coverage.out
             } >> "$GITHUB_STEP_SUMMARY"
-            rm -f go.work go.work.sum
           fi
       - name: Check difference between generation code and commit code
         run: make check_diffs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,17 +47,28 @@ jobs:
               awk '
                 NR == 1 { next }
                 {
-                  n = index($1, ".go:")
-                  pkg = substr($1, 1, n + 1)
-                  sub(/\/[^\/]+$/, "", pkg)
-                  sub(/^github\.com\/lestrrat-go\/jwx\/v[0-9]+\/?/, "", pkg)
-                  if (pkg == "") pkg = "(root)"
-                  total[pkg] += $2
-                  if ($3 > 0) covered[pkg] += $2
-                  gt += $2
-                  if ($3 > 0) gc += $2
+                  key = $1
+                  if (!(key in stmts)) {
+                    stmts[key] = $2
+                    n = index($1, ".go:")
+                    pkg = substr($1, 1, n + 1)
+                    sub(/\/[^\/]+$/, "", pkg)
+                    sub(/^github\.com\/lestrrat-go\/jwx\/v[0-9]+\/?/, "", pkg)
+                    if (pkg == "") pkg = "(root)"
+                    pkgof[key] = pkg
+                  }
+                  if ($3 > 0) hit[key] = 1
                 }
                 END {
+                  for (k in stmts) {
+                    p = pkgof[k]
+                    total[p] += stmts[k]
+                    gt += stmts[k]
+                    if (k in hit) {
+                      covered[p] += stmts[k]
+                      gc += stmts[k]
+                    }
+                  }
                   n = 0
                   for (p in total) keys[++n] = p
                   for (i = 1; i <= n; i++)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,14 @@ jobs:
         if: always()
         run: |
           if [ -f coverage.out ]; then
+            go work init . ./cmd/jwx
             {
               echo "## Coverage"
               echo '```'
               go tool cover -func=coverage.out
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
+            rm -f go.work go.work.sum
           fi
       - name: Check difference between generation code and commit code
         run: make check_diffs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,16 @@ jobs:
         run: make tidy
       - name: Test with coverage
         run: make cover
+      - name: Coverage report
+        if: always()
+        run: |
+          if [ -f coverage.out ]; then
+            {
+              echo "## Coverage"
+              echo '```'
+              go tool cover -func=coverage.out
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Check difference between generation code and commit code
         run: make check_diffs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# github.com/lestrrat-go/jwx/v4 [![CI](https://github.com/lestrrat-go/jwx/actions/workflows/ci.yml/badge.svg)](https://github.com/lestrrat-go/jwx/actions/workflows/ci.yml) [![Go Reference](https://pkg.go.dev/badge/github.com/lestrrat-go/jwx/v4.svg)](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4) [![codecov.io](https://codecov.io/github/lestrrat-go/jwx/coverage.svg?branch=develop-v4)](https://codecov.io/github/lestrrat-go/jwx?branch=develop-v4)
+# github.com/lestrrat-go/jwx/v4 [![CI](https://github.com/lestrrat-go/jwx/actions/workflows/ci.yml/badge.svg)](https://github.com/lestrrat-go/jwx/actions/workflows/ci.yml) [![Go Reference](https://pkg.go.dev/badge/github.com/lestrrat-go/jwx/v4.svg)](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4)
 
 Go module implementing various JWx (JWA/JWE/JWK/JWS/JWT, otherwise known as JOSE) technologies.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-codecov:
-  allow_coverage_offsets: true


### PR DESCRIPTION
After `make cover`, dump `go tool cover -func=coverage.out` into `$GITHUB_STEP_SUMMARY` so per-function coverage and the total appear on each CI run page. Replaces the codecov upload that was removed in #1180.