### PR TITLE
jwk: correct Import godoc for crypto/ecdh dispatch

### DIFF
--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -66,7 +66,10 @@ func init() {
 //   - "crypto/rsa".PrivateKey and "crypto/rsa".PublicKey creates an RSA based key
 //   - "crypto/ecdsa".PrivateKey and "crypto/ecdsa".PublicKey creates an EC based key
 //   - "crypto/ed25519".PrivateKey and "crypto/ed25519".PublicKey creates an OKP based key
-//   - "crypto/ecdh".PrivateKey and "crypto/ecdh".PublicKey creates an OKP based key
+//   - "crypto/ecdh".PrivateKey and "crypto/ecdh".PublicKey for X25519
+//     creates an OKP based key; for the NIST P-curves (P-256, P-384,
+//     P-521) creates an EC based key (the same key material is valid
+//     for both ECDH and ECDSA, so JWK has no separate "EC for ECDH" type)
 //   - []byte creates a symmetric key
 //
 // The type parameter T specifies the expected key type. Use [Key] when you


### PR DESCRIPTION
- The `Import[T]` godoc claimed `crypto/ecdh.{Private,Public}Key` always creates an OKP key. In practice the dispatch is curve-dependent: NIST P-curves (P-256/P-384/P-521) become `kty=EC`, X25519 becomes `kty=OKP`. The current behavior is correct (P-curve key material is valid for both ECDH and ECDSA, and JWK has no separate "EC for ECDH" type), but the doc was wrong.
- Doc-only fix to the bullet.