### PR TITLE
jws: name loose keySet options in fan-out verify error

### DIFF
--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -2269,3 +2269,42 @@ func TestSignKidMatch(t *testing.T) {
 		jws.WithKey(jwa.RS256(), key, jws.WithProtectedHeaders(hdr)))
 	require.NoError(t, err, `matching kids should sign cleanly`)
 }
+
+// TestVerifyFanoutErrorNamesLooseOptions documents that when verification
+// fails after a keySet-driven fan-out widened the candidate set (because
+// the caller opted into WithRequireKid(false) or WithInferAlgorithmFromKey
+// (true)), the resulting error names the option(s) that fired and reports
+// the (alg,key) attempt count. Without this attribution, an operator
+// staring at "could not be verified with any of the keys" mis-diagnoses
+// by adding more keys instead of fixing the JWS or tightening the config.
+func TestVerifyFanoutErrorNamesLooseOptions(t *testing.T) {
+	payload := []byte("hello world")
+
+	// Sign with a key that is NOT in the verifying JWKS so all attempts fail.
+	signKey, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+	signed, err := jws.Sign(payload, jws.WithKey(jwa.HS256(), signKey))
+	require.NoError(t, err, `jws.Sign should succeed`)
+
+	// JWKS contains three different symmetric keys, none of which match
+	// the signer above. Each carries an explicit alg=HS256 so the
+	// keySetProvider sinks (HS256, key) for each under
+	// WithRequireKid(false); the verifier then runs an HS256 verify
+	// against each; all fail.
+	set := jwk.NewSet()
+	for range 3 {
+		k, err := jwxtest.GenerateSymmetricJwk()
+		require.NoError(t, err)
+		require.NoError(t, k.Set(jwk.AlgorithmKey, jwa.HS256()))
+		require.NoError(t, set.AddKey(k))
+	}
+
+	_, err = jws.Verify(signed, jws.WithKeySet(set, jws.WithRequireKid(false)))
+	require.Error(t, err, `verify must fail when no key in the JWKS matches the signer`)
+
+	msg := err.Error()
+	require.Contains(t, msg, `(alg,key) pair`,
+		`error must report the count of attempted (alg,key) pairs when fan-out occurred`)
+	require.Contains(t, msg, `WithRequireKid(false)`,
+		`error must name WithRequireKid(false) so the operator knows which option widened the candidate set`)
+}

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -216,6 +216,7 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 
 		verifyBuf = verifyBuf[:0]
 		verifyBuf = jwsbb.SignBuffer(verifyBuf, rawHeaders, msg.payload, vc.encoder, msg.b64)
+		var attempts int
 		for i, kp := range vc.keyProviders {
 			var sink algKeySink
 			if err := kp.FetchKeys(vc.ctx, &sink, sig, msg); err != nil {
@@ -224,6 +225,7 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 			}
 
 			for _, pair := range sink.list {
+				attempts++
 				alg := pair.alg
 				key := pair.key
 
@@ -235,7 +237,19 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 				return msg.payload, nil
 			}
 		}
-		errs = append(errs, makeVerifyError(`signature #%d could not be verified with any of the keys`, idx+1))
+		// When loose keySet options widened the candidate set above the
+		// usual "kid + alg pin" of 1, name them so the operator can see
+		// why a single Verify call paid N× the cost. An option-blind
+		// "could not be verified with any of the keys" is the kind of
+		// thing operators mis-diagnose by adding more keys instead of
+		// fixing the JWS or tightening the config.
+		if looseOpts := vc.namedLooseKeySetOptions(); len(looseOpts) > 0 && attempts > 1 {
+			errs = append(errs, makeVerifyError(
+				`signature #%d could not be verified with any of %d (alg,key) pair(s); %s widened the candidate set`,
+				idx+1, attempts, strings.Join(looseOpts, " and ")))
+		} else {
+			errs = append(errs, makeVerifyError(`signature #%d could not be verified with any of the keys`, idx+1))
+		}
 	}
 	return nil, makeVerifyError(`could not verify message using any of the signatures or keys: %w`, errors.Join(errs...))
 }
@@ -325,4 +339,36 @@ func validateCritical(protected Headers, allowedExtensions []string) error {
 	}
 
 	return nil
+}
+
+// namedLooseKeySetOptions inspects the registered key providers and
+// returns the human-readable names of the loose-config keySet options
+// in effect for this verify call: jws.WithRequireKid(false) and/or
+// jws.WithInferAlgorithmFromKey(true). These are the options whose
+// presence widens the per-signature (alg,key) candidate set beyond
+// the default "kid + alg pin" of one. The names are used in the final
+// "could not be verified" error so an operator sees which options
+// produced the fan-out without grep'ing the source.
+func (vc *verifyContext) namedLooseKeySetOptions() []string {
+	var requireKidFalse, inferAlgorithm bool
+	for _, kp := range vc.keyProviders {
+		ksp, ok := kp.(*keySetProvider)
+		if !ok {
+			continue
+		}
+		if !ksp.requireKid {
+			requireKidFalse = true
+		}
+		if ksp.inferAlgorithm {
+			inferAlgorithm = true
+		}
+	}
+	var names []string
+	if requireKidFalse {
+		names = append(names, "jws.WithRequireKid(false)")
+	}
+	if inferAlgorithm {
+		names = append(names, "jws.WithInferAlgorithmFromKey(true)")
+	}
+	return names
 }


### PR DESCRIPTION
When verification fails after `WithRequireKid(false)` and/or `WithInferAlgorithmFromKey(true)` widened the per-signature candidate set, the resulting "could not be verified with any of the keys" error gives the operator no signal that a loose option produced the fan-out. The common mis-diagnosis is to add more keys to the JWKS, when the actual problem is either a malformed JWS or a config looser than the deployment needs.

Track the per-signature attempt count and, when the count exceeds 1 under a loose-config `keySetProvider`, name the option(s) that fired in the final error: "signature #N could not be verified with any of M (alg,key) pair(s); jws.WithRequireKid(false) and/or jws.WithInferAlgorithmFromKey(true) widened the candidate set". The default-config message is unchanged, so any caller matching on the existing wording continues to work.

Regression test in `jws/jws_test.go:TestVerifyFanoutErrorNamesLooseOptions` builds a 3-key JWKS with `alg=HS256` set on each, signs with a 4th (un-listed) key, calls `Verify` with `WithKeySet(set, WithRequireKid(false))`, and asserts the error contains both the count phrasing and the option name. Existing verify tests still pass.