### PR TITLE
jwk: stop duplicating JWK fields at JWKS top level on parse

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -43,7 +43,7 @@ Leaf Packages (no internal deps)
 | `transform` | (none — external only: blackmagic) |
 | `jwk` | jwa, cert, transform |
 | `jwk/ecdsa` | jwa |
-| `jwk/jwkbb` | (external only: blackmagic) |
+| `jwk/jwkbb` | (external only: blackmagic, valyala/fastjson) |
 | `jws` | jwa, jwk, cert |
 | `jwe` | jwa, jwk, cert, transform |
 | `jwt` | jwa, jws, jwe, jwk, transform |
@@ -59,7 +59,7 @@ Leaf Packages (no internal deps)
 | `goccy/go-json` | internal/json | Optional fast JSON (build tag) |
 | `segmentio/asm` | internal/base64 | Optional fast base64 (build tag) |
 | `decred/secp256k1` | jwk (direct); jwa, jws (via build tag) | ES256K support (build tag) |
-| `valyala/fastjson` | jws/jwsbb | Fast JSON header parsing |
+| `valyala/fastjson` | jws/jwsbb, jwk/jwkbb | Fast JSON header / object peek |
 | `golang.org/x/crypto` | jwe | Extended crypto (PBKDF2, etc.) |
 | `lestrrat-go/dsig` | jws/jwsbb | Digital signature primitives (HMAC, RSA, ECDSA, EdDSA) |
 | `lestrrat-go/dsig-secp256k1` | jws/jwsbb | ES256K/secp256k1 signature support (build tag) |

--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -43,7 +43,7 @@ JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 - Extension: `RegisterCustomField()`, `RegisterKeyParser()`, `RegisterKeyImporter()`, `RegisterKeyExporter()`
 - Error sentinels: `ImportError()`, `ParseError()`, `WhitelistError()`, `ContinueError()`
 - Files: `jwk.go`, `set.go`, `parser.go`, `convert.go`, `fetch.go`, `cache.go`, `interface.go`, `errors.go`, `x509.go`, `filter.go`, `rsa.go`, `ecdsa.go`, `okp.go`, `symmetric.go`
-- Sub-packages: `jwk/ecdsa` — elliptic curve registration (`RegisterCurve`, `CurveFromAlgorithm`, `AlgorithmFromCurve`); `jwk/jwkbb` — X.509/PEM encoding building blocks (`EncodeX509`, `DecodeX509`)
+- Sub-packages: `jwk/ecdsa` — elliptic curve registration (`RegisterCurve`, `CurveFromAlgorithm`, `AlgorithmFromCurve`); `jwk/jwkbb` — X.509/PEM encoding building blocks (`EncodeX509`, `DecodeX509`) plus a fastjson-backed `Header` (sealed) for fast field probing of JWK / JWKS bytes: `HeaderParse`, `HeaderHas`, `HeaderGetString`, `HeaderGetStringBytes`, sentinel `ErrHeaderNotFound()`. Mirrors the `jws/jwsbb` Header API; experimental.
 - Imports: jwa, cert, transform, internal/{base64,json,ecutil}
 
 ## jws/

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -1756,21 +1756,24 @@ func TestSetWithPrivateParams(t *testing.T) {
 		_ = k1.Set(`renewal_kid`, "foo")
 		_ = json.NewEncoder(&buf).Encode(k1)
 
+		// renewal_kid is a custom field on the KEY, not the JWKS document.
+		// jwk.Parse accepts a single bare JWK by wrapping it in a Set, but
+		// the field belongs to the wrapped key — Set.Get("renewal_kid")
+		// must NOT surface it (that slot is for JWKS-level extension
+		// members; see "JWKS with multiple keys" below).
 		var check = func(t *testing.T, buf []byte) {
 			set, err := jwk.Parse(buf)
 			require.NoError(t, err, `jwk.Parse should succeed`)
 			require.Equal(t, 1, set.Len(), `set.Len() should be 1`)
 
-			var kid string
-			require.NoError(t, set.Get(`renewal_kid`, &kid), `set.Get("renewal_kid") should succeed`)
-
-			require.Equal(t, `foo`, kid, `set.Get("renewal_kid") should return "foo"`)
+			var sink string
+			require.Error(t, set.Get(`renewal_kid`, &sink), `set.Get("renewal_kid") should NOT surface a single-key field at JWKS level`)
 
 			key, ok := set.Key(0)
 			require.True(t, ok, `set.Key(0) should return ok = true`)
 
-			kid = ""
-			require.NoError(t, key.Get(`renewal_kid`, &kid), `key.Get("renewal_kid") should return ok = true`)
+			var kid string
+			require.NoError(t, key.Get(`renewal_kid`, &kid), `key.Get("renewal_kid") should succeed`)
 
 			require.Equal(t, `foo`, kid, `key.Get("renewal_kid") should return "foo"`)
 		}

--- a/jwk/jwkbb/BUILD.bazel
+++ b/jwk/jwkbb/BUILD.bazel
@@ -1,12 +1,25 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "jwkbb",
-    srcs = ["x509.go"],
+    srcs = [
+        "header.go",
+        "x509.go",
+    ],
     importpath = "github.com/lestrrat-go/jwx/v3/jwk/jwkbb",
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_lestrrat_go_blackmagic//:blackmagic",
+        "@com_github_valyala_fastjson//:fastjson",
+    ],
+)
+
+go_test(
+    name = "jwkbb_test",
+    srcs = ["header_test.go"],
+    deps = [
+        ":jwkbb",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/jwk/jwkbb/header.go
+++ b/jwk/jwkbb/header.go
@@ -1,0 +1,130 @@
+package jwkbb
+
+import (
+	"fmt"
+
+	"github.com/valyala/fastjson"
+)
+
+type headerNotFoundError struct {
+	key string
+}
+
+func (e headerNotFoundError) Error() string {
+	return fmt.Sprintf(`jwkbb: field "%s" not found`, e.key)
+}
+
+func (e headerNotFoundError) Is(target error) bool {
+	switch target.(type) {
+	case headerNotFoundError, *headerNotFoundError:
+		return true
+	default:
+		return false
+	}
+}
+
+// ErrHeaderNotFound returns an error that can be passed to errors.Is
+// to check if the error is the result of a field not being found in
+// the parsed JSON.
+func ErrHeaderNotFound() error {
+	return headerNotFoundError{}
+}
+
+// Header is an opaque handle to a parsed JWK or JWKS JSON object.
+// It exists for fast, allocation-light field probing without paying
+// the cost of a full encoding/json unmarshal.
+//
+// Header instances are NOT safe for concurrent use. Create a new one
+// per goroutine. Values returned by HeaderGet* helpers may alias
+// memory owned by the Header; do not retain them past the Header's
+// lifetime unless the helper explicitly copies (HeaderGetString does;
+// HeaderGetStringBytes does not).
+//
+// This type is experimental and may change or be removed in the future.
+type Header interface {
+	// Sealed so callers can't depend on the underlying fastjson type
+	// or substitute their own implementation.
+	jwkbbHeader()
+}
+
+type header struct {
+	v   *fastjson.Value
+	err error
+}
+
+func (h *header) jwkbbHeader() {}
+
+// HeaderParse parses a JSON byte slice and returns a Header for fast
+// field access. Parse errors are deferred to the first HeaderGet* /
+// HeaderHas call.
+//
+// This function is experimental and may change or be removed in the future.
+func HeaderParse(buf []byte) Header {
+	var p fastjson.Parser
+	v, err := p.ParseBytes(buf)
+	if err != nil {
+		return &header{err: err}
+	}
+	return &header{v: v}
+}
+
+func headerGet(h Header, key string) (*fastjson.Value, error) {
+	//nolint:forcetypeassert
+	hh := h.(*header) // we _know_ this can't be another type
+	if hh.err != nil {
+		return nil, hh.err
+	}
+
+	v := hh.v.Get(key)
+	if v == nil {
+		return nil, headerNotFoundError{key: key}
+	}
+	return v, nil
+}
+
+// HeaderHas reports whether the given key exists in the parsed JSON object.
+// Returns false on parse errors.
+//
+// This function is experimental and may change or be removed in the future.
+func HeaderHas(h Header, key string) bool {
+	_, err := headerGet(h, key)
+	return err == nil
+}
+
+// HeaderGetString returns the string value for the given key as a
+// freshly-allocated Go string. The returned value remains valid after
+// the Header is garbage collected.
+//
+// This function is experimental and may change or be removed in the future.
+func HeaderGetString(h Header, key string) (string, error) {
+	v, err := headerGet(h, key)
+	if err != nil {
+		return "", err
+	}
+
+	sb, err := v.StringBytes()
+	if err != nil {
+		return "", err
+	}
+
+	return string(sb), nil
+}
+
+// HeaderGetStringBytes returns the JSON string bytes for the given key
+// without copying.
+//
+// WARNING: the returned slice aliases memory owned by h. It becomes
+// invalid as soon as h is reused, re-parsed, or goes out of scope and
+// is garbage collected. Do not retain the slice, share it across
+// goroutines, or use it after any further call on h. If you need a
+// value that outlives h, use [HeaderGetString].
+//
+// This function is experimental and may change or be removed in the future.
+func HeaderGetStringBytes(h Header, key string) ([]byte, error) {
+	v, err := headerGet(h, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return v.StringBytes()
+}

--- a/jwk/jwkbb/header_test.go
+++ b/jwk/jwkbb/header_test.go
@@ -1,0 +1,53 @@
+package jwkbb_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/jwk/jwkbb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HeaderHas/HeaderGetString on JWKS", func(t *testing.T) {
+		t.Parallel()
+		h := jwkbb.HeaderParse([]byte(`{"keys":[],"renewal_kid":"foo"}`))
+		require.True(t, jwkbb.HeaderHas(h, "keys"), `keys should exist`)
+		require.True(t, jwkbb.HeaderHas(h, "renewal_kid"), `renewal_kid should exist`)
+		require.False(t, jwkbb.HeaderHas(h, "missing"), `missing should not exist`)
+
+		v, err := jwkbb.HeaderGetString(h, "renewal_kid")
+		require.NoError(t, err)
+		require.Equal(t, "foo", v)
+
+		_, err = jwkbb.HeaderGetString(h, "missing")
+		require.ErrorIs(t, err, jwkbb.ErrHeaderNotFound())
+	})
+
+	t.Run("HeaderHas on bare JWK", func(t *testing.T) {
+		t.Parallel()
+		h := jwkbb.HeaderParse([]byte(`{"kty":"oct","k":"AAAA"}`))
+		require.False(t, jwkbb.HeaderHas(h, "keys"), `bare JWK should not have keys`)
+		require.True(t, jwkbb.HeaderHas(h, "kty"))
+	})
+
+	t.Run("parse error deferred", func(t *testing.T) {
+		t.Parallel()
+		h := jwkbb.HeaderParse([]byte(`{not json`))
+		require.False(t, jwkbb.HeaderHas(h, "anything"), `parse error should surface as not-found`)
+
+		_, err := jwkbb.HeaderGetString(h, "anything")
+		require.Error(t, err)
+		require.False(t, errors.Is(err, jwkbb.ErrHeaderNotFound()), `parse error is not a not-found error`)
+	})
+
+	t.Run("HeaderGetStringBytes aliases", func(t *testing.T) {
+		t.Parallel()
+		h := jwkbb.HeaderParse([]byte(`{"kty":"RSA"}`))
+		b, err := jwkbb.HeaderGetStringBytes(h, "kty")
+		require.NoError(t, err)
+		require.Equal(t, []byte("RSA"), b)
+	})
+}

--- a/jwk/set.go
+++ b/jwk/set.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lestrrat-go/jwx/v3/internal/json"
 	"github.com/lestrrat-go/jwx/v3/internal/pool"
 	"github.com/lestrrat-go/jwx/v3/internal/tokens"
+	"github.com/lestrrat-go/jwx/v3/jwk/jwkbb"
 )
 
 const keysKey = `keys` // appease linter
@@ -215,39 +216,6 @@ func (s *set) setRejectDuplicateKID(v bool) {
 	s.rejectDuplicateKID = v
 }
 
-// hasKeysField peeks the top-level JSON object for a "keys" member
-// without consuming or storing field values. Used to distinguish a JWKS
-// document (with "keys") from a single bare JWK (without).
-func hasKeysField(data []byte) (bool, error) {
-	dec := json.NewDecoder(bytes.NewReader(data))
-	tok, err := dec.Token()
-	if err != nil {
-		return false, fmt.Errorf(`error reading token: %w`, err)
-	}
-	delim, ok := tok.(json.Delim)
-	if !ok || delim != tokens.OpenCurlyBracket {
-		return false, fmt.Errorf(`expected '%c' but got %v`, tokens.OpenCurlyBracket, tok)
-	}
-	for dec.More() {
-		tok, err := dec.Token()
-		if err != nil {
-			return false, fmt.Errorf(`error reading token: %w`, err)
-		}
-		name, ok := tok.(string)
-		if !ok {
-			return false, fmt.Errorf(`expected field name, got %v`, tok)
-		}
-		if name == "keys" {
-			return true, nil
-		}
-		var skip json.RawMessage
-		if err := dec.Decode(&skip); err != nil {
-			return false, fmt.Errorf(`error skipping value for %q: %w`, name, err)
-		}
-	}
-	return false, nil
-}
-
 func (s *set) UnmarshalJSON(data []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -270,11 +238,7 @@ func (s *set) UnmarshalJSON(data []byte) error {
 	// present — otherwise top-level fields would be misclassified as
 	// JWKS-level extension members instead of the single key's own
 	// members.
-	isJWKS, err := hasKeysField(data)
-	if err != nil {
-		return err
-	}
-	if !isJWKS {
+	if !jwkbb.HeaderHas(jwkbb.HeaderParse(data), "keys") {
 		key, err := ParseKey(data, options...)
 		if err != nil {
 			return fmt.Errorf(`failed to parse sole key in key set: %w`, err)

--- a/jwk/set.go
+++ b/jwk/set.go
@@ -215,6 +215,39 @@ func (s *set) setRejectDuplicateKID(v bool) {
 	s.rejectDuplicateKID = v
 }
 
+// hasKeysField peeks the top-level JSON object for a "keys" member
+// without consuming or storing field values. Used to distinguish a JWKS
+// document (with "keys") from a single bare JWK (without).
+func hasKeysField(data []byte) (bool, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	tok, err := dec.Token()
+	if err != nil {
+		return false, fmt.Errorf(`error reading token: %w`, err)
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok || delim != tokens.OpenCurlyBracket {
+		return false, fmt.Errorf(`expected '%c' but got %v`, tokens.OpenCurlyBracket, tok)
+	}
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return false, fmt.Errorf(`error reading token: %w`, err)
+		}
+		name, ok := tok.(string)
+		if !ok {
+			return false, fmt.Errorf(`expected field name, got %v`, tok)
+		}
+		if name == "keys" {
+			return true, nil
+		}
+		var skip json.RawMessage
+		if err := dec.Decode(&skip); err != nil {
+			return false, fmt.Errorf(`error skipping value for %q: %w`, name, err)
+		}
+	}
+	return false, nil
+}
+
 func (s *set) UnmarshalJSON(data []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -231,13 +264,31 @@ func (s *set) UnmarshalJSON(data []byte) error {
 		ignoreParseError = dc.IgnoreParseError()
 	}
 
+	// jwk.Parse and direct json.Unmarshal accept either a JWKS document
+	// or a single bare JWK. Decide which one we have up front so the
+	// JWKS-level streaming pass only runs when "keys" is actually
+	// present — otherwise top-level fields would be misclassified as
+	// JWKS-level extension members instead of the single key's own
+	// members.
+	isJWKS, err := hasKeysField(data)
+	if err != nil {
+		return err
+	}
+	if !isJWKS {
+		key, err := ParseKey(data, options...)
+		if err != nil {
+			return fmt.Errorf(`failed to parse sole key in key set: %w`, err)
+		}
+		s.keys = append(s.keys, key)
+		return nil
+	}
+
 	maxK := s.maxKeys
 	if maxK <= 0 {
 		maxK = int(maxKeys.Load())
 	}
 	rejectDupKid := s.rejectDuplicateKID || rejectDuplicateKID.Load()
 
-	var sawKeysField bool
 	dec := json.NewDecoder(bytes.NewReader(data))
 LOOP:
 	for {
@@ -258,7 +309,6 @@ LOOP:
 		case string:
 			switch tok {
 			case "keys":
-				sawKeysField = true
 				var list []json.RawMessage
 				if err := dec.Decode(&list); err != nil {
 					return fmt.Errorf(`failed to decode "keys": %w`, err)
@@ -298,19 +348,6 @@ LOOP:
 				s.privateParams[tok] = v
 			}
 		}
-	}
-
-	// This is really silly, but we can only detect the
-	// lack of the "keys" field after going through the
-	// entire object once
-	// Not checking for len(s.keys) == 0, because it could be
-	// an empty key set
-	if !sawKeysField {
-		key, err := ParseKey(data, options...)
-		if err != nil {
-			return fmt.Errorf(`failed to parse sole key in key set: %w`, err)
-		}
-		s.keys = append(s.keys, key)
 	}
 	return nil
 }

--- a/jwk/set_test.go
+++ b/jwk/set_test.go
@@ -1,6 +1,7 @@
 package jwk_test
 
 import (
+	"encoding/json"
 	"sort"
 	"testing"
 
@@ -74,6 +75,42 @@ func TestSetAddKeyNil(t *testing.T) {
 			_ = jwk.NewSet().AddKey(fakeStructKey{})
 		}, `AddKey must not panic when Key's dynamic type is a struct`)
 	})
+}
+
+// jwk.Parse is documented to accept a single bare JWK and return a Set
+// containing that one key. The streaming UnmarshalJSON pushes every
+// non-"keys" top-level field into privateParams (the slot for JWKS-level
+// extension members), then re-parses the whole blob as a Key when no
+// "keys" field was seen. If privateParams is not cleared on that fallback
+// path, the same key fields end up serialized at both the JWKS top level
+// and inside keys[0] on the next MarshalJSON.
+func TestSetSingleKeyRoundTripDoesNotDuplicateFields(t *testing.T) {
+	src, err := jwxtest.GenerateRsaJwk()
+	require.NoError(t, err, `GenerateRsaJwk should succeed`)
+
+	input, err := json.Marshal(src)
+	require.NoError(t, err, `marshaling the source key should succeed`)
+
+	set, err := jwk.Parse(input)
+	require.NoError(t, err, `Parse should accept a single bare JWK`)
+	require.Equal(t, 1, set.Len(), `Set should contain exactly one key`)
+
+	out, err := json.Marshal(set)
+	require.NoError(t, err, `marshaling the Set should succeed`)
+
+	var top map[string]any
+	require.NoError(t, json.Unmarshal(out, &top), `unmarshal into map should succeed`)
+	require.Equal(t, []string{"keys"}, mapKeysSorted(top),
+		`top level should be a JWKS with exactly the "keys" field; got duplicated fields: %s`, string(out))
+}
+
+func mapKeysSorted(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func TestSetKeys(t *testing.T) {


### PR DESCRIPTION
v3 backport of #2132.

- `jwk.Parse` accepts both a JWKS document and a single bare JWK; the streaming `Set.UnmarshalJSON` was pushing every non-`keys` top-level field into Set-level `privateParams` *before* deciding which shape it was looking at, so a single JWK with `n`/`e`/`d`/etc. ended up stored at both the JWKS top level and inside `keys[0]`. `json.Marshal(set)` then emitted the same fields twice.
- Peek for `keys` up front; dispatch to `ParseKey` for the bare-JWK case (no Set-level `privateParams` writes) and to the existing streaming pass for the JWKS case.
- Regression test round-trips a bare RSA JWK and asserts the marshaled JWKS top level is exactly `{"keys": [...]}`. `TestSetWithPrivateParams/JWK_instead_of_JWKS` updated: per-key `renewal_kid` now surfaces only via `key.Get`, not `set.Get`.