### PR TITLE
jws: reject literal-JSON "protected" in general-form JWS

### DIFF
--- a/jws/message.go
+++ b/jws/message.go
@@ -66,14 +66,18 @@ func (s *Signature) UnmarshalJSON(data []byte) error {
 
 	s.headers = sup.Header
 	if buf := sup.Protected; buf != nil {
-		src := []byte(*buf)
-		if !bytes.HasPrefix(src, []byte{tokens.OpenCurlyBracket}) {
-			decoded, err := base64.Decode(src)
-			if err != nil {
-				return fmt.Errorf(`failed to base64 decode protected headers: %w`, err)
-			}
-			src = decoded
+		// RFC 7515 §3 mandates that "protected" be base64url-encoded.
+		// Earlier code carried a relaxed probe that accepted a literal-
+		// JSON form (a JSON string whose content begins with "{") and
+		// skipped base64 decoding — that was asymmetric with the
+		// flattened branch (which only base64-decodes) and gave callers
+		// a non-conforming wire form useful for evading byte-exact JWS
+		// dedup / replay caches.
+		decoded, err := base64.Decode([]byte(*buf))
+		if err != nil {
+			return fmt.Errorf(`failed to base64 decode protected headers: %w`, err)
 		}
+		src := decoded
 
 		prt := NewHeaders()
 		//nolint:forcetypeassert

--- a/jws/message_test.go
+++ b/jws/message_test.go
@@ -102,3 +102,35 @@ func TestMessage(t *testing.T) {
 		require.Equal(t, expected, string(buf), `output should match`)
 	})
 }
+
+// TestMessageUnmarshalJSONRejectsLiteralJSONProtected documents that the
+// "protected" member of a JSON-form JWS must be a base64url-encoded UTF-8
+// string per RFC 7515 §3. Earlier versions of Signature.UnmarshalJSON had
+// a relaxed-probe shortcut: if the string value of "protected" started
+// with `{`, the decoder treated the value as already-decoded JSON and
+// skipped base64 decoding. That gave callers a non-conforming wire form
+// for the same logically-equivalent message — useful for evading
+// byte-exact JWS deduplication / replay caches and asymmetric with the
+// flattened branch (which only base64-decodes). Removing the probe brings
+// general-form parsing in line with both RFC 7515 and the flattened path.
+func TestMessageUnmarshalJSONRejectsLiteralJSONProtected(t *testing.T) {
+	// General (multi-signature) form with "protected" carrying a
+	// JSON-string-of-literal-JSON instead of a base64url-encoded
+	// header. Per the parser's signatureUnmarshalProbe shape, the
+	// "protected" field is a *string; the value below is a JSON string
+	// whose content begins with `{`, which is what the relaxed probe
+	// used to short-circuit on.
+	const nonConforming = `{
+  "payload": "aGVsbG8",
+  "signatures": [
+    {
+      "protected": "{\"alg\":\"HS256\"}",
+      "signature": "AAAA"
+    }
+  ]
+}`
+	var msg jws.Message
+	err := json.Unmarshal([]byte(nonConforming), &msg)
+	require.Error(t, err,
+		`general-form JWS with literal-JSON "protected" must be rejected (RFC 7515 §3 requires base64url)`)
+}


### PR DESCRIPTION
`Signature.UnmarshalJSON` carried a relaxed probe at jws/message.go:70-76: when the string value of `"protected"` started with `{`, the decoder treated the content as already-decoded JSON and skipped base64 decoding. RFC 7515 §3 mandates that `"protected"` be base64url-encoded, so the probe accepted non-conforming wire forms — and was asymmetric with the flattened branch in `Message.UnmarshalJSON` (which only base64-decodes).

The asymmetry gave callers a second valid wire form for the same logically-equivalent message: useful for evading byte-exact JWS dedup / replay caches and creating parser disagreement between `jwx` and spec-strict implementations. Not a forgery primitive (the canonical signing input is re-encoded via `jwsbb.SignBuffer` before the cryptographic check, so both forms verify against the same digest), but a real spec-deviation worth closing.

Remove the probe; rely on the existing base64 decode path. Both general (multi-signature) and flattened parser branches now agree on what they accept. Regression test in `jws/message_test.go:TestMessageUnmarshalJSONRejectsLiteralJSONProtected` constructs a multi-signature JSON JWS where `"protected"` is `"{\"alg\":\"HS256\"}"` (literal JSON inside a JSON string) and asserts the unmarshal errors. Existing tests still pass.