### PR TITLE
jws: Verify rejects b64=false without "b64" listed in "crit"

### DIFF
--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// nonConformantB64FalseHdrJSON is the protected header for a non-conformant
+// b64=false JWS — i.e. a producer that set "b64":false without including
+// "b64" in "crit" (RFC 7797 §3 violation). Used by multiple b64-related
+// tests to construct hand-rolled compact JWSes that exercise the slow-path
+// and fast-path refusals symmetrically.
+const nonConformantB64FalseHdrJSON = `{"alg":"HS256","b64":false}`
+
 // signWith returns a JWS-compact serialization of `payload` signed with `key`
 // using HS256 and the given protected headers.
 func signWith(t *testing.T, key any, payload []byte, hdrs jws.Headers) []byte {
@@ -385,7 +392,7 @@ func TestVerifyCompactFastRefusesB64False(t *testing.T) {
 	// base64url so the current pre-fix path would silently return wrong
 	// decoded bytes rather than a base64-decode error — the worst-case
 	// behavior the fix prevents.
-	hdrJSON := `{"alg":"HS256","b64":false}`
+	hdrJSON := nonConformantB64FalseHdrJSON
 	hdrB64 := base64.RawURLEncoding.EncodeToString([]byte(hdrJSON))
 
 	rawPayload := []byte("aGVsbG8") // valid base64url for "hello"
@@ -400,6 +407,50 @@ func TestVerifyCompactFastRefusesB64False(t *testing.T) {
 	_, err := jws.VerifyCompactFast(rawKey, compact, jwa.HS256())
 	require.Error(t, err, `VerifyCompactFast must refuse b64-bearing messages`)
 	require.ErrorIs(t, err, jws.ErrB64Present(), `error should match jws.ErrB64Present sentinel`)
+}
+
+// TestVerifyRejectsB64FalseWithoutCrit documents the slow-path mirror of
+// TestVerifyCompactFastRefusesB64False. RFC 7797 §3 requires producers that
+// set b64=false to also include "b64" in "crit"; §6 ties this to RFC 7515's
+// critical-header-parameter rule. A defective producer can still emit a
+// b64=false JWS without "b64" in crit. VerifyCompactFast rejects any b64
+// header outright; jws.Verify must symmetrically reject the non-conformant
+// shape (b64=false without "b64" listed in crit) so the two entry points
+// agree on what they accept. Without this check, jws.Verify silently honors
+// b64=false in the wire and computes its signing input differently from a
+// strictly conformant verifier — exactly the cross-implementation
+// disagreement RFC 7797 §6 was designed to prevent.
+//
+// v3 note: the check is gated by critValidation (default false on v3, true
+// on v4). The test passes WithCritValidation(true) explicitly so the v3
+// backport asserts the same behavior as v4's default-strict path.
+func TestVerifyRejectsB64FalseWithoutCrit(t *testing.T) {
+	rawKey := jwxtest.GenerateSymmetricKey()
+
+	// Construct a non-conformant compact JWS with b64=false in the
+	// protected header but NO "crit" array at all. A conformant producer
+	// would have set crit=["b64"]; a defective one (or an attacker
+	// reaching for cross-impl interop confusion) emits this shape.
+	hdrJSON := nonConformantB64FalseHdrJSON
+	hdrB64 := base64.RawURLEncoding.EncodeToString([]byte(hdrJSON))
+
+	rawPayload := []byte("hello world")
+	signingInput := hdrB64 + "." + string(rawPayload)
+
+	mac := hmac.New(sha256.New, rawKey)
+	mac.Write([]byte(signingInput))
+	sigB64 := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	compact := []byte(signingInput + "." + sigB64)
+
+	_, err := jws.Verify(compact,
+		jws.WithKey(jwa.HS256(), rawKey),
+		jws.WithCritValidation(true),
+	)
+	require.Error(t, err, `jws.Verify must reject b64=false without "b64" in crit (RFC 7797 §3)`)
+	require.ErrorIs(t, err, jws.VerifyError(), `b64-without-crit refusal must match jws.VerifyError() class`)
+	require.ErrorContains(t, err, `b64`, `error should mention b64`)
+	require.ErrorContains(t, err, `crit`, `error should mention crit`)
 }
 
 // TestVerifyCompactFastRefusalsMatchVerifyError documents that the fast-path
@@ -429,7 +480,7 @@ func TestVerifyCompactFastRefusalsMatchVerifyError(t *testing.T) {
 	t.Run("b64 refusal", func(t *testing.T) {
 		rawKey := jwxtest.GenerateSymmetricKey()
 
-		hdrJSON := `{"alg":"HS256","b64":false}`
+		hdrJSON := nonConformantB64FalseHdrJSON
 		hdrB64 := base64.RawURLEncoding.EncodeToString([]byte(hdrJSON))
 		rawPayload := []byte("aGVsbG8")
 		signingInput := hdrB64 + "." + string(rawPayload)

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1010,8 +1010,8 @@ func TestRFC7797(t *testing.T) {
 		for _, tc := range testcases {
 			t.Run(tc.Name, func(t *testing.T) {
 				hdrs := jws.NewHeaders()
-				hdrs.Set("b64", false)
-				hdrs.Set("crit", "b64")
+				require.NoError(t, hdrs.Set("b64", false))
+				require.NoError(t, hdrs.Set("crit", []string{"b64"}))
 
 				payload := tc.Payload
 				signOptions := []jws.SignOption{jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs))}

--- a/jws/streaming_detached.go
+++ b/jws/streaming_detached.go
@@ -244,6 +244,9 @@ func (vc *verifyContext) verifyStreaming(buf []byte) ([]byte, error) {
 	}
 
 	if vc.critValidation {
+		if err := validateB64InCritIfFalse(sig.protected); err != nil {
+			return nil, makeVerifyError(`%w`, err)
+		}
 		if err := validateCritical(sig.protected, vc.criticalExtensions); err != nil {
 			return nil, makeVerifyError(`invalid "crit" header: %w`, err)
 		}

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -212,6 +212,10 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 		}
 
 		if vc.critValidation {
+			if err := validateB64InCritIfFalse(sig.protected); err != nil {
+				errs = append(errs, makeVerifyError(`signature #%d: %w`, idx+1, err))
+				continue
+			}
 			if err := validateCritical(sig.protected, vc.criticalExtensions); err != nil {
 				errs = append(errs, makeVerifyError(`signature #%d has invalid "crit" header: %w`, idx+1, err))
 				continue
@@ -286,6 +290,32 @@ func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, ke
 		*(vc.dst) = *msg
 	}
 
+	return nil
+}
+
+// validateB64InCritIfFalse enforces RFC 7797 §3: producers that set
+// b64=false in the protected header MUST also list "b64" in the protected
+// header's "crit" array. The check runs alongside (and before)
+// validateCritical so a non-conformant b64=false JWS is rejected up front
+// regardless of whether the caller has supplied a crit allowlist via
+// jws.WithCritExtension. Without this check, jws.Verify silently honors
+// b64=false on the wire and computes its signing input differently from a
+// strictly conformant verifier — exactly the cross-implementation
+// disagreement RFC 7797 §6 was designed to prevent. VerifyCompactFast
+// rejects any b64-bearing message outright via jws.ErrB64Present(); this
+// helper is the slow-path mirror that targets only the non-conformant
+// shape rather than blanket-refusing b64=false.
+func validateB64InCritIfFalse(protected Headers) error {
+	if getB64Value(protected) {
+		return nil
+	}
+	if !protected.Has(CriticalKey) {
+		return makeVerifyError(`protected header has "b64":false but no "crit"; RFC 7797 §3 requires producers that set "b64":false to list "b64" in "crit"`)
+	}
+	crit, _ := protected.Critical()
+	if !slices.Contains(crit, "b64") {
+		return makeVerifyError(`protected header has "b64":false but "crit" does not list "b64"; RFC 7797 §3 requires producers that set "b64":false to list "b64" in "crit"`)
+	}
 	return nil
 }
 


### PR DESCRIPTION
v3 backport of #2101.

RFC 7797 §3 requires producers that set `b64=false` to also list `b64` in `crit`; §6 ties this to RFC 7515's critical-header-parameter rule. `VerifyCompactFast` rejects any b64-bearing message outright; `jws.Verify` silently accepted the non-conformant shape (b64=false with no crit, or crit missing b64).

Adds `validateB64InCritIfFalse` called from both `VerifyMessage` and `verifyStreaming` inside the existing `critValidation` block. v3 `critValidation` defaults to **false**, so the new check is opt-in here (`jws.WithCritValidation(true)`); behavior on v3 default config is unchanged. v4's default is true, so the v4 PR rejects the non-conformant shape by default.

Regression test mirrors `TestVerifyCompactFastRefusesB64False` on the slow path. Also extracts the duplicated `{"alg":"HS256","b64":false}` literal into a shared package const.