### PR TITLE
jwt: defensively reject missing claims in MaxDeltaIs / MinDeltaIs

### DIFF
--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -170,10 +170,21 @@ func MinDeltaIs(c1, c2 string, dur time.Duration) Validator {
 func (iitr *isInTimeRange) Validate(ctx context.Context, t Token) error {
 	clock := ValidationCtxClock(ctx) // MUST be populated
 	skew := ValidationCtxSkew(ctx)   // MUST be populated
-	// We don't check if the claims already exist, because we already did that
-	// by piggybacking on `required` check.
 	t1 := timeClaim(t, clock, iitr.c1)
 	t2 := timeClaim(t, clock, iitr.c2)
+	// Defensive: reject zero-value claims before computing delta. The
+	// auto-IsRequired piggyback in WithValidator type-switches on the
+	// concrete *isInTimeRange — wrapping this validator (e.g., in
+	// ValidatorFunc) skips that piggyback, and a missing time claim
+	// would silently produce a hugely-negative delta that trivially
+	// satisfies the upper-bound check. Reject the missing claim
+	// regardless of how the validator was wrapped.
+	if t1.IsZero() {
+		return jwterrs.MissingRequiredClaimErrorf(iitr.c1)
+	}
+	if t2.IsZero() {
+		return jwterrs.MissingRequiredClaimErrorf(iitr.c2)
+	}
 	if iitr.less { // t1 - t2 <= iitr.dur
 		// t1 - t2 < iitr.dur + skew
 		if t1.Sub(t2) > iitr.dur+skew {

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -926,3 +926,34 @@ func TestValidateUnsupportedTimeClaimIsValidateError(t *testing.T) {
 	require.Contains(t, err.Error(), `custom_claim`,
 		`error should name the offending claim`)
 }
+
+// TestValidateTimeRangeRejectsMissingClaim documents that *isInTimeRange
+// (the validator behind MaxDeltaIs/MinDeltaIs) defensively rejects a token
+// whose referenced claims are missing, even when the user wraps the
+// validator in a ValidatorFunc or another Validator type.
+//
+// The auto-IsRequired piggyback in WithValidator type-switches on the
+// concrete *isInTimeRange — wrapping the validator skips that piggyback,
+// and a token with no `exp` would otherwise pass MaxDeltaIs because
+// timeClaim(missing) returns time.Time{} and `delta` becomes a hugely
+// negative number that trivially satisfies the upper-bound check.
+//
+// Defensive rejection inside Validate plugs the gap regardless of how the
+// validator is wrapped — a missing time claim is a missing time claim.
+func TestValidateTimeRangeRejectsMissingClaim(t *testing.T) {
+	t.Parallel()
+
+	tok := jwt.New()
+	require.NoError(t, tok.Set(jwt.IssuedAtKey, time.Now().Round(0)))
+
+	inner := jwt.MaxDeltaIs(jwt.ExpirationKey, jwt.IssuedAtKey, time.Hour)
+	wrapped := jwt.ValidatorFunc(func(ctx context.Context, t jwt.Token) error {
+		return inner.Validate(ctx, t)
+	})
+
+	err := jwt.Validate(tok, jwt.WithValidator(wrapped))
+	require.Error(t, err,
+		`Validate must reject a token with missing exp even when MaxDeltaIs is wrapped`)
+	require.Contains(t, err.Error(), jwt.ExpirationKey,
+		`error should name the missing claim (exp)`)
+}


### PR DESCRIPTION
v3 backport of #2098.

`WithValidator`'s auto-`IsRequired` piggyback type-switches on the concrete `*isInTimeRange` returned by `MaxDeltaIs` / `MinDeltaIs`. Wrapping the validator (e.g., in `ValidatorFunc` — the canonical pattern that `WithValidator`'s godoc encourages) skipped the piggyback: a token with no `exp` would produce a zero-value time claim, the delta between `exp(0)` and `iat(now)` became a hugely negative duration, and the upper-bound check passed trivially. The wrapped validator silently accepted a token that should have required `exp`.

Defensively reject zero-value time claims at the top of `isInTimeRange.Validate`, returning `MissingRequiredClaimError`. Wrapping no longer affects correctness.

Regression test in `jwt/validate_test.go:TestValidateTimeRangeRejectsMissingClaim` wraps `MaxDeltaIs(exp, iat, 1h)` in a `ValidatorFunc`, builds a token with `iat` but no `exp`, and asserts the validator rejects with an error naming the missing claim.