### PR TITLE
jwk: wrap ParseKey/ParseKeyAs errors with ParseError sentinel

### DIFF
--- a/jwk/errors.go
+++ b/jwk/errors.go
@@ -73,6 +73,14 @@ func sparseerr(f string, args ...any) error {
 	return bparseerr(`jwk.ParseString`, f, args...)
 }
 
+func kparseerr(f string, args ...any) error {
+	return bparseerr(`jwk.ParseKey`, f, args...)
+}
+
+func kasparseerr(f string, args ...any) error {
+	return bparseerr(`jwk.ParseKeyAs`, f, args...)
+}
+
 var errDefaultParseError = parseError{errors.New(`parse error`)}
 
 func ParseError() error {

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -360,7 +360,11 @@ func (ctx *setDecodeCtx) IgnoreParseError() bool {
 // Use [ParseKeyAs] when a concrete key subtype (e.g. [RSAPrivateKey],
 // [ECDSAPublicKey]) is required.
 func ParseKey(data []byte, options ...ParseOption) (Key, error) {
-	return doParseKey(data, options...)
+	key, err := doParseKey(data, options...)
+	if err != nil {
+		return nil, kparseerr(`%w`, err)
+	}
+	return key, nil
 }
 
 // ParseKeyAs behaves like [ParseKey] but asserts the parsed key to the
@@ -373,11 +377,11 @@ func ParseKeyAs[T Key](data []byte, options ...ParseOption) (T, error) {
 	var zero T
 	key, err := doParseKey(data, options...)
 	if err != nil {
-		return zero, err
+		return zero, kasparseerr(`%w`, err)
 	}
 	result, ok := key.(T)
 	if !ok {
-		return zero, parseerr(`%w`, KeyTypeMismatchError{
+		return zero, kasparseerr(`%w`, KeyTypeMismatchError{
 			Got:  reflect.TypeOf(key),
 			Want: reflect.TypeFor[T](),
 		})

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -480,6 +480,8 @@ func TestParseKey(t *testing.T) {
 		t.Parallel()
 		_, err := jwk.ParseKey([]byte(`not json`))
 		require.Error(t, err)
+		require.ErrorIs(t, err, jwk.ParseError(),
+			`single-key parse failure should satisfy errors.Is(err, jwk.ParseError())`)
 	})
 }
 
@@ -541,6 +543,13 @@ func TestParseKeyAs(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, key)
 		require.Equal(t, jwa.OctetSeq(), key.KeyType())
+	})
+	t.Run("InvalidJSON", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwk.ParseKeyAs[jwk.RSAPublicKey]([]byte(`not json`))
+		require.Error(t, err)
+		require.ErrorIs(t, err, jwk.ParseError(),
+			`typed parse failure should satisfy errors.Is(err, jwk.ParseError())`)
 	})
 }
 


### PR DESCRIPTION
- The published `errors.Is(err, jwk.ParseError())` contract was honored by `jwk.Parse`, `ParseReader`, and `ParseString`, but `ParseKey` and `ParseKeyAs` returned the inner `doParseKey` error unwrapped — programs branching on the sentinel silently missed every single-key parse failure.
- Wrap at the entry points with new `kparseerr` / `kasparseerr` helpers (prefixes `jwk.ParseKey:` / `jwk.ParseKeyAs:`) so the inner `doParseKey` error chains through the existing `parseError` envelope. `ParseKeyAs`'s `KeyTypeMismatchError` path also moves to `kasparseerr` for consistency; the existing TypeMismatch test continues to pass.
- Regression: `TestParseKey/Invalid` and a new `TestParseKeyAs/InvalidJSON` both now assert `errors.Is(err, jwk.ParseError())` on malformed input.