### PR TITLE
jwk: stream the keys array with cap-before-allocate

### DIFF
--- a/jwk/interface.go
+++ b/jwk/interface.go
@@ -41,15 +41,17 @@ const (
 
 // Set represents JWKS object, a collection of jwk.Key objects.
 //
-// Sets can be safely converted to and from JSON using the standard
-// `"encoding/json".Marshal` and `"encoding/json".Unmarshal`. However,
-// if you do not know if the payload contains a single JWK or a JWK set,
-// consider using `jwk.Parse()` to always get a `jwk.Set` out of it.
+// Sets can be marshaled and unmarshaled with the standard
+// `"encoding/json".Marshal` and `"encoding/json".Unmarshal`. The
+// unmarshal path requires JWKS shape (an object with a "keys" field).
+// For input that may be either a single bare JWK or a JWKS, use
+// [Parse], which dispatches between the two shapes and always returns
+// a `jwk.Set`.
 //
-// Since v1.2.12, JWK sets with private parameters can be parsed as well.
-// Such private parameters can be accessed via the `Field()` method.
-// If a resource contains a single JWK instead of a JWK set, private parameters
-// are stored in _both_ the resulting `jwk.Set` object and the `jwk.Key` object .
+// JWKS-level extension members (any top-level field other than "keys")
+// are preserved as set-level private parameters and are accessible via
+// the `Field()` method. Per-key extension members live on the
+// individual `jwk.Key` objects, accessible via that key's `Field()`.
 //
 //nolint:interfacebloat
 type Set interface {

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -19,6 +19,7 @@ import (
 	"github.com/lestrrat-go/jwx/v3/internal/base64"
 	"github.com/lestrrat-go/jwx/v3/internal/json"
 	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk/jwkbb"
 )
 
 var fieldRegistry = json.NewRegistry()
@@ -448,8 +449,26 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 		defer setter.setRejectDuplicateKID(false)
 	}
 
-	if err := json.Unmarshal(src, s); err != nil {
-		return nil, parseerr(`failed to unmarshal JWK set: %w`, err)
+	// Dispatch JWK-vs-JWKS up front. Set.UnmarshalJSON requires JWKS
+	// shape; the bare-JWK convenience lives here.
+	if jwkbb.HeaderHas(jwkbb.HeaderParse(src), "keys") {
+		if err := json.Unmarshal(src, s); err != nil {
+			return nil, parseerr(`failed to unmarshal JWK set: %w`, err)
+		}
+	} else {
+		key, err := ParseKey(src, options...)
+		if err != nil {
+			return nil, parseerr(`failed to parse sole key: %w`, err)
+		}
+		if err := s.AddKey(key); err != nil {
+			return nil, parseerr(`failed to add jwk.Key to set: %w`, err)
+		}
+	}
+
+	if rejectDupKid {
+		if kid, dup := firstDuplicateKID(s); dup {
+			return nil, parseerr(`duplicate "kid" %q`, kid)
+		}
 	}
 
 	return s, nil

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -3009,7 +3009,7 @@ func TestMaxKeys(t *testing.T) {
 		buildLargeJWKS := func(n int) []byte {
 			var buf bytes.Buffer
 			buf.WriteString(`{"keys":[`)
-			for i := 0; i < n; i++ {
+			for i := range n {
 				if i > 0 {
 					buf.WriteByte(',')
 				}

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -318,8 +318,11 @@ func TestParse(t *testing.T) {
 	verify := func(t *testing.T, src string, expected reflect.Type) {
 		t.Helper()
 		t.Run("json.Unmarshal", func(t *testing.T) {
+			// json.Unmarshal targets the Set type directly, which
+			// requires JWKS shape. For unknown-shape input use
+			// jwk.Parse, which dispatches between bare JWK and JWKS.
 			set := jwk.NewSet()
-			err := json.Unmarshal([]byte(src), set)
+			err := json.Unmarshal([]byte(`{"keys":[`+src+`]}`), set)
 			require.NoError(t, err, `json.Unmarshal should succeed`)
 
 			require.True(t, set.Len() > 0, "set.Keys should be greater than 0")
@@ -2981,6 +2984,50 @@ func TestMaxKeys(t *testing.T) {
 		set, err := jwk.Parse(buildPEM(5), jwk.WithPEM(true), jwk.WithMaxKeys(5))
 		require.NoError(t, err, `jwk.Parse should accept exactly the per-call PEM limit`)
 		require.Equal(t, 5, set.Len())
+	})
+
+	t.Run("cap fires from streaming UnmarshalJSON", func(t *testing.T) {
+		// Valid 3-element JWKS with cap=2. The streaming
+		// UnmarshalJSON reads element-by-element and the cap check
+		// fires after reading element 2 and before decoding element 3.
+		input := []byte(`{"keys":[{"kty":"oct","k":"AAAA"},{"kty":"oct","k":"BBBB"},{"kty":"oct","k":"CCCC"}]}`)
+		_, err := jwk.Parse(input, jwk.WithMaxKeys(2))
+		require.Error(t, err, `jwk.Parse should reject input that exceeds the cap`)
+		require.ErrorIs(t, err, jwk.ParseError())
+		require.Contains(t, err.Error(), `too many keys`,
+			`cap error should be reported, not a downstream parse error: %v`, err)
+	})
+
+	t.Run("allocations scale with cap, not with input length", func(t *testing.T) {
+		// Discriminator for materialize-then-check vs stream-then-cap:
+		// the streaming decoder stops touching elements past the cap,
+		// so allocation should scale with the cap, not with the
+		// (much larger) input element count. We assert a relative
+		// bound — capped parse must allocate much less than an
+		// uncapped parse of the same input — so the test stays
+		// stable across Go versions.
+		buildLargeJWKS := func(n int) []byte {
+			var buf bytes.Buffer
+			buf.WriteString(`{"keys":[`)
+			for i := 0; i < n; i++ {
+				if i > 0 {
+					buf.WriteByte(',')
+				}
+				buf.WriteString(`{"kty":"oct","k":"AAAA"}`)
+			}
+			buf.WriteString(`]}`)
+			return buf.Bytes()
+		}
+		input := buildLargeJWKS(1000)
+		allocsCapped := testing.AllocsPerRun(10, func() {
+			_, _ = jwk.Parse(input, jwk.WithMaxKeys(2))
+		})
+		allocsUncapped := testing.AllocsPerRun(10, func() {
+			_, _ = jwk.Parse(input, jwk.WithMaxKeys(1001))
+		})
+		require.Less(t, allocsCapped*4, allocsUncapped,
+			`capped parse should allocate much less than uncapped; capped=%.0f uncapped=%.0f`,
+			allocsCapped, allocsUncapped)
 	})
 }
 

--- a/jwk/set.go
+++ b/jwk/set.go
@@ -11,7 +11,6 @@ import (
 	"github.com/lestrrat-go/jwx/v3/internal/json"
 	"github.com/lestrrat-go/jwx/v3/internal/pool"
 	"github.com/lestrrat-go/jwx/v3/internal/tokens"
-	"github.com/lestrrat-go/jwx/v3/jwk/jwkbb"
 )
 
 const keysKey = `keys` // appease linter
@@ -216,6 +215,12 @@ func (s *set) setRejectDuplicateKID(v bool) {
 	s.rejectDuplicateKID = v
 }
 
+// UnmarshalJSON streams a JWKS document. The "keys" array is read
+// element-by-element with the configured cap enforced BEFORE the
+// (cap+1)-th element is decoded — an attacker-controlled input length
+// cannot force allocation past the cap. This entry point requires
+// JWKS shape; bare JWK input is rejected here. Callers that don't
+// know the shape ahead of time should use [Parse], which dispatches.
 func (s *set) UnmarshalJSON(data []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -230,21 +235,6 @@ func (s *set) UnmarshalJSON(data []byte) error {
 			options = append(options, withLocalRegistry(localReg))
 		}
 		ignoreParseError = dc.IgnoreParseError()
-	}
-
-	// jwk.Parse and direct json.Unmarshal accept either a JWKS document
-	// or a single bare JWK. Decide which one we have up front so the
-	// JWKS-level streaming pass only runs when "keys" is actually
-	// present — otherwise top-level fields would be misclassified as
-	// JWKS-level extension members instead of the single key's own
-	// members.
-	if !jwkbb.HeaderHas(jwkbb.HeaderParse(data), "keys") {
-		key, err := ParseKey(data, options...)
-		if err != nil {
-			return fmt.Errorf(`failed to parse sole key in key set: %w`, err)
-		}
-		s.keys = append(s.keys, key)
-		return nil
 	}
 
 	maxK := s.maxKeys
@@ -263,9 +253,7 @@ LOOP:
 
 		switch tok := tok.(type) {
 		case json.Delim:
-			// Assuming we're doing everything correctly, we should ONLY
-			// get either tokens.OpenCurlyBracket or tokens.CloseCurlyBracket here.
-			if tok == tokens.CloseCurlyBracket { // End of object
+			if tok == tokens.CloseCurlyBracket {
 				break LOOP
 			} else if tok != tokens.OpenCurlyBracket {
 				return fmt.Errorf(`expected '%c' but got '%c'`, tokens.OpenCurlyBracket, tok)
@@ -273,25 +261,34 @@ LOOP:
 		case string:
 			switch tok {
 			case "keys":
-				var list []json.RawMessage
-				if err := dec.Decode(&list); err != nil {
+				openTok, err := dec.Token()
+				if err != nil {
 					return fmt.Errorf(`failed to decode "keys": %w`, err)
 				}
-
-				if len(list) > maxK {
-					return fmt.Errorf(`too many keys in "keys" array: got %d, max %d`, len(list), maxK)
+				openDelim, ok := openTok.(json.Delim)
+				if !ok || openDelim != tokens.OpenSquareBracket {
+					return fmt.Errorf(`failed to decode "keys": expected '%c' but got %v`, tokens.OpenSquareBracket, openTok)
 				}
 
 				var seenKIDs map[string]struct{}
 				if rejectDupKid {
-					seenKIDs = make(map[string]struct{}, len(list))
+					seenKIDs = make(map[string]struct{})
 				}
-				for i, keysrc := range list {
-					key, err := ParseKey(keysrc, options...)
+				var i int
+				for dec.More() {
+					if i >= maxK {
+						return fmt.Errorf(`too many keys in "keys" array: max %d`, maxK)
+					}
+					var raw json.RawMessage
+					if err := dec.Decode(&raw); err != nil {
+						return fmt.Errorf(`failed to decode "keys": %w`, err)
+					}
+					key, err := ParseKey(raw, options...)
 					if err != nil {
 						if !ignoreParseError {
 							return fmt.Errorf(`failed to decode key #%d in "keys": %w`, i, err)
 						}
+						i++
 						continue
 					}
 					if seenKIDs != nil {
@@ -303,6 +300,15 @@ LOOP:
 						}
 					}
 					s.keys = append(s.keys, key)
+					i++
+				}
+				closeTok, err := dec.Token()
+				if err != nil {
+					return fmt.Errorf(`failed to decode "keys": %w`, err)
+				}
+				closeDelim, ok := closeTok.(json.Delim)
+				if !ok || closeDelim != tokens.CloseSquareBracket {
+					return fmt.Errorf(`failed to decode "keys": expected '%c' but got %v`, tokens.CloseSquareBracket, closeTok)
 				}
 			default:
 				var v any


### PR DESCRIPTION
v3 backport of #2136.

- `Set.UnmarshalJSON` materialized the entire `keys` array into a `[]json.RawMessage` slice before checking the configured cap, so an attacker-controlled JWKS could force allocation of the full input length even when the cap was tiny. The cap was a post-allocation check, not a pre-allocation guard.
- Stream the `keys` array element-by-element with the cap enforced BEFORE the (cap+1)-th element is decoded. v3 uses `encoding/json` v1 (no `UnmarshalJSONFrom` interface needed) — the streaming sits directly in `Set.UnmarshalJSON`, which v1 calls with raw bytes (no pre-validation).
- Move JWK-vs-JWKS dispatch from `Set.UnmarshalJSON` up to `jwk.Parse`. `Set` unmarshalling is JWKS-shape-only now; bare JWK input via `json.Unmarshal(data, jwk.NewSet())` is rejected. The `Set` godoc was already steering callers at `jwk.Parse` for unknown-shape input; updated to make the contract explicit.
- Tests cover the cap firing on streaming input (3-element JWKS with cap=2) and assert that capped allocation is materially smaller than uncapped on a 1000-element input. Existing `TestParse/.../json.Unmarshal` subtests updated to wrap their bare-JWK fixtures in `{"keys":[...]}`.