### PR TITLE
jws: declare "b64" as typed bool header field

### DIFF
--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	AlgorithmKey              = "alg"
+	B64Key                    = "b64"
 	ContentTypeKey            = "cty"
 	CriticalKey               = "crit"
 	JWKKey                    = "jwk"
@@ -41,6 +42,7 @@ const (
 // In most cases, you likely want to use the protected headers, as this is part of the signed content.
 type Headers interface {
 	Algorithm() (jwa.SignatureAlgorithm, bool)
+	B64() (bool, bool)
 	ContentType() (string, bool)
 	Critical() ([]string, bool)
 	JWK() (jwk.Key, bool)
@@ -72,10 +74,11 @@ type Headers interface {
 }
 
 // stdHeaderNames is a list of all standard header names defined in the JWS specification.
-var stdHeaderNames = []string{AlgorithmKey, ContentTypeKey, CriticalKey, JWKKey, JWKSetURLKey, KeyIDKey, TypeKey, X509CertChainKey, X509CertThumbprintKey, X509CertThumbprintS256Key, X509URLKey}
+var stdHeaderNames = []string{AlgorithmKey, B64Key, ContentTypeKey, CriticalKey, JWKKey, JWKSetURLKey, KeyIDKey, TypeKey, X509CertChainKey, X509CertThumbprintKey, X509CertThumbprintS256Key, X509URLKey}
 
 type stdHeaders struct {
 	algorithm              *jwa.SignatureAlgorithm // https://tools.ietf.org/html/rfc7515#section-4.1.1
+	b64                    *bool                   // https://tools.ietf.org/html/rfc7797#section-3
 	contentType            *string                 // https://tools.ietf.org/html/rfc7515#section-4.1.10
 	critical               []string                // https://tools.ietf.org/html/rfc7515#section-4.1.11
 	jwk                    jwk.Key                 // https://tools.ietf.org/html/rfc7515#section-4.1.3
@@ -103,6 +106,15 @@ func (h *stdHeaders) Algorithm() (jwa.SignatureAlgorithm, bool) {
 		return jwa.EmptySignatureAlgorithm(), false
 	}
 	return *(h.algorithm), true
+}
+
+func (h *stdHeaders) B64() (bool, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	if h.b64 == nil {
+		return false, false
+	}
+	return *(h.b64), true
 }
 
 func (h *stdHeaders) ContentType() (string, bool) {
@@ -188,6 +200,7 @@ func (h *stdHeaders) X509URL() (string, bool) {
 
 func (h *stdHeaders) clear() {
 	h.algorithm = nil
+	h.b64 = nil
 	h.contentType = nil
 	h.critical = nil
 	h.jwk = nil
@@ -232,6 +245,8 @@ func (h *stdHeaders) Has(name string) bool {
 	switch name {
 	case AlgorithmKey:
 		return h.algorithm != nil
+	case B64Key:
+		return h.b64 != nil
 	case ContentTypeKey:
 		return h.contentType != nil
 	case CriticalKey:
@@ -267,6 +282,14 @@ func (h *stdHeaders) Get(name string, dst any) error {
 			return fmt.Errorf(`field %q not found`, name)
 		}
 		if err := blackmagic.AssignIfCompatible(dst, *(h.algorithm)); err != nil {
+			return fmt.Errorf(`failed to assign value for field %q: %w`, name, err)
+		}
+		return nil
+	case B64Key:
+		if h.b64 == nil {
+			return fmt.Errorf(`field %q not found`, name)
+		}
+		if err := blackmagic.AssignIfCompatible(dst, *(h.b64)); err != nil {
 			return fmt.Errorf(`failed to assign value for field %q: %w`, name, err)
 		}
 		return nil
@@ -383,6 +406,12 @@ func (h *stdHeaders) setNoLock(name string, value any) error {
 			return nil
 		}
 		return fmt.Errorf("expecte jwa.SignatureAlgorithm, received %T", alg)
+	case B64Key:
+		if v, ok := value.(bool); ok {
+			h.b64 = &v
+			return nil
+		}
+		return fmt.Errorf(`invalid value for %s key: %T`, B64Key, value)
 	case ContentTypeKey:
 		if v, ok := value.(string); ok {
 			h.contentType = &v
@@ -463,6 +492,8 @@ func (h *stdHeaders) Remove(key string) error {
 	switch key {
 	case AlgorithmKey:
 		h.algorithm = nil
+	case B64Key:
+		h.b64 = nil
 	case ContentTypeKey:
 		h.contentType = nil
 	case CriticalKey:
@@ -517,6 +548,12 @@ LOOP:
 					return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)
 				}
 				h.algorithm = &decoded
+			case B64Key:
+				var decoded bool
+				if err := dec.Decode(&decoded); err != nil {
+					return fmt.Errorf(`failed to decode value for key %s: %w`, B64Key, err)
+				}
+				h.b64 = &decoded
 			case ContentTypeKey:
 				if err := json.AssignNextStringToken(&h.contentType, dec, nil); err != nil {
 					return fmt.Errorf(`failed to decode value for key %s: %w`, ContentTypeKey, err)
@@ -585,9 +622,12 @@ LOOP:
 func (h *stdHeaders) Keys() []string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	keys := make([]string, 0, 11+len(h.privateParams))
+	keys := make([]string, 0, 12+len(h.privateParams))
 	if h.algorithm != nil {
 		keys = append(keys, AlgorithmKey)
+	}
+	if h.b64 != nil {
+		keys = append(keys, B64Key)
 	}
 	if h.contentType != nil {
 		keys = append(keys, ContentTypeKey)
@@ -632,7 +672,7 @@ type headerPair struct {
 
 var headerPairPool = sync.Pool{
 	New: func() any {
-		return make([]headerPair, 0, 11)
+		return make([]headerPair, 0, 12)
 	},
 }
 
@@ -655,6 +695,13 @@ func (h *stdHeaders) makePairs() ([]headerPair, error) {
 			return nil, fmt.Errorf(`failed to marshal field %q: %w`, AlgorithmKey, err)
 		}
 		pairs = append(pairs, headerPair{Name: AlgorithmKey, Value: v})
+	}
+	if h.b64 != nil {
+		v, err := json.Marshal(*(h.b64))
+		if err != nil {
+			return nil, fmt.Errorf(`failed to marshal field %q: %w`, B64Key, err)
+		}
+		pairs = append(pairs, headerPair{Name: B64Key, Value: v})
 	}
 	if h.contentType != nil {
 		v, err := json.Marshal(*(h.contentType))

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -177,3 +177,37 @@ func TestHeader(t *testing.T) {
 		})
 	})
 }
+
+// TestHeaderB64Typed documents that "b64" is a typed bool field, so
+// Headers.Set("b64", value) rejects non-bool values at the API
+// boundary instead of silently coercing later. RFC 7797 §3 specifies
+// b64 as a JSON boolean.
+func TestHeaderB64Typed(t *testing.T) {
+	t.Run("bool true accepted", func(t *testing.T) {
+		h := jws.NewHeaders()
+		require.NoError(t, h.Set("b64", true))
+	})
+
+	t.Run("bool false accepted", func(t *testing.T) {
+		h := jws.NewHeaders()
+		require.NoError(t, h.Set("b64", false))
+	})
+
+	t.Run("string false rejected", func(t *testing.T) {
+		h := jws.NewHeaders()
+		err := h.Set("b64", "false")
+		require.Error(t, err, `Set("b64", string) must reject — b64 is typed bool`)
+	})
+
+	t.Run("integer rejected", func(t *testing.T) {
+		h := jws.NewHeaders()
+		err := h.Set("b64", 0)
+		require.Error(t, err, `Set("b64", int) must reject — b64 is typed bool`)
+	})
+
+	t.Run("nil rejected", func(t *testing.T) {
+		h := jws.NewHeaders()
+		err := h.Set("b64", nil)
+		require.Error(t, err, `Set("b64", nil) must reject — b64 is typed bool`)
+	})
+}

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -253,16 +253,14 @@ func Verify(buf []byte, options ...VerifyOption) ([]byte, error) {
 	return vc.VerifyMessage(buf)
 }
 
-// get the value of b64 header field.
-// If the field does not exist, returns true (default)
-// Otherwise return the value specified by the header field.
+// getB64Value reads the typed "b64" header field and returns its value,
+// or RFC 7797's default of true when the field is unset.
 func getB64Value(hdr Headers) bool {
-	var b64 bool
-	if err := hdr.Get("b64", &b64); err != nil {
-		return true // default
+	v, ok := hdr.B64()
+	if !ok {
+		return true // RFC 7797 default
 	}
-
-	return b64
+	return v
 }
 
 func detectParseFormat(src []byte) int {

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -329,8 +329,11 @@ func validateCritical(protected Headers, allowedExtensions []string) error {
 		seen[name] = struct{}{}
 
 		// RFC 7515 Section 4.1.11: "crit" MUST NOT include names defined
-		// by the JOSE Header specification itself.
-		if slices.Contains(stdHeaderNames, name) {
+		// by the JOSE Header specification itself. The "b64" parameter
+		// is RFC 7797, not RFC 7515 — listing it in "crit" is the
+		// canonical use of the field per RFC 7797 §3 — so exclude it
+		// from this check even though it is a typed field on stdHeaders.
+		if name != B64Key && slices.Contains(stdHeaderNames, name) {
 			return makeVerifyError(`"crit" header must not contain standard header parameter %q`, name)
 		}
 

--- a/tools/cmd/genjws/objects.yml
+++ b/tools/cmd/genjws/objects.yml
@@ -54,3 +54,9 @@ fields:
     type: "[]string"
     json: crit
     comment: https://tools.ietf.org/html/rfc7515#section-4.1.11
+  - name: b64
+    exported_name: B64
+    getter: B64
+    type: bool
+    json: b64
+    comment: https://tools.ietf.org/html/rfc7797#section-3


### PR DESCRIPTION
v3 backport of #2105.

The `b64` header parameter (RFC 7797) lived in the untyped `privateParams` map. `Set("b64", "false")` (string) succeeded silently and `getB64Value` then type-asserted on read, defaulting to true on failure — wire bytes said one thing, signing logic used another.

Declare `b64` as a typed `bool` in `tools/cmd/genjws/objects.yml` and regenerate. `Set` rejects non-bool values; `getB64Value` becomes a thin wrapper around the typed accessor.

`validateCritical`'s RFC 7515 §4.1.11 check ("no standard JOSE header parameter in crit") used the auto-generated `stdHeaderNames` list, which now includes `B64Key` — wrong, because b64 is RFC 7797, not 7515, and listing it in crit is the canonical use of the field per RFC 7797 §3. Exclude `B64Key` from that specific check.

Regression test (`TestHeaderB64Typed`) covers Set's type checking; existing crit + b64 tests cover the validateCritical interaction.