### PR TITLE
jwk: add UnknownKeyTypeError typed error

### DIFF
--- a/.claude/docs/error-formatting.md
+++ b/.claude/docs/error-formatting.md
@@ -43,6 +43,7 @@ Only `jwt.UnknownPayloadTypeError()` remains a sentinel function (no struct type
 | Type | Structured Fields | Meaning |
 |------|------------------|---------|
 | `KeyTypeMismatchError` | `Got`, `Want` (both `reflect.Type`) | Generic type parameter on `Import[T]` / `ParseKeyAs[T]` does not match the resolved key type |
+| `UnknownKeyTypeError` | `KeyType` (string; empty when `kty` was missing) | Probe couldn't resolve `kty` to a known key family. Empty `KeyType` = `kty` field absent or non-string; populated = `kty` was a string but unrecognized |
 | `FieldNotFoundError` | `Name` | Field not present (`jwk.Get` miss) |
 | `FieldTypeMismatchError` | `Name`, `Got`, `Want` | Field present but wrong type (`jwk.Get` type assertion failed) |
 

--- a/jwk/errors.go
+++ b/jwk/errors.go
@@ -126,6 +126,41 @@ func typeName(t reflect.Type) string {
 }
 
 //-------------------------------------------------------------------
+// UnknownKeyTypeError
+//-------------------------------------------------------------------
+
+// UnknownKeyTypeError is returned by [Parse] / [ParseKey] / [ParseKeyAs]
+// when the input's "kty" hint cannot be resolved to a known key
+// family.
+//
+// KeyType is empty when the input had no "kty" field at all, or when
+// "kty" was present but not a JSON string (the probe could not extract
+// a usable identifier). KeyType is populated when the input carried a
+// string "kty" that didn't match any registered key family — useful
+// for callers that want to suggest installing an extension module.
+//
+// Use [errors.Is] with UnknownKeyTypeError{} to recognize the
+// condition, or [errors.AsType] to recover the KeyType field. The
+// error chain also satisfies [errors.Is] with [ParseError].
+type UnknownKeyTypeError struct {
+	// KeyType is the raw "kty" value the input carried, or "" when
+	// "kty" was missing or non-string.
+	KeyType string
+}
+
+func (e UnknownKeyTypeError) Error() string {
+	if e.KeyType == "" {
+		return `failed to get "kty" hint`
+	}
+	return fmt.Sprintf(`invalid key type from JSON (%s)`, e.KeyType)
+}
+
+func (UnknownKeyTypeError) Is(target error) bool {
+	_, ok := target.(UnknownKeyTypeError)
+	return ok
+}
+
+//-------------------------------------------------------------------
 // FieldNotFoundError
 //-------------------------------------------------------------------
 

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -483,6 +483,34 @@ func TestParseKey(t *testing.T) {
 		require.ErrorIs(t, err, jwk.ParseError(),
 			`single-key parse failure should satisfy errors.Is(err, jwk.ParseError())`)
 	})
+	// Probe-stage failures that boil down to "we couldn't determine
+	// the key type from the input" surface as jwk.UnknownKeyTypeError.
+	// The KeyType field is empty when "kty" was missing or non-string,
+	// and populated when "kty" was a string but didn't match a known
+	// or registered key family. Callers can branch on KeyType to log
+	// "install jwx-go/<extension> for kty=X" or skip the entry.
+	t.Run("UnknownKeyType/missing kty", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwk.ParseKey([]byte(`{"foo":"bar"}`))
+		require.Error(t, err)
+		require.ErrorIs(t, err, jwk.UnknownKeyTypeError{})
+		require.ErrorIs(t, err, jwk.ParseError(), `should also satisfy the ParseError sentinel`)
+
+		var unkErr jwk.UnknownKeyTypeError
+		require.ErrorAs(t, err, &unkErr)
+		require.Empty(t, unkErr.KeyType, `KeyType should be empty when kty was absent`)
+	})
+	t.Run("UnknownKeyType/unregistered kty", func(t *testing.T) {
+		t.Parallel()
+		_, err := jwk.ParseKey([]byte(`{"kty":"FOO-NOT-A-REAL-KTY"}`))
+		require.Error(t, err)
+		require.ErrorIs(t, err, jwk.UnknownKeyTypeError{})
+
+		var unkErr jwk.UnknownKeyTypeError
+		require.ErrorAs(t, err, &unkErr)
+		require.Equal(t, "FOO-NOT-A-REAL-KTY", unkErr.KeyType,
+			`KeyType should carry the unrecognized kty value`)
+	})
 }
 
 // TestParseKeyAs exercises the typed entry point and the

--- a/jwk/parser.go
+++ b/jwk/parser.go
@@ -64,7 +64,7 @@ func defaultParseKey(probe *KeyProbe, unmarshaler KeyUnmarshaler, data []byte) (
 	var key Key
 	ktyV, ok := probe.Field("Kty")
 	if !ok {
-		return nil, fmt.Errorf(`jwk.Parse: failed to get "kty" hint`)
+		return nil, fmt.Errorf(`jwk.Parse: %w`, UnknownKeyTypeError{})
 	}
 	kty, ok := ktyV.(string)
 	if !ok {
@@ -104,7 +104,7 @@ func defaultParseKey(probe *KeyProbe, unmarshaler KeyUnmarshaler, data []byte) (
 			key = newAKPPublicKey()
 		}
 	default:
-		return nil, fmt.Errorf(`invalid key type from JSON (%s)`, kty)
+		return nil, UnknownKeyTypeError{KeyType: kty}
 	}
 
 	if err := unmarshaler.UnmarshalKey(data, key); err != nil {


### PR DESCRIPTION
- Probe-stage failures from `jwk.Parse` / `jwk.ParseKey` / `jwk.ParseKeyAs` were untyped `fmt.Errorf` strings — callers couldn't distinguish "input had no usable kty" from "kty was a string but doesn't match a known family" without string-matching.
- Add `jwk.UnknownKeyTypeError{KeyType string}` (zero-value `Is` matching, follows the existing `KeyTypeMismatchError` / `FieldNotFoundError` pattern). Empty `KeyType` = `kty` was missing; populated = `kty` was a string but unrecognized — useful for callers that want to suggest installing an extension module.
- Wrap two reachable sites in `jwk/parser.go` (the missing-kty branch and the unknown-kty default arm). Visible error strings unchanged. The "kty hint is not a string" branch is unreachable in practice today (the probe's `readString` coerces non-string kty values into strings) and stays as-is.
- Regression test asserts `errors.Is(err, jwk.UnknownKeyTypeError{})` for both missing-kty and unknown-kty inputs, and that `errors.As` extracts the `KeyType` field for the unknown case.