### PR TITLE
MIGRATION: document PublicSetOf default-reject for symmetric keys

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -63,6 +63,7 @@ Text output labels each finding as `(auto)` or `(manual)`, with migration notes 
 | `jwk.InsecureWhitelist{}` / `jwk.MapWhitelist` / `jwk.RegexpWhitelist` / `jwk.WhitelistFunc` | `jwkfetch.InsecureWhitelist{}` / `jwkfetch.MapWhitelist` / `jwkfetch.RegexpWhitelist` / `jwkfetch.WhitelistFunc` | Extension module |
 | `jwk.WhitelistError()` | `jwkfetch.WhitelistError()` | Extension module |
 | `jwk.Fetcher` | `jwk.Fetcher` (unchanged name, new shape: `Fetch(ctx, url) (Set, error)` — no variadic options) | Core interface, no in-package implementation |
+| `jwk.PublicSetOf(set)` (silent pass-through for symmetric keys) | `jwk.PublicSetOf(set)` (returns error if any oct key is present) / `jwk.PublicSetOf(set, jwk.WithAllowSymmetric(true))` | Behavioral. Default-rejects sets containing symmetric keys to prevent accidental publication of secret material (e.g. as `/.well-known/jwks.json`). Pass `WithAllowSymmetric(true)` to opt into the v3 pass-through. |
 | `jws.WithVerifyAuto(f, fetchOpts...)` | `jws.WithVerifyAuto(f)` | Variadic options dropped; nil fetcher now errors instead of silently using `jwk.Fetch` |
 | `jwt.WithVerifyAuto(f, fetchOpts...)` | `jwt.WithVerifyAuto(f)` | Same as jws |
 | `jws.Signer2` | `jws.Signer` | Interface renamed |


### PR DESCRIPTION
- The v4 `PublicSetOf` godoc explains the default-reject-symmetric behavior, but `MIGRATION.md`'s Quick Reference table didn't mention it. Pre-v3.x users migrating to v4 hit the new default at runtime with no in-doc breadcrumb.
- Add a behavioral row to the jwk section pointing at `WithAllowSymmetric(true)` for the legacy pass-through.
- Companion `jwxmigrate` rule lands separately.