### PR TITLE
jwk: probe tolerates duplicate JSON field names

### DIFF
--- a/jwk/parser.go
+++ b/jwk/parser.go
@@ -215,7 +215,13 @@ func (pt *probeTarget) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 		key := tok.String()
 
 		def, ok := pt.kp.jsonKeys[key]
-		if !ok || remaining <= 0 {
+		// Skip when: the key is not registered for probing, we've
+		// already filled every slot, OR this slot is already filled
+		// (a duplicate occurrence of an earlier field — first-wins).
+		// Without the duplicate-skip, N repeats of one field would
+		// drain `remaining` and prevent later registered fields from
+		// being read, silently misclassifying the key.
+		if !ok || remaining <= 0 || pt.results[def.index] != nil {
 			if err := dec.SkipValue(); err != nil {
 				return err
 			}

--- a/jwk/probe_test.go
+++ b/jwk/probe_test.go
@@ -7,6 +7,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestProbeToleratesDuplicateFieldNames exercises the probe's
+// duplicate-key handling. The probe pass intentionally allows
+// duplicate JSON member names (jsontext.AllowDuplicateNames(true))
+// so probe failure on duplicates can't be turned into denial-of-
+// service. The internal "remaining" counter must not be drained by
+// repeated occurrences of the same field, otherwise N duplicate "kty"
+// entries (where N = number of registered probe fields) will prevent
+// later fields like "d" from being read — which would silently
+// misclassify a private key as public.
+func TestProbeToleratesDuplicateFieldNames(t *testing.T) {
+	const dKey = "AAAA"
+	src := []byte(`{"kty":"RSA","kty":"RSA","kty":"RSA","d":"` + dKey + `"}`)
+
+	probe, err := keyProbe.Probe(src)
+	require.NoError(t, err, `Probe should succeed`)
+
+	dV, ok := probe.Field("D")
+	require.True(t, ok, `probe should detect "d" even when "kty" appears multiple times`)
+	require.NotNil(t, dV, `probe.Field("D") value should be non-nil`)
+}
+
 // TestProbeFieldRegistrationConcurrent exercises the race between
 // RegisterProbeField (mutating the prober's field/name maps) and
 // concurrent KeyProbe.Field reads on a KeyProbe captured from an


### PR DESCRIPTION
- The probe pass at `jwk/parser.go` allows duplicate JSON member names by design (`jsontext.AllowDuplicateNames(true)`), but the inner loop decremented its `remaining` counter on every observed registered field — including duplicates. With N registered probe fields and N+ duplicate `kty` entries, the counter drained before later registered fields like `d` or `priv` were read, silently misclassifying a private key as public. Today the second-pass `json.Unmarshal` rejects duplicate names and errors out before the misclassified key reaches any cryptographic path, so the bug is latent — but the probe-internal correctness invariant ("we definitely saw `d` if it was present") was broken, and any future loosening of the second-pass policy would turn this into a private/public misclassification primitive.
- First-wins per registered field: skip when `pt.results[def.index] != nil`, decrement `remaining` only on the first occurrence. Tolerates duplicates the same way stdlib `encoding/json` does for struct unmarshal.
- Internal regression test (`TestProbeToleratesDuplicateFieldNames`) feeds three duplicate `kty` entries followed by `d` and asserts the probe surfaces `d`.