### PR TITLE
jwt: ParseInsecure: parse loop-local payload, not original input

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -463,8 +463,11 @@ OUTER:
 				}
 			}
 
-			// No verification.
-			m, err := jws.Parse(data, jws.WithCompact())
+			// No verification. Parse the LOOP-LOCAL `payload` (not the
+			// original `data`); for a 2-layer nested JWS, iter 2 must
+			// see the inner JWS bytes that iter 1 produced, not re-
+			// parse the outer envelope.
+			m, err := jws.Parse(payload, jws.WithCompact())
 			if err != nil {
 				return nil, fmt.Errorf(`invalid jws message: %w`, err)
 			}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -2156,3 +2156,42 @@ func TestParsePedanticEnforcesCtyJWTNesting(t *testing.T) {
 		require.Error(t, err, `pedantic mode must enforce cty=JWT signals a further nested envelope`)
 	})
 }
+
+// TestParseInsecureUnwrapsNestedJWS documents that ParseInsecure correctly
+// unwraps a 2-layer nested compact JWS (JWS-around-JWS-around-JWT) and
+// returns the innermost JWT's claims. The skip-verify branch in parse()
+// previously called jws.Parse(data, ...) against the full original input
+// rather than the loop-local payload — iter 1 produced the inner JWS bytes
+// in `payload` but iter 2 re-parsed the outer envelope, leaving the loop
+// stuck on the inner JWS bytes. The token-unmarshal step then failed
+// because the bytes weren't JSON. With Parse + key the same shape works
+// (because the verify path's payload threading is correct), so the
+// failure was specifically a ParseInsecure correctness divergence, not a
+// security boundary.
+func TestParseInsecureUnwrapsNestedJWS(t *testing.T) {
+	innerKey, err := jwxtest.GenerateRsaJwk()
+	require.NoError(t, err)
+	require.NoError(t, innerKey.Set(jwk.AlgorithmKey, jwa.RS256()))
+	outerKey, err := jwxtest.GenerateEcdsaJwk()
+	require.NoError(t, err)
+	require.NoError(t, outerKey.Set(jwk.AlgorithmKey, jwa.ES256()))
+
+	tok := jwt.New()
+	require.NoError(t, tok.Set(jwt.IssuerKey, "nested-test"))
+	require.NoError(t, tok.Set(jwt.IssuedAtKey, time.Now().Round(0)))
+
+	// Inner: JWT signed with innerKey → compact JWS
+	innerSigned, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256(), innerKey))
+	require.NoError(t, err)
+
+	// Outer: JWS wrapping the inner JWS bytes, signed with outerKey
+	outerSigned, err := jws.Sign(innerSigned,
+		jws.WithKey(jwa.ES256(), outerKey))
+	require.NoError(t, err)
+
+	got, err := jwt.ParseInsecure(outerSigned)
+	require.NoError(t, err, `ParseInsecure should successfully unwrap a 2-layer nested JWS`)
+	iss, ok := got.Issuer()
+	require.True(t, ok, `inner issuer claim should be present after unwrap`)
+	require.Equal(t, "nested-test", iss)
+}


### PR DESCRIPTION
The skip-verify branch in `parse()` called `jws.Parse(data, ...)` at the end of the `case jwx.JWS` arm — passing the FULL original input rather than the loop-local `payload`. For a 2-layer nested JWS (JWS-around-JWS-around-JWT) the impact was: iter 1 produced the inner JWS bytes in `payload` correctly, but iter 2 re-parsed the outer envelope, leaving `payload` stuck on the inner JWS bytes. The token-unmarshal step then failed because the bytes weren't JSON.

Fail-closed (no claim-substitution primitive — the bad payload fails JSON unmarshal and an error is returned), but a real correctness divergence between `Parse` (with key, payload threading correct) and `ParseInsecure` (without key, hits the bug).

Change the call site to `jws.Parse(payload, ...)` so iter 2 sees the inner JWS bytes iter 1 produced. Regression test in `jwt/jwt_test.go:TestParseInsecureUnwrapsNestedJWS` builds a 2-layer nested JWS-around-JWS-around-JWT and asserts `ParseInsecure` returns the inner JWT's claims.