### PR TITLE
jwe: DecryptMessage observes ctx cancellation between loop iterations

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -543,6 +543,12 @@ func (dc *decryptContext) DecryptMessage(buf []byte) ([]byte, error) {
 
 	errs := make([]error, 0, len(recipients))
 	for _, recipient := range recipients {
+		// Honor caller's deadline between recipients. Symmetric with
+		// the per-keyProvider and per-(alg,key) checks in tryRecipient.
+		if err := dc.ctx.Err(); err != nil {
+			return nil, makeDecryptError(`%w`, err)
+		}
+
 		decrypted, err := dc.tryRecipient(msg, recipient, h, aad, computedAad)
 		if err != nil {
 			errs = append(errs, makeRecipientError(err))
@@ -562,12 +568,22 @@ func (dc *decryptContext) tryRecipient(msg *Message, recipient Recipient, protec
 	var tried int
 	var lastError error
 	for i, kp := range dc.keyProviders {
+		// Honor caller's deadline between key providers.
+		if err := dc.ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		var sink algKeySink
 		if err := kp.FetchKeys(dc.ctx, &sink, recipient, msg); err != nil {
 			return nil, fmt.Errorf(`key provider %d failed: %w`, i, err)
 		}
 
 		for _, pair := range sink.list {
+			// Honor caller's deadline between (alg,key) pairs.
+			if err := dc.ctx.Err(); err != nil {
+				return nil, err
+			}
+
 			tried++
 			// alg is converted here because pair.alg is of type jwa.KeyAlgorithm.
 			// this may seem ugly, but we're trying to avoid declaring separate

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1718,3 +1718,36 @@ func TestDecryptRejectsAlgConflictBetweenProtectedAndPerRecipient(t *testing.T) 
 	require.ErrorIs(t, err, jwe.DecryptError())
 	require.Contains(t, err.Error(), "differs between protected", `error should name the conflict`)
 }
+
+// TestDecryptHonorsContextCancellation locks the contract that
+// jwe.Decrypt observes ctx cancellation between iterations of its
+// outer loops. Mirror of the JWS verify-loop ctx-honoring fix.
+func TestDecryptHonorsContextCancellation(t *testing.T) {
+	payload := []byte("hello world")
+
+	encryptKey, err := jwxtest.GenerateRsaJwk()
+	require.NoError(t, err)
+	encryptPub, err := jwk.PublicKeyOf(encryptKey)
+	require.NoError(t, err)
+	encrypted, err := jwe.Encrypt(payload, jwe.WithKey(jwa.RSA_OAEP(), encryptPub))
+	require.NoError(t, err)
+
+	set := jwk.NewSet()
+	for range 10 {
+		k, err := jwxtest.GenerateRsaJwk()
+		require.NoError(t, err)
+		require.NoError(t, k.Set(jwk.AlgorithmKey, jwa.RSA_OAEP()))
+		require.NoError(t, set.AddKey(k))
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err = jwe.Decrypt(encrypted,
+		jwe.WithContext(ctx),
+		jwe.WithKeySet(set, jwe.WithRequireKid(false)),
+	)
+	require.Error(t, err, `Decrypt must observe a pre-cancelled ctx`)
+	require.ErrorIs(t, err, context.Canceled,
+		`cancellation must propagate as context.Canceled`)
+}


### PR DESCRIPTION
v3 backport of #2116.

`DecryptMessage`'s three loop levels (recipient × keyProvider × (alg,key)) ran unconditionally. `dc.ctx` was consulted only when passed into `kp.FetchKeys`. Worst-case under explicit opt-in (large keyset + `WithRequireKid(false)`) was hundreds of CEK-unwrap attempts with the deadline silently ignored.

Add `ctx.Err()` checks at each loop level. Failure wraps `context.Canceled`/`DeadlineExceeded`. Default config is already bounded.