### PR TITLE
jwk: treat nil key from custom KeyParser as continue, not success

### DIFF
--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -322,6 +322,13 @@ func doParseKey(data []byte, options ...ParseOption) (Key, error) {
 		parser := parsers[i]
 		key, err := parser.ParseKey(probe, &unmarshaler, data)
 		if err == nil {
+			// A buggy custom parser may return (nil, nil); treat
+			// that as if it had returned ContinueError so the next
+			// parser runs instead of handing the caller a nil Key
+			// they will dereference.
+			if key == nil {
+				continue
+			}
 			return key, nil
 		}
 

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -326,6 +326,32 @@ func TestParseKeyError(t *testing.T) {
 	})
 }
 
+type nilNilReturningParser struct{}
+
+func (nilNilReturningParser) ParseKey(_ *jwk.KeyProbe, _ jwk.KeyUnmarshaler, payload []byte) (jwk.Key, error) {
+	if !bytes.Contains(payload, []byte(`"force-nil-parser":true`)) {
+		return nil, jwk.ContinueError()
+	}
+	// Intentional bug pattern under test: a buggy parser may return
+	// (nil, nil); jwk.ParseKey must treat it as ContinueError, not as
+	// a successful nil-Key result that gets handed back to the caller.
+	//nolint:nilnil
+	return nil, nil
+}
+
+// A buggy KeyParser returning (nil, nil) must not be treated as a
+// successful parse: the caller would receive a nil jwk.Key with nil
+// error and panic on the next method call. The dispatch should treat
+// (nil, nil) the same as ContinueError and fall through to the next
+// registered parser.
+func TestParseKeyContinuesPastNilNilCustomParser(t *testing.T) {
+	jwk.RegisterKeyParser(nilNilReturningParser{})
+
+	key, err := jwk.ParseKey([]byte(`{"kty":"oct","k":"AAAA","force-nil-parser":true}`))
+	require.NoError(t, err, `ParseKey should fall through to the default parser, not return (nil, nil)`)
+	require.NotNil(t, key, `ParseKey must not return a nil Key`)
+}
+
 func TestParse(t *testing.T) {
 	t.Parallel()
 	verify := func(t *testing.T, src string, expected reflect.Type) {


### PR DESCRIPTION
v3 backport of #2139.

- A registered custom `KeyParser` that returns `(nil, nil)` propagated a nil `jwk.Key` with nil error all the way back to the caller of `jwk.Parse` / `jwk.ParseKey`. Any subsequent method call on that nil Key panics with a nil-receiver dereference.
- In the parser-dispatch loop in `ParseKey`, when the parser returned `(nil, nil)`, treat it as if `ContinueError` had been returned and continue to the next parser. The default parser then runs as usual.
- Regression test registers a parser that returns `(nil, nil)` only when the input carries a marker field, then asserts `jwk.ParseKey` produces a non-nil key for a valid oct JWK with that marker.