### PR TITLE
jwk: RegisterKeyImporter takes KeyImporter, not a typed function

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -408,15 +408,14 @@ jwk.RegisterKeyImporter(&myKeyType{}, jwk.KeyImportFunc(func(raw any) (jwk.Key, 
     // ... convert
 }))
 
-// After (v4): RegisterKeyImporter[T] takes a jwk.KeyImporter; use
-// jwk.KeyImportFunc[T] to adapt a typed function. The type
-// parameter T identifies the dispatch key.
-jwk.RegisterKeyImporter[*myKeyType](
-    jwk.KeyImportFunc[*myKeyType](func(src *myKeyType) (jwk.Key, error) {
-        // The adapter has already type-asserted; no manual assertion needed.
-        // ... convert
-    }),
-)
+// After (v4): RegisterKeyImporter takes a jwk.KeyImporter[T]; use
+// jwk.KeyImportFunc[T] to adapt a typed function. The outer type
+// parameter is inferred from the adapter's typed Import method.
+jwk.RegisterKeyImporter(jwk.KeyImportFunc[*myKeyType](func(src *myKeyType) (jwk.Key, error) {
+    // The interface is typed, so src is *myKeyType in the body —
+    // no manual assertion.
+    // ... convert
+}))
 ```
 
 ### Recipe 11: Iterating Over Sets and Tokens

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -409,10 +409,10 @@ jwk.RegisterKeyImporter(&myKeyType{}, jwk.KeyImportFunc(func(raw any) (jwk.Key, 
 }))
 
 // After (v4): RegisterKeyImporter[T] takes a jwk.KeyImporter; use
-// jwk.TypedKeyImportFunc[T] to adapt a typed function. The type
+// jwk.KeyImportFunc[T] to adapt a typed function. The type
 // parameter T identifies the dispatch key.
 jwk.RegisterKeyImporter[*myKeyType](
-    jwk.TypedKeyImportFunc[*myKeyType](func(src *myKeyType) (jwk.Key, error) {
+    jwk.KeyImportFunc[*myKeyType](func(src *myKeyType) (jwk.Key, error) {
         // The adapter has already type-asserted; no manual assertion needed.
         // ... convert
     }),

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -399,7 +399,7 @@ import _ "github.com/jwx-go/asmbase64/v4" // registration only
 ### Recipe 10: Custom Key Importer
 
 ```go
-// Before
+// Before (v3)
 jwk.RegisterKeyImporter(&myKeyType{}, jwk.KeyImportFunc(func(raw any) (jwk.Key, error) {
     src, ok := raw.(*myKeyType)
     if !ok {
@@ -408,10 +408,15 @@ jwk.RegisterKeyImporter(&myKeyType{}, jwk.KeyImportFunc(func(raw any) (jwk.Key, 
     // ... convert
 }))
 
-// After
-jwk.RegisterKeyImporter(func(src *myKeyType) (jwk.Key, error) {
-    // ... convert — type parameter inferred, no assertion needed
-})
+// After (v4): RegisterKeyImporter[T] takes a jwk.KeyImporter; use
+// jwk.TypedKeyImportFunc[T] to adapt a typed function. The type
+// parameter T identifies the dispatch key.
+jwk.RegisterKeyImporter[*myKeyType](
+    jwk.TypedKeyImportFunc[*myKeyType](func(src *myKeyType) (jwk.Key, error) {
+        // The adapter has already type-asserted; no manual assertion needed.
+        // ... convert
+    }),
+)
 ```
 
 ### Recipe 11: Iterating Over Sets and Tokens

--- a/docs/04-jwk.md
+++ b/docs/04-jwk.md
@@ -827,12 +827,12 @@ crypto types (`*rsa.PrivateKey`, `*ecdsa.PublicKey`, `ed25519.PrivateKey`,
 etc.); register your own with `jwk.RegisterKeyImporter[T](KeyImporter)`.
 The type parameter `T` is the dispatch key (the Go type the importer
 handles); the value is any `KeyImporter` implementation. Use
-`jwk.TypedKeyImportFunc[T]` to adapt a typed function:
+`jwk.KeyImportFunc[T]` to adapt a typed function:
 
 ```go
 func init() {
     if err := jwk.RegisterKeyImporter[*mypkg.SuperSecretKey](
-        jwk.TypedKeyImportFunc[*mypkg.SuperSecretKey](
+        jwk.KeyImportFunc[*mypkg.SuperSecretKey](
             func(raw *mypkg.SuperSecretKey) (jwk.Key, error) {
                 // The adapter has already type-asserted raw to the
                 // declared T; no `any`-cast needed in the body.

--- a/docs/04-jwk.md
+++ b/docs/04-jwk.md
@@ -821,23 +821,46 @@ func (MyKeyParser) ParseKey(probe *jwk.KeyProbe, unmarshaler jwk.KeyUnmarshaler,
 
 ### How import / export dispatch
 
-`jwk.Import[T](raw)` looks up a `KeyImporter[T]` registered for the
+`jwk.Import[T](raw)` looks up the `KeyImporter` registered for the
 exact Go type of `raw`. Pre-registered importers exist for the standard
 crypto types (`*rsa.PrivateKey`, `*ecdsa.PublicKey`, `ed25519.PrivateKey`,
-etc.); add your own:
+etc.); register your own with `jwk.RegisterKeyImporter[T](KeyImporter)`.
+The type parameter `T` is the dispatch key (the Go type the importer
+handles); the value is any `KeyImporter` implementation. Use
+`jwk.TypedKeyImportFunc[T]` to adapt a typed function:
 
 ```go
 func init() {
     if err := jwk.RegisterKeyImporter[*mypkg.SuperSecretKey](
-        func(raw *mypkg.SuperSecretKey) (jwk.Key, error) {
-            // raw is already typed — no `any`-cast or ContinueError
-            // needed. v4's import surface is one importer per Go type.
-            return mypkg.NewSuperSecretJWK(raw), nil
-        },
+        jwk.TypedKeyImportFunc[*mypkg.SuperSecretKey](
+            func(raw *mypkg.SuperSecretKey) (jwk.Key, error) {
+                // The adapter has already type-asserted raw to the
+                // declared T; no `any`-cast needed in the body.
+                return mypkg.NewSuperSecretJWK(raw), nil
+            },
+        ),
     ); err != nil {
         panic(err)
     }
 }
+```
+
+For an importer with non-trivial state, implement the `KeyImporter`
+interface on your own type and pass an instance directly:
+
+```go
+type mySuperSecretImporter struct { /* config, caches, ... */ }
+
+func (i *mySuperSecretImporter) Import(raw any) (jwk.Key, error) {
+    src, ok := raw.(*mypkg.SuperSecretKey)
+    if !ok {
+        return nil, fmt.Errorf("expected *mypkg.SuperSecretKey, got %T", raw)
+    }
+    return i.convert(src)
+}
+
+// Registration:
+jwk.RegisterKeyImporter[*mypkg.SuperSecretKey](&mySuperSecretImporter{...})
 ```
 
 `jwk.Export[T](key)` runs a `KeyExporter` keyed by `jwk.KeyKind`

--- a/docs/04-jwk.md
+++ b/docs/04-jwk.md
@@ -759,7 +759,7 @@ registration points:
 - `KeyParser` — converts a JSON payload into a `jwk.Key` using the
   probe's hints. Register with [`jwk.RegisterKeyParser`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#RegisterKeyParser).
 - `KeyImporter[T]` — converts a raw Go crypto value into a `jwk.Key`.
-  Register with [`jwk.RegisterKeyImporter[T]`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#RegisterKeyImporter).
+  Register with [`jwk.RegisterKeyImporter`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#RegisterKeyImporter).
 - `KeyExporter` — converts a `jwk.Key` back into a raw Go value.
   Register with [`jwk.RegisterKeyExporter`](https://pkg.go.dev/github.com/lestrrat-go/jwx/v4/jwk#RegisterKeyExporter),
   keyed by `jwk.KeyKind` (case-insensitive — usually
@@ -821,21 +821,21 @@ func (MyKeyParser) ParseKey(probe *jwk.KeyProbe, unmarshaler jwk.KeyUnmarshaler,
 
 ### How import / export dispatch
 
-`jwk.Import[T](raw)` looks up the `KeyImporter` registered for the
+`jwk.Import[T](raw)` looks up the `KeyImporter[T]` registered for the
 exact Go type of `raw`. Pre-registered importers exist for the standard
 crypto types (`*rsa.PrivateKey`, `*ecdsa.PublicKey`, `ed25519.PrivateKey`,
-etc.); register your own with `jwk.RegisterKeyImporter[T](KeyImporter)`.
-The type parameter `T` is the dispatch key (the Go type the importer
-handles); the value is any `KeyImporter` implementation. Use
-`jwk.KeyImportFunc[T]` to adapt a typed function:
+etc.); register your own with `jwk.RegisterKeyImporter(KeyImporter[T])`.
+The interface is generic — its `Import(raw T) (Key, error)` method is
+typed — so the registration's type parameter is inferred from whatever
+you pass in. Use `jwk.KeyImportFunc[T]` to adapt a typed function:
 
 ```go
 func init() {
-    if err := jwk.RegisterKeyImporter[*mypkg.SuperSecretKey](
+    if err := jwk.RegisterKeyImporter(
         jwk.KeyImportFunc[*mypkg.SuperSecretKey](
             func(raw *mypkg.SuperSecretKey) (jwk.Key, error) {
-                // The adapter has already type-asserted raw to the
-                // declared T; no `any`-cast needed in the body.
+                // The interface is typed, so raw is *mypkg.SuperSecretKey
+                // — no any-cast needed in the body.
                 return mypkg.NewSuperSecretJWK(raw), nil
             },
         ),
@@ -845,22 +845,20 @@ func init() {
 }
 ```
 
-For an importer with non-trivial state, implement the `KeyImporter`
+For an importer with non-trivial state, implement the `KeyImporter[T]`
 interface on your own type and pass an instance directly:
 
 ```go
 type mySuperSecretImporter struct { /* config, caches, ... */ }
 
-func (i *mySuperSecretImporter) Import(raw any) (jwk.Key, error) {
-    src, ok := raw.(*mypkg.SuperSecretKey)
-    if !ok {
-        return nil, fmt.Errorf("expected *mypkg.SuperSecretKey, got %T", raw)
-    }
-    return i.convert(src)
+// Typed Import method makes mySuperSecretImporter satisfy
+// jwk.KeyImporter[*mypkg.SuperSecretKey].
+func (i *mySuperSecretImporter) Import(raw *mypkg.SuperSecretKey) (jwk.Key, error) {
+    return i.convert(raw)
 }
 
-// Registration:
-jwk.RegisterKeyImporter[*mypkg.SuperSecretKey](&mySuperSecretImporter{...})
+// Registration: T inferred from the Import method's parameter type.
+jwk.RegisterKeyImporter(&mySuperSecretImporter{...})
 ```
 
 `jwk.Export[T](key)` runs a `KeyExporter` keyed by `jwk.KeyKind`

--- a/docs/design/v4-generics.md
+++ b/docs/design/v4-generics.md
@@ -22,7 +22,7 @@ func myFunc(src any) (jwk.Key, error) {
 **v4:**
 ```go
 jwk.RegisterKeyImporter[*rsa.PrivateKey](
-    jwk.TypedKeyImportFunc[*rsa.PrivateKey](myFunc),
+    jwk.KeyImportFunc[*rsa.PrivateKey](myFunc),
 )
 // myFunc accepts the concrete type — the adapter type-asserts for it
 func myFunc(src *rsa.PrivateKey) (jwk.Key, error) {
@@ -32,9 +32,9 @@ func myFunc(src *rsa.PrivateKey) (jwk.Key, error) {
 
 Implementation: `RegisterKeyImporter[T any](ki KeyImporter) error` uses `reflect.TypeFor[T]()` to derive the map key at registration time. The runtime dispatch in `Import()` still uses `reflect.TypeOf(raw)` — this is unavoidable since the input type is only known at call time. The type parameter `T` is solely a dispatch-key declaration; it does not appear in the function signature.
 
-The intermediate adapter `TypedKeyImportFunc[T]` satisfies `KeyImporter` from a typed function: it type-asserts the raw `any` argument to `T` and invokes the underlying typed function. Callers with a full `KeyImporter` implementation pass it directly without the adapter.
+`KeyImportFunc[T any]` is the typed-function adapter: its `Import` method type-asserts the raw `any` argument to `T` and invokes the underlying typed function. Callers with a full `KeyImporter` implementation pass it directly without the adapter.
 
-Earlier v4 iterations had `RegisterKeyImporter[T](fn func(T) (Key, error))` — accepting a typed function rather than a `KeyImporter`. That shape made the public `KeyImporter` interface and `KeyImportFunc` adapter unreachable from registration, contradicting the project's interface-over-callback rule. The current shape restores the interface as the canonical registration value.
+Earlier v4 iterations had `RegisterKeyImporter[T](fn func(T) (Key, error))` — accepting a typed function rather than a `KeyImporter`, with `KeyImportFunc` exposed as a separate untyped adapter that was never reachable from registration. The current shape restores the interface as the canonical registration value and makes `KeyImportFunc[T]` generic, so a single name covers the typed-function convenience.
 
 ### Type-safe generic accessors
 
@@ -71,9 +71,9 @@ jwk.RegisterKeyImporter(&myKey{}, jwk.KeyImportFunc(func(src any) (jwk.Key, erro
 }))
 
 // v4: type parameter declares the dispatch key; pass a KeyImporter
-// (TypedKeyImportFunc adapts a typed function).
+// (KeyImportFunc adapts a typed function).
 jwk.RegisterKeyImporter[*myKey](
-    jwk.TypedKeyImportFunc[*myKey](func(k *myKey) (jwk.Key, error) {
+    jwk.KeyImportFunc[*myKey](func(k *myKey) (jwk.Key, error) {
         return doImport(k)
     }),
 )

--- a/docs/design/v4-generics.md
+++ b/docs/design/v4-generics.md
@@ -21,20 +21,17 @@ func myFunc(src any) (jwk.Key, error) {
 
 **v4:**
 ```go
-jwk.RegisterKeyImporter[*rsa.PrivateKey](
-    jwk.KeyImportFunc[*rsa.PrivateKey](myFunc),
-)
-// myFunc accepts the concrete type — the adapter type-asserts for it
+jwk.RegisterKeyImporter(jwk.KeyImportFunc[*rsa.PrivateKey](myFunc))
+// myFunc accepts the concrete type. The outer T is inferred from the
+// adapter's typed Import method.
 func myFunc(src *rsa.PrivateKey) (jwk.Key, error) {
     ...
 }
 ```
 
-Implementation: `RegisterKeyImporter[T any](ki KeyImporter) error` uses `reflect.TypeFor[T]()` to derive the map key at registration time. The runtime dispatch in `Import()` still uses `reflect.TypeOf(raw)` — this is unavoidable since the input type is only known at call time. The type parameter `T` is solely a dispatch-key declaration; it does not appear in the function signature.
+Implementation: `KeyImporter[T any]` is a generic interface whose `Import(raw T) (Key, error)` method is itself typed; `KeyImportFunc[T any]` is a `func(T) (Key, error)` that satisfies it. `RegisterKeyImporter[T any](ki KeyImporter[T]) error` uses `reflect.TypeFor[T]()` to derive the map key at registration time and stores a closure that re-types `any` → T at dispatch. The runtime lookup in `Import()` still keys by `reflect.TypeOf(raw)`.
 
-`KeyImportFunc[T any]` is the typed-function adapter: its `Import` method type-asserts the raw `any` argument to `T` and invokes the underlying typed function. Callers with a full `KeyImporter` implementation pass it directly without the adapter.
-
-Earlier v4 iterations had `RegisterKeyImporter[T](fn func(T) (Key, error))` — accepting a typed function rather than a `KeyImporter`, with `KeyImportFunc` exposed as a separate untyped adapter that was never reachable from registration. The current shape restores the interface as the canonical registration value and makes `KeyImportFunc[T]` generic, so a single name covers the typed-function convenience.
+The earlier v4.0.0 release shipped `RegisterKeyImporter[T](fn func(T) (Key, error))` — accepting a typed function rather than a `KeyImporter`, with the public `KeyImporter` interface and `KeyImportFunc` adapter exposed but never reachable from registration. The current shape restores the interface as the canonical registration value, makes the interface generic so type-parameter inference covers the registration call, and makes `KeyImportFunc[T]` a generic typed-function adapter that satisfies it.
 
 ### Type-safe generic accessors
 
@@ -70,13 +67,10 @@ jwk.RegisterKeyImporter(&myKey{}, jwk.KeyImportFunc(func(src any) (jwk.Key, erro
     return doImport(k)
 }))
 
-// v4: type parameter declares the dispatch key; pass a KeyImporter
-// (KeyImportFunc adapts a typed function).
-jwk.RegisterKeyImporter[*myKey](
-    jwk.KeyImportFunc[*myKey](func(k *myKey) (jwk.Key, error) {
-        return doImport(k)
-    }),
-)
+// v4: pass a KeyImporter[T]; T inferred from the adapter's typed Import.
+jwk.RegisterKeyImporter(jwk.KeyImportFunc[*myKey](func(k *myKey) (jwk.Key, error) {
+    return doImport(k)
+}))
 ```
 
 ```go

--- a/docs/design/v4-generics.md
+++ b/docs/design/v4-generics.md
@@ -21,16 +21,20 @@ func myFunc(src any) (jwk.Key, error) {
 
 **v4:**
 ```go
-jwk.RegisterKeyImporter(myFunc)
-// myFunc accepts the concrete type — no type switch needed
+jwk.RegisterKeyImporter[*rsa.PrivateKey](
+    jwk.TypedKeyImportFunc[*rsa.PrivateKey](myFunc),
+)
+// myFunc accepts the concrete type — the adapter type-asserts for it
 func myFunc(src *rsa.PrivateKey) (jwk.Key, error) {
     ...
 }
 ```
 
-Implementation: `RegisterKeyImporter[T any](fn func(T) (Key, error))` uses `reflect.TypeFor[T]()` to derive the map key at registration time. The runtime dispatch in `Import()` still uses `reflect.TypeOf(raw)` — this is unavoidable since the input type is only known at call time.
+Implementation: `RegisterKeyImporter[T any](ki KeyImporter) error` uses `reflect.TypeFor[T]()` to derive the map key at registration time. The runtime dispatch in `Import()` still uses `reflect.TypeOf(raw)` — this is unavoidable since the input type is only known at call time. The type parameter `T` is solely a dispatch-key declaration; it does not appear in the function signature.
 
-Callers holding a full `KeyImporter` value can register it through the same entry point by passing `imp.Import` as the function: `RegisterKeyImporter[T](imp.Import)`.
+The intermediate adapter `TypedKeyImportFunc[T]` satisfies `KeyImporter` from a typed function: it type-asserts the raw `any` argument to `T` and invokes the underlying typed function. Callers with a full `KeyImporter` implementation pass it directly without the adapter.
+
+Earlier v4 iterations had `RegisterKeyImporter[T](fn func(T) (Key, error))` — accepting a typed function rather than a `KeyImporter`. That shape made the public `KeyImporter` interface and `KeyImportFunc` adapter unreachable from registration, contradicting the project's interface-over-callback rule. The current shape restores the interface as the canonical registration value.
 
 ### Type-safe generic accessors
 
@@ -66,10 +70,13 @@ jwk.RegisterKeyImporter(&myKey{}, jwk.KeyImportFunc(func(src any) (jwk.Key, erro
     return doImport(k)
 }))
 
-// v4: type-safe, no zero-value discriminator needed
-jwk.RegisterKeyImporter(func(k *myKey) (jwk.Key, error) {
-    return doImport(k)
-})
+// v4: type parameter declares the dispatch key; pass a KeyImporter
+// (TypedKeyImportFunc adapts a typed function).
+jwk.RegisterKeyImporter[*myKey](
+    jwk.TypedKeyImportFunc[*myKey](func(k *myKey) (jwk.Key, error) {
+        return doImport(k)
+    }),
+)
 ```
 
 ```go

--- a/jwk/convert.go
+++ b/jwk/convert.go
@@ -96,10 +96,10 @@ var muKeyExporters sync.RWMutex
 // error and panic on failure.
 //
 // To register from a typed function (the common case for extensions),
-// use [TypedKeyImportFunc] as the adapter:
+// use [KeyImportFunc] as the adapter:
 //
 //	jwk.RegisterKeyImporter[*mypkg.Key](
-//	    jwk.TypedKeyImportFunc[*mypkg.Key](importMyKey),
+//	    jwk.KeyImportFunc[*mypkg.Key](importMyKey),
 //	)
 func RegisterKeyImporter[T any](ki KeyImporter) error {
 	muKeyImporters.Lock()
@@ -198,35 +198,26 @@ type KeyImporter interface {
 	Import(any) (Key, error)
 }
 
-// KeyImportFunc is a convenience type to implement KeyImporter as a
-// function operating on the untyped any. Use [TypedKeyImportFunc]
-// instead when the importer expects a specific raw key type — it
-// performs the type assertion for you.
-type KeyImportFunc func(any) (Key, error)
-
-func (f KeyImportFunc) Import(raw any) (Key, error) {
-	return f(raw)
-}
-
-// TypedKeyImportFunc is a convenience adapter that satisfies
-// [KeyImporter] from a typed import function. The Import method
-// type-asserts its argument to T and invokes the underlying function;
-// on a type mismatch (which should not happen given dispatch is keyed
-// by reflect.Type, but is still defensible) it returns an error.
+// KeyImportFunc is the typed-function adapter that satisfies
+// [KeyImporter]. Its Import method type-asserts the raw any argument
+// to T and invokes the underlying function; on a type mismatch (which
+// should not happen given dispatch is keyed by reflect.Type, but is
+// still defensible) it returns an error.
 //
-// This is the preferred adapter for extensions that have a typed import
-// function — the alternative ([KeyImportFunc] over an untyped any) puts
-// the assertion burden on the caller.
+// This is the canonical way to register a typed import function:
 //
 //	jwk.RegisterKeyImporter[*mypkg.Key](
-//	    jwk.TypedKeyImportFunc[*mypkg.Key](importMyKey),
+//	    jwk.KeyImportFunc[*mypkg.Key](importMyKey),
 //	)
-type TypedKeyImportFunc[T any] func(T) (Key, error)
+//
+// For an importer with non-trivial state, implement [KeyImporter] on
+// your own type and pass an instance of it directly.
+type KeyImportFunc[T any] func(T) (Key, error)
 
-func (f TypedKeyImportFunc[T]) Import(raw any) (Key, error) {
+func (f KeyImportFunc[T]) Import(raw any) (Key, error) {
 	v, ok := raw.(T)
 	if !ok {
-		return nil, fmt.Errorf(`jwk.TypedKeyImportFunc: cannot convert key type %T to %T`, raw, *new(T))
+		return nil, fmt.Errorf(`jwk.KeyImportFunc: cannot convert key type %T to %T`, raw, *new(T))
 	}
 	return f(v)
 }
@@ -290,7 +281,7 @@ func init() {
 func registerBuiltinKeyImporter[T any](fn func(T) (Key, error)) {
 	t := reflect.TypeFor[T]()
 	builtinImporterTypes[t] = struct{}{}
-	keyImporters[t] = TypedKeyImportFunc[T](fn)
+	keyImporters[t] = KeyImportFunc[T](fn)
 }
 
 // panicOnRegistrationError converts a non-nil error returned by a Register*

--- a/jwk/convert.go
+++ b/jwk/convert.go
@@ -22,7 +22,14 @@ import (
 // A converter that converts from a raw key to a `jwk.Key` is called a KeyImporter.
 // A converter that converts from a `jwk.Key` to a raw key is called a KeyExporter.
 
-var keyImporters = make(map[reflect.Type]KeyImporter)
+// keyImporters stores per-Go-type closures that adapt a typed
+// [KeyImporter] (parameterized by the same Go type that keys this map)
+// down to a non-generic any-taking dispatch shape. The closure carries
+// T and performs the raw.(T) type-assertion before delegating to the
+// underlying typed Import method; the assertion is safe because the
+// dispatch in [convertRawKey] keys this entry by reflect.TypeOf(raw)
+// matching reflect.TypeFor[T]().
+var keyImporters = make(map[reflect.Type]func(any) (Key, error))
 
 // builtinImporterTypes is the set of raw key types whose importers
 // are owned by the jwk package and cannot be overridden by callers.
@@ -64,13 +71,14 @@ var keyExporters = make(map[KeyKind][]KeyExporter)
 var muKeyImporters sync.RWMutex
 var muKeyExporters sync.RWMutex
 
-// RegisterKeyImporter registers a [KeyImporter] under the raw key type
-// T. The type parameter T identifies the dispatch key — it is the Go
-// type of the raw value [Import] will be called with — and is not used
-// in the function signature itself; pass it explicitly at the call site.
+// RegisterKeyImporter registers a [KeyImporter] for the raw key type T.
+// The type parameter is normally inferred from the importer's typed
+// Import method; pass it explicitly only when inference would fail
+// (e.g. when supplying a [KeyImportFunc] without arguments).
 //
 // When [Import] is called, the library looks up the importer for the
-// raw value's runtime type (via reflect) and invokes its Import method.
+// raw value's runtime type (via reflect) and invokes its Import method
+// through a closure that handles the any → T re-typing.
 //
 // Importer dispatch is single-valued per Go type T: there is exactly
 // one importer per reflect.Type. Subsequent registrations for the same
@@ -96,12 +104,10 @@ var muKeyExporters sync.RWMutex
 // error and panic on failure.
 //
 // To register from a typed function (the common case for extensions),
-// use [KeyImportFunc] as the adapter:
+// wrap it with [KeyImportFunc]:
 //
-//	jwk.RegisterKeyImporter[*mypkg.Key](
-//	    jwk.KeyImportFunc[*mypkg.Key](importMyKey),
-//	)
-func RegisterKeyImporter[T any](ki KeyImporter) error {
+//	jwk.RegisterKeyImporter(jwk.KeyImportFunc[*mypkg.Key](importMyKey))
+func RegisterKeyImporter[T any](ki KeyImporter[T]) error {
 	muKeyImporters.Lock()
 	defer muKeyImporters.Unlock()
 	t := reflect.TypeFor[T]()
@@ -111,7 +117,13 @@ func RegisterKeyImporter[T any](ki KeyImporter) error {
 	if _, exists := keyImporters[t]; exists {
 		return fmt.Errorf(`jwk.RegisterKeyImporter: an importer for %s is already registered; call jwk.UnregisterKeyImporter[%s]() first if you need to replace it`, t, t)
 	}
-	keyImporters[t] = ki
+	keyImporters[t] = func(raw any) (Key, error) {
+		// Safe: dispatch in convertRawKey keys this entry by
+		// reflect.TypeOf(raw) matching reflect.TypeFor[T](), so the
+		// assertion cannot fail in the lookup path.
+		//nolint:forcetypeassert
+		return ki.Import(raw.(T))
+	}
 	return nil
 }
 
@@ -191,35 +203,34 @@ func RegisterKeyExporter(ident KeyKind, conv KeyExporter) error {
 	return nil
 }
 
-// KeyImporter is used to convert from a raw key to a `jwk.Key`. mneumonic: from the PoV of the `jwk.Key`,
-// we're _importing_ a raw key.
-type KeyImporter interface {
-	// Import takes the raw key to be converted, and returns a `jwk.Key` or an error if the conversion fails.
-	Import(any) (Key, error)
+// KeyImporter converts a raw key of Go type T into a [jwk.Key]. The
+// type parameter T is the raw-key type the importer handles. From the
+// point of view of the `jwk.Key`, we're _importing_ a raw key.
+//
+// Implementations are registered with [RegisterKeyImporter]; T flows
+// through to [reflect.TypeFor] at registration time to key the import
+// dispatch table.
+type KeyImporter[T any] interface {
+	// Import takes the raw key to be converted, and returns a
+	// [jwk.Key] or an error if the conversion fails.
+	Import(raw T) (Key, error)
 }
 
 // KeyImportFunc is the typed-function adapter that satisfies
-// [KeyImporter]. Its Import method type-asserts the raw any argument
-// to T and invokes the underlying function; on a type mismatch (which
-// should not happen given dispatch is keyed by reflect.Type, but is
-// still defensible) it returns an error.
+// [KeyImporter] for type T. The Import method just calls f directly —
+// no internal type assertion is needed because [KeyImporter]'s Import
+// is itself typed.
 //
 // This is the canonical way to register a typed import function:
 //
-//	jwk.RegisterKeyImporter[*mypkg.Key](
-//	    jwk.KeyImportFunc[*mypkg.Key](importMyKey),
-//	)
+//	jwk.RegisterKeyImporter(jwk.KeyImportFunc[*mypkg.Key](importMyKey))
 //
 // For an importer with non-trivial state, implement [KeyImporter] on
 // your own type and pass an instance of it directly.
 type KeyImportFunc[T any] func(T) (Key, error)
 
-func (f KeyImportFunc[T]) Import(raw any) (Key, error) {
-	v, ok := raw.(T)
-	if !ok {
-		return nil, fmt.Errorf(`jwk.KeyImportFunc: cannot convert key type %T to %T`, raw, *new(T))
-	}
-	return f(v)
+func (f KeyImportFunc[T]) Import(raw T) (Key, error) {
+	return f(raw)
 }
 
 // KeyExporter is used to convert from a `jwk.Key` to a raw key. From the PoV of the `jwk.Key`,
@@ -281,7 +292,13 @@ func init() {
 func registerBuiltinKeyImporter[T any](fn func(T) (Key, error)) {
 	t := reflect.TypeFor[T]()
 	builtinImporterTypes[t] = struct{}{}
-	keyImporters[t] = KeyImportFunc[T](fn)
+	keyImporters[t] = func(raw any) (Key, error) {
+		// Safe: dispatch keys this entry by reflect.TypeOf(raw)
+		// matching reflect.TypeFor[T](); the assertion cannot fail
+		// when the closure is invoked from convertRawKey.
+		//nolint:forcetypeassert
+		return fn(raw.(T))
+	}
 }
 
 // panicOnRegistrationError converts a non-nil error returned by a Register*

--- a/jwk/convert.go
+++ b/jwk/convert.go
@@ -64,12 +64,13 @@ var keyExporters = make(map[KeyKind][]KeyExporter)
 var muKeyImporters sync.RWMutex
 var muKeyExporters sync.RWMutex
 
-// RegisterKeyImporter registers a typed import function for converting
-// raw keys of type T to jwk.Key. The type is derived from the type
-// parameter, eliminating the need to pass a zero value.
+// RegisterKeyImporter registers a [KeyImporter] under the raw key type
+// T. The type parameter T identifies the dispatch key — it is the Go
+// type of the raw value [Import] will be called with — and is not used
+// in the function signature itself; pass it explicitly at the call site.
 //
-// When `jwk.Import()` is called, the library looks up the appropriate
-// importer for the given raw key type (via `reflect`) and executes it.
+// When [Import] is called, the library looks up the importer for the
+// raw value's runtime type (via reflect) and invokes its Import method.
 //
 // Importer dispatch is single-valued per Go type T: there is exactly
 // one importer per reflect.Type. Subsequent registrations for the same
@@ -93,7 +94,14 @@ var muKeyExporters sync.RWMutex
 //
 // Extension modules calling this from init() must check the returned
 // error and panic on failure.
-func RegisterKeyImporter[T any](fn func(T) (Key, error)) error {
+//
+// To register from a typed function (the common case for extensions),
+// use [TypedKeyImportFunc] as the adapter:
+//
+//	jwk.RegisterKeyImporter[*mypkg.Key](
+//	    jwk.TypedKeyImportFunc[*mypkg.Key](importMyKey),
+//	)
+func RegisterKeyImporter[T any](ki KeyImporter) error {
 	muKeyImporters.Lock()
 	defer muKeyImporters.Unlock()
 	t := reflect.TypeFor[T]()
@@ -103,7 +111,7 @@ func RegisterKeyImporter[T any](fn func(T) (Key, error)) error {
 	if _, exists := keyImporters[t]; exists {
 		return fmt.Errorf(`jwk.RegisterKeyImporter: an importer for %s is already registered; call jwk.UnregisterKeyImporter[%s]() first if you need to replace it`, t, t)
 	}
-	keyImporters[t] = &keyImportAdapter[T]{fn: fn}
+	keyImporters[t] = ki
 	return nil
 }
 
@@ -190,24 +198,37 @@ type KeyImporter interface {
 	Import(any) (Key, error)
 }
 
-// KeyImportFunc is a convenience type to implement KeyImporter as a function.
+// KeyImportFunc is a convenience type to implement KeyImporter as a
+// function operating on the untyped any. Use [TypedKeyImportFunc]
+// instead when the importer expects a specific raw key type — it
+// performs the type assertion for you.
 type KeyImportFunc func(any) (Key, error)
 
 func (f KeyImportFunc) Import(raw any) (Key, error) {
 	return f(raw)
 }
 
-// keyImportAdapter wraps a typed function into a KeyImporter.
-type keyImportAdapter[T any] struct {
-	fn func(T) (Key, error)
-}
+// TypedKeyImportFunc is a convenience adapter that satisfies
+// [KeyImporter] from a typed import function. The Import method
+// type-asserts its argument to T and invokes the underlying function;
+// on a type mismatch (which should not happen given dispatch is keyed
+// by reflect.Type, but is still defensible) it returns an error.
+//
+// This is the preferred adapter for extensions that have a typed import
+// function — the alternative ([KeyImportFunc] over an untyped any) puts
+// the assertion burden on the caller.
+//
+//	jwk.RegisterKeyImporter[*mypkg.Key](
+//	    jwk.TypedKeyImportFunc[*mypkg.Key](importMyKey),
+//	)
+type TypedKeyImportFunc[T any] func(T) (Key, error)
 
-func (a *keyImportAdapter[T]) Import(raw any) (Key, error) {
+func (f TypedKeyImportFunc[T]) Import(raw any) (Key, error) {
 	v, ok := raw.(T)
 	if !ok {
-		return nil, fmt.Errorf(`cannot convert key type '%T' to %T`, raw, *new(T))
+		return nil, fmt.Errorf(`jwk.TypedKeyImportFunc: cannot convert key type %T to %T`, raw, *new(T))
 	}
-	return a.fn(v)
+	return f(v)
 }
 
 // KeyExporter is used to convert from a `jwk.Key` to a raw key. From the PoV of the `jwk.Key`,
@@ -269,7 +290,7 @@ func init() {
 func registerBuiltinKeyImporter[T any](fn func(T) (Key, error)) {
 	t := reflect.TypeFor[T]()
 	builtinImporterTypes[t] = struct{}{}
-	keyImporters[t] = &keyImportAdapter[T]{fn: fn}
+	keyImporters[t] = TypedKeyImportFunc[T](fn)
 }
 
 // panicOnRegistrationError converts a non-nil error returned by a Register*

--- a/jwk/convert_test.go
+++ b/jwk/convert_test.go
@@ -55,8 +55,8 @@ type recipe10RawKey struct{ secret []byte }
 
 // TestMigrationRecipe10KeyImporterSyntax pins the syntax shown in
 // MIGRATION.md Recipe 10: register a [jwk.KeyImporter] (typically via
-// [jwk.TypedKeyImportFunc] for a typed function) under an explicit
-// raw-key Go type parameter.
+// [jwk.KeyImportFunc] for a typed function) under an explicit raw-key
+// Go type parameter.
 func TestMigrationRecipe10KeyImporterSyntax(t *testing.T) {
 	importFn := func(src *recipe10RawKey) (jwk.Key, error) {
 		k, err := jwk.Import[jwk.Key](src.secret)
@@ -68,7 +68,7 @@ func TestMigrationRecipe10KeyImporterSyntax(t *testing.T) {
 	}
 	require.NoError(t,
 		jwk.RegisterKeyImporter[*recipe10RawKey](
-			jwk.TypedKeyImportFunc[*recipe10RawKey](importFn),
+			jwk.KeyImportFunc[*recipe10RawKey](importFn),
 		),
 		"RegisterKeyImporter should accept the typed-function adapter form")
 
@@ -90,7 +90,7 @@ func TestRegisterKeyImporterRejectsDuplicate(t *testing.T) {
 	// Register/Unregister bookkeeping is correct. Return a non-nil
 	// error so the function doesn't look like a (nil, nil) sentinel
 	// that nilnil flags.
-	importer := jwk.TypedKeyImportFunc[dupImporterKey](func(dupImporterKey) (jwk.Key, error) {
+	importer := jwk.KeyImportFunc[dupImporterKey](func(dupImporterKey) (jwk.Key, error) {
 		return nil, errors.New("dupImporterKey: importer body not exercised by this test")
 	})
 
@@ -133,9 +133,16 @@ func TestRegisterKeyImporterRejectsDuplicate(t *testing.T) {
 //
 // The stub importer returns a non-nil error so the test does not
 // resemble a (nil, nil) sentinel.
+// stubImporter is a no-op importer used by tests that only exercise
+// the registration bookkeeping (e.g. built-in-type rejection). It
+// satisfies jwk.KeyImporter for any registration T without needing
+// per-T plumbing.
+type stubImporter struct{ err error }
+
+func (s stubImporter) Import(any) (jwk.Key, error) { return nil, s.err }
+
 func TestRegisterKeyImporterRejectsBuiltinTypes(t *testing.T) {
-	stubErr := errors.New("stub importer must not be invoked: built-in types are reserved")
-	stub := jwk.KeyImportFunc(func(any) (jwk.Key, error) { return nil, stubErr })
+	stub := stubImporter{err: errors.New("stub importer must not be invoked: built-in types are reserved")}
 
 	t.Run("RegisterKeyImporter[*rsa.PrivateKey]", func(t *testing.T) {
 		err := jwk.RegisterKeyImporter[*rsa.PrivateKey](stub)

--- a/jwk/convert_test.go
+++ b/jwk/convert_test.go
@@ -67,9 +67,7 @@ func TestMigrationRecipe10KeyImporterSyntax(t *testing.T) {
 		return k, nil
 	}
 	require.NoError(t,
-		jwk.RegisterKeyImporter[*recipe10RawKey](
-			jwk.KeyImportFunc[*recipe10RawKey](importFn),
-		),
+		jwk.RegisterKeyImporter(jwk.KeyImportFunc[*recipe10RawKey](importFn)),
 		"RegisterKeyImporter should accept the typed-function adapter form")
 
 	key, err := jwk.Import[jwk.Key](&recipe10RawKey{secret: []byte("recipe-10-secret-material")})
@@ -95,25 +93,25 @@ func TestRegisterKeyImporterRejectsDuplicate(t *testing.T) {
 	})
 
 	t.Run("first registration succeeds", func(t *testing.T) {
-		require.NoError(t, jwk.RegisterKeyImporter[dupImporterKey](importer))
+		require.NoError(t, jwk.RegisterKeyImporter(importer))
 		defer jwk.UnregisterKeyImporter[dupImporterKey]()
 	})
 
 	t.Run("duplicate registration is rejected", func(t *testing.T) {
-		require.NoError(t, jwk.RegisterKeyImporter[dupImporterKey](importer))
+		require.NoError(t, jwk.RegisterKeyImporter(importer))
 		defer jwk.UnregisterKeyImporter[dupImporterKey]()
 
-		err := jwk.RegisterKeyImporter[dupImporterKey](importer)
+		err := jwk.RegisterKeyImporter(importer)
 		require.Error(t, err, `second RegisterKeyImporter should error`)
 		require.Contains(t, err.Error(), `already registered`,
 			`error should say the type is already registered`)
 	})
 
 	t.Run("Unregister + Register allows replacement", func(t *testing.T) {
-		require.NoError(t, jwk.RegisterKeyImporter[dupImporterKey](importer))
+		require.NoError(t, jwk.RegisterKeyImporter(importer))
 		require.True(t, jwk.UnregisterKeyImporter[dupImporterKey](),
 			`UnregisterKeyImporter should report removal`)
-		require.NoError(t, jwk.RegisterKeyImporter[dupImporterKey](importer),
+		require.NoError(t, jwk.RegisterKeyImporter(importer),
 			`RegisterKeyImporter should succeed after Unregister`)
 		defer jwk.UnregisterKeyImporter[dupImporterKey]()
 	})
@@ -134,18 +132,18 @@ func TestRegisterKeyImporterRejectsDuplicate(t *testing.T) {
 // The stub importer returns a non-nil error so the test does not
 // resemble a (nil, nil) sentinel.
 // stubImporter is a no-op importer used by tests that only exercise
-// the registration bookkeeping (e.g. built-in-type rejection). It
-// satisfies jwk.KeyImporter for any registration T without needing
-// per-T plumbing.
-type stubImporter struct{ err error }
+// the registration bookkeeping (e.g. built-in-type rejection). It is
+// generic so the same shape works for any T the test wants to
+// register against.
+type stubImporter[T any] struct{ err error }
 
-func (s stubImporter) Import(any) (jwk.Key, error) { return nil, s.err }
+func (s stubImporter[T]) Import(T) (jwk.Key, error) { return nil, s.err }
 
 func TestRegisterKeyImporterRejectsBuiltinTypes(t *testing.T) {
-	stub := stubImporter{err: errors.New("stub importer must not be invoked: built-in types are reserved")}
+	stubErr := errors.New("stub importer must not be invoked: built-in types are reserved")
 
 	t.Run("RegisterKeyImporter[*rsa.PrivateKey]", func(t *testing.T) {
-		err := jwk.RegisterKeyImporter[*rsa.PrivateKey](stub)
+		err := jwk.RegisterKeyImporter(stubImporter[*rsa.PrivateKey]{err: stubErr})
 		require.Error(t, err, `RegisterKeyImporter should refuse a built-in raw key type`)
 		require.Contains(t, err.Error(), `built-in`,
 			`error should explain that built-in importers cannot be overridden`)
@@ -157,20 +155,20 @@ func TestRegisterKeyImporterRejectsBuiltinTypes(t *testing.T) {
 		name string
 		fn   func() error
 	}{
-		{"rsa.PrivateKey", func() error { return jwk.RegisterKeyImporter[rsa.PrivateKey](stub) }},
-		{"*rsa.PublicKey", func() error { return jwk.RegisterKeyImporter[*rsa.PublicKey](stub) }},
-		{"rsa.PublicKey", func() error { return jwk.RegisterKeyImporter[rsa.PublicKey](stub) }},
-		{"*ecdsa.PrivateKey", func() error { return jwk.RegisterKeyImporter[*ecdsa.PrivateKey](stub) }},
-		{"ecdsa.PrivateKey", func() error { return jwk.RegisterKeyImporter[ecdsa.PrivateKey](stub) }},
-		{"*ecdsa.PublicKey", func() error { return jwk.RegisterKeyImporter[*ecdsa.PublicKey](stub) }},
-		{"ecdsa.PublicKey", func() error { return jwk.RegisterKeyImporter[ecdsa.PublicKey](stub) }},
-		{"ed25519.PrivateKey", func() error { return jwk.RegisterKeyImporter[ed25519.PrivateKey](stub) }},
-		{"ed25519.PublicKey", func() error { return jwk.RegisterKeyImporter[ed25519.PublicKey](stub) }},
-		{"*ecdh.PrivateKey", func() error { return jwk.RegisterKeyImporter[*ecdh.PrivateKey](stub) }},
-		{"ecdh.PrivateKey", func() error { return jwk.RegisterKeyImporter[ecdh.PrivateKey](stub) }},
-		{"*ecdh.PublicKey", func() error { return jwk.RegisterKeyImporter[*ecdh.PublicKey](stub) }},
-		{"ecdh.PublicKey", func() error { return jwk.RegisterKeyImporter[ecdh.PublicKey](stub) }},
-		{"[]byte", func() error { return jwk.RegisterKeyImporter[[]byte](stub) }},
+		{"rsa.PrivateKey", func() error { return jwk.RegisterKeyImporter(stubImporter[rsa.PrivateKey]{err: stubErr}) }},
+		{"*rsa.PublicKey", func() error { return jwk.RegisterKeyImporter(stubImporter[*rsa.PublicKey]{err: stubErr}) }},
+		{"rsa.PublicKey", func() error { return jwk.RegisterKeyImporter(stubImporter[rsa.PublicKey]{err: stubErr}) }},
+		{"*ecdsa.PrivateKey", func() error { return jwk.RegisterKeyImporter(stubImporter[*ecdsa.PrivateKey]{err: stubErr}) }},
+		{"ecdsa.PrivateKey", func() error { return jwk.RegisterKeyImporter(stubImporter[ecdsa.PrivateKey]{err: stubErr}) }},
+		{"*ecdsa.PublicKey", func() error { return jwk.RegisterKeyImporter(stubImporter[*ecdsa.PublicKey]{err: stubErr}) }},
+		{"ecdsa.PublicKey", func() error { return jwk.RegisterKeyImporter(stubImporter[ecdsa.PublicKey]{err: stubErr}) }},
+		{"ed25519.PrivateKey", func() error { return jwk.RegisterKeyImporter(stubImporter[ed25519.PrivateKey]{err: stubErr}) }},
+		{"ed25519.PublicKey", func() error { return jwk.RegisterKeyImporter(stubImporter[ed25519.PublicKey]{err: stubErr}) }},
+		{"*ecdh.PrivateKey", func() error { return jwk.RegisterKeyImporter(stubImporter[*ecdh.PrivateKey]{err: stubErr}) }},
+		{"ecdh.PrivateKey", func() error { return jwk.RegisterKeyImporter(stubImporter[ecdh.PrivateKey]{err: stubErr}) }},
+		{"*ecdh.PublicKey", func() error { return jwk.RegisterKeyImporter(stubImporter[*ecdh.PublicKey]{err: stubErr}) }},
+		{"ecdh.PublicKey", func() error { return jwk.RegisterKeyImporter(stubImporter[ecdh.PublicKey]{err: stubErr}) }},
+		{"[]byte", func() error { return jwk.RegisterKeyImporter(stubImporter[[]byte]{err: stubErr}) }},
 	}
 	for _, tc := range builtins {
 		t.Run("RegisterKeyImporter["+tc.name+"]", func(t *testing.T) {

--- a/jwk/convert_test.go
+++ b/jwk/convert_test.go
@@ -49,31 +49,28 @@ func TestFindExportersCaseInsensitiveKeyKind(t *testing.T) {
 	require.Equal(t, sentinel, got, "Export should return sentinel from registered exporter")
 }
 
-// recipe10RawKey exercises the MIGRATION.md Recipe 10 custom-importer
-// syntax. Any change to jwk.RegisterKeyImporter's signature that breaks
-// bare-literal type inference (e.g. adding a second type parameter)
-// must break this test so the migration guide doesn't silently rot.
+// recipe10RawKey exercises the custom-importer registration syntax
+// shown in MIGRATION.md Recipe 10.
 type recipe10RawKey struct{ secret []byte }
 
-// TestMigrationRecipe10KeyImporterSyntax pins the Recipe 10 syntax shown
-// in MIGRATION.md: a bare function literal with a pointer argument whose
-// type parameter is inferred.
+// TestMigrationRecipe10KeyImporterSyntax pins the syntax shown in
+// MIGRATION.md Recipe 10: register a [jwk.KeyImporter] (typically via
+// [jwk.TypedKeyImportFunc] for a typed function) under an explicit
+// raw-key Go type parameter.
 func TestMigrationRecipe10KeyImporterSyntax(t *testing.T) {
-	// Intentionally mirrors MIGRATION.md Recipe 10 verbatim:
-	//
-	//	jwk.RegisterKeyImporter(func(src *myKeyType) (jwk.Key, error) {
-	//	    // ... convert — type parameter inferred, no assertion needed
-	//	})
+	importFn := func(src *recipe10RawKey) (jwk.Key, error) {
+		k, err := jwk.Import[jwk.Key](src.secret)
+		if err != nil {
+			return nil, err
+		}
+		require.NoError(t, k.Set(jwk.KeyIDKey, "recipe10"))
+		return k, nil
+	}
 	require.NoError(t,
-		jwk.RegisterKeyImporter(func(src *recipe10RawKey) (jwk.Key, error) {
-			k, err := jwk.Import[jwk.Key](src.secret)
-			if err != nil {
-				return nil, err
-			}
-			require.NoError(t, k.Set(jwk.KeyIDKey, "recipe10"))
-			return k, nil
-		}),
-		"RegisterKeyImporter should accept Recipe 10 bare-literal form")
+		jwk.RegisterKeyImporter[*recipe10RawKey](
+			jwk.TypedKeyImportFunc[*recipe10RawKey](importFn),
+		),
+		"RegisterKeyImporter should accept the typed-function adapter form")
 
 	key, err := jwk.Import[jwk.Key](&recipe10RawKey{secret: []byte("recipe-10-secret-material")})
 	require.NoError(t, err, "Import should dispatch to the Recipe 10 importer")
@@ -93,30 +90,30 @@ func TestRegisterKeyImporterRejectsDuplicate(t *testing.T) {
 	// Register/Unregister bookkeeping is correct. Return a non-nil
 	// error so the function doesn't look like a (nil, nil) sentinel
 	// that nilnil flags.
-	fn := func(dupImporterKey) (jwk.Key, error) {
+	importer := jwk.TypedKeyImportFunc[dupImporterKey](func(dupImporterKey) (jwk.Key, error) {
 		return nil, errors.New("dupImporterKey: importer body not exercised by this test")
-	}
+	})
 
 	t.Run("first registration succeeds", func(t *testing.T) {
-		require.NoError(t, jwk.RegisterKeyImporter(fn))
+		require.NoError(t, jwk.RegisterKeyImporter[dupImporterKey](importer))
 		defer jwk.UnregisterKeyImporter[dupImporterKey]()
 	})
 
 	t.Run("duplicate registration is rejected", func(t *testing.T) {
-		require.NoError(t, jwk.RegisterKeyImporter(fn))
+		require.NoError(t, jwk.RegisterKeyImporter[dupImporterKey](importer))
 		defer jwk.UnregisterKeyImporter[dupImporterKey]()
 
-		err := jwk.RegisterKeyImporter(fn)
+		err := jwk.RegisterKeyImporter[dupImporterKey](importer)
 		require.Error(t, err, `second RegisterKeyImporter should error`)
 		require.Contains(t, err.Error(), `already registered`,
 			`error should say the type is already registered`)
 	})
 
 	t.Run("Unregister + Register allows replacement", func(t *testing.T) {
-		require.NoError(t, jwk.RegisterKeyImporter(fn))
+		require.NoError(t, jwk.RegisterKeyImporter[dupImporterKey](importer))
 		require.True(t, jwk.UnregisterKeyImporter[dupImporterKey](),
 			`UnregisterKeyImporter should report removal`)
-		require.NoError(t, jwk.RegisterKeyImporter(fn),
+		require.NoError(t, jwk.RegisterKeyImporter[dupImporterKey](importer),
 			`RegisterKeyImporter should succeed after Unregister`)
 		defer jwk.UnregisterKeyImporter[dupImporterKey]()
 	})
@@ -138,11 +135,10 @@ func TestRegisterKeyImporterRejectsDuplicate(t *testing.T) {
 // resemble a (nil, nil) sentinel.
 func TestRegisterKeyImporterRejectsBuiltinTypes(t *testing.T) {
 	stubErr := errors.New("stub importer must not be invoked: built-in types are reserved")
+	stub := jwk.KeyImportFunc(func(any) (jwk.Key, error) { return nil, stubErr })
 
 	t.Run("RegisterKeyImporter[*rsa.PrivateKey]", func(t *testing.T) {
-		err := jwk.RegisterKeyImporter(func(*rsa.PrivateKey) (jwk.Key, error) {
-			return nil, stubErr
-		})
+		err := jwk.RegisterKeyImporter[*rsa.PrivateKey](stub)
 		require.Error(t, err, `RegisterKeyImporter should refuse a built-in raw key type`)
 		require.Contains(t, err.Error(), `built-in`,
 			`error should explain that built-in importers cannot be overridden`)
@@ -154,48 +150,20 @@ func TestRegisterKeyImporterRejectsBuiltinTypes(t *testing.T) {
 		name string
 		fn   func() error
 	}{
-		{"rsa.PrivateKey", func() error {
-			return jwk.RegisterKeyImporter(func(rsa.PrivateKey) (jwk.Key, error) { return nil, stubErr })
-		}},
-		{"*rsa.PublicKey", func() error {
-			return jwk.RegisterKeyImporter(func(*rsa.PublicKey) (jwk.Key, error) { return nil, stubErr })
-		}},
-		{"rsa.PublicKey", func() error {
-			return jwk.RegisterKeyImporter(func(rsa.PublicKey) (jwk.Key, error) { return nil, stubErr })
-		}},
-		{"*ecdsa.PrivateKey", func() error {
-			return jwk.RegisterKeyImporter(func(*ecdsa.PrivateKey) (jwk.Key, error) { return nil, stubErr })
-		}},
-		{"ecdsa.PrivateKey", func() error {
-			return jwk.RegisterKeyImporter(func(ecdsa.PrivateKey) (jwk.Key, error) { return nil, stubErr })
-		}},
-		{"*ecdsa.PublicKey", func() error {
-			return jwk.RegisterKeyImporter(func(*ecdsa.PublicKey) (jwk.Key, error) { return nil, stubErr })
-		}},
-		{"ecdsa.PublicKey", func() error {
-			return jwk.RegisterKeyImporter(func(ecdsa.PublicKey) (jwk.Key, error) { return nil, stubErr })
-		}},
-		{"ed25519.PrivateKey", func() error {
-			return jwk.RegisterKeyImporter(func(ed25519.PrivateKey) (jwk.Key, error) { return nil, stubErr })
-		}},
-		{"ed25519.PublicKey", func() error {
-			return jwk.RegisterKeyImporter(func(ed25519.PublicKey) (jwk.Key, error) { return nil, stubErr })
-		}},
-		{"*ecdh.PrivateKey", func() error {
-			return jwk.RegisterKeyImporter(func(*ecdh.PrivateKey) (jwk.Key, error) { return nil, stubErr })
-		}},
-		{"ecdh.PrivateKey", func() error {
-			return jwk.RegisterKeyImporter(func(ecdh.PrivateKey) (jwk.Key, error) { return nil, stubErr })
-		}},
-		{"*ecdh.PublicKey", func() error {
-			return jwk.RegisterKeyImporter(func(*ecdh.PublicKey) (jwk.Key, error) { return nil, stubErr })
-		}},
-		{"ecdh.PublicKey", func() error {
-			return jwk.RegisterKeyImporter(func(ecdh.PublicKey) (jwk.Key, error) { return nil, stubErr })
-		}},
-		{"[]byte", func() error {
-			return jwk.RegisterKeyImporter(func([]byte) (jwk.Key, error) { return nil, stubErr })
-		}},
+		{"rsa.PrivateKey", func() error { return jwk.RegisterKeyImporter[rsa.PrivateKey](stub) }},
+		{"*rsa.PublicKey", func() error { return jwk.RegisterKeyImporter[*rsa.PublicKey](stub) }},
+		{"rsa.PublicKey", func() error { return jwk.RegisterKeyImporter[rsa.PublicKey](stub) }},
+		{"*ecdsa.PrivateKey", func() error { return jwk.RegisterKeyImporter[*ecdsa.PrivateKey](stub) }},
+		{"ecdsa.PrivateKey", func() error { return jwk.RegisterKeyImporter[ecdsa.PrivateKey](stub) }},
+		{"*ecdsa.PublicKey", func() error { return jwk.RegisterKeyImporter[*ecdsa.PublicKey](stub) }},
+		{"ecdsa.PublicKey", func() error { return jwk.RegisterKeyImporter[ecdsa.PublicKey](stub) }},
+		{"ed25519.PrivateKey", func() error { return jwk.RegisterKeyImporter[ed25519.PrivateKey](stub) }},
+		{"ed25519.PublicKey", func() error { return jwk.RegisterKeyImporter[ed25519.PublicKey](stub) }},
+		{"*ecdh.PrivateKey", func() error { return jwk.RegisterKeyImporter[*ecdh.PrivateKey](stub) }},
+		{"ecdh.PrivateKey", func() error { return jwk.RegisterKeyImporter[ecdh.PrivateKey](stub) }},
+		{"*ecdh.PublicKey", func() error { return jwk.RegisterKeyImporter[*ecdh.PublicKey](stub) }},
+		{"ecdh.PublicKey", func() error { return jwk.RegisterKeyImporter[ecdh.PublicKey](stub) }},
+		{"[]byte", func() error { return jwk.RegisterKeyImporter[[]byte](stub) }},
 	}
 	for _, tc := range builtins {
 		t.Run("RegisterKeyImporter["+tc.name+"]", func(t *testing.T) {

--- a/jwk/convert_test.go
+++ b/jwk/convert_test.go
@@ -78,6 +78,51 @@ func TestMigrationRecipe10KeyImporterSyntax(t *testing.T) {
 	require.Equal(t, "recipe10", kid, "KID should match the value set by the importer")
 }
 
+// structImporterKey is a fake raw key type used by
+// TestRegisterKeyImporterStructImpl. It is intentionally
+// package-local so it does not collide with any built-in importer.
+type structImporterKey struct{ payload []byte }
+
+// structImporter implements jwk.KeyImporter[*structImporterKey]
+// directly — no KeyImportFunc wrapper. This pins that the
+// closure-wrapping inside RegisterKeyImporter dispatches to a
+// KeyImporter[T] implementation other than KeyImportFunc[T] and
+// passes the raw value through with the correct T.
+type structImporter struct {
+	tag string
+}
+
+func (i *structImporter) Import(raw *structImporterKey) (jwk.Key, error) {
+	k, err := jwk.Import[jwk.Key](raw.payload)
+	if err != nil {
+		return nil, err
+	}
+	if err := k.Set(jwk.KeyIDKey, i.tag); err != nil {
+		return nil, err
+	}
+	return k, nil
+}
+
+// TestRegisterKeyImporterStructImpl exercises the closure-wrapping
+// path for a struct-shaped KeyImporter[T] — the variant a stateful
+// extension would use (config / caches / locks on the importer
+// receiver, etc.). The Recipe 10 test covers KeyImportFunc[T];
+// without this test the struct path would be silently uncovered.
+func TestRegisterKeyImporterStructImpl(t *testing.T) {
+	importer := &structImporter{tag: "struct-importer"}
+	require.NoError(t,
+		jwk.RegisterKeyImporter(importer),
+		"RegisterKeyImporter should accept a struct-shaped KeyImporter[T] (T inferred from the typed Import method)")
+	defer jwk.UnregisterKeyImporter[*structImporterKey]()
+
+	key, err := jwk.Import[jwk.Key](&structImporterKey{payload: []byte("struct-importer-secret")})
+	require.NoError(t, err, "Import should dispatch through the struct importer's typed Import method")
+
+	kid, ok := key.KeyID()
+	require.True(t, ok, "imported key should carry the KID set by the struct importer")
+	require.Equal(t, "struct-importer", kid)
+}
+
 // dupImporterKey is a fake raw key type used by TestRegisterKeyImporterRejectsDuplicate.
 // It is intentionally package-local so it does not collide with any
 // built-in importer.

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -168,7 +168,7 @@ func convertRawKey(raw any) (Key, error) {
 		return nil, fmt.Errorf(`failed to convert %T to jwk.Key: no converters were able to convert`, raw)
 	}
 
-	return conv.Import(raw)
+	return conv(raw)
 }
 
 func doImport(raw any) (Key, error) {

--- a/jwk/validation_boundary_test.go
+++ b/jwk/validation_boundary_test.go
@@ -74,7 +74,7 @@ func registerInvalidImporter(t *testing.T) {
 	t.Helper()
 	registerInvalidImporterOnce.Do(func() {
 		err := jwk.RegisterKeyImporter[invalidImportRaw](
-			jwk.TypedKeyImportFunc[invalidImportRaw](func(invalidImportRaw) (jwk.Key, error) {
+			jwk.KeyImportFunc[invalidImportRaw](func(invalidImportRaw) (jwk.Key, error) {
 				return makeInvalidECDSAJWK()
 			}),
 		)

--- a/jwk/validation_boundary_test.go
+++ b/jwk/validation_boundary_test.go
@@ -73,7 +73,7 @@ func makeInvalidECDSAJWK() (jwk.Key, error) {
 func registerInvalidImporter(t *testing.T) {
 	t.Helper()
 	registerInvalidImporterOnce.Do(func() {
-		err := jwk.RegisterKeyImporter[invalidImportRaw](
+		err := jwk.RegisterKeyImporter(
 			jwk.KeyImportFunc[invalidImportRaw](func(invalidImportRaw) (jwk.Key, error) {
 				return makeInvalidECDSAJWK()
 			}),

--- a/jwk/validation_boundary_test.go
+++ b/jwk/validation_boundary_test.go
@@ -73,9 +73,11 @@ func makeInvalidECDSAJWK() (jwk.Key, error) {
 func registerInvalidImporter(t *testing.T) {
 	t.Helper()
 	registerInvalidImporterOnce.Do(func() {
-		err := jwk.RegisterKeyImporter(func(invalidImportRaw) (jwk.Key, error) {
-			return makeInvalidECDSAJWK()
-		})
+		err := jwk.RegisterKeyImporter[invalidImportRaw](
+			jwk.TypedKeyImportFunc[invalidImportRaw](func(invalidImportRaw) (jwk.Key, error) {
+				return makeInvalidECDSAJWK()
+			}),
+		)
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
**Breaking change.** v4.0.0 shipped `RegisterKeyImporter[T any](fn func(T) (Key, error))` — a generic that took a typed function and never exercised the public `KeyImporter` interface or `KeyImportFunc` adapter that were also exported. The interface design (mirrored from v3, where `RegisterKeyImporter(from any, conv KeyImporter)` worked correctly) was effectively dead code.

This PR fixes the API to be interface-anchored and as type-inference-friendly as the language allows.

## Final shape

```go
type KeyImporter[T any] interface {
    Import(raw T) (Key, error)
}

type KeyImportFunc[T any] func(T) (Key, error)
func (f KeyImportFunc[T]) Import(raw T) (Key, error) { return f(raw) }

func RegisterKeyImporter[T any](ki KeyImporter[T]) error
```

The `KeyImporter` interface is now generic — its `Import` method is itself typed — so the registration's `T` is inferred from whatever you pass in. `KeyImportFunc` is the canonical typed-function adapter; for stateful importers, implement `KeyImporter[T]` directly on your own type.

## Caller forms

```go
// Custom struct — T inferred from the typed Import method:
type myImporter struct{ /* state */ }
func (myImporter) Import(raw *MyType) (jwk.Key, error) { ... }
jwk.RegisterKeyImporter(myImporter{})

// Typed function via KeyImportFunc — outer T inferred from the adapter:
jwk.RegisterKeyImporter(jwk.KeyImportFunc[*MyType](myFunc))
```

## Internal storage

`keyImporters` is now `map[reflect.Type]func(any) (Key, error)` — a closure per registration that captures `T` and `ki`, performs the safe `raw.(T)` re-typing, and forwards to the typed `Import`. The assertion can't fail because the lookup key matches `reflect.TypeFor[T]()`.

Built-in-type protection (stdlib `*rsa.PrivateKey` etc. cannot be overridden) is preserved unchanged.

## Tests

- `TestMigrationRecipe10KeyImporterSyntax` — pins the canonical `KeyImportFunc[T]` registration form.
- `TestRegisterKeyImporterStructImpl` — covers the closure-wrapping path for a struct-shaped `KeyImporter[T]` (no `KeyImportFunc`), with state on the receiver and round-trip through `jwk.Import`.
- `TestRegisterKeyImporterRejectsDuplicate` — register / unregister / replace bookkeeping.
- `TestRegisterKeyImporterRejectsBuiltinTypes` — refuses overrides of stdlib raw key types; verifies built-in importers stay functional after attempted unregister.
- `validation_boundary_test.go` — end-to-end Import flow.

## Docs

- `MIGRATION.md` Recipe 10 updated.
- `docs/04-jwk.md` extension-authoring section shows both struct and `KeyImportFunc` forms.
- `docs/design/v4-generics.md` documents the v4.0.0 mistake and the corrected design.

## Companion modules

Every importing companion (`ed448`, `mldsa`, `mlkem`, `compsig`, `x448`, `reddy-pqchpke`, `examples`) breaks at compile time. Coordinated bulk update will follow once this lands.

## Commits

Four commits on the branch — squash at merge.