### PR TITLE
jws: declare "b64" as typed bool header field

### DIFF
--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	AlgorithmKey              = "alg"
+	B64Key                    = "b64"
 	ContentTypeKey            = "cty"
 	CriticalKey               = "crit"
 	JWKKey                    = "jwk"
@@ -40,6 +41,7 @@ const (
 // In most cases, you likely want to use the protected headers, as this is part of the signed content.
 type Headers interface {
 	Algorithm() (jwa.SignatureAlgorithm, bool)
+	B64() (bool, bool)
 	ContentType() (string, bool)
 	Critical() ([]string, bool)
 	JWK() (jwk.Key, bool)
@@ -66,10 +68,11 @@ type Headers interface {
 }
 
 // stdHeaderNames is a list of all standard header names defined in the JWS specification.
-var stdHeaderNames = []string{AlgorithmKey, ContentTypeKey, CriticalKey, JWKKey, JWKSetURLKey, KeyIDKey, TypeKey, X509CertChainKey, X509CertThumbprintKey, X509CertThumbprintS256Key, X509URLKey}
+var stdHeaderNames = []string{AlgorithmKey, B64Key, ContentTypeKey, CriticalKey, JWKKey, JWKSetURLKey, KeyIDKey, TypeKey, X509CertChainKey, X509CertThumbprintKey, X509CertThumbprintS256Key, X509URLKey}
 
 type stdHeaders struct {
 	algorithm              *jwa.SignatureAlgorithm // https://tools.ietf.org/html/rfc7515#section-4.1.1
+	b64                    *bool                   // https://tools.ietf.org/html/rfc7797#section-3
 	contentType            *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.10
 	critical               []string                // https://tools.ietf.org/html/rfc7515#section-4.1.11
 	jwk                    jwk.Key                 // https://tools.ietf.org/html/rfc7515#section-4.1.3
@@ -97,6 +100,15 @@ func (h *stdHeaders) Algorithm() (jwa.SignatureAlgorithm, bool) {
 		return jwa.EmptySignatureAlgorithm(), false
 	}
 	return *(h.algorithm), true
+}
+
+func (h *stdHeaders) B64() (bool, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	if h.b64 == nil {
+		return false, false
+	}
+	return *(h.b64), true
 }
 
 func (h *stdHeaders) ContentType() (string, bool) {
@@ -191,6 +203,7 @@ func (h *stdHeaders) X509URL() (string, bool) {
 
 func (h *stdHeaders) clear() {
 	h.algorithm = nil
+	h.b64 = nil
 	h.contentType = nil
 	h.critical = nil
 	h.jwk = nil
@@ -207,6 +220,7 @@ func (h *stdHeaders) clear() {
 
 func (h *stdHeaders) isZero() bool {
 	return h.algorithm == nil &&
+		h.b64 == nil &&
 		h.contentType == nil &&
 		h.critical == nil &&
 		h.jwk == nil &&
@@ -250,6 +264,8 @@ func (h *stdHeaders) Has(name string) bool {
 	switch name {
 	case AlgorithmKey:
 		return h.algorithm != nil
+	case B64Key:
+		return h.b64 != nil
 	case ContentTypeKey:
 		return h.contentType != nil
 	case CriticalKey:
@@ -285,6 +301,11 @@ func (h *stdHeaders) Field(name string) (any, bool) {
 			return nil, false
 		}
 		return *(h.algorithm), true
+	case B64Key:
+		if h.b64 == nil {
+			return nil, false
+		}
+		return *(h.b64), true
 	case ContentTypeKey:
 		if h.contentType == nil {
 			return nil, false
@@ -359,6 +380,12 @@ func (h *stdHeaders) setNoLock(name string, value any) error {
 			return nil
 		}
 		return fmt.Errorf("expecte jwa.SignatureAlgorithm, received %T", alg)
+	case B64Key:
+		if v, ok := value.(bool); ok {
+			h.b64 = &v
+			return nil
+		}
+		return fmt.Errorf(`invalid value for %s key: %T`, B64Key, value)
 	case ContentTypeKey:
 		if v, ok := value.(string); ok {
 			h.contentType = &v
@@ -439,6 +466,8 @@ func (h *stdHeaders) Remove(key string) error {
 	switch key {
 	case AlgorithmKey:
 		h.algorithm = nil
+	case B64Key:
+		h.b64 = nil
 	case ContentTypeKey:
 		h.contentType = nil
 	case CriticalKey:
@@ -489,6 +518,12 @@ func (h *stdHeaders) UnmarshalJSON(buf []byte) error {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)
 			}
 			h.algorithm = &decoded
+		case B64Key:
+			var decoded bool
+			if err := json.UnmarshalDecode(dec, &decoded); err != nil {
+				return fmt.Errorf(`failed to decode value for key %s: %w`, B64Key, err)
+			}
+			h.b64 = &decoded
 		case ContentTypeKey:
 			if err := json.AssignNextStringToken(&h.contentType, dec, nil); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, ContentTypeKey, err)
@@ -563,9 +598,12 @@ func (h *stdHeaders) UnmarshalJSON(buf []byte) error {
 func (h *stdHeaders) Keys() []string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	keys := make([]string, 0, 11+len(h.privateParams))
+	keys := make([]string, 0, 12+len(h.privateParams))
 	if h.algorithm != nil {
 		keys = append(keys, AlgorithmKey)
+	}
+	if h.b64 != nil {
+		keys = append(keys, B64Key)
 	}
 	if h.contentType != nil {
 		keys = append(keys, ContentTypeKey)
@@ -613,6 +651,12 @@ func (dst *stdHeaders) cloneFrom(src *stdHeaders) {
 		dst.algorithm = &tmp
 	} else {
 		dst.algorithm = nil
+	}
+	if src.b64 != nil {
+		tmp := *(src.b64)
+		dst.b64 = &tmp
+	} else {
+		dst.b64 = nil
 	}
 	if src.contentType != nil {
 		tmp := *(src.contentType)
@@ -723,6 +767,9 @@ func (h *stdHeaders) MarshalJSON() ([]byte, error) {
 	h.mu.RLock()
 	if h.algorithm != nil {
 		l.pairs = append(l.pairs, fieldPair{Name: AlgorithmKey, Value: *(h.algorithm)})
+	}
+	if h.b64 != nil {
+		l.pairs = append(l.pairs, fieldPair{Name: B64Key, Value: *(h.b64)})
 	}
 	if h.contentType != nil {
 		l.pairs = append(l.pairs, fieldPair{Name: ContentTypeKey, Value: *(h.contentType)})

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -176,3 +176,40 @@ func TestHeader(t *testing.T) {
 		})
 	})
 }
+
+// TestHeaderB64Typed documents that "b64" is a typed bool field, so
+// Headers.Set("b64", value) rejects non-bool values at the API
+// boundary instead of silently coercing later. RFC 7797 §3 specifies
+// b64 as a JSON boolean; the previous untyped storage accepted any
+// type and produced a JWS where the wire bytes said one thing
+// (e.g. `"b64":"false"`) and the signing logic used another (the
+// type-assertion failed and getB64Value defaulted to true).
+func TestHeaderB64Typed(t *testing.T) {
+	t.Run("bool true accepted", func(t *testing.T) {
+		h := jws.NewHeaders()
+		require.NoError(t, h.Set("b64", true))
+	})
+
+	t.Run("bool false accepted", func(t *testing.T) {
+		h := jws.NewHeaders()
+		require.NoError(t, h.Set("b64", false))
+	})
+
+	t.Run("string false rejected", func(t *testing.T) {
+		h := jws.NewHeaders()
+		err := h.Set("b64", "false")
+		require.Error(t, err, `Set("b64", string) must reject — b64 is typed bool`)
+	})
+
+	t.Run("integer rejected", func(t *testing.T) {
+		h := jws.NewHeaders()
+		err := h.Set("b64", 0)
+		require.Error(t, err, `Set("b64", int) must reject — b64 is typed bool`)
+	})
+
+	t.Run("nil rejected", func(t *testing.T) {
+		h := jws.NewHeaders()
+		err := h.Set("b64", nil)
+		require.Error(t, err, `Set("b64", nil) must reject — b64 is typed bool`)
+	})
+}

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -252,19 +252,17 @@ func Verify(buf []byte, options ...VerifyOption) ([]byte, error) {
 	return vc.VerifyMessage(buf)
 }
 
-// get the value of b64 header field.
-// If the field does not exist, returns true (default)
-// Otherwise return the value specified by the header field.
+// getB64Value reads the typed "b64" header field and returns its value,
+// or RFC 7797's default of true when the field is unset. The field is
+// declared in jws/objects.yml as a typed bool, so Set rejects non-bool
+// values at the API boundary; this helper exists so callers do not have
+// to write the same nil-default check at every read site.
 func getB64Value(hdr Headers) bool {
-	v, ok := hdr.Field("b64")
+	v, ok := hdr.B64()
 	if !ok {
-		return true // default
+		return true // RFC 7797 default
 	}
-	b64, ok := v.(bool)
-	if !ok {
-		return true // default
-	}
-	return b64
+	return v
 }
 
 // detectParseFormat inspects the first non-whitespace rune in src to

--- a/jws/objects.yml
+++ b/jws/objects.yml
@@ -103,3 +103,9 @@ fields:
     type: "[]string"
     json: crit
     comment: https://tools.ietf.org/html/rfc7515#section-4.1.11
+  - name: b64
+    exported_name: B64
+    getter: B64
+    type: bool
+    json: b64
+    comment: https://tools.ietf.org/html/rfc7797#section-3

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -322,8 +322,11 @@ func validateCritical(protected Headers, allowedExtensions []string) error {
 		seen[name] = struct{}{}
 
 		// RFC 7515 Section 4.1.11: "crit" MUST NOT include names defined
-		// by the JOSE Header specification itself.
-		if slices.Contains(stdHeaderNames, name) {
+		// by the JOSE Header specification itself. The "b64" parameter
+		// is RFC 7797, not RFC 7515 — listing it in "crit" is the
+		// canonical use of the field per RFC 7797 §3 — so exclude it
+		// from this check even though it is a typed field on stdHeaders.
+		if name != "b64" && slices.Contains(stdHeaderNames, name) {
 			return makeVerifyError(`"crit" header must not contain standard header parameter %q`, name)
 		}
 

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -326,7 +326,7 @@ func validateCritical(protected Headers, allowedExtensions []string) error {
 		// is RFC 7797, not RFC 7515 — listing it in "crit" is the
 		// canonical use of the field per RFC 7797 §3 — so exclude it
 		// from this check even though it is a typed field on stdHeaders.
-		if name != "b64" && slices.Contains(stdHeaderNames, name) {
+		if name != B64Key && slices.Contains(stdHeaderNames, name) {
 			return makeVerifyError(`"crit" header must not contain standard header parameter %q`, name)
 		}
 


### PR DESCRIPTION
The `b64` header parameter (RFC 7797) lived in the untyped `privateParams` map. Two consequences:

1. `Headers.Set("b64", "false")` (string) succeeded silently.
2. `getB64Value` read via `Field("b64")`, type-asserted to bool, and on failure silently returned true (the RFC 7797 default).

A producer who hand-rolled the protected header could write `"b64":"false"` and the library treated it as `b64=true` — wire bytes said one thing, signing logic used another. Cross-implementation interop fails because strict verifiers reject the type-mismatched header.

Declare `b64` as a typed `bool` in `jws/objects.yml` and regenerate. `Set` now rejects non-bool values with the standard `invalid value for b64 key: <T>` error, JSON unmarshaling rejects type-mismatched input, and `getB64Value` becomes a thin wrapper around the typed accessor.

`validateCritical`'s RFC 7515 §4.1.11 check ("no standard JOSE header parameter in crit") used the auto-generated `stdHeaderNames` list, which now includes b64 — that's wrong because b64 is RFC 7797, not 7515, and listing it in crit is the canonical use of the field per RFC 7797 §3. Exclude b64 from that specific check explicitly.

Regression test (`TestHeaderB64Typed`) covers Set's bool-vs-non-bool type checking; existing crit + b64 tests cover the validateCritical interaction.