### PR TITLE
jws: VerifyMessage observes ctx cancellation between loop iterations

### DIFF
--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -3,6 +3,7 @@ package jws_test
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/ecdh"
 	"crypto/ecdsa"
@@ -2377,4 +2378,38 @@ func TestVerifyFanoutErrorNamesLooseOptions(t *testing.T) {
 		`error must report the count of attempted (alg,key) pairs when fan-out occurred`)
 	require.Contains(t, msg, `WithRequireKid(false)`,
 		`error must name WithRequireKid(false) so the operator knows which option widened the candidate set`)
+}
+
+// TestVerifyHonorsContextCancellation locks the contract that
+// jws.Verify observes ctx cancellation between iterations of its outer
+// loops. Previously vc.ctx was passed into kp.FetchKeys but never read
+// directly by VerifyMessage; under fan-out a hostile JWS could keep the
+// verifier crunching through hundreds of crypto operations after the
+// caller's deadline had fired.
+func TestVerifyHonorsContextCancellation(t *testing.T) {
+	payload := []byte("hello world")
+
+	signKey, err := jwxtest.GenerateSymmetricJwk()
+	require.NoError(t, err)
+	signed, err := jws.Sign(payload, jws.WithKey(jwa.HS256(), signKey))
+	require.NoError(t, err)
+
+	set := jwk.NewSet()
+	for range 10 {
+		k, err := jwxtest.GenerateSymmetricJwk()
+		require.NoError(t, err)
+		require.NoError(t, k.Set(jwk.AlgorithmKey, jwa.HS256()))
+		require.NoError(t, set.AddKey(k))
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // pre-cancel: the very first iteration must observe it
+
+	_, err = jws.Verify(signed,
+		jws.WithContext(ctx),
+		jws.WithKeySet(set, jws.WithRequireKid(false)),
+	)
+	require.Error(t, err, `Verify must observe a pre-cancelled ctx`)
+	require.ErrorIs(t, err, context.Canceled,
+		`cancellation must propagate as context.Canceled`)
 }

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -196,6 +196,15 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 		pool.ErrorSlice().Put(errs)
 	}()
 	for idx, sig := range msg.signatures {
+		// Honor caller's deadline between signatures. Without this
+		// check, a hostile JWS with many signatures keeps the loop
+		// running long after the deadline; only kp.FetchKeys had
+		// visibility into vc.ctx, and not every key provider observes
+		// it. Cheap (~1ns) on the success path.
+		if err := vc.ctx.Err(); err != nil {
+			return nil, makeVerifyError(`%w`, err)
+		}
+
 		var rawHeaders []byte
 		if rbp, ok := sig.protected.(interface{ rawBuffer() []byte }); ok {
 			if raw := rbp.rawBuffer(); raw != nil {
@@ -222,6 +231,11 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 		verifyBuf = jwsbb.SignBuffer(verifyBuf, rawHeaders, msg.payload, vc.encoder, msg.b64)
 		keysAttempted := 0
 		for i, kp := range vc.keyProviders {
+			// Honor caller's deadline between key providers.
+			if err := vc.ctx.Err(); err != nil {
+				return nil, makeVerifyError(`%w`, err)
+			}
+
 			var sink algKeySink
 			if err := kp.FetchKeys(vc.ctx, &sink, sig, msg); err != nil {
 				errs = append(errs, makeVerifyError(`signature #%d: key provider %d failed: %w`, idx+1, i, err))
@@ -229,6 +243,15 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 			}
 
 			for _, pair := range sink.list {
+				// Honor caller's deadline between (alg,key) pairs.
+				// Under WithRequireKid(false) + WithInferAlgorithmFromKey(true)
+				// + a large JWKS, this inner loop is the dominant
+				// cost — checking ctx between attempts caps the
+				// post-deadline crypto work at one operation.
+				if err := vc.ctx.Err(); err != nil {
+					return nil, makeVerifyError(`%w`, err)
+				}
+
 				alg := pair.alg
 				key := pair.key
 				keysAttempted++


### PR DESCRIPTION
v3 backport of #2111.

`VerifyMessage`'s three loop levels (per-signature, per-keyProvider, per-(alg,key) pair) ran unconditionally. Only `jkuProvider` honored `vc.ctx`. A caller passing `WithContext(ctx)` with a deadline got the deadline honored only when the verifier happened to be inside `FetchKeys`. Worst-case under explicit opt-in (`WithRequireKid(false)`+`WithInferAlgorithmFromKey(true)`+large JWKS): hundreds of crypto ops with the deadline silently ignored.

Add `ctx.Err()` checks at the top of each loop level. ~1ns on the success path; failure wraps `context.Canceled`/`DeadlineExceeded`. Default config is already bounded; this makes the existing `WithContext` contract real.