### PR TITLE
jwe: add WithDisabledKeyAlgorithms global policy hook

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -78,7 +78,7 @@ JSON Web Encryption per RFC 7516. Encrypt, decrypt, parse.
 - **Settings(options ...GlobalOption)** — configure global jwe settings
 - Key types: `Message`, `Recipient`, `Headers`, `KeyProvider`, `KeyEncrypter`, `KeyDecrypter`
 - Options: `WithKey()`, `WithKeySet()`, `WithContentEncryption()`, `WithCompress()`, `WithJSON()`, `WithProtectedHeaders()`
-- Global/per-call settings: `WithMaxPBES2Count()`, `WithMinPBES2Count()`, `WithMaxDecompressBufferSize()`, `WithMaxRecipients()` (usable in both `Settings()` and `Decrypt()`); `WithCBCBufferSize()` (global only)
+- Global/per-call settings: `WithMaxPBES2Count()`, `WithMinPBES2Count()`, `WithMaxDecompressBufferSize()`, `WithMaxRecipients()` (usable in both `Settings()` and `Decrypt()`); `WithCBCBufferSize()`, `WithDisabledKeyAlgorithms(...jwa.KeyEncryptionAlgorithm)` (global only; the latter blocks listed key algorithms in both Encrypt and Decrypt)
 - Error sentinels: `EncryptError()`, `DecryptError()`, `HPKEError()`, `RecipientError()`, `ParseError()`
 - Internal subpackages: `jwe/internal/{aescbc,cipher,concatkdf,content_crypt,keygen}`, `jwe/jwebb` — building blocks including HPKE extension interfaces (`HPKEKeyEncrypter`, `HPKEKeyDecrypter`), custom HPKE encrypt/decrypt bridges (`KeyEncryptHPKECustom`, `KeyDecryptHPKECustom`), and dynamic algorithm registration (`RegisterHPKEAlgorithm`)
 - Files: `jwe.go`, `message.go`, `interface.go`, `headers.go`, `errors.go`, `options.go`, `key_provider.go`, `compress.go`, `filter.go`

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -39,6 +39,7 @@ var minPBES2Count atomic.Int64
 var pbes2Count atomic.Int64
 var maxRecipients atomic.Int64
 var maxDecompressBufferSize atomic.Int64
+var disabledKeyAlgs atomic.Pointer[map[string]struct{}]
 
 func init() {
 	// maxPBES2Count: 1_000_000 covers OWASP 2023's 600k HS256 floor with
@@ -72,9 +73,31 @@ func Settings(options ...GlobalOption) error {
 			maxDecompressBufferSize.Store(option.MustGet[int64](opt))
 		case identCBCBufferSize{}:
 			aescbc.SetMaxBufferSize(option.MustGet[int64](opt))
+		case identDisabledKeyAlgorithms{}:
+			algs := option.MustGet[[]jwa.KeyEncryptionAlgorithm](opt)
+			if len(algs) == 0 {
+				disabledKeyAlgs.Store(nil)
+				continue
+			}
+			m := make(map[string]struct{}, len(algs))
+			for _, alg := range algs {
+				m[alg.String()] = struct{}{}
+			}
+			disabledKeyAlgs.Store(&m)
 		}
 	}
 	return nil
+}
+
+// isKeyAlgorithmDisabled reports whether alg is in the global
+// jwe.WithDisabledKeyAlgorithms set.
+func isKeyAlgorithmDisabled(alg jwa.KeyEncryptionAlgorithm) bool {
+	m := disabledKeyAlgs.Load()
+	if m == nil {
+		return false
+	}
+	_, ok := (*m)[alg.String()]
+	return ok
 }
 
 const (
@@ -95,6 +118,9 @@ type recipientBuilder struct {
 }
 
 func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryptionAlgorithm) ([]byte, error) {
+	if isKeyAlgorithmDisabled(b.alg) {
+		return nil, fmt.Errorf(`jwe.Encrypt: key encryption algorithm %q is disabled by jwe.WithDisabledKeyAlgorithms`, b.alg)
+	}
 	// Resolve the key to its raw form and extract key ID.
 	resolvedKey := b.key
 
@@ -635,6 +661,9 @@ func (dc *decryptContext) tryRecipient(msg *Message, recipient Recipient, protec
 }
 
 func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgorithm, key any, recipient Recipient, protectedHeaders Headers, aad, computedAad []byte) ([]byte, error) {
+	if isKeyAlgorithmDisabled(alg) {
+		return nil, decryptError{fmt.Errorf(`jwe.Decrypt: key encryption algorithm %q is disabled by jwe.WithDisabledKeyAlgorithms`, alg)}
+	}
 	if jwkKey, ok := key.(jwk.Key); ok {
 		raw, err := jwk.Export[any](jwkKey)
 		if err != nil {

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -2337,3 +2337,52 @@ func TestKeySetProviderSurfacesPerKeyErrors(t *testing.T) {
 	require.Contains(t, err.Error(), `failed to select`,
 		`error must surface keyset selection failure when no key matched`)
 }
+
+func TestDisabledKeyAlgorithms(t *testing.T) {
+	plaintext := []byte("Live long and prosper.")
+
+	// Mint an RSA1_5 message with the algorithm allowed, then re-test decrypt
+	// after the policy flips. Encryption must remain available before the
+	// disable so the test can produce a real input.
+	encrypted, err := jwe.Encrypt(plaintext, jwe.WithKey(jwa.RSA1_5(), &rsaPrivKey.PublicKey), jwe.WithContentEncryption(jwa.A128CBC_HS256()))
+	require.NoError(t, err, `Encrypt with RSA1_5 should succeed before policy is set`)
+
+	require.NoError(t, jwe.Settings(jwe.WithDisabledKeyAlgorithms(jwa.RSA1_5())), `Settings(WithDisabledKeyAlgorithms) should succeed`)
+	t.Cleanup(func() {
+		// Clear the disabled set so other tests that exercise RSA1_5 are
+		// unaffected by leftover process-global state.
+		_ = jwe.Settings(jwe.WithDisabledKeyAlgorithms())
+	})
+
+	t.Run("Decrypt rejects disabled alg before any crypto runs", func(t *testing.T) {
+		_, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.RSA1_5(), rsaPrivKey))
+		require.Error(t, err, `Decrypt should reject a disabled key algorithm`)
+		require.ErrorIs(t, err, jwe.DecryptError(), `error should wrap jwe.DecryptError`)
+		require.Contains(t, err.Error(), `RSA1_5`, `error should name the disabled algorithm`)
+		require.Contains(t, err.Error(), `disabled by jwe.WithDisabledKeyAlgorithms`, `error should explain why the alg was rejected`)
+	})
+
+	t.Run("Encrypt refuses to produce a disabled-alg recipient", func(t *testing.T) {
+		_, err := jwe.Encrypt(plaintext, jwe.WithKey(jwa.RSA1_5(), &rsaPrivKey.PublicKey), jwe.WithContentEncryption(jwa.A128CBC_HS256()))
+		require.Error(t, err, `Encrypt should refuse to produce a disabled-alg recipient`)
+		require.Contains(t, err.Error(), `RSA1_5`, `error should name the disabled algorithm`)
+		require.Contains(t, err.Error(), `disabled by jwe.WithDisabledKeyAlgorithms`, `error should explain why the alg was rejected`)
+	})
+
+	t.Run("Other algorithms remain usable", func(t *testing.T) {
+		// RSA-OAEP is still allowed; round-trip must succeed even with
+		// RSA1_5 disabled.
+		ct, err := jwe.Encrypt(plaintext, jwe.WithKey(jwa.RSA_OAEP(), &rsaPrivKey.PublicKey))
+		require.NoError(t, err, `Encrypt with RSA_OAEP should succeed`)
+		got, err := jwe.Decrypt(ct, jwe.WithKey(jwa.RSA_OAEP(), rsaPrivKey))
+		require.NoError(t, err, `Decrypt with RSA_OAEP should succeed`)
+		require.Equal(t, plaintext, got, `RSA_OAEP round-trip should produce the original plaintext`)
+	})
+
+	t.Run("Empty list re-enables the algorithm", func(t *testing.T) {
+		require.NoError(t, jwe.Settings(jwe.WithDisabledKeyAlgorithms()), `Settings(WithDisabledKeyAlgorithms()) with no args should clear the set`)
+		got, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.RSA1_5(), rsaPrivKey))
+		require.NoError(t, err, `Decrypt should succeed after the disabled set is cleared`)
+		require.Equal(t, plaintext, got, `Decrypt should return the original plaintext after re-enabling`)
+	})
+}

--- a/jwe/options.go
+++ b/jwe/options.go
@@ -7,6 +7,28 @@ import (
 )
 
 type identCritExtension struct{}
+type identDisabledKeyAlgorithms struct{}
+
+// WithDisabledKeyAlgorithms returns a process-global option for jwe.Settings()
+// that refuses the named key encryption algorithms in both directions. After
+// the call returns, jwe.Encrypt() will not produce a recipient using any
+// listed algorithm, and jwe.Decrypt() will reject any recipient whose "alg"
+// is in the list, before any cryptographic work runs. The check fires per
+// recipient: a multi-recipient JWE is rejected as soon as a disabled "alg"
+// is seen on any recipient.
+//
+// The list is replaced (not unioned) on each Settings() call. To clear the
+// disabled set, call jwe.Settings(jwe.WithDisabledKeyAlgorithms()) with no
+// arguments.
+//
+// This is a deployment-time policy hook for the canonical "disable RSA1_5"
+// case (RFC 8725 §3.1) and similar legacy-algorithm bans. The jwa package
+// does not unregister these algorithms — keeping them registered preserves
+// header parsing for diagnostic logs, while this option blocks any actual
+// crypto use.
+func WithDisabledKeyAlgorithms(algorithms ...jwa.KeyEncryptionAlgorithm) GlobalOption {
+	return &globalOption{option.New(identDisabledKeyAlgorithms{}, algorithms)}
+}
 
 // WithCritExtension declares that the caller understands and will process
 // the named "crit" (Critical) header parameter extension(s) per RFC 7516


### PR DESCRIPTION
Adds `jwe.Settings(jwe.WithDisabledKeyAlgorithms(...))` so deployments can ban legacy key encryption algorithms — primarily RSA1_5 (RFC 8725 §3.1) — without unregistering them from `jwa`.

`jwe.Encrypt` refuses to produce a recipient using a listed alg. `jwe.Decrypt` rejects any recipient whose `alg` is in the list before any cryptographic work runs, which also short-circuits the RFC 3218 random-CEK fallback path for RSA1_5. The list replaces (not unions) on each `Settings()` call; pass with no arguments to clear.

Keeping algorithms registered in `jwa` preserves header parsing and diagnostics — this is policy, not deregistration. Picking the JWE-package level (rather than flipping `jwa.Unregister*`'s built-in guard) scopes the policy to JWE without affecting any future JWS use of the same identifiers.

Regression test covers: Decrypt rejects after disable, Encrypt refuses after disable, sibling algorithm round-trips still succeed, empty-list call clears the policy.