### PR TITLE
jwe: compression cap error names "decompressed" payload, the option, and the size

### DIFF
--- a/jwe/compress.go
+++ b/jwe/compress.go
@@ -19,7 +19,7 @@ func uncompress(src []byte, maxBufferSize int64) ([]byte, error) {
 		n, readErr := r.Read(buf[:])
 		sofar += int64(n)
 		if sofar > maxBufferSize {
-			return nil, fmt.Errorf(`compressed payload exceeds maximum allowed size`)
+			return nil, fmt.Errorf(`decompressed payload exceeds WithMaxDecompressBufferSize=%d (saw %d bytes after a %d-byte read)`, maxBufferSize, sofar, n)
 		}
 		if readErr != nil {
 			// if we have a read error, and it's not EOF, then we need to stop


### PR DESCRIPTION
v3 backport of #2122.