### PR TITLE
jwk: move extension-authoring walkthrough from doc.go to docs/04-jwk.md

### DIFF
--- a/docs/04-jwk.md
+++ b/docs/04-jwk.md
@@ -746,3 +746,122 @@ For convenience, the library provides pre-defined filters that include standard 
 - [`jwk.SymmetricStandardFieldsFilter()`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#SymmetricStandardFieldsFilter) - for symmetric keys
 
 These functions return filters configured to include the standard fields defined in the JWK specification for each key type.
+
+## Registering a custom key type
+
+The library supports adding new key types not implemented out of the
+box (e.g. a vendor-specific algorithm). The mechanism rests on four
+registration points:
+
+- `KeyProbe` — partial JSON unmarshaling that picks out hint fields used
+  to decide what concrete key type to construct. Add new hint fields with
+  [`jwk.RegisterProbeField[T]`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#RegisterProbeField).
+- `KeyParser` — converts a JSON payload into a `jwk.Key` using the
+  probe's hints. Register with [`jwk.RegisterKeyParser`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#RegisterKeyParser).
+- `KeyImporter[T]` — converts a raw Go crypto value into a `jwk.Key`.
+  Register with [`jwk.RegisterKeyImporter[T]`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#RegisterKeyImporter).
+- `KeyExporter` — converts a `jwk.Key` back into a raw Go value.
+  Register with [`jwk.RegisterKeyExporter`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#RegisterKeyExporter),
+  keyed by `jwk.KeyKind` (case-insensitive — usually
+  `jwk.KeyKind(jwa.RSA().String())` or similar).
+
+The whole extension surface is marked **experimental** — the API may
+change in backward-incompatible ways even between minor versions.
+
+### How parsing dispatches
+
+`jwk.Parse` / `jwk.ParseKey` runs in two passes:
+
+1. **Probe.** A small sweep that captures the JSON values registered via
+   `RegisterProbeField`. The default probe captures `kty`, `d`, and
+   `priv`, which is enough to decide RSA / EC / OKP / oct / AKP and
+   whether the key is private.
+2. **Parse.** Each registered `KeyParser`'s `ParseKey` method is called
+   in reverse-registration order until one returns a non-`ContinueError`
+   result. The default parser handles the built-in key types last; your
+   parser runs first and either claims the key or returns
+   `jwk.ContinueError()` to fall through.
+
+A custom parser using a custom probe field looks like:
+
+```go
+func init() {
+    if err := jwk.RegisterProbeField[string]("MyHint", "my_hint"); err != nil {
+        panic(err)
+    }
+    if err := jwk.RegisterKeyParser(MyKeyParser{}); err != nil {
+        panic(err)
+    }
+}
+
+type MyKeyParser struct{}
+
+func (MyKeyParser) ParseKey(probe *jwk.KeyProbe, unmarshaler jwk.KeyUnmarshaler, data []byte) (jwk.Key, error) {
+    hintV, ok := probe.Field("MyHint")
+    if !ok {
+        // Not for us — let the next parser try.
+        return nil, jwk.ContinueError()
+    }
+    hint, _ := hintV.(string)
+
+    var key jwk.Key
+    switch hint {
+    case "...":
+        key = newMyAwesomeJWK()
+    default:
+        return nil, jwk.ContinueError()
+    }
+
+    if err := unmarshaler.UnmarshalKey(data, key); err != nil {
+        return nil, err
+    }
+    return key, nil
+}
+```
+
+### How import / export dispatch
+
+`jwk.Import[T](raw)` looks up a `KeyImporter[T]` registered for the
+exact Go type of `raw`. Pre-registered importers exist for the standard
+crypto types (`*rsa.PrivateKey`, `*ecdsa.PublicKey`, `ed25519.PrivateKey`,
+etc.); add your own:
+
+```go
+func init() {
+    if err := jwk.RegisterKeyImporter[*mypkg.SuperSecretKey](
+        func(raw *mypkg.SuperSecretKey) (jwk.Key, error) {
+            // raw is already typed — no `any`-cast or ContinueError
+            // needed. v4's import surface is one importer per Go type.
+            return mypkg.NewSuperSecretJWK(raw), nil
+        },
+    ); err != nil {
+        panic(err)
+    }
+}
+```
+
+`jwk.Export[T](key)` runs a `KeyExporter` keyed by `jwk.KeyKind`
+(matched case-insensitively against `key.KeyType()`):
+
+```go
+func init() {
+    if err := jwk.RegisterKeyExporter(
+        jwk.KeyKind("MY_AWESOME"),
+        jwk.KeyExportFunc(exportMyKey),
+    ); err != nil {
+        panic(err)
+    }
+}
+
+func exportMyKey(key jwk.Key, hint any) (any, error) {
+    k, ok := key.(*mypkg.SuperSecretJWK)
+    if !ok {
+        // Not compatible — let other exporters try.
+        return nil, jwk.ContinueError()
+    }
+    return k.Raw(), nil
+}
+```
+
+For built-in key types you can build the `KeyKind` from the matching
+`jwa` constant: `jwk.KeyKind(jwa.RSA().String())`.

--- a/jwk/doc.go
+++ b/jwk/doc.go
@@ -35,230 +35,26 @@
 //
 // See examples/jwk_parse_example_test.go and other files in the exmaples/ directory for more.
 //
-// # Advanced Usage: Registering a custom key type and conversion routines
+// # Registering a custom key type
 //
-// Caveat Emptor: Functionality around registering keys
-// (KeyProbe/KeyParser/KeyImporter/KeyExporter) should be considered experimental.
-// While we expect that the functionality itself will remain, the API may
-// change in backward incompatible ways, even during minor version
-// releases.
+// The library supports adding new key types not implemented out of the
+// box (vendor-specific algorithms, post-quantum work, etc.) via four
+// registration points:
 //
-// ## tl;dr
+//   - KeyProbe — partial JSON unmarshaling that picks out hint fields
+//     used to decide what concrete key type to construct.
+//     Add fields with [RegisterProbeField].
+//   - KeyParser — converts a JSON payload into a jwk.Key using the
+//     probe's hints. Register with [RegisterKeyParser].
+//   - KeyImporter — converts a raw Go crypto value into a jwk.Key.
+//     Register with [RegisterKeyImporter] (generic, one importer per
+//     Go type).
+//   - KeyExporter — converts a jwk.Key back into a raw Go value.
+//     Register with [RegisterKeyExporter], keyed by [KeyKind].
 //
-// * KeyProbe: Used for parsing JWKs in JSON format. Probes hint fields to be used for later parsing by KeyParser
-// * KeyParser: Used for parsing JWKs in JSON format. Parses the JSON payload into a jwk.Key using the KeyProbe as hint
-// * KeyImporter: Used for converting raw key into jwk.Key.
-// * KeyExporter: Used for converting jwk.Key into raw key.
+// The whole extension surface is **experimental**: the API may change
+// in backward-incompatible ways even between minor versions.
 //
-// ## Overview
-//
-// You can add the ability to use a JWK type that this library does not
-// implement out of the box. You can do this by registering your own
-// KeyParser, KeyImporter, and KeyExporter instances.
-//
-//	func init() {
-//	  jwk.RegisterProbeField[string]("SomeHint", "some_hint")
-//	  jwk.RegisterKeyParser(&MyKeyParser{})
-//	  jwk.RegisterKeyImporter(&MyKeyImporter{})
-//	  jwk.RegisterKeyExporter(&MyKeyExporter{})
-//	}
-//
-// The KeyParser is used to parse JSON payloads and conver them into a jwk.Key.
-// The KeyImporter is used to convert a raw key (e.g. *rsa.PrivateKey, *ecdsa.PrivateKey, etc) into a jwk.Key.
-// The KeyExporter is used to convert a jwk.Key into a raw key.
-//
-// Although we believe the mechanism has been streamline quite a lot, it is also true
-// that the entire process of parsing and converting keys are much more convoluted than you might
-// think. Please know before hand that if you intend to add support for a new key type,
-// it _WILL_ require you to learn this module pretty much in-and-out.
-//
-// Read on for more explanation.
-//
-// ## Registering a KeyParser
-//
-// In order to understand how parsing works, we need to explain how the `jwk.ParseKey()` works.
-//
-// The first thing that occurs when parsing a key is a partial
-// unmarshaling of the payload into a hint / probe object.
-//
-// Because the `json.Unmarshal` works by calling the `UnmarshalJSON`
-// method on a concrete object, we need to create a concrete object first.
-// In order/ to create the appropriate Go object, we need to know which concrete
-// object to create from the JSON payload, meaning we need to peek into the
-// payload and figure out what type of key it is.
-//
-// In order to do this, we effectively need to parse the JSON payload twice.
-// First, we "probe" the payload to figure out what kind of key it is, then
-// we parse it again to create the actual key object.
-//
-// For probing, we create a new "probe" object (KeyProbe, which is not
-// directly available to end users) to populate the object with hints from the payload.
-// For example, a JWK representing an RSA key would look like:
-//
-//	{ "kty": "RSA", "n": ..., "e": ..., ... }
-//
-// The default KeyProbe is constructed to unmarshal "kty" and "d" fields,
-// because that is enough information to determine what kind of key to
-// construct.
-//
-// For example, if the payload contains "kty" field with the value "RSA",
-// we know that it's an RSA key. If it contains "EC", we know that it's
-// an EC key. Furthermore, if the payload contains some value in the "d" field, we can
-// also tell that this is a private key, as only private keys need
-// this field.
-//
-// For most cases, the default KeyProbe implementation should be sufficient.
-// However, there may be cases in the future where there are new key types
-// that require further information. Perhaps you are embedding another hint
-// in your JWK to further specify what kind of key it is. In that case, you
-// would need to probe more.
-//
-// To add a new field to be probed, call `RegisterProbeField` with the
-// Go name for the field, and the JSON key to extract. For example, the
-// code below would register a field named "MyHint" of type string,
-// extracted from the "my_hint" JSON key:
-//
-//	jwk.RegisterProbeField[string]("MyHint", "my_hint")
-//
-// The value of this field can be retrieved by calling `Field()` method on the
-// KeyProbe object (from the `KeyParser`'s `ParseKey()` method discussed later)
-//
-//	myhint, ok := probe.Field("MyHint")
-//
-//	kty, ok := probe.Field("Kty")
-//
-// This mechanism allows you to be flexible when trying to determine the key type
-// to instantiate.
-//
-// ## Parse via the KeyParser
-//
-// When `jwk.Parse` / `jwk.ParseKey` is called, the library will first probe
-// the payload as discussed above.
-//
-// Once the probe is done, the library will iterate over the registered parsers
-// and attempt to parse the key by calling their `ParseKey()` methods.
-//
-// The parsers will be called in reverse order that they were registered.
-// This means that it will try all parsers that were registered by third
-// parties, and once those are exhausted, the default parser will be used.
-//
-// Each parser's `ParseKey()“ method will receive three arguments: the probe object, a
-// KeyUnmarshaler, and the raw payload. The probe object can be used
-// as a hint to determine what kind of key to instantiate. An example
-// pseudocode may look like this:
-//
-//	ktyV, ok := probe.Field("Kty")
-//	kty := ktyV.(string)
-//	switch kty {
-//	case "RSA":
-//	  // create an RSA key
-//	case "EC":
-//	  // create an EC key
-//	...
-//	}
-//
-// The `KeyUnmarshaler` is a thin wrapper around `json.Unmarshal`. It works almost
-// identical to `json.Unmarshal`, but it allows us to add extra magic that is
-// specific to this library (which users do not need to be aware of) before calling
-// the actual `json.Unmarshal`. Please use the `KeyUnmarshaler` to unmarshal JWKs instead of `json.Unmarshal`.
-//
-// Putting it all together, the boiler plate for registering a new parser may look like this:
-//
-//	   func init() {
-//	     jwk.RegisterProbeField[string]("MyHint", "my_hint")
-//	     jwk.RegisterParser(&MyKeyParser{})
-//	   }
-//
-//	   type MyKeyParser struct { ... }
-//	   func(*MyKeyParser) ParseKey(probe *KeyProbe, unmarshaler KeyUnmarshaler, data []byte) (jwk.Key, error) {
-//	     // Create concrete type
-//	     hintV, ok := probe.Field("MyHint")
-//	     if !ok {
-//	        // if it doesn't have the `my_hint` field, it probably means
-//	        // it's not for us, so we return ContinueError so that
-//	        // the next parser can pick it up
-//	        return nil, jwk.ContinueError()
-//	     }
-//	     hint := hintV.(string)
-//
-//	     // Use hint to determine concrete key type
-//	     var key jwk.Key
-//	     switch hint {
-//	     case ...:
-//	      key = = myNewAwesomeJWK()
-//			  ...
-//	     }
-//
-//	     return unmarshaler.UnmarshalKey(data, key)
-//	   }
-//
-// ## Registering KeyImporter/KeyExporter
-//
-// If you are going to do anything with the key that was parsed by your KeyParser,
-// you will need to tell the library how to convert back and forth between
-// raw keys and JWKs. Conversion from raw keys to jwk.Keys are done by KeyImporters,
-// and conversion from jwk.Keys to raw keys are done by KeyExporters.
-//
-// ## Using jwk.Import() using KeyImporter
-//
-// Each KeyImporter is hooked to run against a specific raw key type.
-//
-// When `jwk.Import()` is called, the library will iterate over all registered
-// KeyImporters for the specified raw key type, and attempt to convert the raw
-// key to a JWK by calling the `Import()` method on each KeyImporter.
-//
-// The KeyImporter's `Import()` method will receive the raw key to be converted,
-// and should return a JWK or an error if the conversion fails, or the return
-// `jwk.ContinueError()` if the specified raw key cannot be handled by ths/ KeyImporter.
-//
-// Once a KeyImporter is available, you will be able to pass the raw key to `jwk.Import()`.
-// The following example shows how you might register a KeyImporter for a hypotheical
-// mypkg.SuperSecretKey:
-//
-//	 	jwk.RegisterKeyImporter(&mypkg.SuperSecretKey{}, jwk.KeyImportFunc(imnportSuperSecretKey))
-//
-//	 	func importSuperSecretKey(key any) (jwk.Key, error) {
-//	 	  mykey, ok := key.(*mypkg.SuperSecretKey)
-//	 	  if !ok {
-//	         // You must return jwk.ContinueError here, or otherwise
-//	         // processing will stop with an error
-//	 	    return nil, fmt.Errorf("invalid key type %T for importer: %w", key, jwk.ContinueError())
-//	 	  }
-//
-//	 	  return mypkg.SuperSecretJWK{ .... }, nil // You could reuse existing JWK types if you can
-//			}
-//
-// ## Registering a KeyExporter
-//
-// KeyExporters are the opposite of KeyImporters: they convert a JWK to a raw key when `jwk.Export()`
-// is called. If you intend to use `jwk.Export()` for a JWK created using one of your KeyImporters,
-// you will need to register a corresponding KeyExporter.
-//
-// KeyExporters are registered by key type. For example, if you want to register a KeyExporter for
-// RSA keys, you would do:
-//
-//	jwk.RegisterKeyExporter(jwa.RSA, jwk.KeyExportFunc(exportRSAKey))
-//
-// `jwk.Export()` returns the raw key directly:
-//
-//	raw, err := jwk.Export(key)
-//	privkey := raw.(*rsa.PrivateKey)
-//
-// To implement a custom exporter your code should look like the following:
-//
-//	jwk.RegisterKeyExporter(jwk.EC, jwk.KeyExportFunc(exportMyKey))
-//
-//	func exportMyKey(key jwk.Key, hint any) (any, error) {
-//	   // key is a jwk.ECDSAPrivateKey or jwk.ECDSAPublicKey
-//	   switch key := key.(type) {
-//	   case jwk.ECDSAPrivateKey:
-//	      // convert key to mypkg.PrivateKey
-//	   case jwk.ECDSAPublicKey:
-//	      // convert key to mypkg.PublicKey
-//	   default:
-//	     // Not compatible, return jwk.ContinueError
-//	     return nil, jwk.ContinueError()
-//	   }
-//	   return ..., nil
-//	}
+// See the "Registering a custom key type" section in
+// docs/04-jwk.md for the full walkthrough including a worked example.
 package jwk


### PR DESCRIPTION
- `jwk/doc.go` carried a long extension-authoring walkthrough (KeyProbe / KeyParser / KeyImporter / KeyExporter) with v3-era code samples — `jwk.RegisterKeyImporter(&type{}, KeyImportFunc(...))` (v3 two-arg form, won't compile in v4), `jwk.RegisterKeyExporter(jwa.RSA, ...)` (`jwa.RSA` is a func value, not a `KeyKind`), `jwk.EC` (nonexistent symbol), and a stale "iterate over registered KeyImporters" mental model.
- Move the content into a new "Registering a custom key type" section in `docs/04-jwk.md`, rewritten against the v4 API (generic `RegisterKeyImporter[T]`, `KeyKind`-based `RegisterKeyExporter`, current `KeyParser` signature). Trim `jwk/doc.go` to a 5-bullet summary that points at the new docs section. The Simple Usage block at the top of `jwk/doc.go` is preserved.