### PR TITLE
jwk: clarify that any value <= 0 disables the RSA strength floor

### DIFF
--- a/jwk/options.yaml
+++ b/jwk/options.yaml
@@ -92,7 +92,7 @@ options:
       accepted by JWK validation and raw/PEM/X.509 import.
 
       The default is 2048. Lower this only for legacy interoperability with
-      older key material. A value of 0 disables the modulus-size floor.
+      older key material. Any value <= 0 disables the modulus-size floor.
   - ident: MinRSAPublicExponent
     interface: GlobalOption
     argument_type: int
@@ -101,8 +101,8 @@ options:
       accepted by JWK validation and raw/PEM/X.509 import.
 
       The default is 3. The exponent must still be odd and fit in a Go `int`.
-      Lower this only for legacy interoperability. A value of 0 disables the
-      minimum-exponent floor.
+      Lower this only for legacy interoperability. Any value <= 0 disables
+      the minimum-exponent floor.
   - ident: MaxKeys
     interface: GlobalParseOption
     argument_type: int

--- a/jwk/options_gen.go
+++ b/jwk/options_gen.go
@@ -210,7 +210,7 @@ func WithMaxKeys(v int) GlobalParseOption {
 // accepted by JWK validation and raw/PEM/X.509 import.
 //
 // The default is 2048. Lower this only for legacy interoperability with
-// older key material. A value of 0 disables the modulus-size floor.
+// older key material. Any value <= 0 disables the modulus-size floor.
 func WithMinRSAModulusBits(v int) GlobalOption {
 	return &globalOption{option.New(identMinRSAModulusBits{}, v)}
 }
@@ -219,8 +219,8 @@ func WithMinRSAModulusBits(v int) GlobalOption {
 // accepted by JWK validation and raw/PEM/X.509 import.
 //
 // The default is 3. The exponent must still be odd and fit in a Go `int`.
-// Lower this only for legacy interoperability. A value of 0 disables the
-// minimum-exponent floor.
+// Lower this only for legacy interoperability. Any value <= 0 disables
+// the minimum-exponent floor.
 func WithMinRSAPublicExponent(v int) GlobalOption {
 	return &globalOption{option.New(identMinRSAPublicExponent{}, v)}
 }


### PR DESCRIPTION
- The godoc on `WithMinRSAModulusBits` and `WithMinRSAPublicExponent` only listed `0` as the disable sentinel, but the validator's `if minBits > 0` short-circuit also treats negative values as disable. A caller passing `-1` thinking "no floor" silently got exactly that.
- Update the option godoc (via `jwk/options.yaml`) to read "Any value <= 0 disables the floor" so the actual behavior is no surprise.
- Regenerated `jwk/options_gen.go`.