### PR TITLE
jwt: pedantic mode enforces cty=JWT nested-envelope shape

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -325,7 +325,7 @@ func verifyJWS(ctx *parseCtx, payload []byte) ([]byte, int, error) {
 		if ok && len(wk.options) == 0 {
 			verified, err := jws.VerifyCompactFast(wk.key, payload, alg)
 			if err == nil {
-				return verified, _JwsVerifyDone, nil
+				return verified, peekJWSNestedState(ctx, payload), nil
 			}
 			// VerifyCompactFast refuses crit-bearing messages. In v3
 			// jws.Verify defaults critValidation=false, so the generic
@@ -335,7 +335,10 @@ func verifyJWS(ctx *parseCtx, payload []byte) ([]byte, int, error) {
 			if errors.Is(err, jws.ErrCritPresent()) {
 				verifyOpts := append(ctx.verifyOpts, jws.WithCompact(), jws.WithCritValidation(true))
 				verified, err := jws.Verify(payload, verifyOpts...)
-				return verified, _JwsVerifyDone, err
+				if err != nil {
+					return nil, _JwsVerifyDone, err
+				}
+				return verified, peekJWSNestedState(ctx, payload), nil
 			}
 			return nil, _JwsVerifyDone, err
 		}
@@ -343,7 +346,39 @@ func verifyJWS(ctx *parseCtx, payload []byte) ([]byte, int, error) {
 
 	verifyOpts := append(ctx.verifyOpts, jws.WithCompact())
 	verified, err := jws.Verify(payload, verifyOpts...)
-	return verified, _JwsVerifyDone, err
+	if err != nil {
+		return nil, _JwsVerifyDone, err
+	}
+	return verified, peekJWSNestedState(ctx, payload), nil
+}
+
+// peekJWSNestedState returns _JwsVerifyExpectNested when pedantic mode is on
+// and the verified JWS protected header carries cty=JWT (RFC 7519 §5.2 — the
+// payload is itself a Nested JWT; the outer envelope expects another signed/
+// encrypted layer wrapping the JWT, not a raw JWT). Otherwise returns
+// _JwsVerifyDone. The signature has already been verified at this point, so
+// re-parsing the protected header is safe — it operates on bytes the producer
+// signed.
+func peekJWSNestedState(ctx *parseCtx, payload []byte) int {
+	if !ctx.pedantic {
+		return _JwsVerifyDone
+	}
+	msg, err := jws.Parse(payload, jws.WithCompact())
+	if err != nil || len(msg.Signatures()) == 0 {
+		return _JwsVerifyDone
+	}
+	hdr := msg.Signatures()[0].ProtectedHeaders()
+	if hdr == nil {
+		return _JwsVerifyDone
+	}
+	cty, ok := hdr.ContentType()
+	if !ok {
+		return _JwsVerifyDone
+	}
+	if cty == "JWT" {
+		return _JwsVerifyExpectNested
+	}
+	return _JwsVerifyDone
 }
 
 // verify parameter exists to make sure that we don't accidentally skip

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1851,3 +1851,58 @@ func TestGH1484(t *testing.T) {
 		}
 	})
 }
+
+// TestParsePedanticEnforcesCtyJWTNesting documents that with WithPedantic(true)
+// on the verify path, jwt.Parse enforces RFC 7519 §5.2 nested-JWT structural
+// expectations: when the outer JWS protected header carries cty=JWT, the
+// inner payload must itself be enveloped (another JWS or JWE wrapping a JWT),
+// not a raw JWT JSON object. The producer side already sets cty=JWT in
+// jwt/serialize.go for nested signing; the verify-side enforcement was
+// asymmetric — _JwsVerifyExpectNested and the rejection branch existed in
+// jwt.go but verifyJWS never returned the ExpectNested state, so the check
+// could not fire on any input.
+//
+// Pedantic mode applies to the verify path only (ParseInsecure is incompatible
+// with structural strictness by design).
+func TestParsePedanticEnforcesCtyJWTNesting(t *testing.T) {
+	privkey, err := jwxtest.GenerateEcdsaJwk()
+	require.NoError(t, err)
+	require.NoError(t, privkey.Set(jwk.AlgorithmKey, jwa.ES256()))
+	pubkey, err := jwk.PublicKeyOf(privkey)
+	require.NoError(t, err)
+	require.NoError(t, pubkey.Set(jwk.AlgorithmKey, jwa.ES256()))
+
+	// Build a raw JWT (just JSON, no signature) and wrap it in a single
+	// JWS layer whose protected header carries cty=JWT. RFC 7519 §5.2
+	// reserves cty=JWT for nested signing/encryption; the inner here is
+	// raw JWT, which under pedantic rules should be rejected with
+	// "expected nested encrypted/signed payload, got raw JWT".
+	innerToken := jwt.New()
+	require.NoError(t, innerToken.Set(jwt.IssuerKey, "test-issuer"))
+	innerToken.Set(jwt.IssuedAtKey, time.Now().Round(0))
+	innerJSON, err := json.Marshal(innerToken)
+	require.NoError(t, err)
+
+	hdrs := jws.NewHeaders()
+	require.NoError(t, hdrs.Set("cty", "JWT"))
+	outerJWS, err := jws.Sign(innerJSON,
+		jws.WithKey(jwa.ES256(), privkey, jws.WithProtectedHeaders(hdrs)))
+	require.NoError(t, err)
+
+	t.Run("lenient parse accepts cty=JWT envelope around raw JWT", func(t *testing.T) {
+		// Without pedantic mode, the parser is lenient and unwraps to
+		// the inner JWT.
+		got, err := jwt.Parse(outerJWS, jwt.WithKey(jwa.ES256(), pubkey))
+		require.NoError(t, err, `lenient parse should accept the envelope`)
+		iss, ok := got.Issuer()
+		require.True(t, ok)
+		require.Equal(t, "test-issuer", iss)
+	})
+
+	t.Run("pedantic parse rejects cty=JWT enveloping raw JWT", func(t *testing.T) {
+		_, err := jwt.Parse(outerJWS,
+			jwt.WithKey(jwa.ES256(), pubkey),
+			jwt.WithPedantic(true))
+		require.Error(t, err, `pedantic mode must enforce cty=JWT signals a further nested envelope`)
+	})
+}


### PR DESCRIPTION
v3 backport of #2093.

The producer side at `jwt/serialize.go` sets `cty=JWT` in the protected header when wrapping a JWT in a JWS, signaling RFC 7519 §5.2 nested-JWT semantics. The verify-side enforcement was asymmetric: `jwt.go` had a `_JwsVerifyExpectNested` state, a consumer at the OUTER decode loop, and a "expected nested encrypted/signed payload, got raw JWT" rejection branch — but `verifyJWS` never returned the `ExpectNested` state, so the check could not fire on any input regardless of pedantic mode.

After successful signature verification (fast path, crit-fallback path, or `jws.Verify` slow path), when `ctx.pedantic` is set and the verified protected header carries `cty=JWT`, return `_JwsVerifyExpectNested` so the OUTER loop applies the existing rejection branch on the next iteration. The check is gated on pedantic to preserve current lenient behavior. Pedantic applies to the verify path only — `ParseInsecure` is incompatible with structural strictness by design and is not affected.

Regression test in `jwt/jwt_test.go:TestParsePedanticEnforcesCtyJWTNesting` builds a JWS whose protected header carries `cty=JWT` wrapping a raw JWT JSON payload (the canonical violation). Without pedantic, the parser leniently unwraps to the inner JWT. With pedantic, the rejection now fires.