### PR TITLE
jwk: fix phantom ContinueParseError refs and unmarshaler typo in docs

### DIFF
--- a/jwk/doc.go
+++ b/jwk/doc.go
@@ -177,9 +177,9 @@
 //	     var hint string
 //	     if err := probe.Get("MyHint", &hint); err != nil {
 //	        // if it doesn't have the `my_hint` field, it probably means
-//	        // it's not for us, so we return ContinueParseError so that
+//	        // it's not for us, so we return ContinueError so that
 //	        // the next parser can pick it up
-//	        return nil, jwk.ContinueParseError()
+//	        return nil, jwk.ContinueError()
 //	     }
 //
 //	     // Use hint to determine concrete key type
@@ -190,7 +190,7 @@
 //			  ...
 //	     }
 //
-//	     return unmarshaler.Unmarshal(data, key)
+//	     return unmarshaler.UnmarshalKey(data, key)
 //	   }
 //
 // ## Registering KeyImporter/KeyExporter

--- a/jwk/parser.go
+++ b/jwk/parser.go
@@ -21,7 +21,7 @@ type KeyParser interface {
 	// If your KeyParser decides that the payload is not something
 	// you can parse, and you would like to continue parsing with
 	// the remaining KeyParser instances that are registered,
-	// return a `jwk.ContinueParseError`. Any other errors will immediately
+	// return a `jwk.ContinueError()`. Any other errors will immediately
 	// halt the parsing process.
 	//
 	// When unmarshaling JSON, use the unmarshaler object supplied as


### PR DESCRIPTION
v3 backport of the v4 doc fix.

- Both `jwk/parser.go` (godoc on `KeyParser.ParseKey`) and `jwk/doc.go` (worked example for custom KeyParser) referenced `jwk.ContinueParseError` — a symbol that doesn't exist. The actual sentinel is `jwk.ContinueError()`. Copy-pasting the documented example failed `go build`.
- Same example also called `unmarshaler.Unmarshal(data, key)`; the actual `KeyUnmarshaler` method is `UnmarshalKey`.
- Pure documentation: replaced both phantom names with the real ones.