### PR TITLE
jwk: wrap ParseKey errors with ParseError sentinel

### DIFF
--- a/jwk/errors.go
+++ b/jwk/errors.go
@@ -72,6 +72,10 @@ func sparseerr(f string, args ...any) error {
 	return bparseerr(`jwk.ParseString`, f, args...)
 }
 
+func kparseerr(f string, args ...any) error {
+	return bparseerr(`jwk.ParseKey`, f, args...)
+}
+
 type whitelistError struct {
 	error
 }

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -248,6 +248,14 @@ func (ctx *setDecodeCtx) IgnoreParseError() bool {
 // are performed for certificate expiration, no checks against missing
 // parameters are performed, etc.
 func ParseKey(data []byte, options ...ParseOption) (Key, error) {
+	key, err := doParseKey(data, options...)
+	if err != nil {
+		return nil, kparseerr(`%w`, err)
+	}
+	return key, nil
+}
+
+func doParseKey(data []byte, options ...ParseOption) (Key, error) {
 	var parsePEM bool
 	var localReg *json.Registry
 	var pemDecoder PEMDecoder

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -313,6 +313,19 @@ func TestNew(t *testing.T) {
 	require.Error(t, err, "nil key should cause an error")
 }
 
+// TestParseKeyError exercises the published `errors.Is(err, jwk.ParseError())`
+// contract on the single-key entry point.
+func TestParseKeyError(t *testing.T) {
+	t.Parallel()
+	t.Run("Invalid", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwk.ParseKey([]byte(`not json`))
+		require.Error(t, err)
+		require.ErrorIs(t, err, jwk.ParseError(),
+			`single-key parse failure should satisfy errors.Is(err, jwk.ParseError())`)
+	})
+}
+
 func TestParse(t *testing.T) {
 	t.Parallel()
 	verify := func(t *testing.T, src string, expected reflect.Type) {


### PR DESCRIPTION
v3 backport of #2134.

- The published `errors.Is(err, jwk.ParseError())` contract was honored by `jwk.Parse`, `ParseReader`, and `ParseString`, but `ParseKey` returned every error path unwrapped — programs branching on the sentinel silently missed every single-key parse failure.
- Extract the existing `ParseKey` body into `doParseKey`; the new `ParseKey` wraps the inner error with a new `kparseerr` helper (prefix `jwk.ParseKey:`) so the chain satisfies the sentinel. v3 has no `ParseKeyAs` (generics-based, v4-only); only `ParseKey` is touched here.
- Regression: `TestParseKeyError/Invalid` asserts `errors.Is(err, jwk.ParseError())` on malformed input.