### PR TITLE
jws: typed sentinel for AlgorithmsForKey unclassifiable-key failures

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -31,6 +31,7 @@ if errors.Is(err, jwt.TokenExpiredError()) { ... }
 | `jws` | `ParseError()` | Parse failed |
 | `jws` | `ErrCritPresent()` | `VerifyCompactFast` refused a `crit`-bearing protected header (use `jws.Verify`) |
 | `jws` | `ErrB64Present()` | `VerifyCompactFast` refused a `b64`-bearing protected header (use `jws.Verify`) |
+| `jws` | `ErrUnclassifiableKey()` | `AlgorithmsForKey` couldn't classify the key shape (Import failed, kty not registered, or key-agreement-only key like ecdh) |
 | `jwe` | `EncryptError()` | Encryption failed |
 | `jwe` | `DecryptError()` | Decryption failed |
 | `jwe` | `RecipientError()` | Recipient processing error |

--- a/jws/errors.go
+++ b/jws/errors.go
@@ -45,6 +45,27 @@ func ErrB64Present() error {
 	return errB64Present
 }
 
+// errUnclassifiableKey is the common sentinel for AlgorithmsForKey
+// failures: the key shape cannot be matched to any registered key type
+// for signing. Three different code paths land here — Import-failed,
+// kty-not-registered, and shape-rejected (e.g. ecdh) — but they're all
+// the same logical "we can't classify this key" outcome from the
+// caller's perspective. Wrap-with-this lets callers branch on
+// errors.Is(err, jws.ErrUnclassifiableKey()) instead of pattern-matching
+// the three error-message shapes the function previously emitted.
+var errUnclassifiableKey = errors.New("jws: key cannot be classified for signing")
+
+// ErrUnclassifiableKey returns the sentinel that jws.AlgorithmsForKey
+// (and indirectly jws.Sign / jws.Verify when option-time validation
+// fails) wraps when the supplied key cannot be matched to a registered
+// key type. Branching on this sentinel is the right way to ask "is this
+// a 'we can't tell what this key is' failure?" — the wrapping error
+// also carries the concrete %T or %q diagnostic in its message, so the
+// human-readable error stays specific.
+func ErrUnclassifiableKey() error {
+	return errUnclassifiableKey
+}
+
 type signError struct {
 	error
 }

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -603,7 +603,7 @@ func AlgorithmsForKey(key any) ([]jwa.SignatureAlgorithm, error) {
 		// ecdh keys are for key agreement (X25519/X448), not signing.
 		// Reject at the API boundary instead of returning a misleading
 		// algorithm list that would fail deeper in the signing stack.
-		return nil, fmt.Errorf(`key type %T cannot be used for signing (ecdh keys are key-agreement only)`, key)
+		return nil, fmt.Errorf(`%w: key type %T cannot be used for signing (ecdh keys are key-agreement only)`, errUnclassifiableKey, key)
 	case []byte:
 		kty = jwa.OctetSeq()
 	default:
@@ -623,7 +623,7 @@ func AlgorithmsForKey(key any) ([]jwa.SignatureAlgorithm, error) {
 		}
 		imported, err := jwk.Import(key)
 		if err != nil {
-			return nil, fmt.Errorf(`unknown key type %T`, key)
+			return nil, fmt.Errorf(`%w: unknown key type %T`, errUnclassifiableKey, key)
 		}
 		kty = imported.KeyType()
 		if ck, ok := imported.(curver); ok {
@@ -636,7 +636,7 @@ func AlgorithmsForKey(key any) ([]jwa.SignatureAlgorithm, error) {
 
 	ktyAlgs, ok := keyTypeToAlgorithms[kty]
 	if !ok {
-		return nil, fmt.Errorf(`unregistered key type %q`, kty)
+		return nil, fmt.Errorf(`%w: unregistered key type %q`, errUnclassifiableKey, kty)
 	}
 
 	// If we know the curve and there are curve-specific registrations,

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1544,6 +1544,35 @@ func TestAlgorithmsForKeyECDHRejects(t *testing.T) {
 	}
 }
 
+// TestAlgorithmsForKeyUnclassifiableSentinel locks the typed-sentinel
+// contract for AlgorithmsForKey: every "we can't classify this key"
+// failure path wraps jws.ErrUnclassifiableKey() so callers can branch
+// with errors.Is rather than pattern-matching three different error
+// messages (Import-failed, kty-not-registered, ecdh-rejected). The
+// concrete %T or %q diagnostic stays in the wrapping error's message.
+func TestAlgorithmsForKeyUnclassifiableSentinel(t *testing.T) {
+	t.Run("unknown Go struct (Import fails)", func(t *testing.T) {
+		type bogusKey struct{}
+		_, err := jws.AlgorithmsForKey(bogusKey{})
+		require.Error(t, err)
+		require.ErrorIs(t, err, jws.ErrUnclassifiableKey(),
+			`Import-failed path must wrap ErrUnclassifiableKey`)
+		require.Contains(t, err.Error(), `bogusKey`,
+			`error message must keep the concrete type for diagnostics`)
+	})
+
+	t.Run("ecdh key (rejected at API boundary)", func(t *testing.T) {
+		x25519priv, err := ecdh.X25519().GenerateKey(rand.Reader)
+		require.NoError(t, err)
+		_, err = jws.AlgorithmsForKey(x25519priv)
+		require.Error(t, err)
+		require.ErrorIs(t, err, jws.ErrUnclassifiableKey(),
+			`ecdh-rejected path must wrap ErrUnclassifiableKey`)
+		require.Contains(t, err.Error(), `ecdh`,
+			`error message must keep the diagnostic phrase`)
+	})
+}
+
 // unclassifiableSigner is a crypto.Signer whose Public() is itself a
 // crypto.Signer, so AlgorithmsForKey cannot classify it — the documented
 // "opaque KMS-backed signer" escape hatch in validateAlgorithmForKey.


### PR DESCRIPTION
v3 backport of #2109.

`AlgorithmsForKey` emitted three different error-message shapes for the same logical "we can't classify this key" outcome (Import-failed, kty-not-registered, ecdh-rejected). Add `jws.ErrUnclassifiableKey()` sentinel + accessor following the existing `ErrCritPresent` / `ErrB64Present` pattern; wrap each error site so `errors.Is` matches all three. Concrete `%T` or `%q` diagnostic stays in the wrapping error's message.