### PR TITLE
jws: VerifyCompactFast refusals match jws.VerifyError() class

### DIFF
--- a/jws/errors.go
+++ b/jws/errors.go
@@ -8,15 +8,17 @@ import (
 // errCritPresent is returned by VerifyCompactFast when the protected
 // header carries a "crit" list. The fast path cannot enforce RFC 7515
 // §4.1.11 (it has no WithCritExtension allowlist), so it refuses rather
-// than silently accepting. Callers that wrap VerifyCompactFast and want
-// the full validateCritical rule set applied should detect this via
-// errors.Is(err, jws.ErrCritPresent()) and retry through jws.Verify.
+// than silently accepting. The sentinel is wrapped in verifyError at the
+// return site so the resulting error matches BOTH errors.Is(err,
+// jws.ErrCritPresent()) (the specific reason) AND errors.Is(err,
+// jws.VerifyError()) (the general class), letting callers choose the
+// classification granularity that fits their code path.
 var errCritPresent = errors.New("VerifyCompactFast: protected header contains \"crit\"; use jws.Verify")
 
 // ErrCritPresent returns the sentinel error returned by VerifyCompactFast
-// when the protected header contains a "crit" list. Callers that front
-// VerifyCompactFast with an auto-fallback to jws.Verify can detect it
-// via errors.Is.
+// when the protected header contains a "crit" list. The error returned
+// from VerifyCompactFast also matches jws.VerifyError(), so callers that
+// only branch on the general class still classify the refusal correctly.
 func ErrCritPresent() error {
 	return errCritPresent
 }
@@ -30,14 +32,15 @@ func ErrCritPresent() error {
 // a decoded payload that differs from the producer's intent. Refusing
 // here defers such messages to jws.Verify, which has the
 // WithDetachedPayload and WithCritExtension machinery to handle b64=false
-// correctly. Callers that wrap VerifyCompactFast can detect this via
-// errors.Is(err, jws.ErrB64Present()).
+// correctly. As with errCritPresent, the sentinel is wrapped in
+// verifyError at the return site so the resulting error matches both
+// errors.Is(err, jws.ErrB64Present()) and errors.Is(err, jws.VerifyError()).
 var errB64Present = errors.New("VerifyCompactFast: protected header contains \"b64\"; use jws.Verify")
 
 // ErrB64Present returns the sentinel error returned by VerifyCompactFast
-// when the protected header contains a "b64" entry. Callers that front
-// VerifyCompactFast with an auto-fallback to jws.Verify can detect it
-// via errors.Is.
+// when the protected header contains a "b64" entry. The error returned
+// from VerifyCompactFast also matches jws.VerifyError(), so callers that
+// only branch on the general class still classify the refusal correctly.
 func ErrB64Present() error {
 	return errB64Present
 }

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -824,8 +824,11 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	// allowlist, so accepting them would silently violate RFC 7515 §4.1.11.
 	// Callers that wrap VerifyCompactFast can detect this via
 	// errors.Is(err, jws.ErrCritPresent()) and fall through to jws.Verify.
+	// The sentinel is wrapped in verifyError so the same error also matches
+	// errors.Is(err, jws.VerifyError()) — fast-path refusals are a verify
+	// error, just one with a more specific classification available.
 	if jwsbb.HeaderHas(parsedHdr, CriticalKey) {
-		return nil, errCritPresent
+		return nil, verifyError{errCritPresent}
 	}
 
 	// Refuse "b64"-bearing messages, regardless of whether "crit" also
@@ -835,9 +838,11 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	// post-verify base64 decode with a misleading error, or — worse —
 	// return base64-decoded garbage as the payload while the producer's
 	// raw bytes silently disagree. jws.Verify has the WithDetachedPayload
-	// / WithCritExtension machinery to handle b64=false correctly.
+	// / WithCritExtension machinery to handle b64=false correctly. As with
+	// the crit refusal above, the sentinel is wrapped in verifyError so the
+	// same error matches both jws.ErrB64Present() and jws.VerifyError().
 	if jwsbb.HeaderHas(parsedHdr, "b64") {
-		return nil, errB64Present
+		return nil, verifyError{errB64Present}
 	}
 
 	// Cross-check the protected header "alg" against the caller-supplied

--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -400,3 +400,48 @@ func TestVerifyCompactFastRefusesB64False(t *testing.T) {
 	require.Error(t, err, `VerifyCompactFast must refuse b64-bearing messages`)
 	require.ErrorIs(t, err, jws.ErrB64Present(), `error should match jws.ErrB64Present sentinel`)
 }
+
+// TestVerifyCompactFastRefusalsMatchVerifyError documents that the fast-path
+// refusal sentinels (ErrCritPresent, ErrB64Present) participate in the
+// general jws.VerifyError() taxonomy as well as their own specific
+// classifications. Code that uses errors.Is(err, jws.VerifyError()) to
+// classify "is this a verify error" must succeed on these refusals — the
+// refusals are returned by VerifyCompactFast and any caller that fronts the
+// function with a single VerifyError() branch should not have to special-
+// case them. Both classifications hold simultaneously: ErrCritPresent /
+// ErrB64Present continue to identify the specific reason for the refusal.
+func TestVerifyCompactFastRefusalsMatchVerifyError(t *testing.T) {
+	t.Run("crit refusal", func(t *testing.T) {
+		key, err := jwxtest.GenerateSymmetricJwk()
+		require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+
+		hdrs := jws.NewHeaders()
+		require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"x-test"}))
+		signed := signWith(t, key, []byte("hello world"), hdrs)
+
+		_, err = jws.VerifyCompactFast(key, signed, jwa.HS256())
+		require.Error(t, err)
+		require.ErrorIs(t, err, jws.ErrCritPresent(), `specific sentinel match must remain`)
+		require.ErrorIs(t, err, jws.VerifyError(), `crit refusal must also match jws.VerifyError() class`)
+	})
+
+	t.Run("b64 refusal", func(t *testing.T) {
+		rawKey := jwxtest.GenerateSymmetricKey()
+
+		hdrJSON := `{"alg":"HS256","b64":false}`
+		hdrB64 := base64.RawURLEncoding.EncodeToString([]byte(hdrJSON))
+		rawPayload := []byte("aGVsbG8")
+		signingInput := hdrB64 + "." + string(rawPayload)
+
+		mac := hmac.New(sha256.New, rawKey)
+		mac.Write([]byte(signingInput))
+		sigB64 := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+		compact := []byte(signingInput + "." + sigB64)
+
+		_, err := jws.VerifyCompactFast(rawKey, compact, jwa.HS256())
+		require.Error(t, err)
+		require.ErrorIs(t, err, jws.ErrB64Present(), `specific sentinel match must remain`)
+		require.ErrorIs(t, err, jws.VerifyError(), `b64 refusal must also match jws.VerifyError() class`)
+	})
+}


### PR DESCRIPTION
v3 backport of #2082.

`errCritPresent` and `errB64Present` are currently returned bare from `VerifyCompactFast`'s fast-path refusal branches. `errors.Is(err, jws.VerifyError())` therefore returns `false` for those refusals even though they came out of a verify entry point — a single-branch hole in the documented error taxonomy.

Wrap both sentinels in `verifyError` at the return site. The resulting error matches **both** `jws.ErrCritPresent()` / `jws.ErrB64Present()` (the specific reason) **and** `jws.VerifyError()` (the general class), so callers can choose the classification granularity that fits.

Regression test in `jws/jws_crit_test.go:TestVerifyCompactFastRefusalsMatchVerifyError` asserts both classifications hold simultaneously for both refusal types. Existing crit/b64 refusal tests continue to pass.