### PR TITLE
jwk: stream the keys array with cap-before-allocate

### DIFF
--- a/jwk/interface.go
+++ b/jwk/interface.go
@@ -42,15 +42,17 @@ const (
 
 // Set represents JWKS object, a collection of jwk.Key objects.
 //
-// Sets can be safely converted to and from JSON using the standard
-// `"encoding/json".Marshal` and `"encoding/json".Unmarshal`. However,
-// if you do not know if the payload contains a single JWK or a JWK set,
-// consider using `jwk.Parse()` to always get a `jwk.Set` out of it.
+// Sets can be marshaled and unmarshaled with the standard
+// `"encoding/json".Marshal` and `"encoding/json".Unmarshal`. The
+// unmarshal path requires JWKS shape (an object with a "keys" field).
+// For input that may be either a single bare JWK or a JWKS, use
+// [Parse], which dispatches between the two shapes and always returns
+// a `jwk.Set`.
 //
-// Since v1.2.12, JWK sets with private parameters can be parsed as well.
-// Such private parameters can be accessed via the `Field()` method.
-// If a resource contains a single JWK instead of a JWK set, private parameters
-// are stored in _both_ the resulting `jwk.Set` object and the `jwk.Key` object .
+// JWKS-level extension members (any top-level field other than "keys")
+// are preserved as set-level private parameters and are accessible via
+// the `Field()` method. Per-key extension members live on the
+// individual `jwk.Key` objects, accessible via that key's `Field()`.
 //
 //nolint:interfacebloat
 type Set interface {

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lestrrat-go/jwx/v4/internal/base64"
 	"github.com/lestrrat-go/jwx/v4/internal/json"
 	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwk/jwkbb"
 	"github.com/lestrrat-go/option/v3"
 )
 
@@ -552,8 +553,26 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 		defer setter.setRejectDuplicateKID(false)
 	}
 
-	if err := json.Unmarshal(src, s); err != nil {
-		return nil, parseerr(`failed to unmarshal JWK set: %w`, err)
+	// Dispatch JWK-vs-JWKS up front. Set.UnmarshalJSON / UnmarshalJSONFrom
+	// require JWKS shape; the bare-JWK convenience lives here.
+	if jwkbb.HeaderHas(jwkbb.HeaderParse(src), "keys") {
+		if err := json.Unmarshal(src, s); err != nil {
+			return nil, parseerr(`failed to unmarshal JWK set: %w`, err)
+		}
+	} else {
+		key, err := doParseKey(src, options...)
+		if err != nil {
+			return nil, parseerr(`failed to parse sole key: %w`, err)
+		}
+		if err := s.AddKey(key); err != nil {
+			return nil, parseerr(`failed to add jwk.Key to set: %w`, err)
+		}
+	}
+
+	if rejectDupKid {
+		if kid, dup := firstDuplicateKID(s); dup {
+			return nil, parseerr(`duplicate "kid" %q`, kid)
+		}
 	}
 
 	return s, nil

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -549,8 +549,11 @@ func TestParse(t *testing.T) {
 	verify := func(t *testing.T, src string, expected reflect.Type) {
 		t.Helper()
 		t.Run("json.Unmarshal", func(t *testing.T) {
+			// json.Unmarshal targets the Set type directly, which
+			// requires JWKS shape. For unknown-shape input use
+			// jwk.Parse, which dispatches between bare JWK and JWKS.
 			set := jwk.NewSet()
-			err := json.Unmarshal([]byte(src), set)
+			err := json.Unmarshal([]byte(`{"keys":[`+src+`]}`), set)
 			require.NoError(t, err, `json.Unmarshal should succeed`)
 
 			require.True(t, set.Len() > 0, "set.Keys should be greater than 0")
@@ -2679,6 +2682,51 @@ func TestMaxKeys(t *testing.T) {
 		set, err := jwk.Parse(buildPEM(5), jwk.WithX509(true), jwk.WithMaxKeys(5))
 		require.NoError(t, err, `jwk.Parse should accept exactly the per-call PEM limit`)
 		require.Equal(t, 5, set.Len())
+	})
+
+	t.Run("cap fires from streaming UnmarshalJSONFrom", func(t *testing.T) {
+		// Valid 3-element JWKS with cap=2. With the streaming
+		// UnmarshalJSONFrom hooked into jsonv2, the (cap+1)-th
+		// element is never tokenized — the cap check fires after
+		// reading element 2 and before peeking element 3.
+		input := []byte(`{"keys":[{"kty":"oct","k":"AAAA"},{"kty":"oct","k":"BBBB"},{"kty":"oct","k":"CCCC"}]}`)
+		_, err := jwk.Parse(input, jwk.WithMaxKeys(2))
+		require.Error(t, err, `jwk.Parse should reject input that exceeds the cap`)
+		require.ErrorIs(t, err, jwk.ParseError())
+		require.Contains(t, err.Error(), `too many keys`,
+			`cap error should be reported, not a downstream parse error: %v`, err)
+	})
+
+	t.Run("allocations scale with cap, not with input length", func(t *testing.T) {
+		// Discriminator for materialize-then-check vs stream-then-cap:
+		// the streaming decoder stops touching elements past the cap,
+		// so allocation should scale with the cap, not with the
+		// (much larger) input element count. We assert a relative
+		// bound — capped parse must allocate much less than an
+		// uncapped parse of the same input — so the test stays
+		// stable across Go and jsonv2 versions.
+		buildLargeJWKS := func(n int) []byte {
+			var buf bytes.Buffer
+			buf.WriteString(`{"keys":[`)
+			for i := 0; i < n; i++ {
+				if i > 0 {
+					buf.WriteByte(',')
+				}
+				buf.WriteString(`{"kty":"oct","k":"AAAA"}`)
+			}
+			buf.WriteString(`]}`)
+			return buf.Bytes()
+		}
+		input := buildLargeJWKS(1000)
+		allocsCapped := testing.AllocsPerRun(10, func() {
+			_, _ = jwk.Parse(input, jwk.WithMaxKeys(2))
+		})
+		allocsUncapped := testing.AllocsPerRun(10, func() {
+			_, _ = jwk.Parse(input, jwk.WithMaxKeys(1001))
+		})
+		require.Less(t, allocsCapped*4, allocsUncapped,
+			`capped parse should allocate much less than uncapped; capped=%.0f uncapped=%.0f`,
+			allocsCapped, allocsUncapped)
 	})
 }
 

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -2708,7 +2708,7 @@ func TestMaxKeys(t *testing.T) {
 		buildLargeJWKS := func(n int) []byte {
 			var buf bytes.Buffer
 			buf.WriteString(`{"keys":[`)
-			for i := 0; i < n; i++ {
+			for i := range n {
 				if i > 0 {
 					buf.WriteByte(',')
 				}

--- a/jwk/set.go
+++ b/jwk/set.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/lestrrat-go/jwx/v4/internal/json"
 	"github.com/lestrrat-go/jwx/v4/internal/pool"
-	"github.com/lestrrat-go/jwx/v4/jwk/jwkbb"
 )
 
 const keysKey = `keys` // appease linter
@@ -214,7 +213,21 @@ func (s *set) setRejectDuplicateKID(v bool) {
 	s.rejectDuplicateKID = v
 }
 
+// UnmarshalJSON delegates to UnmarshalJSONFrom so the streaming /
+// cap-before-allocate behavior is identical for stdlib v1 callers
+// (encoding/json) and jsonv2 callers. This entry point requires JWKS
+// shape — bare JWK input is rejected here. Callers that don't know
+// the shape ahead of time should use [Parse], which dispatches.
 func (s *set) UnmarshalJSON(data []byte) error {
+	return s.UnmarshalJSONFrom(jsontext.NewDecoder(bytes.NewReader(data)))
+}
+
+// UnmarshalJSONFrom streams the JWKS document via the supplied decoder.
+// The "keys" array is read element-by-element with the per-Set cap
+// (or the global default) enforced BEFORE the (cap+1)-th element is
+// tokenized — an attacker-controlled input length cannot force
+// allocation past the cap.
+func (s *set) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -230,28 +243,12 @@ func (s *set) UnmarshalJSON(data []byte) error {
 		ignoreParseError = dc.IgnoreParseError()
 	}
 
-	// jwk.Parse and direct json.Unmarshal accept either a JWKS document
-	// or a single bare JWK. Decide which one we have up front so the
-	// JWKS-level streaming pass only runs when "keys" is actually
-	// present — otherwise top-level fields would be misclassified as
-	// JWKS-level extension members instead of the single key's own
-	// members.
-	if !jwkbb.HeaderHas(jwkbb.HeaderParse(data), "keys") {
-		key, err := doParseKey(data, options...)
-		if err != nil {
-			return fmt.Errorf(`failed to parse sole key in key set: %w`, err)
-		}
-		s.keys = append(s.keys, key)
-		return nil
-	}
-
 	maxK := s.maxKeys
 	if maxK <= 0 {
 		maxK = int(maxKeys.Load())
 	}
 	rejectDupKid := s.rejectDuplicateKID || rejectDuplicateKID.Load()
 
-	dec := json.NewDecoder(bytes.NewReader(data))
 	tok, err := dec.ReadToken()
 	if err != nil {
 		return fmt.Errorf(`error reading token: %w`, err)
@@ -267,25 +264,33 @@ func (s *set) UnmarshalJSON(data []byte) error {
 		fieldName := tok.String()
 		switch fieldName {
 		case "keys":
-			var list []json.RawMessage
-			if err := json.UnmarshalDecode(dec, &list); err != nil {
+			tok, err := dec.ReadToken()
+			if err != nil {
 				return fmt.Errorf(`failed to decode "keys": %w`, err)
 			}
-
-			if len(list) > maxK {
-				return fmt.Errorf(`too many keys in "keys" array: got %d, max %d`, len(list), maxK)
+			if tok.Kind() != '[' {
+				return fmt.Errorf(`failed to decode "keys": expected '[' but got '%c'`, tok.Kind())
 			}
 
 			var seenKIDs map[string]struct{}
 			if rejectDupKid {
-				seenKIDs = make(map[string]struct{}, len(list))
+				seenKIDs = make(map[string]struct{})
 			}
-			for i, keysrc := range list {
-				key, err := doParseKey(keysrc, options...)
+			var i int
+			for dec.PeekKind() != ']' {
+				if i >= maxK {
+					return fmt.Errorf(`too many keys in "keys" array: max %d`, maxK)
+				}
+				raw, err := dec.ReadValue()
+				if err != nil {
+					return fmt.Errorf(`failed to decode "keys": %w`, err)
+				}
+				key, err := doParseKey([]byte(raw), options...)
 				if err != nil {
 					if !ignoreParseError {
 						return fmt.Errorf(`failed to decode key #%d in "keys": %w`, i, err)
 					}
+					i++
 					continue
 				}
 				if seenKIDs != nil {
@@ -297,6 +302,10 @@ func (s *set) UnmarshalJSON(data []byte) error {
 					}
 				}
 				s.keys = append(s.keys, key)
+				i++
+			}
+			if _, err := dec.ReadToken(); err != nil {
+				return fmt.Errorf(`failed to decode "keys": %w`, err)
 			}
 		default:
 			var v any
@@ -310,7 +319,6 @@ func (s *set) UnmarshalJSON(data []byte) error {
 			s.privateParams[fieldName] = v
 		}
 	}
-	// consume closing '}'
 	if _, err := dec.ReadToken(); err != nil {
 		return fmt.Errorf(`error reading closing token: %w`, err)
 	}


### PR DESCRIPTION
- `Set.UnmarshalJSON` materialized the entire `keys` array into a `[]json.RawMessage` slice before checking the configured cap, so an attacker-controlled JWKS could force allocation of the full input length even when the cap was tiny. The cap was a post-allocation check, not a pre-allocation guard.
- Add `Set.UnmarshalJSONFrom(*jsontext.Decoder)`. jsonv2 prefers it over the legacy `UnmarshalJSON([]byte)` and hands us a streaming decoder, so the JWKS is read element-by-element and the cap check fires before the (cap+1)-th element is tokenized. `UnmarshalJSON` delegates to it for stdlib v1 callers.
- Move JWK-vs-JWKS dispatch from `Set.UnmarshalJSON*` up to `jwk.Parse`. `Set` unmarshalling is JWKS-shape-only now; bare JWK input via `json.Unmarshal(data, jwk.NewSet())` is rejected. The `Set` godoc was already steering callers at `jwk.Parse` for unknown-shape input; updated to make the contract explicit.
- Tests cover the cap firing on streaming input (3-element JWKS with cap=2) and assert that capped allocation is materially smaller than uncapped on a 1000-element input. Existing `TestParse/.../json.Unmarshal` subtests updated to wrap their bare-JWK fixtures in `{"keys":[...]}`.