### PR TITLE
jwe: DecryptMessage observes ctx cancellation between loop iterations

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -534,6 +534,14 @@ func (dc *decryptContext) DecryptMessage(buf []byte) ([]byte, error) {
 
 	errs := make([]error, 0, len(recipients))
 	for _, recipient := range recipients {
+		// Honor caller's deadline between recipients. Without this
+		// check, a hostile JWE with many recipients keeps the loop
+		// running long after the deadline. Symmetric with the
+		// per-keyProvider and per-(alg,key) checks in tryRecipient.
+		if err := dc.ctx.Err(); err != nil {
+			return nil, makeDecryptError(`%w`, err)
+		}
+
 		decrypted, err := dc.tryRecipient(msg, recipient, h, aad, computedAad)
 		if err != nil {
 			errs = append(errs, makeRecipientError(err))
@@ -553,12 +561,26 @@ func (dc *decryptContext) tryRecipient(msg *Message, recipient Recipient, protec
 	var tried int
 	var attemptErrors []error
 	for i, kp := range dc.keyProviders {
+		// Honor caller's deadline between key providers.
+		if err := dc.ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		var sink algKeySink
 		if err := kp.FetchKeys(dc.ctx, &sink, recipient, msg); err != nil {
 			return nil, fmt.Errorf(`key provider %d failed: %w`, i, err)
 		}
 
 		for _, pair := range sink.list {
+			// Honor caller's deadline between (alg,key) pairs.
+			// Under WithRequireKid(false) + a large keyset, this
+			// inner loop is the dominant cost — checking ctx
+			// between attempts caps the post-deadline crypto
+			// work at one operation.
+			if err := dc.ctx.Err(); err != nil {
+				return nil, err
+			}
+
 			tried++
 			// alg is converted here because pair.alg is of type jwa.KeyAlgorithm.
 			// this may seem ugly, but we're trying to avoid declaring separate

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -2100,3 +2100,46 @@ func TestDecryptSubstepTypedErrors(t *testing.T) {
 		require.Equal(t, jwa.RSA1_5(), mismatch.Got, `Got should be the message-declared algorithm`)
 	})
 }
+
+// TestDecryptHonorsContextCancellation locks the contract that
+// jwe.Decrypt observes ctx cancellation between iterations of its
+// outer loops. The slow-path verifier was patched the same way for
+// jws.Verify; jwe was the asymmetric counterpart. Default config
+// bounds the worst case (MaxRecipients=100, requireKid=true), but
+// under explicit opt-in (large keyset + WithRequireKid(false)) the
+// fan-out can run hundreds of CEK-unwrap attempts after the
+// caller's deadline fires unless the loops check ctx.Err().
+func TestDecryptHonorsContextCancellation(t *testing.T) {
+	payload := []byte("hello world")
+
+	// Encrypt under one key; the keyset below contains different
+	// keys so every decrypt attempt fails (we want the loop busy
+	// when ctx fires).
+	encryptKey, err := jwxtest.GenerateRsaJwk()
+	require.NoError(t, err)
+	encryptPub, err := jwk.PublicKeyOf(encryptKey)
+	require.NoError(t, err)
+	encrypted, err := jwe.Encrypt(payload, jwe.WithKey(jwa.RSA_OAEP(), encryptPub))
+	require.NoError(t, err)
+
+	// Build a JWKS large enough that without ctx checks the loop
+	// would burn through every key.
+	set := jwk.NewSet()
+	for range 10 {
+		k, err := jwxtest.GenerateRsaJwk()
+		require.NoError(t, err)
+		require.NoError(t, k.Set(jwk.AlgorithmKey, jwa.RSA_OAEP()))
+		require.NoError(t, set.AddKey(k))
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // pre-cancel so the very first iteration must observe it
+
+	_, err = jwe.Decrypt(encrypted,
+		jwe.WithContext(ctx),
+		jwe.WithKeySet(set, jwe.WithRequireKid(false)),
+	)
+	require.Error(t, err, `Decrypt must observe a pre-cancelled ctx`)
+	require.ErrorIs(t, err, context.Canceled,
+		`cancellation must propagate as context.Canceled`)
+}


### PR DESCRIPTION
`DecryptMessage`'s three loop levels (recipient × keyProvider × (alg,key)) ran unconditionally. `dc.ctx` was consulted only when passed into `kp.FetchKeys`, and neither shipped key provider honors it. Worst-case under explicit opt-in (`WithKeySet(setOf1000Keys, WithRequireKid(false))` × 100 recipients): ~100K CEK-unwrap attempts with the deadline silently ignored.

Add `ctx.Err()` checks at each loop level. ~1ns on the hot path. Failure wraps `context.Canceled`/`DeadlineExceeded`. Default config is already bounded; this makes the existing `WithContext` contract real.

Mirror of `jws.Verify`'s ctx-honoring fix.