### PR TITLE
jwe: keySetProvider surfaces per-key errors via errors.Join

### DIFF
--- a/docs/03-jwe.md
+++ b/docs/03-jwe.md
@@ -386,12 +386,11 @@ source: [examples/jwe_decrypt_with_key_example_test.go](https://github.com/jwx-g
 
 ## Decrypting using a JWKS
 
-To decrypt a payload using JWKS, by default you will need your payload and JWKS to have matching `alg` field.
+To decrypt a payload using JWKS, the JWE's `kid` header selects a key from the set; the key's `alg` field (when present) is used for the decrypt-time dispatch. When the JWK lacks `alg`, the recipient's `alg` header (per-recipient first, then protected) is used as a fallback — `jwe.Decrypt` re-checks the chosen `alg` against the integrity-protected protected header before any cryptographic call (RFC 7516 §7.2.1).
 
-The `alg` field's requirement is the same for using a single key. See "[Why don't you automatically infer the algorithm for `jws.Verify`?](99-faq.md#why-dont-you-automatically-infer-the-algorithm-for-jwsverify-)", it's the same for `jwe.Decrypt()`.
+For more discussion on why `alg` cannot be inferred from the key alone, see "[Why don't you automatically infer the algorithm for `jws.Verify`?](99-faq.md#why-dont-you-automatically-infer-the-algorithm-for-jwsverify-)" — the same reasoning applies to `jwe.Decrypt()`.
 
-Note that unlike in JWT, the `kid` is not required by default, although you _can_ make it so
-by passing `jwe.WithRequireKid(true)`.
+`kid` IS required by default. The example below uses `jwe.WithRequireKid(false)` to opt out and try every key in the set; this is slower and looser, intended for legacy peers that don't emit `kid`.
 
 For more discussion on why/how `alg`/`kid` values work, please read the [relevant section in the JWT documentation](01-jwt.md#parse-and-verify-a-jwt-with-a-key-set-matching-kid).
 

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -2293,3 +2293,47 @@ func TestDecryptErrorBounded(t *testing.T) {
 	require.Equal(t, 1, strings.Count(msg, `jwe.Decrypt: failed to decrypt any of the recipients`),
 		`top-level "failed to decrypt any of the recipients" should appear exactly once (no double-wrap)`)
 }
+
+// TestKeySetProviderSurfacesPerKeyErrors locks the contract that
+// keySetProvider.FetchKeys returns a useful error when no key in the
+// set yielded a usable (alg, key) pair. Previously the per-key error
+// from selectKey ("key %q in set has no 'alg' field...") was
+// constructed but silently swallowed in the non-requireKid loop.
+func TestKeySetProviderSurfacesPerKeyErrors(t *testing.T) {
+	payload := []byte("hello")
+
+	encryptKey, err := jwxtest.GenerateRsaJwk()
+	require.NoError(t, err)
+	encryptPub, err := jwk.PublicKeyOf(encryptKey)
+	require.NoError(t, err)
+	encrypted, err := jwe.Encrypt(payload, jwe.WithKey(jwa.RSA_OAEP(), encryptPub))
+	require.NoError(t, err)
+
+	// Build a keyset where every key lacks "alg" and the JWE's
+	// recipient header has no "alg" either (it's only on the
+	// protected header). With WithRequireKid(false) the loop walks
+	// every key; selectKey rejects each one with the descriptive
+	// error. After the fix, that error reaches the caller.
+	set := jwk.NewSet()
+	for range 3 {
+		k, err := jwxtest.GenerateRsaJwk()
+		require.NoError(t, err)
+		// Strip the alg so selectKey hits the header-fallback path,
+		// then strip the recipient-header alg... actually the
+		// fallback uses the protected header alg, which IS present
+		// for our test JWE. So instead of testing the no-alg path
+		// (which would succeed), test the use=sig filter path.
+		require.NoError(t, k.Set(jwk.KeyUsageKey, "sig"))
+		require.NoError(t, set.AddKey(k))
+	}
+
+	_, err = jwe.Decrypt(encrypted,
+		jwe.WithKeySet(set, jwe.WithRequireKid(false)),
+	)
+	require.Error(t, err, `Decrypt must fail when no key in the set is usable`)
+	// The keyset error should appear in the joined error chain.
+	// We don't pin the exact wording; we just check that something
+	// from the keyset selection layer is reachable.
+	require.Contains(t, err.Error(), `failed to select`,
+		`error must surface keyset selection failure when no key matched`)
+}

--- a/jwe/key_provider.go
+++ b/jwe/key_provider.go
@@ -2,6 +2,7 @@ package jwe
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -109,7 +110,8 @@ type keySetProvider struct {
 func (kp *keySetProvider) selectKey(sink KeySink, key jwk.Key, r Recipient, msg *Message) error {
 	if usage, ok := key.KeyUsage(); ok {
 		if usage != "" && usage != jwk.ForEncryption.String() {
-			return nil
+			kid, _ := key.KeyID()
+			return fmt.Errorf(`key %q has key_use=%q (expected %q for encryption)`, kid, usage, jwk.ForEncryption.String())
 		}
 	}
 
@@ -167,11 +169,24 @@ func (kp *keySetProvider) FetchKeys(_ context.Context, sink KeySink, r Recipient
 		return kp.selectKey(sink, key, r, msg)
 	}
 
+	// Collect per-key errors and surface them via errors.Join when
+	// nothing produced a usable (alg, key) pair. Without this, a
+	// caller debugging "why didn't my keyset match" got no signal —
+	// the descriptive error in selectKey ("key %q in set has no
+	// 'alg' field...") was constructed but silently swallowed.
+	var perKeyErrs []error
+	var emitted bool
 	for i := range kp.set.Len() {
 		key, _ := kp.set.Key(i)
-		if err := kp.selectKey(sink, key, r, msg); err != nil {
+		err := kp.selectKey(sink, key, r, msg)
+		if err != nil {
+			perKeyErrs = append(perKeyErrs, err)
 			continue
 		}
+		emitted = true
+	}
+	if !emitted && len(perKeyErrs) > 0 {
+		return fmt.Errorf(`failed to select any usable key from set of %d (no key produced a usable (alg, key) pair): %w`, kp.set.Len(), errors.Join(perKeyErrs...))
 	}
 	return nil
 }

--- a/jwe/options.go
+++ b/jwe/options.go
@@ -167,6 +167,31 @@ func WithKey(alg jwa.KeyAlgorithm, key any, options ...WithKeySuboption) Encrypt
 	})}
 }
 
+// WithKeySet specifies a JWKS (jwk.Set) to use for decryption. The
+// recipient's protected/per-recipient `kid` header selects a key from
+// the set, and the key's `alg` (or, when the JWK lacks `alg`, the
+// recipient's declared `alg`) drives the decrypt-time dispatch.
+//
+// By default WithKeySet requires the JWE to carry a `kid` header that
+// matches a key in the set. Pass `WithRequireKid(false)` to fall back
+// to trying every key in the set (slower, looser; intended for legacy
+// peers that don't emit `kid`). Per-key errors from the set are
+// surfaced via `errors.Join` when nothing matched, so a caller
+// debugging "why didn't my keyset match" sees the per-key reasons.
+//
+// Security caveats:
+//
+//   - The recipient's per-recipient header is unprotected. When the
+//     selected JWK has no `alg`, the keyset provider falls back to
+//     the per-recipient `alg`, then the protected header's `alg`.
+//     `jwe.Decrypt` re-checks `alg` against the integrity-protected
+//     protected header before any cryptographic call (RFC 7516
+//     §7.2.1 disjointness) — see the active prior
+//     `jwe-keyset-alg-confusion-blocked` for the full attack-tree
+//     analysis.
+//   - For untrusted issuers, prefer narrowing the keyset to keys
+//     already typed for the expected algorithm rather than relying
+//     on the header-fallback path.
 func WithKeySet(set jwk.Set, options ...WithKeySetSuboption) DecryptOption {
 	requireKid := true
 	for _, opt := range options {


### PR DESCRIPTION
The non-`requireKid` loop swallowed `selectKey`'s per-key errors silently — descriptive errors ("key %q has no 'alg'...", "key_use=sig...") were constructed but never reached the caller.

Collect per-key errors and surface them via `errors.Join` when nothing in the set produced a usable `(alg, key)` pair. Mirrors the JWS-side pattern.

Adjacent fixes:
- `selectKey`'s `use=sig` filter now returns a descriptive error instead of silently returning nil.
- `WithKeySet` godoc documents the routing rules and the per-recipient alg fallback (with pointer to the disjointness re-check).
- `docs/03-jwe.md` "Decrypting using a JWKS" corrected: it claimed `alg` must match (no longer true) and `kid is not required by default` (it IS).