### PR TITLE
docs: explain fuzz template skip-list

### DIFF
--- a/.companions/templates.yaml
+++ b/.companions/templates.yaml
@@ -26,6 +26,12 @@ templates:
     dest: .github/workflows/assign-pr.yml
   auto-assign-pr.yml:
     dest: .github/auto-assign-pr.yml
+  # Fuzz templates skip these for distinct reasons:
+  #   benchmarks  — no application code, only benchmark suites
+  #   examples    — example_test.go only, no Fuzz* targets
+  #   jwkfetch    — no Fuzz* targets defined
+  #   jwxmigrate  — no Fuzz* targets defined
+  #   x448        — has Fuzz* targets in subpackages (dhkem, hpke); uses a bespoke matrix workflow, not the standard template
   fuzz.yml:
     dest: .github/workflows/fuzz.yml
     skip: [benchmarks, examples, jwkfetch, jwxmigrate, x448]


### PR DESCRIPTION
- adds inline rationale next to the `fuzz.yml` / `fuzz-pr.yml` skip lists in `.companions/templates.yaml` so the reason each module is excluded is visible at the entry, not implicit
- `x448` is the easy-to-misread case: it has Fuzz* targets in subpackages and a bespoke matrix workflow, not an absence of fuzz tests