### PR TITLE
ci: make v4 fuzz workflow actually run

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,10 +34,6 @@ jobs:
           restore-keys: |
             fuzz-${{ matrix.package }}-
       - name: Run fuzz tests
-        run: |
-          FUZZTIME="${{ github.event.inputs.fuzz-time || '5m' }}"
-          for target in $(go test ./${{ matrix.package }}/ -list 'Fuzz.*' -run '^$' 2>/dev/null | grep '^Fuzz'); do
-            echo "::group::${target}"
-            go test ./${{ matrix.package }}/ -run '^$' -fuzz "^${target}\$" -fuzztime "${FUZZTIME}"
-            echo "::endgroup::"
-          done
+        env:
+          FUZZTIME: ${{ github.event.inputs.fuzz-time || '5m' }}
+        run: make fuzz-${{ matrix.package }}


### PR DESCRIPTION
- inline `go test -list` was missing `GOEXPERIMENT=jsonv2` and the `2>/dev/null` hid the build failure; every weekly run since 2026-04-22 exited 0 after ~15s with zero fuzzing
- switch to `make fuzz-<pkg>` so `GOEXPERIMENT` and target list come from the Makefile
- cache config unchanged