### PR TITLE
ci: pin golangci-lint to v2.11.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ jobs:
         with:
           go-version-file: "go.mod"
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.11.4
       - name: Run go vet
         run: |
           go vet ./...


### PR DESCRIPTION
- Lint workflow ran golangci-lint `latest`, which floated to v2.12.0+ and enabled `goconst`, failing on existing repeated strings
- Pin binary to v2.11.4 — last release before `goconst` enforcement; lints clean on `develop/v2`
