### PR TITLE
jws: refuse "b64" header in VerifyCompactFast

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -71,6 +71,8 @@ Only `jwt.UnknownPayloadTypeError()` remains a sentinel function (no struct type
 | `jws` | `VerifyError()` | Verification process error |
 | `jws` | `VerificationError()` | Signature mismatch |
 | `jws` | `ParseError()` | Parse failed |
+| `jws` | `ErrCritPresent()` | `VerifyCompactFast` refused a `crit`-bearing protected header (use `jws.Verify`) |
+| `jws` | `ErrB64Present()` | `VerifyCompactFast` refused a `b64`-bearing protected header (use `jws.Verify`) |
 | `jwe` | `EncryptError()` | Encryption failed |
 | `jwe` | `DecryptError()` | Decryption failed |
 | `jwe` | `HPKEError()` | HPKE encrypt/decrypt operation failed |

--- a/jws/errors.go
+++ b/jws/errors.go
@@ -21,6 +21,27 @@ func ErrCritPresent() error {
 	return errCritPresent
 }
 
+// errB64Present is returned by VerifyCompactFast when the protected
+// header carries a "b64" entry (typically b64=false per RFC 7797). The
+// fast path assumes the default b64=true encoding for both the
+// signing-input reconstruction and the post-verify payload decode; a
+// b64=false message signed under non-conformant rules (b64 not declared
+// in "crit") would otherwise verify cryptographically while returning
+// a decoded payload that differs from the producer's intent. Refusing
+// here defers such messages to jws.Verify, which has the
+// WithDetachedPayload and WithCritExtension machinery to handle b64=false
+// correctly. Callers that wrap VerifyCompactFast can detect this via
+// errors.Is(err, jws.ErrB64Present()).
+var errB64Present = errors.New("VerifyCompactFast: protected header contains \"b64\"; use jws.Verify")
+
+// ErrB64Present returns the sentinel error returned by VerifyCompactFast
+// when the protected header contains a "b64" entry. Callers that front
+// VerifyCompactFast with an auto-fallback to jws.Verify can detect it
+// via errors.Is.
+func ErrB64Present() error {
+	return errB64Present
+}
+
 type signError struct {
 	error
 }

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -791,12 +791,17 @@ func Settings(options ...GlobalOption) error {
 // set. Applications that may legitimately receive "crit" headers should
 // call jws.Verify directly.
 //
-// VerifyCompactFast also assumes the JWS uses the default "b64":true
-// (base64url-encoded) payload encoding. A conforming RFC 7797 b64:false
-// JWS is required to list "b64" in "crit", so it is automatically routed
-// away from the fast path by the crit refusal above. Detached-payload
-// callers must use jws.Verify with jws.WithDetachedPayload regardless,
-// since VerifyCompactFast has no way to accept a detached payload.
+// VerifyCompactFast assumes the JWS uses the default "b64":true
+// (base64url-encoded) payload encoding. Any protected header carrying
+// a "b64" entry is refused with jws.ErrB64Present(), regardless of
+// whether "crit" also lists it: the fast path's signing-input
+// reconstruction and post-verify base64 decode both depend on the
+// default encoding, and a non-conformant b64=false producer (one that
+// omits "b64" from "crit") would otherwise verify cryptographically
+// while returning bytes that differ from the producer's intent.
+// Detached-payload callers must use jws.Verify with jws.WithDetachedPayload
+// regardless, since VerifyCompactFast has no way to accept a detached
+// payload.
 func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]byte, error) {
 	if err := validateAlgorithmForKey(alg, key); err != nil {
 		return nil, makeVerifyError(`%w`, err)
@@ -818,6 +823,18 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	// errors.Is(err, jws.ErrCritPresent()) and fall through to jws.Verify.
 	if jwsbb.HeaderHas(parsedHdr, CriticalKey) {
 		return nil, errCritPresent
+	}
+
+	// Refuse "b64"-bearing messages, regardless of whether "crit" also
+	// lists it. The signing-input reconstruction and the post-verify
+	// base64 decode both assume the default b64=true encoding; a
+	// b64=false JWS that the fast path "verified" would either fail the
+	// post-verify base64 decode with a misleading error, or — worse —
+	// return base64-decoded garbage as the payload while the producer's
+	// raw bytes silently disagree. jws.Verify has the WithDetachedPayload
+	// / WithCritExtension machinery to handle b64=false correctly.
+	if jwsbb.HeaderHas(parsedHdr, "b64") {
+		return nil, errB64Present
 	}
 
 	// Cross-check the protected header "alg" against the caller-supplied

--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -1,6 +1,9 @@
 package jws_test
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v4/internal/jwxtest"
@@ -331,4 +334,42 @@ func TestVerifyCompactFastRefusesCrit(t *testing.T) {
 			require.ErrorIs(t, err, jws.ErrCritPresent(), `error should match jws.ErrCritPresent sentinel`)
 		})
 	}
+}
+
+// TestVerifyCompactFastRefusesB64False documents that the fast path refuses
+// any protected header carrying "b64" (typically b64=false), regardless of
+// whether "crit" is also present. Without this check, a non-RFC-7797-
+// conformant producer that sets b64=false but omits "b64" from "crit" would
+// slip past the crit refusal: the fast path's signing-input reconstruction
+// (`base64(hdr).rawPayload`) coincidentally matches what such a producer
+// signed, so the signature verifies, and the function would then base64-
+// decode the wire payload — silently returning bytes that differ from the
+// producer's intent. jws.Verify and VerifyCompactFast must agree on what
+// they accept; refusing b64-bearing messages on the fast path defers them
+// to jws.Verify, which has the WithDetachedPayload / WithCritExtension
+// machinery to handle b64=false correctly.
+func TestVerifyCompactFastRefusesB64False(t *testing.T) {
+	rawKey := jwxtest.GenerateSymmetricKey()
+
+	// Construct a non-conformant b64=false JWS WITHOUT declaring "b64" in
+	// "crit" (RFC 7797 §3 requires b64 ∈ crit; a defective producer can
+	// emit this anyway). Pick a payload whose raw bytes are also valid
+	// base64url so the current pre-fix path would silently return wrong
+	// decoded bytes rather than a base64-decode error — the worst-case
+	// behavior the fix prevents.
+	hdrJSON := `{"alg":"HS256","b64":false}`
+	hdrB64 := base64.RawURLEncoding.EncodeToString([]byte(hdrJSON))
+
+	rawPayload := []byte("aGVsbG8") // valid base64url for "hello"
+	signingInput := hdrB64 + "." + string(rawPayload)
+
+	mac := hmac.New(sha256.New, rawKey)
+	mac.Write([]byte(signingInput))
+	sigB64 := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	compact := []byte(signingInput + "." + sigB64)
+
+	_, err := jws.VerifyCompactFast(rawKey, compact, jwa.HS256())
+	require.Error(t, err, `VerifyCompactFast must refuse b64-bearing messages`)
+	require.ErrorIs(t, err, jws.ErrB64Present(), `error should match jws.ErrB64Present sentinel`)
 }


### PR DESCRIPTION
A non-conformant `b64=false` producer that omits `b64` from `crit` slips past the existing `crit` refusal in `VerifyCompactFast`: the fast path's signing-input reconstruction happens to match what such a producer signed, so the signature verifies, and the wire payload then gets base64-decoded. For raw payloads that are also valid base64url, this silently returns wrong bytes with `nil` error; for others, it surfaces a misleading post-verify decode error. Either way, `jws.Verify` and `VerifyCompactFast` accept the same input but return different bytes — an interop hazard, especially when `VerifyCompactFast` is wired into JWT parsing.

The fix probes `b64` right after the existing `crit` check and refuses with a new `ErrB64Present` sentinel. `jws.Verify` (with `WithDetachedPayload` / `WithCritExtension`) handles `b64=false` correctly, so callers that need it should fall through there. Godoc on `VerifyCompactFast` is updated to drop the conformance-dependent "automatically routed away by the crit refusal" claim.

Regression test in `jws/jws_crit_test.go:TestVerifyCompactFastRefusesB64False` constructs a non-conformant b64=false JWS by hand (since `jws.Sign` would reject one) with a payload that is also valid base64url, so the test asserts against the worst-case silent-wrong-bytes path. Existing `TestVerifyCompactFastRefusesCrit` and the conformant b64-with-crit tests still pass.