### PR TITLE
jwe: document WithMaxDecompressBufferSize behavior at non-positive values

### DIFF
--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -244,6 +244,12 @@ options:
       exceeds this amount when decompressed, jwe.Decrypt will return an error.
       The default value is 10MB.
 
+      A non-positive value rejects every compressed JWE: the cap fires on
+      the first byte of inflated output, so any "zip"-compressed message
+      fails with an exceeds-cap error before any payload is delivered. Use
+      this when the deployment refuses to accept compressed JWEs at all.
+      Pass an explicit positive cap when compressed payloads are expected.
+
       This option can be used for `jwe.Settings()`, which changes the behavior
       globally, or for `jwe.Decrypt()`, which changes the behavior for that
       specific call.

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -434,6 +434,12 @@ func WithLegacyHeaderMerging(v bool) EncryptOption {
 // exceeds this amount when decompressed, jwe.Decrypt will return an error.
 // The default value is 10MB.
 //
+// A non-positive value rejects every compressed JWE: the cap fires on
+// the first byte of inflated output, so any "zip"-compressed message
+// fails with an exceeds-cap error before any payload is delivered. Use
+// this when the deployment refuses to accept compressed JWEs at all.
+// Pass an explicit positive cap when compressed payloads are expected.
+//
 // This option can be used for `jwe.Settings()`, which changes the behavior
 // globally, or for `jwe.Decrypt()`, which changes the behavior for that
 // specific call.


### PR DESCRIPTION
v3 backport of #2130.

The cap-check loop in `uncompress` fires on the first byte of inflated output when the cap is 0 (or negative), so passing a non-positive value rejects every `zip`-compressed JWE before any payload is delivered. That behavior is intentional but was undocumented; the godoc only described the positive-value case, leaving `0` looking like a Go-idiom "no cap" to readers.

Doc-only change. The new paragraph spells out both how non-positive values behave and when to use them.