### PR TITLE
jwe: add WithDisabledKeyAlgorithms global policy hook

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -73,7 +73,7 @@ JSON Web Encryption per RFC 7516. Encrypt, decrypt, parse.
 - **Parse(buf []byte, ...ParseOption) (*Message, error)** — parse without decryption
 - Key types: `Message`, `Recipient`, `Headers`, `KeyProvider`, `KeyEncrypter`, `KeyDecrypter`
 - Options: `WithKey()`, `WithKeySet()`, `WithContentEncryption()`, `WithCompress()`, `WithJSON()`, `WithProtectedHeaders()`
-- Global/per-call settings: `WithMaxPBES2Count()`, `WithMinPBES2Count()`, `WithMaxDecompressBufferSize()`, `WithMaxRecipients()` (usable in both `Settings()` and `Decrypt()`); `WithCBCBufferSize()` (global only)
+- Global/per-call settings: `WithMaxPBES2Count()`, `WithMinPBES2Count()`, `WithMaxDecompressBufferSize()`, `WithMaxRecipients()` (usable in both `Settings()` and `Decrypt()`); `WithCBCBufferSize()`, `WithDisabledKeyAlgorithms(...jwa.KeyEncryptionAlgorithm)` (global only; the latter blocks listed key algorithms in both Encrypt and Decrypt)
 - Error sentinels: `EncryptError()`, `DecryptError()`, `RecipientError()`, `ParseError()`
 - Internal subpackages: `jwe/internal/{aescbc,cipher,concatkdf,content_crypt,keygen}`, `jwe/jwebb`
 - Files: `jwe.go`, `message.go`, `interface.go`, `headers.go`, `errors.go`, `options.go`, `key_provider.go`, `compress.go`, `filter.go`

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -40,6 +40,7 @@ var minPBES2Count atomic.Int64
 var pbes2Count atomic.Int64
 var maxRecipients atomic.Int64
 var maxDecompressBufferSize atomic.Int64
+var disabledKeyAlgs atomic.Pointer[map[string]struct{}]
 
 func init() {
 	maxPBES2Count.Store(10000)
@@ -91,8 +92,33 @@ func Settings(options ...GlobalOption) {
 				panic(fmt.Sprintf("jwe.Settings: value for option WithCBCBufferSize must be an int64: %s", err))
 			}
 			aescbc.SetMaxBufferSize(v)
+		case identDisabledKeyAlgorithms{}:
+			var algs []jwa.KeyEncryptionAlgorithm
+			if err := option.Value(&algs); err != nil {
+				panic(fmt.Sprintf("jwe.Settings: value for option WithDisabledKeyAlgorithms must be []jwa.KeyEncryptionAlgorithm: %s", err))
+			}
+			if len(algs) == 0 {
+				disabledKeyAlgs.Store(nil)
+				continue
+			}
+			m := make(map[string]struct{}, len(algs))
+			for _, alg := range algs {
+				m[alg.String()] = struct{}{}
+			}
+			disabledKeyAlgs.Store(&m)
 		}
 	}
+}
+
+// isKeyAlgorithmDisabled reports whether alg is in the global
+// jwe.WithDisabledKeyAlgorithms set.
+func isKeyAlgorithmDisabled(alg jwa.KeyEncryptionAlgorithm) bool {
+	m := disabledKeyAlgs.Load()
+	if m == nil {
+		return false
+	}
+	_, ok := (*m)[alg.String()]
+	return ok
 }
 
 const (
@@ -113,6 +139,9 @@ type recipientBuilder struct {
 }
 
 func (b *recipientBuilder) Build(r Recipient, cek []byte, calg jwa.ContentEncryptionAlgorithm, _ *content_crypt.Generic) ([]byte, error) {
+	if isKeyAlgorithmDisabled(b.alg) {
+		return nil, fmt.Errorf(`jwe.Encrypt: key encryption algorithm %q is disabled by jwe.WithDisabledKeyAlgorithms`, b.alg)
+	}
 	// we need the raw key for later use
 	rawKey := b.key
 
@@ -632,6 +661,9 @@ func (dc *decryptContext) tryRecipient(msg *Message, recipient Recipient, protec
 }
 
 func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgorithm, key any, recipient Recipient, protectedHeaders Headers, aad, computedAad []byte) ([]byte, error) {
+	if isKeyAlgorithmDisabled(alg) {
+		return nil, makeDecryptError(`key encryption algorithm %q is disabled by jwe.WithDisabledKeyAlgorithms`, alg)
+	}
 	if jwkKey, ok := key.(jwk.Key); ok {
 		var raw any
 		if err := jwk.Export(jwkKey, &raw); err != nil {

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -1856,3 +1856,45 @@ func TestWithKeyValidatesAlgKeyShape(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestDisabledKeyAlgorithms(t *testing.T) {
+	plaintext := []byte("Live long and prosper.")
+
+	encrypted, err := jwe.Encrypt(plaintext, jwe.WithKey(jwa.RSA1_5(), &rsaPrivKey.PublicKey), jwe.WithContentEncryption(jwa.A128CBC_HS256()))
+	require.NoError(t, err, `Encrypt with RSA1_5 should succeed before policy is set`)
+
+	jwe.Settings(jwe.WithDisabledKeyAlgorithms(jwa.RSA1_5()))
+	t.Cleanup(func() {
+		jwe.Settings(jwe.WithDisabledKeyAlgorithms())
+	})
+
+	t.Run("Decrypt rejects disabled alg before any crypto runs", func(t *testing.T) {
+		_, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.RSA1_5(), rsaPrivKey))
+		require.Error(t, err, `Decrypt should reject a disabled key algorithm`)
+		require.ErrorIs(t, err, jwe.DecryptError(), `error should wrap jwe.DecryptError`)
+		require.Contains(t, err.Error(), `RSA1_5`, `error should name the disabled algorithm`)
+		require.Contains(t, err.Error(), `disabled by jwe.WithDisabledKeyAlgorithms`, `error should explain why the alg was rejected`)
+	})
+
+	t.Run("Encrypt refuses to produce a disabled-alg recipient", func(t *testing.T) {
+		_, err := jwe.Encrypt(plaintext, jwe.WithKey(jwa.RSA1_5(), &rsaPrivKey.PublicKey), jwe.WithContentEncryption(jwa.A128CBC_HS256()))
+		require.Error(t, err, `Encrypt should refuse to produce a disabled-alg recipient`)
+		require.Contains(t, err.Error(), `RSA1_5`, `error should name the disabled algorithm`)
+		require.Contains(t, err.Error(), `disabled by jwe.WithDisabledKeyAlgorithms`, `error should explain why the alg was rejected`)
+	})
+
+	t.Run("Other algorithms remain usable", func(t *testing.T) {
+		ct, err := jwe.Encrypt(plaintext, jwe.WithKey(jwa.RSA_OAEP(), &rsaPrivKey.PublicKey))
+		require.NoError(t, err, `Encrypt with RSA_OAEP should succeed`)
+		got, err := jwe.Decrypt(ct, jwe.WithKey(jwa.RSA_OAEP(), rsaPrivKey))
+		require.NoError(t, err, `Decrypt with RSA_OAEP should succeed`)
+		require.Equal(t, plaintext, got, `RSA_OAEP round-trip should produce the original plaintext`)
+	})
+
+	t.Run("Empty list re-enables the algorithm", func(t *testing.T) {
+		jwe.Settings(jwe.WithDisabledKeyAlgorithms())
+		got, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.RSA1_5(), rsaPrivKey))
+		require.NoError(t, err, `Decrypt should succeed after the disabled set is cleared`)
+		require.Equal(t, plaintext, got, `Decrypt should return the original plaintext after re-enabling`)
+	})
+}

--- a/jwe/options.go
+++ b/jwe/options.go
@@ -7,6 +7,28 @@ import (
 )
 
 type identCritExtension struct{}
+type identDisabledKeyAlgorithms struct{}
+
+// WithDisabledKeyAlgorithms returns a process-global option for jwe.Settings()
+// that refuses the named key encryption algorithms in both directions. After
+// the call returns, jwe.Encrypt() will not produce a recipient using any
+// listed algorithm, and jwe.Decrypt() will reject any recipient whose "alg"
+// is in the list, before any cryptographic work runs. The check fires per
+// recipient: a multi-recipient JWE is rejected as soon as a disabled "alg"
+// is seen on any recipient.
+//
+// The list is replaced (not unioned) on each Settings() call. To clear the
+// disabled set, call jwe.Settings(jwe.WithDisabledKeyAlgorithms()) with no
+// arguments.
+//
+// This is a deployment-time policy hook for the canonical "disable RSA1_5"
+// case (RFC 8725 §3.1) and similar legacy-algorithm bans. The jwa package
+// does not unregister these algorithms — keeping them registered preserves
+// header parsing for diagnostic logs, while this option blocks any actual
+// crypto use.
+func WithDisabledKeyAlgorithms(algorithms ...jwa.KeyEncryptionAlgorithm) GlobalOption {
+	return &globalOption{option.New(identDisabledKeyAlgorithms{}, algorithms)}
+}
 
 // WithCritExtension declares that the caller understands and will process
 // the named "crit" (Critical) header parameter extension(s) per RFC 7516


### PR DESCRIPTION
v3 backport of #2128.

Adds `jwe.Settings(jwe.WithDisabledKeyAlgorithms(...))` so deployments can ban legacy key encryption algorithms — primarily RSA1_5 (RFC 8725 §3.1) — without unregistering them from `jwa`.

`jwe.Encrypt` refuses to produce a recipient using a listed alg. `jwe.Decrypt` rejects any recipient whose `alg` is in the list before any cryptographic work runs, which also short-circuits the RFC 3218 random-CEK fallback path for RSA1_5. The list replaces (not unions) on each `Settings()` call; pass with no arguments to clear.

Keeping algorithms registered in `jwa` preserves header parsing and diagnostics — this is policy, not deregistration. Picking the JWE-package level (rather than flipping `jwa.Unregister*`'s built-in guard) scopes the policy to JWE without affecting any future JWS use of the same identifiers.

Regression test covers: Decrypt rejects after disable, Encrypt refuses after disable, sibling algorithm round-trips still succeed, empty-list call clears the policy.