### PR TITLE
jwt: Settings rejects out-of-range NumericDate precision

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -42,16 +42,16 @@ func Settings(options ...GlobalOption) error {
 			parsePedantic = option.MustGet[bool](opt)
 		case identNumericDateParsePrecision{}:
 			v := option.MustGet[int](opt)
-			// only accept this value if it's in our desired range
-			if v >= 0 && v <= int(types.MaxPrecision) {
-				parsePrecision = uint32(v)
+			if v < 0 || v > int(types.MaxPrecision) {
+				return fmt.Errorf(`jwt.Settings: WithNumericDateParsePrecision(%d) is out of range; must be between 0 and %d (inclusive)`, v, types.MaxPrecision)
 			}
+			parsePrecision = uint32(v)
 		case identNumericDateFormatPrecision{}:
 			v := option.MustGet[int](opt)
-			// only accept this value if it's in our desired range
-			if v >= 0 && v <= int(types.MaxPrecision) {
-				formatPrecision = uint32(v)
+			if v < 0 || v > int(types.MaxPrecision) {
+				return fmt.Errorf(`jwt.Settings: WithNumericDateFormatPrecision(%d) is out of range; must be between 0 and %d (inclusive)`, v, types.MaxPrecision)
 			}
+			formatPrecision = uint32(v)
 		}
 	}
 

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1753,6 +1753,40 @@ func TestFractional(t *testing.T) {
 	})
 }
 
+// TestSettingsRejectsOutOfRangePrecision documents that out-of-range
+// values for WithNumericDate{Parse,Format}Precision (negative or above
+// types.MaxPrecision) cause Settings() to return an error rather than
+// silently swallowing the value. The previous behavior was to ignore
+// out-of-range values and always return nil — a caller mis-typing the
+// precision would get no signal, and the global state would silently
+// stay at its previous value.
+func TestSettingsRejectsOutOfRangePrecision(t *testing.T) {
+	t.Run("parse precision above MaxPrecision", func(t *testing.T) {
+		err := jwt.Settings(jwt.WithNumericDateParsePrecision(int(types.MaxPrecision) + 1))
+		require.Error(t, err, `Settings must reject parse-precision > MaxPrecision`)
+	})
+
+	t.Run("parse precision negative", func(t *testing.T) {
+		err := jwt.Settings(jwt.WithNumericDateParsePrecision(-1))
+		require.Error(t, err, `Settings must reject negative parse-precision`)
+	})
+
+	t.Run("format precision above MaxPrecision", func(t *testing.T) {
+		err := jwt.Settings(jwt.WithNumericDateFormatPrecision(int(types.MaxPrecision) + 1))
+		require.Error(t, err, `Settings must reject format-precision > MaxPrecision`)
+	})
+
+	t.Run("format precision negative", func(t *testing.T) {
+		err := jwt.Settings(jwt.WithNumericDateFormatPrecision(-1))
+		require.Error(t, err, `Settings must reject negative format-precision`)
+	})
+
+	t.Run("valid precision still succeeds", func(t *testing.T) {
+		require.NoError(t, jwt.Settings(jwt.WithNumericDateParsePrecision(0)))
+		require.NoError(t, jwt.Settings(jwt.WithNumericDateParsePrecision(int(types.MaxPrecision))))
+	})
+}
+
 func TestGH836(t *testing.T) {
 	// tests on TokenOptionSet are found elsewhere.
 


### PR DESCRIPTION
`jwt.Settings()` previously silently swallowed out-of-range values for `WithNumericDateParsePrecision` and `WithNumericDateFormatPrecision` — the option loop guarded `v >= 0 && v <= MaxPrecision` and dropped non-matching values, then `Settings` always returned `nil`. A caller mis-typing the precision got no signal; the global state stayed at its previous value, and parsing/formatting proceeded with the old (possibly default) precision.

Replace the silent-ignore with an explicit error returned before the mutex is acquired, naming the offending option and the valid range. Out-of-range values no longer mutate global state under any circumstances. Valid values still succeed unchanged.

Regression test in `jwt/jwt_test.go:TestSettingsRejectsOutOfRangePrecision` covers parse-precision, format-precision, both above-`MaxPrecision` and negative values, plus a positive case that valid values still succeed.