### PR TITLE
ci: rotate companion fuzz cache via per-run key

### DIFF
--- a/.companions/templates/fuzz.yml
+++ b/.companions/templates/fuzz.yml
@@ -28,14 +28,19 @@ jobs:
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build/fuzz
-          key: fuzz-${{ hashFiles('go.mod') }}-${{ github.ref }}
+          key: fuzz-${{ github.run_id }}
           restore-keys: |
-            fuzz-${{ hashFiles('go.mod') }}-
+            fuzz-
       - name: Run fuzz tests
         run: |
           FUZZTIME="${{ github.event.inputs.fuzz-time || '5m' }}"
           mkdir -p /tmp/fuzz-output
-          for target in $(go test . -list '^Fuzz' -run '^$' | grep '^Fuzz' || true); do
+          targets=$(go test . -list '^Fuzz' -run '^$' | grep '^Fuzz')
+          if [ -z "$targets" ]; then
+            echo "no fuzz targets found"
+            exit 1
+          fi
+          for target in $targets; do
             echo "::group::${target}"
             go test . -run '^$' -fuzz "^${target}\$" -fuzztime "${FUZZTIME}" 2>&1 \
               | tee -a /tmp/fuzz-output/log.txt


### PR DESCRIPTION
- companion `fuzz.yml` used a static cache key (`fuzz-<go.mod-hash>-<ref>`); GitHub skips saves when the primary key already exists, so corpus never accumulated past the first save
- switch to `fuzz-<run_id>` with `fuzz-` restore-prefix — mirrors the main repo fix (#2169); GitHub LRU/10 GB cap handles rotation
- also exit non-zero when `go test -list` finds zero `^Fuzz` targets so a future build break can't silently no-op