### PR TITLE
jwt: ParseRequest: don't skip form body on chunked transfer

### DIFF
--- a/jwt/http.go
+++ b/jwt/http.go
@@ -161,11 +161,13 @@ func ParseRequest(req *http.Request, options ...ParseOption) (Token, error) {
 
 	// Only touch the request body when the caller actually asked us
 	// to look at form fields. Without this guard ParseRequest would
-	// call req.ParseForm() on every request with a non-zero
-	// ContentLength — for form-encoded bodies that drains the body,
-	// leaving downstream handlers with an empty io.Reader; for other
-	// Content-Types it is still wasted work on the URL query.
-	if len(formkeys) > 0 && req.ContentLength > 0 {
+	// call req.ParseForm() on every request — for form-encoded bodies
+	// that drains the body, leaving downstream handlers with an empty
+	// io.Reader; for other Content-Types it is still wasted work on
+	// the URL query. We DO NOT gate on ContentLength: chunked-transfer
+	// requests have ContentLength == -1, and RFC 6750 §2.2 allows
+	// form-borne bearer tokens including under chunked encoding.
+	if len(formkeys) > 0 {
 		if err := req.ParseForm(); err != nil {
 			return nil, fmt.Errorf(`failed to parse form: %w`, err)
 		}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1198,6 +1198,30 @@ func TestParseRequest(t *testing.T) {
 		require.NoError(t, err, `req.Body should still be readable after ParseRequest`)
 		require.Equal(t, body, string(got), `req.Body must be intact when no WithFormKey is supplied`)
 	})
+
+	// Regression: ParseRequest used to gate ParseForm on
+	// `req.ContentLength > 0`, which silently skipped chunked-transfer
+	// requests (ContentLength == -1) and zero-length requests. RFC 6750
+	// §2.2 allows form-borne bearer tokens, including under chunked
+	// encoding. The guard belongs only on `len(formkeys) > 0` (the
+	// caller opted in to body parsing); ContentLength shouldn't gate
+	// it. Verifies a token in a chunked POST is found.
+	t.Run("token in chunked-transfer form body is found", func(t *testing.T) {
+		body := `access_token=` + string(signed)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, u, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		// Force chunked transfer: clear ContentLength and add the
+		// transfer encoding. This mirrors a streaming client that
+		// doesn't know the body size in advance.
+		req.ContentLength = -1
+		req.TransferEncoding = []string{"chunked"}
+
+		got, err := jwt.ParseRequest(req,
+			jwt.WithFormKey("access_token"),
+			jwt.WithKey(jwa.ES256(), pubkey))
+		require.NoError(t, err, `jwt.ParseRequest must accept chunked-transfer form bodies (RFC 6750 §2.2)`)
+		require.NotNil(t, got)
+	})
 }
 
 func TestGHIssue368(t *testing.T) {


### PR DESCRIPTION
The form-parsing guard at `jwt/http.go:168` gated `req.ParseForm()` on both `len(formkeys) > 0` AND `req.ContentLength > 0`. The first half is the right gate (only consume the body when the caller opted in via `WithFormKey`); the `ContentLength > 0` half silently skips chunked-transfer requests (`ContentLength == -1`) and zero-length requests. RFC 6750 §2.2 allows form-borne bearer tokens including under chunked encoding, so a streaming client sending a token in a chunked form body got "no token found" instead of the expected parse.

Drop the `ContentLength > 0` half of the guard. Body consumption remains gated on caller opt-in via `WithFormKey`, so the existing tests for "body must remain intact when no `WithFormKey` is supplied" continue to pass.

Regression test in `jwt/jwt_test.go:TestParseRequest/token_in_chunked-transfer_form_body_is_found` forces a chunked POST (`req.ContentLength = -1`, `req.TransferEncoding = ["chunked"]`) carrying `access_token=<jwt>` and asserts the parsed token is returned.