### PR TITLE
jwe: parse and bound-check PBES2 p2c in int64 space; name the violated bound

### DIFF
--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -727,44 +727,58 @@ func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgo
 			return nil, fmt.Errorf(`failed to get %q field`, SaltKey)
 		}
 
-		// check if WithUseNumber is effective, because it will change the
-		// type of the underlying value (#1140)
-		var countFlt float64
+		// Parse p2c into int64 directly. Float64 cannot represent
+		// integers above 2^53 exactly; comparing a parsed value
+		// against a high MaxPBES2Count cap in float-space and then
+		// casting via int(...) lets out-of-range values silently
+		// round into the accepted range when callers raise the cap
+		// past 2^53. int64 keeps the bound check exact.
+		var count int64
 		if json.UseNumber() {
-			var count json.Number
-			if err := h2.Get(CountKey, &count); err != nil {
+			var n json.Number
+			if err := h2.Get(CountKey, &n); err != nil {
 				return nil, fmt.Errorf(`failed to get %q field`, CountKey)
 			}
-			v, err := count.Float64()
+			c, err := n.Int64()
 			if err != nil {
-				return nil, fmt.Errorf("failed to convert 'p2c' to float64: %w", err)
+				return nil, fmt.Errorf(`invalid 'p2c' value: %q is not a valid integer: %w`, n.String(), err)
 			}
-			countFlt = v
+			count = c
 		} else {
-			var count float64
-			if err := h2.Get(CountKey, &count); err != nil {
+			var v float64
+			if err := h2.Get(CountKey, &v); err != nil {
 				return nil, fmt.Errorf(`failed to get %q field`, CountKey)
 			}
-			countFlt = count
+			if math.IsNaN(v) || math.IsInf(v, 0) || math.Trunc(v) != v {
+				return nil, fmt.Errorf(`invalid 'p2c' value: not a positive integer (got %v)`, v)
+			}
+			// Use explicit float-domain bounds (2^63 / -2^63) so
+			// the comparison is platform-independent and does not
+			// go through math.MaxInt64's implicit conversion.
+			const (
+				int64MaxAsFloat = float64(1 << 63) // 2^63, smallest float > MaxInt64
+				int64MinAsFloat = -int64MaxAsFloat // -2^63, exact float = MinInt64
+			)
+			if v >= int64MaxAsFloat || v < int64MinAsFloat {
+				return nil, fmt.Errorf(`invalid 'p2c' value: not representable as int64 (got %v)`, v)
+			}
+			count = int64(v)
 		}
 
 		maxCount := dc.maxPBES2Count
 		minCount := dc.minPBES2Count
-		if math.IsNaN(countFlt) || math.IsInf(countFlt, 0) || math.Trunc(countFlt) != countFlt {
-			return nil, fmt.Errorf("invalid 'p2c' value")
+		if count < int64(minCount) {
+			return nil, fmt.Errorf(`invalid 'p2c' value: %d is below WithMinPBES2Count=%d (RFC 7518 §4.8.1.2 floor; loosen via jwe.WithMinPBES2Count)`, count, minCount)
 		}
-		if countFlt > float64(maxCount) {
-			return nil, fmt.Errorf("invalid 'p2c' value")
-		}
-		if countFlt < float64(minCount) {
-			return nil, fmt.Errorf("invalid 'p2c' value")
+		if count > int64(maxCount) {
+			return nil, fmt.Errorf(`invalid 'p2c' value: %d exceeds WithMaxPBES2Count=%d (DoS amplification cap; raise via jwe.WithMaxPBES2Count)`, count, maxCount)
 		}
 		salt, err := base64.DecodeString(saltB64)
 		if err != nil {
 			return nil, fmt.Errorf(`failed to b64-decode 'salt': %w`, err)
 		}
 		dec.KeySalt(salt)
-		dec.KeyCount(int(countFlt))
+		dec.KeyCount(int(count))
 	}
 
 	plaintext, err := dec.Decrypt(recipient, msg.cipherText, msg)
@@ -1181,6 +1195,16 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 //
 //	jwe.Settings(jwe.WithMaxDecompressBufferSize(10*1024*1024)) // changes value globally
 //	jwe.Decrypt(..., jwe.WithMaxDecompressBufferSize(250*1024)) // changes just for this call
+//
+// PBES2 amplification: PBES2 algorithms (PBES2-HS256+A128KW, etc.)
+// derive the CEK via PBKDF2 with the iteration count taken from the
+// JWE's `p2c` header. An attacker-controlled iteration count multiplied
+// by `WithMaxRecipients` is the major CPU-amplification vector on the
+// decrypt side. Bound it via `WithMaxPBES2Count` (default 1,000,000)
+// and reject too-low counts via `WithMinPBES2Count` (default 1000;
+// RFC 7518 §4.8.1.2 floor — note OWASP 2023 recommends ≥600,000 for
+// production password-derived key material). Both options accept a
+// `Settings()` global or a per-call value.
 func Decrypt(buf []byte, options ...DecryptOption) ([]byte, error) {
 	dc := decryptContextPool.Get()
 	defer decryptContextPool.Put(dc)

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1201,6 +1201,8 @@ func TestPBES2RejectsNonIntegerCount(t *testing.T) {
 		_, err := jwe.Decrypt(tampered, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
 		require.Error(t, err, `jwe.Decrypt should fail`)
 		require.Contains(t, err.Error(), `invalid 'p2c' value`)
+		require.Contains(t, err.Error(), `not a positive integer`,
+			`error should name the constraint`)
 	})
 
 	t.Run("UseNumber decoder rejects fractional count", func(t *testing.T) {
@@ -1210,6 +1212,56 @@ func TestPBES2RejectsNonIntegerCount(t *testing.T) {
 		_, err := jwe.Decrypt(tampered, jwe.WithKey(jwa.PBES2_HS256_A128KW(), key))
 		require.Error(t, err, `jwe.Decrypt should fail`)
 		require.Contains(t, err.Error(), `invalid 'p2c' value`)
+		require.Contains(t, err.Error(), `not a valid integer`,
+			`UseNumber path should name the integer-parse failure`)
+	})
+}
+
+// TestPBES2P2cBoundsErrors locks the error-wording contract that the
+// max/min bound errors name the option, the offending value, and the
+// configured bound — replacing the previous opaque
+// "invalid 'p2c' value" string. Same site also moved from float-space
+// to int64-space comparison so the cap is enforced exactly.
+func TestPBES2P2cBoundsErrors(t *testing.T) {
+	password := []byte(`supersecret`)
+	key, err := jwk.Import(password)
+	require.NoError(t, err)
+
+	encrypted, err := jwe.Encrypt(
+		[]byte(`hello world`),
+		jwe.WithKey(jwa.PBES2_HS256_A128KW(), key),
+		jwe.WithPBES2Count(2000),
+	)
+	require.NoError(t, err)
+
+	t.Run("error names the bound that was violated (max)", func(t *testing.T) {
+		tampered := rewriteCompactPBES2Count(t, encrypted, 99999999)
+		_, err := jwe.Decrypt(tampered,
+			jwe.WithKey(jwa.PBES2_HS256_A128KW(), key),
+			jwe.WithMaxPBES2Count(10000),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `WithMaxPBES2Count`,
+			`max-bound error must name the option`)
+		require.Contains(t, err.Error(), `99999999`,
+			`max-bound error must include the offending value`)
+		require.Contains(t, err.Error(), `10000`,
+			`max-bound error must include the cap`)
+	})
+
+	t.Run("error names the bound that was violated (min)", func(t *testing.T) {
+		tampered := rewriteCompactPBES2Count(t, encrypted, 100)
+		_, err := jwe.Decrypt(tampered,
+			jwe.WithKey(jwa.PBES2_HS256_A128KW(), key),
+			jwe.WithMinPBES2Count(1000),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `WithMinPBES2Count`,
+			`min-bound error must name the option`)
+		require.Contains(t, err.Error(), `100`,
+			`min-bound error must include the offending value`)
+		require.Contains(t, err.Error(), `1000`,
+			`min-bound error must include the floor`)
 	})
 }
 

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -188,7 +188,21 @@ options:
     comment: |
       WithMinPBES2Count specifies the minimum number of PBES2 iterations
       to accept when decrypting a message. If not specified, the default
-      value of 1,000 is used. Set to 0 to disable the minimum check.
+      value of 1,000 is used (RFC 7518 §4.8.1.2 floor). Set to 0 to
+      disable the minimum check (NOT RECOMMENDED for untrusted issuers
+      — without a floor, recipients accept arbitrarily-weak password-
+      derived keys and silently spend the producer-chosen amount of
+      crypto work to verify them).
+
+      Threat model: a malicious or careless issuer signs a PBES2-wrapped
+      JWE with a very low p2c (e.g. 100) so they spend almost no CPU on
+      their side, while the recipient happily derives the wrap key with
+      the same low iteration count. The result is an authenticated
+      message whose key-derivation strength is well below industry
+      practice (OWASP 2023 recommends ≥600,000 PBKDF2-SHA256 iterations
+      for password-derived keys; the RFC floor of 1,000 is far below
+      that). For receiver-side hardening against under-iteration, raise
+      WithMinPBES2Count above 1,000.
 
       This option can be used for `jwe.Settings()`, which changes the behavior
       globally, or for `jwe.Decrypt()`, which changes the behavior for that

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -488,7 +488,21 @@ func WithMessage(v *Message) DecryptOption {
 
 // WithMinPBES2Count specifies the minimum number of PBES2 iterations
 // to accept when decrypting a message. If not specified, the default
-// value of 1,000 is used. Set to 0 to disable the minimum check.
+// value of 1,000 is used (RFC 7518 §4.8.1.2 floor). Set to 0 to
+// disable the minimum check (NOT RECOMMENDED for untrusted issuers
+// — without a floor, recipients accept arbitrarily-weak password-
+// derived keys and silently spend the producer-chosen amount of
+// crypto work to verify them).
+//
+// Threat model: a malicious or careless issuer signs a PBES2-wrapped
+// JWE with a very low p2c (e.g. 100) so they spend almost no CPU on
+// their side, while the recipient happily derives the wrap key with
+// the same low iteration count. The result is an authenticated
+// message whose key-derivation strength is well below industry
+// practice (OWASP 2023 recommends ≥600,000 PBKDF2-SHA256 iterations
+// for password-derived keys; the RFC floor of 1,000 is far below
+// that). For receiver-side hardening against under-iteration, raise
+// WithMinPBES2Count above 1,000.
 //
 // This option can be used for `jwe.Settings()`, which changes the behavior
 // globally, or for `jwe.Decrypt()`, which changes the behavior for that


### PR DESCRIPTION
v3 backport of #2118.

Move the PBES2 `p2c` parse and bound check from float64 to int64 space. At default `MaxPBES2Count=1_000_000` everything is exact; the risk is at the cap-raising end where float-precision drift can influence which values the cap accepts. int64 throughout removes the precision class.

Reword the previously-opaque `"invalid 'p2c' value"` errors to include the value, the violated bound, and the option name.

Bundled doc improvements: `Decrypt` godoc now mentions both PBES2 cap options alongside `WithMaxDecompressBufferSize`; `WithMinPBES2Count` godoc adds the under-iteration threat model and the OWASP vs RFC floor asymmetry.

Float-domain bounds use `float64(1 << 63)` (untyped constant) so the comparison is platform-independent and doesn't go through `math.MaxInt64`'s implicit conversion. Cross-compiles on `GOARCH=386` and `GOARCH=arm`.