### PR TITLE
jwt: align Validate fast/slow paths to same iat,exp,nbf check order

### DIFF
--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -163,21 +163,25 @@ func Validate(t Token, options ...ValidateOption) error {
 // validateDefault is the fast path for Validate with no options.
 // It inlines the default iat/exp/nbf checks without allocating
 // context values, validator structs, or iterating through options.
+//
+// Order MUST match the slow path's baseValidators: iat, exp, nbf. A
+// token failing multiple checks must produce the same concrete error
+// type regardless of whether any option was supplied.
 func validateDefault(t Token) error {
 	trunc := getDefaultTruncation()
 	now := time.Now().Truncate(trunc)
-
-	// exp: expiration must be after now
-	if tv, ok := t.Expiration(); ok {
-		if !now.Before(tv.Truncate(trunc)) {
-			return validateErrorf(`validation failed: %w`, newTokenExpiredError(tv.Truncate(trunc), now, 0))
-		}
-	}
 
 	// iat: issued-at must not be in the future
 	if tv, ok := t.IssuedAt(); ok {
 		if now.Before(tv.Truncate(trunc)) {
 			return validateErrorf(`validation failed: %w`, newInvalidIssuedAtError(tv.Truncate(trunc), now, 0))
+		}
+	}
+
+	// exp: expiration must be after now
+	if tv, ok := t.Expiration(); ok {
+		if !now.Before(tv.Truncate(trunc)) {
+			return validateErrorf(`validation failed: %w`, newTokenExpiredError(tv.Truncate(trunc), now, 0))
 		}
 	}
 

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -1006,3 +1006,44 @@ func TestValidateTimeRangeRejectsMissingClaim(t *testing.T) {
 	require.Contains(t, err.Error(), jwt.ExpirationKey,
 		`error should name the missing claim (exp)`)
 }
+
+// TestValidateDefaultOrderMatchesSlowPath documents that the fast path
+// (Validate with no options, validateDefault) and the slow path (Validate
+// with any option, baseValidators loop) check claims in the SAME order.
+// Without the symmetry guarantee, the same token + zero options vs. the
+// same token + one trivial option produces different concrete error types
+// because whichever validator fires first determines the error returned.
+//
+// Pin the canonical order to match the slow path's `iat, exp, nbf`: that
+// order matches the typical RFC 7519 mental model (iat is set first, exp
+// is the upper bound of validity, nbf is the lower bound). The fast path
+// historically ran `exp, iat, nbf` — different from the slow path —
+// surfacing as a different concrete error type for code that branches on
+// errors.Is(err, jwt.TokenExpiredError{}).
+func TestValidateDefaultOrderMatchesSlowPath(t *testing.T) {
+	t.Parallel()
+
+	// Build a token whose iat AND exp both fail: iat in the future,
+	// exp in the past. Whichever validator fires first determines the
+	// error.
+	tok := jwt.New()
+	require.NoError(t, tok.Set(jwt.IssuedAtKey, time.Now().Add(time.Hour)))
+	require.NoError(t, tok.Set(jwt.ExpirationKey, time.Now().Add(-time.Hour)))
+
+	// Fast path: no options, runs validateDefault.
+	errFast := jwt.Validate(tok)
+	require.Error(t, errFast)
+
+	// Slow path: any option flips off the fast path. WithAcceptableSkew(0)
+	// is functionally a no-op but routes through baseValidators.
+	errSlow := jwt.Validate(tok, jwt.WithAcceptableSkew(0))
+	require.Error(t, errSlow)
+
+	// Slow path's baseValidators is `[iat, exp, nbf]` so it returns
+	// InvalidIssuedAtError. The fast path must agree to avoid quiet
+	// drift between the two code paths.
+	require.ErrorIs(t, errSlow, jwt.InvalidIssuedAtError{},
+		`slow path must report iat error first (canonical order)`)
+	require.ErrorIs(t, errFast, jwt.InvalidIssuedAtError{},
+		`fast path must report iat error first too (symmetry with slow path)`)
+}


### PR DESCRIPTION
`Validate` has two code paths: a fast inline check when called with no options, and a generic loop over `baseValidators` when called with at least one option. Both run the same three default checks (iat, exp, nbf), but they ran them in different orders — fast path checked exp first, slow path checked iat first. A token failing multiple checks returned different concrete error types depending on whether the caller passed an option: `errors.Is(err, jwt.TokenExpiredError{})` matched on the no-options call, `errors.Is(err, jwt.InvalidIssuedAtError{})` matched on a call that included even a no-op option like `WithAcceptableSkew(0)`.

Reorder `validateDefault` to match the slow path's canonical iat, exp, nbf order. The slow path's order is the one to keep — it matches the RFC 7519 mental model (issued-at first, exp upper bound, nbf lower bound) and the slow path is the more discoverable one for callers reading the validator list.

Regression test constructs a token failing iat AND exp and asserts both code paths return the same concrete error type.