### PR TITLE
ci: also run on push to target branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - v*
       - develop/*
+  push:
+    branches:
+      - v*
+      - develop/*
 
 jobs:
   build:


### PR DESCRIPTION
Adds a push trigger so CI (including the coverage summary from #2078) runs on merges into develop/* and v* branches, not only on PRs against them.