### PR TITLE
jws: VerifyMessage observes ctx cancellation between loop iterations

### DIFF
--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"cmp"
+	"context"
 	"crypto"
 	"crypto/ecdh"
 	"crypto/ecdsa"
@@ -2307,4 +2308,46 @@ func TestVerifyFanoutErrorNamesLooseOptions(t *testing.T) {
 		`error must report the count of attempted (alg,key) pairs when fan-out occurred`)
 	require.Contains(t, msg, `WithRequireKid(false)`,
 		`error must name WithRequireKid(false) so the operator knows which option widened the candidate set`)
+}
+
+// TestVerifyHonorsContextCancellation locks the contract that
+// jws.Verify observes ctx cancellation between iterations of its outer
+// loops. Previously vc.ctx was passed into kp.FetchKeys but never read
+// directly by VerifyMessage; under fan-out (WithRequireKid(false) +
+// WithInferAlgorithmFromKey(true) + a JWKS with many keys), a hostile
+// JWS could keep the verifier crunching through hundreds of crypto
+// operations after the caller's deadline had fired. Adding ctx.Err()
+// checks at the per-signature, per-keyProvider, and per-(alg,key)
+// levels makes the existing WithContext deadline real without
+// introducing a new cap.
+func TestVerifyHonorsContextCancellation(t *testing.T) {
+	payload := []byte("hello world")
+
+	// Sign with a key NOT in the verifying JWKS so every verify attempt
+	// would fail (we want the loop to be busy when cancellation fires).
+	signKey, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err)
+	signed, err := jws.Sign(payload, jws.WithKey(jwa.HS256(), signKey))
+	require.NoError(t, err)
+
+	// Build a JWKS large enough that without ctx checks the loop would
+	// burn through all keys.
+	set := jwk.NewSet()
+	for range 10 {
+		k, err := jwxtest.GenerateSymmetricJwk()
+		require.NoError(t, err)
+		require.NoError(t, k.Set(jwk.AlgorithmKey, jwa.HS256()))
+		require.NoError(t, set.AddKey(k))
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // pre-cancel: the very first iteration must observe it
+
+	_, err = jws.Verify(signed,
+		jws.WithContext(ctx),
+		jws.WithKeySet(set, jws.WithRequireKid(false)),
+	)
+	require.Error(t, err, `Verify must observe a pre-cancelled ctx`)
+	require.ErrorIs(t, err, context.Canceled,
+		`cancellation must propagate as context.Canceled`)
 }

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -192,6 +192,15 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 		pool.ErrorSlice().Put(errs)
 	}()
 	for idx, sig := range msg.signatures {
+		// Honor caller's deadline between signatures. Without this
+		// check, a hostile JWS with many signatures keeps the loop
+		// running long after the deadline; only kp.FetchKeys had
+		// visibility into vc.ctx, and not every key provider observes
+		// it. Cheap (~1ns) on the success path.
+		if err := vc.ctx.Err(); err != nil {
+			return nil, makeVerifyError(`%w`, err)
+		}
+
 		var rawHeaders []byte
 		if rbp, ok := sig.protected.(interface{ rawBuffer() []byte }); ok {
 			if raw := rbp.rawBuffer(); raw != nil {
@@ -218,6 +227,11 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 		verifyBuf = jwsbb.SignBuffer(verifyBuf, rawHeaders, msg.payload, vc.encoder, msg.b64)
 		var attempts int
 		for i, kp := range vc.keyProviders {
+			// Honor caller's deadline between key providers.
+			if err := vc.ctx.Err(); err != nil {
+				return nil, makeVerifyError(`%w`, err)
+			}
+
 			var sink algKeySink
 			if err := kp.FetchKeys(vc.ctx, &sink, sig, msg); err != nil {
 				errs = append(errs, makeVerifyError(`signature #%d: key provider %d failed: %w`, idx+1, i, err))
@@ -225,6 +239,15 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 			}
 
 			for _, pair := range sink.list {
+				// Honor caller's deadline between (alg,key) pairs.
+				// Under WithRequireKid(false) + WithInferAlgorithmFromKey(true)
+				// + a large JWKS, this inner loop is the dominant
+				// cost — checking ctx between attempts caps the
+				// post-deadline crypto work at one operation.
+				if err := vc.ctx.Err(); err != nil {
+					return nil, makeVerifyError(`%w`, err)
+				}
+
 				attempts++
 				alg := pair.alg
 				key := pair.key


### PR DESCRIPTION
`VerifyMessage`'s three loop levels (per-signature, per-keyProvider, per-(alg,key) pair) ran unconditionally. Only `jkuProvider` honored `vc.ctx`; `staticKeyProvider` and `keySetProvider` ignored it. A caller passing `WithContext(ctx)` with a deadline got the deadline honored only when the verifier happened to be inside `FetchKeys`.

Worst-case under explicit opt-in (`WithRequireKid(false)`+`WithInferAlgorithmFromKey(true)`+large JWKS): a 64KB JWS with 100 signatures, 1000 keys, 3 algs produces ~300K verifier calls with the deadline silently ignored.

Add `ctx.Err()` checks at the top of each loop level. ~1ns on the success path; failure wraps `context.Canceled`/`DeadlineExceeded` so `errors.Is` matches the stdlib sentinels. Default config (requireKid=true) is already bounded; this makes the existing `WithContext` contract real, not a new cap.