### PR TITLE
jws: honor RFC 7797 b64=false in Message.MarshalJSON

### DIFF
--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v4/internal/jwxtest"
@@ -417,4 +418,48 @@ func TestVerifyCompactFastRefusalsMatchVerifyError(t *testing.T) {
 		require.ErrorIs(t, err, jws.ErrB64Present(), `specific sentinel match must remain`)
 		require.ErrorIs(t, err, jws.VerifyError(), `b64 refusal must also match jws.VerifyError() class`)
 	})
+}
+
+// TestMessageMarshalJSONHonorsB64False documents that Message.MarshalJSON
+// must NOT re-base64-encode the payload when the protected header carries
+// b64=false. The parser path (UnmarshalJSON) stores raw bytes in m.payload
+// for b64=false; the matching serialization in Compact() honors that flag,
+// but marshalFlattened/marshalFull historically did not — a Parse →
+// MarshalJSON round-trip silently produced JSON whose "payload" field
+// was the raw bytes RE-base64-encoded, mismatching the protected header.
+func TestMessageMarshalJSONHonorsB64False(t *testing.T) {
+	rawPayload := []byte("hello world")
+	key, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err, `jwxtest.GenerateSymmetricJwk should succeed`)
+
+	hdrs := jws.NewHeaders()
+	require.NoError(t, hdrs.Set("b64", false))
+	require.NoError(t, hdrs.Set(jws.CriticalKey, []string{"b64"}))
+	signed, err := jws.Sign(rawPayload,
+		jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)))
+	require.NoError(t, err, `jws.Sign with b64=false should succeed`)
+
+	msg, err := jws.Parse(signed)
+	require.NoError(t, err, `jws.Parse should succeed`)
+
+	// Flattened form: one signature → marshalFlattened
+	flatJSON, err := json.Marshal(msg)
+	require.NoError(t, err, `json.Marshal of Message should succeed (flattened)`)
+
+	var flatParsed struct {
+		Payload string `json:"payload"`
+	}
+	require.NoError(t, json.Unmarshal(flatJSON, &flatParsed))
+	require.Equal(t, string(rawPayload), flatParsed.Payload,
+		`flattened-form b64=false JSON serialization must NOT re-base64-encode the payload`)
+
+	// Round-trip: re-parsing the JSON output should produce a Message
+	// whose payload bytes match the original. Without the fix, the
+	// re-parsed message would store base64(rawPayload) as raw bytes
+	// (because the protected header still says b64=false), corrupting
+	// the producer's signing input.
+	msg2, err := jws.Parse(flatJSON)
+	require.NoError(t, err, `re-Parse of MarshalJSON output should succeed`)
+	require.Equal(t, msg.Payload(), msg2.Payload(),
+		`Parse → MarshalJSON → Parse round-trip must preserve b64=false payload bytes`)
 }

--- a/jws/message.go
+++ b/jws/message.go
@@ -321,9 +321,22 @@ func (m Message) marshalFlattened() ([]byte, error) {
 		if wrote {
 			buf.WriteRune(tokens.Comma)
 		}
-		buf.WriteString(`"payload":"`)
-		buf.Write(base64.Encode(m.payload))
-		buf.WriteRune('"')
+		if !getB64Value(sig.protected) {
+			// RFC 7797 b64=false: emit the raw payload as a JSON string
+			// rather than re-base64-encoding it. json.Marshal handles
+			// any necessary escaping for byte sequences that aren't
+			// JSON-safe as-is.
+			payloadbuf, err := json.Marshal(string(m.payload))
+			if err != nil {
+				return nil, fmt.Errorf(`failed to marshal "payload" (flattened, b64=false): %w`, err)
+			}
+			buf.WriteString(`"payload":`)
+			buf.Write(payloadbuf)
+		} else {
+			buf.WriteString(`"payload":"`)
+			buf.Write(base64.Encode(m.payload))
+			buf.WriteRune('"')
+		}
 		wrote = true
 	}
 
@@ -359,9 +372,28 @@ func (m Message) marshalFull() ([]byte, error) {
 
 	buf.WriteRune(tokens.OpenCurlyBracket)
 	if !m.detached {
-		buf.WriteString(`"payload":"`)
-		buf.Write(base64.Encode(m.payload))
-		buf.WriteString(`",`)
+		// RFC 7797 b64=false: emit the raw payload as a JSON string
+		// rather than re-base64-encoding it. The general JWS form has
+		// one shared payload across signatures; per RFC 7797, all
+		// signers must agree on the b64 flag, so we consult the first
+		// signature's protected header.
+		var b64 = true
+		if len(m.signatures) > 0 {
+			b64 = getB64Value(m.signatures[0].protected)
+		}
+		if !b64 {
+			payloadbuf, err := json.Marshal(string(m.payload))
+			if err != nil {
+				return nil, fmt.Errorf(`failed to marshal "payload" (full, b64=false): %w`, err)
+			}
+			buf.WriteString(`"payload":`)
+			buf.Write(payloadbuf)
+			buf.WriteRune(tokens.Comma)
+		} else {
+			buf.WriteString(`"payload":"`)
+			buf.Write(base64.Encode(m.payload))
+			buf.WriteString(`",`)
+		}
 	}
 	buf.WriteString(`"signatures":[`)
 	for i, sig := range m.signatures {


### PR DESCRIPTION
`marshalFlattened` and `marshalFull` both unconditionally base64-encode `m.payload`, even though the parser path (`Message.UnmarshalJSON`) stores raw bytes for `b64=false` JWS and the matching `Compact()` serialization honors the flag. A `Parse(b64FalseJWS) → MarshalJSON` round-trip therefore silently produces JSON whose `"payload"` field is the raw bytes RE-base64-encoded under a protected header that still says `b64=false` — re-`Parse` of that JSON treats the field as raw bytes and stores the double-encoded bytes as `m.payload`, breaking signature verification on the round-tripped message.

Mirror `Compact()`'s pattern in both serializers: when the relevant signature's protected header carries `b64=false`, emit the payload as a JSON string of the raw bytes (`json.Marshal` handles escaping for any non-JSON-safe byte sequences). Default `b64=true` behavior is unchanged, so callers and tests not using RFC 7797 see no difference.

Regression test in `jws/jws_crit_test.go:TestMessageMarshalJSONHonorsB64False` builds an in-band `b64=false` JWS via `jws.Sign` with `crit=["b64"]`, marshals it via `json.Marshal(msg)`, asserts the `"payload"` field of the resulting JSON is the raw bytes (not the base64-encoded form), then re-parses the marshaled JSON and asserts the round-tripped `Message.Payload()` matches the original bytes.