### PR TITLE
jwe: WithKey validates alg-vs-key shape at option-time

### DIFF
--- a/jwe/encrypt.go
+++ b/jwe/encrypt.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lestrrat-go/jwx/v3/jwa"
 	"github.com/lestrrat-go/jwx/v3/jwe/internal/keygen"
 	"github.com/lestrrat-go/jwx/v3/jwe/jwebb"
+	"github.com/lestrrat-go/jwx/v3/jwk"
 )
 
 // encrypter is responsible for taking various components to encrypt a key.
@@ -187,4 +188,64 @@ func (e *encrypter) EncryptKey(cek []byte) (keygen.ByteSource, error) {
 	}
 
 	return nil, fmt.Errorf(`unsupported algorithm for key encryption (%s)`, keyalgStr)
+}
+
+// validateAlgorithmForKey checks that alg is family-compatible with
+// key at the WithKey option boundary, surfacing wrong-shape mismatches
+// as crisp `jwe.WithKey: ...` errors instead of nested errors deep in
+// the dispatcher (e.g. `[]byte is required as the key to encrypt ...`
+// from inside the AESKW path).
+//
+// Permissive carve-outs (return nil, deferring validation):
+//
+//   - jwk.Key wrappers: kty-vs-alg check happens at jwk.Export time.
+//   - Caller-supplied KeyEncrypter / KeyDecrypter implementations:
+//     the caller takes responsibility for the key-shape contract.
+//   - Nil key: legitimate for `dir` (caller provides CEK separately).
+//
+// All other built-in algorithm families enforce a concrete key-shape
+// expectation here. The error is wrapped by the WithKey site so the
+// caller sees `jwe.WithKey: ...` consistently.
+func validateAlgorithmForKey(alg jwa.KeyEncryptionAlgorithm, key any) error {
+	if key == nil {
+		return nil
+	}
+	if _, ok := key.(jwk.Key); ok {
+		return nil
+	}
+	if _, ok := key.(KeyEncrypter); ok {
+		return nil
+	}
+	if _, ok := key.(KeyDecrypter); ok {
+		return nil
+	}
+
+	algStr := alg.String()
+	switch {
+	case jwebb.IsDirect(algStr):
+		if _, ok := key.([]byte); !ok {
+			return fmt.Errorf(`algorithm %q requires a []byte key (got %T)`, algStr, key)
+		}
+	case jwebb.IsAESKW(algStr) || jwebb.IsAESGCMKW(algStr) || jwebb.IsPBES2(algStr):
+		if _, ok := key.([]byte); !ok {
+			return fmt.Errorf(`algorithm %q requires a []byte key (got %T)`, algStr, key)
+		}
+	case jwebb.IsRSA15(algStr) || jwebb.IsRSAOAEP(algStr):
+		switch key.(type) {
+		case *rsa.PublicKey, rsa.PublicKey, *rsa.PrivateKey, rsa.PrivateKey:
+		default:
+			return fmt.Errorf(`algorithm %q requires an RSA key (got %T)`, algStr, key)
+		}
+	case jwebb.IsECDHES(algStr):
+		switch key.(type) {
+		case *ecdsa.PublicKey, ecdsa.PublicKey, *ecdsa.PrivateKey, ecdsa.PrivateKey,
+			*ecdh.PublicKey, ecdh.PublicKey, *ecdh.PrivateKey, ecdh.PrivateKey:
+		default:
+			return fmt.Errorf(`algorithm %q requires an ECDSA or ECDH key (got %T)`, algStr, key)
+		}
+	default:
+		// Unknown algorithm family: defer to dispatch.
+		return nil
+	}
+	return nil
 }

--- a/jwe/interface.go
+++ b/jwe/interface.go
@@ -39,6 +39,25 @@ type KeyIDer interface {
 // expose the secret key in memory, for example, when you want to use
 // hardware security modules (HSMs) to decrypt the key.
 //
+// Library contract for implementers (read carefully):
+//
+//   - The library has already verified that the wire-level `alg` is
+//     consistent across the protected header and per-recipient header
+//     (RFC 7516 §7.2.1 disjointness). Your DecryptKey is invoked with
+//     the alg the library has decided to use for this attempt.
+//   - The library has NOT validated key-shape-vs-alg compatibility for
+//     your custom decrypter. You receive the raw recipient and message;
+//     headers are split between protected (signed/integrity-protected)
+//     and per-recipient (unprotected). If you read a value from the
+//     unprotected per-recipient header for a security decision, you
+//     must enforce its consistency with the protected header yourself.
+//   - Returning a non-nil error short-circuits this recipient. Returning
+//     nil bytes with nil error is treated as "decryption failed" by the
+//     dispatcher (use a non-nil error for clarity).
+//   - You are responsible for any constant-time considerations relevant
+//     to your decryption primitive (e.g. RFC 3218 random-CEK fallback
+//     for RSA-PKCS1v1.5; the library does this for the built-in path).
+//
 // This API is experimental and may change without notice, even
 // in minor releases.
 type KeyDecrypter interface {

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -365,6 +365,9 @@ func (dc *decryptContext) ProcessOptions(options []DecryptOption) error {
 			if !ok {
 				return fmt.Errorf("jwe.decrypt: WithKey() option must be specified using jwa.KeyEncryptionAlgorithm (got %T)", pair.alg)
 			}
+			if err := validateAlgorithmForKey(alg, pair.key); err != nil {
+				return fmt.Errorf("jwe.WithKey: %w", err)
+			}
 			dc.keyProviders = append(dc.keyProviders, &staticKeyProvider{alg: alg, key: pair.key})
 		case identCEK{}:
 			if err := option.Value(&dc.cek); err != nil {
@@ -863,6 +866,9 @@ func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
 			v, ok := wk.alg.(jwa.KeyEncryptionAlgorithm)
 			if !ok {
 				return fmt.Errorf("jwe.encrypt: WithKey() option must be specified using jwa.KeyEncryptionAlgorithm (got %T)", wk.alg)
+			}
+			if err := validateAlgorithmForKey(v, wk.key); err != nil {
+				return fmt.Errorf("jwe.WithKey: %w", err)
 			}
 			if v == jwa.DIRECT() || v == jwa.ECDH_ES() {
 				useRawCEK = true

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1803,3 +1803,56 @@ func TestDecryptHonorsContextCancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled,
 		`cancellation must propagate as context.Canceled`)
 }
+
+// TestWithKeyValidatesAlgKeyShape locks the option-time alg-vs-key
+// shape check on jwe.WithKey for v3.
+func TestWithKeyValidatesAlgKeyShape(t *testing.T) {
+	rsaKey, err := jwxtest.GenerateRsaJwk()
+	require.NoError(t, err)
+	rsaPub, err := jwk.PublicKeyOf(rsaKey)
+	require.NoError(t, err)
+	var rawRSAPriv rsa.PrivateKey
+	require.NoError(t, jwk.Export(rsaKey, &rawRSAPriv))
+
+	t.Run("rejects RSA-OAEP + []byte at option-time on Encrypt", func(t *testing.T) {
+		_, err := jwe.Encrypt([]byte("payload"),
+			jwe.WithKey(jwa.RSA_OAEP(), []byte("not-an-rsa-key")),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `jwe.WithKey:`)
+		require.Contains(t, err.Error(), `requires an RSA key`)
+	})
+
+	t.Run("rejects A128KW + RSA key at option-time on Encrypt", func(t *testing.T) {
+		_, err := jwe.Encrypt([]byte("payload"),
+			jwe.WithKey(jwa.A128KW(), &rawRSAPriv),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `jwe.WithKey:`)
+		require.Contains(t, err.Error(), `requires a []byte key`)
+	})
+
+	t.Run("rejects ECDH-ES + []byte at option-time", func(t *testing.T) {
+		_, err := jwe.Encrypt([]byte("payload"),
+			jwe.WithKey(jwa.ECDH_ES(), []byte("not-an-ec-key")),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `jwe.WithKey:`)
+		require.Contains(t, err.Error(), `requires an ECDSA or ECDH key`)
+	})
+
+	t.Run("accepts jwk.Key wrapper (defers to dispatch)", func(t *testing.T) {
+		encrypted, err := jwe.Encrypt([]byte("payload"),
+			jwe.WithKey(jwa.RSA_OAEP(), rsaPub),
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, encrypted)
+	})
+
+	t.Run("accepts symmetric byte key for AES-KW", func(t *testing.T) {
+		_, err := jwe.Encrypt([]byte("payload"),
+			jwe.WithKey(jwa.A128KW(), make([]byte, 16)),
+		)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
v3 backport of #2120.

Mismatched `(alg, key)` pairs that cannot succeed downstream produce a crisp `jwe.WithKey: ...` error at option-time instead of a deep nested error from the dispatcher.

Permissive carve-outs: `jwk.Key` wrappers, caller-supplied `KeyEncrypter`/`KeyDecrypter` implementations.

Bundled doc improvement: `KeyDecrypter` interface godoc now spells out the library contract.