### PR TITLE
jwe/jwebb: document Register{HPKE,MLKEM,MLKEMDirect}Algorithm as privileged extension points

### DIFF
--- a/jwe/jwebb/export_test.go
+++ b/jwe/jwebb/export_test.go
@@ -1,3 +1,15 @@
 package jwebb
 
 var UnregisterHPKEAlgorithm = unregisterHPKEAlgorithm
+
+func UnregisterMLKEMAlgorithm(alg string) {
+	muMLKEMAlgs.Lock()
+	defer muMLKEMAlgs.Unlock()
+	delete(mlkemAlgSet, alg)
+}
+
+func UnregisterMLKEMDirectAlgorithm(alg string) {
+	muMLKEMAlgs.Lock()
+	defer muMLKEMAlgs.Unlock()
+	delete(mlkemDirectAlgSet, alg)
+}

--- a/jwe/jwebb/hpke_ext.go
+++ b/jwe/jwebb/hpke_ext.go
@@ -83,12 +83,36 @@ func init() {
 
 // RegisterHPKEAlgorithm registers an algorithm identifier as an HPKE
 // algorithm. After registration, IsHPKE returns true for this identifier,
-// causing the JWE encrypt/decrypt dispatch to route it through the HPKE path.
+// causing the JWE encrypt/decrypt dispatch to route it through the HPKE
+// path. Registration is idempotent.
 //
-// The error return is reserved for future validation. The current
-// implementation always returns nil, but callers — especially extension
-// modules calling this from init() — must check the return value and panic
-// on failure to stay forward-compatible.
+// # Privileged extension point
+//
+// This registry is an extension point on purpose: extension modules
+// (the canonical example is github.com/jwx-go/mlkem) install support
+// for new key-encryption algorithm identifiers from init(). Override
+// of an existing identifier — including a built-in HPKE token or a
+// non-HPKE token from another family (RSA, AES-KW, ECDH-ES, PBES2,
+// dir) — is allowed by design: an extension may legitimately need
+// to swap a default dispatch, and a programmatic check would either
+// break that pattern or be trivially bypassable (since extensions
+// can call any Register* from init()).
+//
+// Because override is the design, this function does NOT refuse
+// re-registration of any identifier and does NOT verify the caller's
+// intent. Anything in your import graph at init() can reshape the
+// HPKE dispatch surface. The supply-chain risk this implies lives one
+// layer up: audit your transitive dependencies, pin your go.mod, and
+// treat extensions that touch this registry the same way you would
+// treat any other init()-time hook into your crypto path. Contrast
+// with closed-set registers like jwk/ecdsa.RegisterCurve, which DO
+// refuse to re-register built-ins because no legitimate extension
+// wants to swap a built-in NIST curve.
+//
+// Companion modules calling this from init() must check the returned
+// error and panic on failure to stay forward-compatible — even though
+// the current implementation always returns nil, the error return is
+// part of the contract.
 func RegisterHPKEAlgorithm(alg string) error {
 	muHPKEAlgs.Lock()
 	defer muHPKEAlgs.Unlock()

--- a/jwe/jwebb/hpke_ext_test.go
+++ b/jwe/jwebb/hpke_ext_test.go
@@ -132,4 +132,22 @@ func TestRegisterHPKEAlgorithm(t *testing.T) {
 		t.Cleanup(func() { jwebb.UnregisterHPKEAlgorithm(custom) })
 		require.True(t, jwebb.IsHPKE(custom))
 	})
+
+	// RegisterHPKEAlgorithm is a privileged extension point — override
+	// of any identifier (including built-in HPKE tokens) is allowed by
+	// design. Re-registering a built-in HPKE identifier is a successful
+	// no-op.
+	t.Run("re-registering existing HPKE identifier is idempotent", func(t *testing.T) {
+		err := jwebb.RegisterHPKEAlgorithm("HPKE-0-KE")
+		require.NoError(t, err, `re-registering a built-in HPKE identifier should succeed (idempotent)`)
+		require.True(t, jwebb.IsHPKE("HPKE-0-KE"))
+	})
+
+	t.Run("accepts new HPKE-shaped identifiers", func(t *testing.T) {
+		const custom = "HPKE-CUSTOM-KE"
+		err := jwebb.RegisterHPKEAlgorithm(custom)
+		require.NoError(t, err, `new identifier should register`)
+		t.Cleanup(func() { jwebb.UnregisterHPKEAlgorithm(custom) })
+		require.True(t, jwebb.IsHPKE(custom))
+	})
 }

--- a/jwe/jwebb/mlkem_ext.go
+++ b/jwe/jwebb/mlkem_ext.go
@@ -70,12 +70,14 @@ var (
 // RegisterMLKEMAlgorithm registers an algorithm identifier as an ML-KEM
 // algorithm. After registration, IsMLKEM returns true for this identifier,
 // causing the JWE encrypt/decrypt dispatch to route it through the
-// ML-KEM path.
+// ML-KEM path. Registration is idempotent.
 //
-// The error return is reserved for future validation. The current
-// implementation always returns nil, but callers — especially extension
-// modules calling this from init() — must check the return value and panic
-// on failure to stay forward-compatible.
+// This is a privileged extension point — see [RegisterHPKEAlgorithm]
+// for the full design discussion of override semantics and supply-
+// chain considerations. The same rules apply: override is allowed by
+// design, callers must audit their import graph, and companion modules
+// calling this from init() must check the returned error and panic on
+// failure to stay forward-compatible.
 func RegisterMLKEMAlgorithm(alg string) error {
 	muMLKEMAlgs.Lock()
 	defer muMLKEMAlgs.Unlock()
@@ -88,10 +90,10 @@ func RegisterMLKEMAlgorithm(alg string) error {
 // derived shared secret as the CEK. Implementations should also call
 // RegisterMLKEMAlgorithm for the same identifier.
 //
-// The error return is reserved for future validation. The current
-// implementation always returns nil, but callers — especially extension
-// modules calling this from init() — must check the return value and panic
-// on failure to stay forward-compatible.
+// This is a privileged extension point — see [RegisterHPKEAlgorithm]
+// for override semantics. Companion modules calling this from init()
+// must check the returned error and panic on failure to stay forward-
+// compatible.
 func RegisterMLKEMDirectAlgorithm(alg string) error {
 	muMLKEMAlgs.Lock()
 	defer muMLKEMAlgs.Unlock()

--- a/jwe/jwebb/mlkem_ext_test.go
+++ b/jwe/jwebb/mlkem_ext_test.go
@@ -1,0 +1,30 @@
+package jwebb_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwe/jwebb"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisterMLKEMAlgorithmAcceptsNewIdentifier locks that the
+// public Register* surface adds the algorithm to the dispatch
+// registry and IsMLKEM reports it. Override semantics (built-in
+// identifiers can be re-registered) are documented as a privileged
+// extension point — see RegisterHPKEAlgorithm's godoc for the full
+// design rationale.
+func TestRegisterMLKEMAlgorithmAcceptsNewIdentifier(t *testing.T) {
+	const custom = "ML-KEM-768-CUSTOM"
+	err := jwebb.RegisterMLKEMAlgorithm(custom)
+	require.NoError(t, err)
+	t.Cleanup(func() { jwebb.UnregisterMLKEMAlgorithm(custom) })
+	require.True(t, jwebb.IsMLKEM(custom))
+}
+
+func TestRegisterMLKEMDirectAlgorithmAcceptsNewIdentifier(t *testing.T) {
+	const custom = "ML-KEM-1024-DIRECT-CUSTOM"
+	err := jwebb.RegisterMLKEMDirectAlgorithm(custom)
+	require.NoError(t, err)
+	t.Cleanup(func() { jwebb.UnregisterMLKEMDirectAlgorithm(custom) })
+	require.True(t, jwebb.IsMLKEMDirect(custom))
+}


### PR DESCRIPTION
The `Register*` family in `jwe/jwebb` has the same shape as the `jwk/jwkbb` X509 registry: an extension point intended for companion modules to install support for new algorithm identifiers from `init()`. Override of any identifier — including built-in HPKE/MLKEM tokens or tokens from other algorithm families — is allowed by design, mirroring the project's settled stance on privileged extension registers (see `jwk/jwkbb/x509_registry.go` for the canonical statement, citing the `github.com/jwx-go/es256k` extension).

A programmatic "reject built-in name" check would either break this pattern (extensions sometimes need to swap a default) or be trivially bypassable (extensions can call any `Register*` from `init()`). The supply-chain risk lives one layer up, in the import graph.

**This PR is doc-only — no behavior change.** The godoc on `RegisterHPKEAlgorithm` explains override semantics and the supply-chain caveat in the same shape as `RegisterX509Decoder`; `RegisterMLKEMAlgorithm` / `RegisterMLKEMDirectAlgorithm` cross-reference.

Replaces an earlier draft of this PR that added a cross-family rejection — that approach was at odds with the project's settled stance on privileged extension points.