### PR TITLE
jws: cleanup follow-ups from recent review (low-severity batch)

### DIFF
--- a/jws/interface.go
+++ b/jws/interface.go
@@ -79,6 +79,14 @@ type DecodeCtx interface {
 // headers and the signatures don't match.
 //
 // To sign and verify, use the appropriate `Sign()` and `Verify()` functions.
+//
+// JSON round-trip note: Message.MarshalJSON collapses any single-signature
+// general-form input (one with a top-level "signatures" array of length 1)
+// into the flattened form (with top-level "protected"/"signature" fields)
+// on output. The conversion is cryptographically lossless — the protected,
+// signature, and payload bytes survive — but byte-level identity changes,
+// so callers that hash or dedup JWS messages by their JSON encoding will
+// not recognize a round-tripped message as equal to its input.
 type Message struct {
 	dc            DecodeCtx
 	payload       []byte

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -31,6 +31,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -144,6 +145,16 @@ func validateKeyBeforeUse(key any) error {
 // signing process, as you will likely be required to set the `b64` field
 // when using detached payload.
 //
+// RFC 7797 note: producing an in-band compact JWS with `b64=false`
+// (i.e. setting the `b64` protected header to `false` without also
+// passing [WithDetachedPayload]) is "NOT RECOMMENDED" per §5.2; strict
+// peers commonly reject such messages. The canonical pairing for
+// `b64=false` is [WithDetachedPayload] (or [WithDetachedPayloadReader]
+// for streaming), which keeps the unencoded payload out of the wire
+// format. Sign auto-declares `"b64"` in `crit` whenever `b64=false`
+// is set, so the produced JWS is at least RFC 7797 §3 conformant on
+// the producer side.
+//
 // Look for options that return `jws.SignOption` or `jws.SignVerifyOption`
 // for a complete list of options that can be passed to this function.
 //
@@ -242,6 +253,14 @@ var allowNoneWhitelist = jwk.WhitelistFunc(func(string) bool {
 // success; the verified bytes are whatever the caller read from the Reader.
 // Do not treat the returned slice as "the payload is empty" — callers that
 // need the payload bytes must retain their own copy.
+//
+// Context cancellation is governed by [WithContext]. The slow-path verify
+// loop checks ctx.Err() between each signature, each key provider, and
+// each (alg, key) attempt; jkuProvider passes ctx to its underlying
+// jwk.Fetcher; the streaming path checks ctx between payload Reads.
+// staticKeyProvider and keySetProvider do not consult ctx inside
+// FetchKeys themselves (their backing data is already in memory) — see
+// the [WithContext] godoc for the full per-layer breakdown.
 func Verify(buf []byte, options ...VerifyOption) ([]byte, error) {
 	vc := verifyContextPool.Get()
 	defer verifyContextPool.Put(vc)
@@ -578,6 +597,31 @@ func RegisterAlgorithmForCurve(crv jwa.EllipticCurveAlgorithm, alg jwa.Signature
 // inferred from the raw Go type), curve-specific algorithms registered via
 // [RegisterAlgorithmForCurve] are combined with key-type-level algorithms
 // to produce a more precise result.
+//
+// Accepted key shapes (resolved in order):
+//
+//  1. [jwk.Key] — kty is read directly; if the implementation also exposes
+//     Crv(), the curve refines the result.
+//  2. Stdlib crypto types: [rsa.PublicKey] / [rsa.PrivateKey] (and pointer
+//     forms), [ecdsa.PublicKey] / [ecdsa.PrivateKey] (and pointer forms),
+//     [ed25519.PublicKey], [ed25519.PrivateKey], and [byte] slices for
+//     symmetric keys.
+//  3. [crypto/ecdh.PublicKey] / [crypto/ecdh.PrivateKey] (and pointer
+//     forms) — explicitly rejected; ECDH keys are key-agreement only.
+//     Returns an error wrapping [ErrUnclassifiableKey].
+//  4. [crypto.Signer] (e.g. KMS-backed adapters) — resolved once via
+//     .Public(); the public key is then re-classified through tiers 1–2
+//     or the [jwk.Import] fallback below. To prevent infinite recursion,
+//     a Signer whose .Public() is itself a Signer is left for the
+//     downstream dispatcher to handle.
+//  5. [jwk.Import] fallback — anything else is offered to the import
+//     registry, allowing extension modules to register their own raw key
+//     types.
+//
+// All "we cannot classify this key" failures wrap [ErrUnclassifiableKey],
+// so callers can branch with errors.Is rather than pattern-matching error
+// strings. The wrapping error keeps the concrete %T or %q diagnostic in
+// its message for human readers.
 func AlgorithmsForKey(key any) ([]jwa.SignatureAlgorithm, error) {
 	var kty jwa.KeyType
 	var crv jwa.EllipticCurveAlgorithm
@@ -609,19 +653,31 @@ func AlgorithmsForKey(key any) ([]jwa.SignatureAlgorithm, error) {
 		// extract the underlying public key type via .Public().
 		// Standard library types (*rsa.PrivateKey, etc.) are already handled
 		// by the concrete cases above.
+		var signerPubErr error
 		if signer, ok := key.(crypto.Signer); ok {
 			pub := signer.Public()
 			// Guard: only recurse if the public key is not itself a crypto.Signer,
 			// to prevent infinite recursion from pathological implementations.
 			if _, isSigner := pub.(crypto.Signer); !isSigner {
-				if algs, err := AlgorithmsForKey(pub); err == nil {
+				algs, err := AlgorithmsForKey(pub)
+				if err == nil {
 					return algs, nil
 				}
+				// Save the inner classification error so a
+				// downstream Import-fallback failure can surface
+				// both diagnostics. A successful Import discards
+				// signerPubErr — only the eventual failure path
+				// joins them.
+				signerPubErr = err
 			}
 		}
 		imported, err := jwk.Import(key)
 		if err != nil {
-			return nil, fmt.Errorf(`%w: unknown key type %T`, errUnclassifiableKey, key)
+			outer := fmt.Errorf(`%w: unknown key type %T`, errUnclassifiableKey, key)
+			if signerPubErr != nil {
+				return nil, errors.Join(outer, signerPubErr)
+			}
+			return nil, outer
 		}
 		kty = imported.KeyType()
 		if ck, ok := imported.(curver); ok {
@@ -699,13 +755,13 @@ func validateAlgorithmForKey(alg jwa.SignatureAlgorithm, key any) error {
 				return nil
 			}
 		}
-		return err
+		return fmt.Errorf(`jws.WithKey: %w`, err)
 	}
 	if !slices.Contains(algs, alg) {
 		if hasCustomSigVerifier(alg) {
 			return nil
 		}
-		return fmt.Errorf(`algorithm %q is not compatible with key type %T`, alg, key)
+		return fmt.Errorf(`jws.WithKey: algorithm %q is not compatible with key type %T`, alg, key)
 	}
 	return nil
 }

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -2322,7 +2322,9 @@ func TestCompactErrorsUseSignError(t *testing.T) {
 		_, err := jws.Compact(msg)
 		require.Error(t, err)
 		require.True(t, errors.Is(err, jws.SignError()))
-		require.Contains(t, err.Error(), `jws.Compact: payload must not contain a "."`)
+		require.Contains(t, err.Error(), `jws.Compact:`)
+		require.Contains(t, err.Error(), `RFC 7797 §5.2`)
+		require.Contains(t, err.Error(), `jws.WithDetachedPayload`)
 		require.NotContains(t, err.Error(), "jws.Compress")
 	})
 }

--- a/jws/message.go
+++ b/jws/message.go
@@ -182,7 +182,7 @@ func (s *Signature) sign2(payload []byte, signer interface{ Algorithm() jwa.Sign
 	} else {
 		if !s.detached {
 			if bytes.Contains(payload, []byte{tokens.Period}) {
-				return nil, nil, fmt.Errorf(`payload must not contain a "."`)
+				return nil, nil, fmt.Errorf(`compact serialization with b64=false requires payload to contain no "." characters per RFC 7797 §5.2; use jws.WithDetachedPayload to keep the payload out of the wire format`)
 			}
 		}
 		plen = len(payload)
@@ -343,8 +343,8 @@ func (m *Message) UnmarshalJSON(buf []byte) error {
 					b64 = false
 				}
 			} else {
-				if b64 != getB64Value(sig.protected) {
-					return fmt.Errorf(`b64 value must be the same for all signatures`)
+				if got := getB64Value(sig.protected); b64 != got {
+					return fmt.Errorf(`b64 value must be the same for all signatures; signature #%d declared b64=%t but earlier signature(s) declared b64=%t`, i+1, got, b64)
 				}
 			}
 
@@ -618,7 +618,7 @@ func Compact(msg *Message, options ...CompactOption) ([]byte, error) {
 			buf.WriteString(encoded)
 		} else {
 			if bytes.Contains(msg.payload, []byte{tokens.Period}) {
-				return nil, makeSignError(prefixJwsCompact, `payload must not contain a "."`)
+				return nil, makeSignError(prefixJwsCompact, `compact serialization with b64=false requires payload to contain no "." characters per RFC 7797 §5.2; use jws.WithDetachedPayload to keep the payload out of the wire format`)
 			}
 			buf.Write(msg.payload)
 		}

--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -295,6 +295,22 @@ options:
   - ident: Context
     interface: VerifyOption
     argument_type: context.Context
+    comment: |
+      WithContext attaches a context.Context to the verify call. The
+      context is observed at three layers:
+
+        - jws.Verify (slow path) checks ctx.Err() between each signature,
+          each key provider, and each (alg, key) attempt — a deadline
+          fired between iterations short-circuits the loop with the
+          context error.
+        - jkuProvider.FetchKeys passes ctx to jwk.Fetcher.Fetch.
+        - The streaming detached-payload path checks ctx between Reads
+          of the caller's payload reader.
+
+      staticKeyProvider and keySetProvider do not themselves consult
+      ctx inside FetchKeys (the backing data is already in memory);
+      cancellation observation between key candidates is handled by
+      Verify's loop checks above.
   - ident: ProtectedHeaders
     interface: WithKeySuboption
     argument_type: Headers

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -321,6 +321,21 @@ func WithBase64Encoder(v Base64Encoder) SignVerifyCompactOption {
 	return &signVerifyCompactOption{option.New(identBase64Encoder{}, v)}
 }
 
+// WithContext attaches a context.Context to the verify call. The
+// context is observed at three layers:
+//
+//   - jws.Verify (slow path) checks ctx.Err() between each signature,
+//     each key provider, and each (alg, key) attempt — a deadline
+//     fired between iterations short-circuits the loop with the
+//     context error.
+//   - jkuProvider.FetchKeys passes ctx to jwk.Fetcher.Fetch.
+//   - The streaming detached-payload path checks ctx between Reads
+//     of the caller's payload reader.
+//
+// staticKeyProvider and keySetProvider do not themselves consult
+// ctx inside FetchKeys (the backing data is already in memory);
+// cancellation observation between key candidates is handled by
+// Verify's loop checks above.
 func WithContext(v context.Context) VerifyOption {
 	return &verifyOption{option.New(identContext{}, v)}
 }

--- a/jws/signature_builder.go
+++ b/jws/signature_builder.go
@@ -110,7 +110,7 @@ func (sb *signatureBuilder) Build(sc *signContext, payload []byte) (*Signature, 
 	b64 := getB64Value(hdrs)
 	if !b64 && !sc.detached {
 		if bytes.IndexByte(payload, tokens.Period) != -1 {
-			return nil, fmt.Errorf(`payload must not contain a "."`)
+			return nil, fmt.Errorf(`compact serialization with b64=false requires payload to contain no "." characters per RFC 7797 §5.2; use jws.WithDetachedPayload to keep the payload out of the wire format`)
 		}
 	}
 

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -397,6 +397,13 @@ func validateCritical(protected Headers, allowedExtensions []string) error {
 
 		// The recipient must have declared support for the extension.
 		if !slices.Contains(allowedExtensions, name) {
+			if name == B64Key {
+				// b64=false is the canonical RFC 7797 case. The
+				// auto-declare only fires for WithDetachedPayload /
+				// WithDetachedPayloadReader; in-band b64=false still
+				// requires the caller to opt in explicitly.
+				return makeVerifyError(`"crit" header references extension "b64", but the recipient has not declared support for it; pass jws.WithCritExtension("b64") to accept in-band b64=false (auto-declare only fires for jws.WithDetachedPayload / jws.WithDetachedPayloadReader)`)
+			}
 			return makeVerifyError(`"crit" header references extension %q, but the recipient has not declared support for it (use jws.WithCritExtension(%q))`, name, name)
 		}
 	}


### PR DESCRIPTION
v3 backport of #2113.

Bundle low-severity / doc-only items from the recent jws/ adversarial review (2026-04-30). Skips item 4 from the v4 PR — `Signer2`/`Verifier2` are real type names in v3, not stale references.

- `AlgorithmsForKey` godoc enumerates the four key-shape tiers and documents that classification failures wrap `ErrUnclassifiableKey`.
- `WithContext` godoc explains which loops/providers observe ctx.
- `Verify` godoc adds a paragraph on per-layer ctx-cancellation behavior.
- `Sign` godoc notes that in-band compact b64=false is RFC 7797 §5.2 "NOT RECOMMENDED" and points at `WithDetachedPayload`.
- `Message` godoc documents the single-signature general-form → flattened collapse on round-trip.
- Sign error wording for "compact + b64=false + payload contains `.`" now names RFC 7797 §5.2 and `WithDetachedPayload` (three sites in v3).
- Verify crit-rejection error gives a b64-specific hint pointing at `WithCritExtension("b64")` when the rejected extension is `"b64"`.
- Multi-sig b64-mismatch error names the offending signature index and the conflicting boolean value.
- `validateAlgorithmForKey` error wrap adds a `jws.WithKey:` prefix so `AlgorithmsForKey` errors carry option-boundary context.
- `AlgorithmsForKey` crypto.Signer recursion preserves the inner classification error and joins it with the eventual `jwk.Import` fallback failure (was previously dropped), so KMS-adapter debugging surfaces both diagnostics.