### PR TITLE
jwt: reshape base64-corruption hint as diagnosis-first

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -323,15 +323,20 @@ func verifyJWS(ctx *parseCtx, payload []byte) ([]byte, int, error) {
 			// the full validateCritical rule set applies.
 			if !errors.Is(err, jws.ErrCritPresent()) {
 				// The fast path uses strict base64url (RFC 7515).
-				// A caller whose issuer emits padded/standard
-				// base64 can re-run with jwt.WithStrictBase64Encoding(false)
-				// to fall back to jws.Verify's lenient decoder.
-				// The error message itself doesn't point at that
-				// escape hatch, so surface the hint here.
+				// On a strict-decode failure, surface a diagnosis
+				// first ("input is not strict RFC 7515 base64url")
+				// and only then mention the conditional remedy —
+				// the failure shape can't distinguish a known-non-
+				// conforming issuer from genuinely malformed /
+				// tampered input, so the caller has to make that
+				// call deliberately. Without the diagnosis-first
+				// shape, the previous wording read as a fix-it
+				// instruction and tilted users toward weakening
+				// strictness reflexively.
 				var corrupt base64.CorruptInputError
 				if errors.As(err, &corrupt) {
 					return nil, _JwsVerifyDone, fmt.Errorf(
-						`jwt.Parse: base64 decode failed; if the issuer emits padded/standard base64, set jwt.WithStrictBase64Encoding(false): %w`,
+						`jwt.Parse: base64url decode failed under strict RFC 7515 rule; if the issuer is known to emit padded or standard-base64 alphabet, retry with jwt.WithStrictBase64Encoding(false), otherwise treat the input as malformed: %w`,
 						err,
 					)
 				}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -191,6 +191,26 @@ func TestStrictBase64Encoding(t *testing.T) {
 			`error should name the option that flips to lenient base64`)
 	})
 
+	// The error wording should be diagnosis-first: lead with the standards
+	// reference (RFC 7515 strict base64url), then offer the remedy as
+	// conditional ("if the issuer is known to ..."), and finish with the
+	// "otherwise treat as malformed" branch. The previous wording was
+	// imperative ("set WithStrictBase64Encoding(false)") and tilted users
+	// toward weakening strictness reflexively without considering whether
+	// the input might be tampered.
+	t.Run("error message is diagnosis-first, not imperative", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwt.Parse(paddedCompact, jwt.WithKey(alg, key))
+		require.Error(t, err)
+		msg := err.Error()
+		require.Contains(t, msg, `RFC 7515`,
+			`error should anchor on the standard the input violated`)
+		require.Contains(t, msg, `if the issuer is known`,
+			`remedy should be presented as a conditional, not an imperative`)
+		require.Contains(t, msg, `otherwise treat the input as malformed`,
+			`error should explicitly mention the malformed-input branch`)
+	})
+
 	// Lenient mode with no verification: auto-detection handles padded base64.
 	t.Run("padded payload succeeds lenient no-verify", func(t *testing.T) {
 		t.Parallel()

--- a/jwt/parse_fast.go
+++ b/jwt/parse_fast.go
@@ -82,16 +82,17 @@ func parseCompactFast(data []byte, ctx *fastParseCtx) (Token, error) {
 		if errors.Is(err, jws.ErrCritPresent()) {
 			return parseCompactCritFallback(data, ctx)
 		}
-		// The fast path uses strict base64url (RFC 7515). A caller
-		// whose issuer emits padded/standard base64 can re-parse with
-		// jwt.WithStrictBase64Encoding(false) to fall back to the
-		// lenient decoder used by jws.Verify. The underlying error
-		// doesn't point at that escape hatch, so surface the hint
-		// before wrapping.
+		// The fast path uses strict base64url (RFC 7515). On a
+		// strict-decode failure, surface a diagnosis first ("input
+		// is not strict RFC 7515 base64url") and only then mention
+		// the conditional remedy — the failure shape can't
+		// distinguish a known-non-conforming issuer from genuinely
+		// malformed / tampered input, so the caller has to make
+		// that call deliberately.
 		var corrupt base64.CorruptInputError
 		if errors.As(err, &corrupt) {
 			return nil, parseErrorf(`jwt.Parse`,
-				`base64 decode failed; if the issuer emits padded/standard base64, set jwt.WithStrictBase64Encoding(false): %w`, err)
+				`base64url decode failed under strict RFC 7515 rule; if the issuer is known to emit padded or standard-base64 alphabet, retry with jwt.WithStrictBase64Encoding(false), otherwise treat the input as malformed: %w`, err)
 		}
 		return nil, parseErrorf(`jwt.Parse`, `%w`, err)
 	}


### PR DESCRIPTION
The previous wording — "base64 decode failed; if the issuer emits padded/standard base64, set jwt.WithStrictBase64Encoding(false)" — read as a fix-it instruction and tilted users toward weakening the strict decoder reflexively. A `base64.CorruptInputError` cannot distinguish "your producer is non-conforming" from "the input is malformed or tampered with"; the user has to make that call deliberately.

Reshape the error to lead with the diagnosis ("base64url decode failed under strict RFC 7515 rule"), present the remedy as a conditional ("if the issuer is known to emit padded or standard-base64 alphabet, retry with `jwt.WithStrictBase64Encoding(false)`"), and explicitly mention the default action ("otherwise treat the input as malformed"). Same change at both hint sites: `jwt/jwt.go` (fast-path verify branch) and `jwt/parse_fast.go` (`parseCompactFast`).

Existing tests that match on the option name continue to pass. A new test in `jwt/jwt_test.go:TestStrictBase64Encoding/error_message_is_diagnosis-first` asserts the new wording carries (a) the RFC 7515 anchor, (b) the conditional "if the issuer is known", (c) the "otherwise treat the input as malformed" branch.