### PR TITLE
jwk: treat nil key from custom KeyParser as continue, not success

### DIFF
--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -441,6 +441,13 @@ func doParseKey(data []byte, options ...ParseOption) (Key, error) {
 		parser := parsers[i]
 		key, err := parser.ParseKey(probe, &unmarshaler, data)
 		if err == nil {
+			// A buggy custom parser may return (nil, nil); treat
+			// that as if it had returned ContinueError so the next
+			// parser runs instead of handing the caller a nil Key
+			// they will dereference.
+			if key == nil {
+				continue
+			}
 			if err := validateReturnedKey(key); err != nil {
 				return nil, fmt.Errorf(`jwk.Parse: %w`, err)
 			}

--- a/jwk/validation_boundary_test.go
+++ b/jwk/validation_boundary_test.go
@@ -28,6 +28,28 @@ func (invalidReturningParser) ParseKey(_ *jwk.KeyProbe, _ jwk.KeyUnmarshaler, pa
 
 var registerInvalidImporterOnce sync.Once
 var registerInvalidParserOnce sync.Once
+var registerNilNilParserOnce sync.Once
+
+type nilNilReturningParser struct{}
+
+func (nilNilReturningParser) ParseKey(_ *jwk.KeyProbe, _ jwk.KeyUnmarshaler, payload []byte) (jwk.Key, error) {
+	if !bytes.Contains(payload, []byte(`"force-nil-parser":true`)) {
+		return nil, jwk.ContinueError()
+	}
+	// Intentional bug pattern under test: a buggy parser may return
+	// (nil, nil); jwk.ParseKey must treat it as ContinueError, not as
+	// a successful nil-Key result that gets handed back to the caller.
+	//nolint:nilnil
+	return nil, nil
+}
+
+func registerNilNilParser(t *testing.T) {
+	t.Helper()
+	registerNilNilParserOnce.Do(func() {
+		err := jwk.RegisterKeyParser(nilNilReturningParser{})
+		require.NoError(t, err)
+	})
+}
 
 func makeInvalidECDSAJWK() (jwk.Key, error) {
 	raw, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -108,4 +130,17 @@ func TestParseKeyRejectsInvalidKeyFromCustomParser(t *testing.T) {
 	_, err := jwk.ParseKey([]byte(`{"kty":"EC","force-invalid-parser":true}`))
 	require.Error(t, err)
 	require.True(t, jwk.IsKeyValidationError(err), `ParseKey should validate keys returned from custom parsers`)
+}
+
+// A buggy KeyParser returning (nil, nil) must not be treated as a
+// successful parse: the caller would receive a nil jwk.Key with nil
+// error and panic on the next method call. The dispatch should treat
+// (nil, nil) the same as ContinueError and fall through to the next
+// registered parser.
+func TestParseKeyContinuesPastNilNilCustomParser(t *testing.T) {
+	registerNilNilParser(t)
+
+	key, err := jwk.ParseKey([]byte(`{"kty":"oct","k":"AAAA","force-nil-parser":true}`))
+	require.NoError(t, err, `ParseKey should fall through to the default parser, not return (nil, nil)`)
+	require.NotNil(t, key, `ParseKey must not return a nil Key`)
 }


### PR DESCRIPTION
- A registered custom `KeyParser` that returns `(nil, nil)` propagated a nil `jwk.Key` with nil error all the way back to the caller of `jwk.Parse` / `jwk.ParseKey`. Any subsequent method call on that nil Key panics with a nil-receiver dereference. `validateReturnedKey(nil)` was a no-op and let the value through.
- In the parser-dispatch loop in `doParseKey`, when the parser returned `(nil, nil)`, treat it as if `ContinueError` had been returned and continue to the next parser. The default parser then runs as usual.
- Regression test registers a parser that returns `(nil, nil)` only when the input carries a marker field, then asserts `jwk.ParseKey` produces a non-nil key for a valid oct JWK with that marker.