### PR TITLE
jwe: document WithMaxDecompressBufferSize behavior at non-positive values

### DIFF
--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -247,6 +247,12 @@ options:
       exceeds this amount when decompressed, jwe.Decrypt will return an error.
       The default value is 10MB.
 
+      A non-positive value rejects every compressed JWE: the cap fires on
+      the first byte of inflated output, so any "zip"-compressed message
+      fails with an exceeds-cap error before any payload is delivered. Use
+      this when the deployment refuses to accept compressed JWEs at all.
+      Pass an explicit positive cap when compressed payloads are expected.
+
       This option can be used for `jwe.Settings()`, which changes the behavior
       globally, or for `jwe.Decrypt()`, which changes the behavior for that
       specific call.

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -366,6 +366,12 @@ func WithKeyUsed(v *any) DecryptOption {
 // exceeds this amount when decompressed, jwe.Decrypt will return an error.
 // The default value is 10MB.
 //
+// A non-positive value rejects every compressed JWE: the cap fires on
+// the first byte of inflated output, so any "zip"-compressed message
+// fails with an exceeds-cap error before any payload is delivered. Use
+// this when the deployment refuses to accept compressed JWEs at all.
+// Pass an explicit positive cap when compressed payloads are expected.
+//
 // This option can be used for `jwe.Settings()`, which changes the behavior
 // globally, or for `jwe.Decrypt()`, which changes the behavior for that
 // specific call.


### PR DESCRIPTION
The cap-check loop in `uncompress` fires on the first byte of inflated output when the cap is 0 (or negative), so passing a non-positive value rejects every `zip`-compressed JWE before any payload is delivered. That behavior is intentional but was undocumented; the godoc only described the positive-value case, leaving `0` looking like a Go-idiom "no cap" to readers.

Doc-only change. The new paragraph spells out both how non-positive values behave and when to use them (refuse compressed JWEs entirely) versus when to pass a positive cap (compressed payloads expected, bound the size).