### PR TITLE
clear pooled error slice before reuse

### DIFF
--- a/internal/pool/BUILD.bazel
+++ b/internal/pool/BUILD.bazel
@@ -21,9 +21,10 @@ alias(
 
 go_test(
     name = "pool_test",
-    srcs = ["byte_slice_test.go"],
-    deps = [
-        ":pool",
-        "@com_github_stretchr_testify//require",
+    srcs = [
+        "byte_slice_test.go",
+        "error_slice_test.go",
     ],
+    embed = [":pool"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/internal/pool/error_slice.go
+++ b/internal/pool/error_slice.go
@@ -7,7 +7,12 @@ func allocErrorSlice() []error {
 }
 
 func freeErrorSlice(s []error) []error {
-	// Reset the slice to its zero value
+	// Defensive: scrub the entire backing array, not just s[:len(s)]. The
+	// pooled errors may reference request data; clearing the full capacity
+	// keeps stale values from staying reachable in the pool's backing
+	// storage until they happen to be overwritten.
+	s = s[:cap(s)]
+	clear(s)
 	return s[:0]
 }
 

--- a/internal/pool/error_slice_test.go
+++ b/internal/pool/error_slice_test.go
@@ -14,22 +14,25 @@ import (
 // pool's backing storage. This is a white-box test calling freeErrorSlice
 // directly so it does not depend on sync.Pool returning the same backing array.
 func TestFreeErrorSliceClearsBackingArray(t *testing.T) {
-	// Construct a slice with stale, non-nil error elements occupying the full
-	// backing array, then hand it to freeErrorSlice.
+	// Fill the entire backing array with stale, non-nil errors, then shrink the
+	// slice so len < cap. The stale elements in [1:n] now live beyond len but
+	// remain reachable through the slice's capacity.
 	const n = 4
-	s := make([]error, n, n)
-	for i := range s {
-		s[i] = errors.New("stale error")
+	backing := make([]error, n)
+	for i := range backing {
+		backing[i] = errors.New("stale error")
 	}
+	s := backing[:1]
 
 	got := freeErrorSlice(s)
 
 	require.Equal(t, 0, len(got), "freed slice should have length 0")
 	require.Equal(t, n, cap(got), "freed slice should retain its capacity")
 
-	// The entire backing array (up to cap) must be nil. This assertion fails
-	// against a no-clear implementation (e.g. returning s[:0] without clear),
-	// where the stale elements remain reachable via got[:cap(got)].
+	// The entire backing array (up to cap), including the region beyond the
+	// original len, must be nil. This assertion fails against an implementation
+	// that only clears s[:len] without first widening to cap, because the stale
+	// elements in [1:n] would remain reachable via got[:cap(got)].
 	full := got[:cap(got)]
 	for i, e := range full {
 		require.Nil(t, e, "backing array element %d should be cleared", i)

--- a/internal/pool/error_slice_test.go
+++ b/internal/pool/error_slice_test.go
@@ -1,0 +1,35 @@
+package pool_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/internal/pool"
+	"github.com/stretchr/testify/require"
+)
+
+// TestErrorSlicePoolClearsBackingArray verifies that returning an error slice to
+// the pool scrubs the backing array, so a later Get cannot observe stale error
+// values via the capacity range (which may reference request data).
+func TestErrorSlicePoolClearsBackingArray(t *testing.T) {
+	p := pool.ErrorSlice()
+
+	s := p.Get()
+	require.Equal(t, 0, len(s), "initial slice should have length 0")
+
+	s = append(s, errors.New("stale error"))
+	require.Equal(t, 1, len(s), "slice length should reflect appended error")
+
+	c := cap(s)
+	p.Put(s)
+
+	s2 := p.Get()
+	require.Equal(t, 0, len(s2), "slice length after Put should be reset to 0")
+
+	// Inspect the full backing array up to its capacity: no stale element must remain.
+	full := s2[:cap(s2)]
+	require.GreaterOrEqual(t, cap(s2), c, "capacity should be retained after reuse")
+	for i, e := range full {
+		require.Nil(t, e, "backing array element %d should be cleared", i)
+	}
+}

--- a/internal/pool/error_slice_test.go
+++ b/internal/pool/error_slice_test.go
@@ -1,34 +1,36 @@
-package pool_test
+package pool
 
 import (
 	"errors"
 	"testing"
 
-	"github.com/lestrrat-go/jwx/v4/internal/pool"
 	"github.com/stretchr/testify/require"
 )
 
-// TestErrorSlicePoolClearsBackingArray verifies that returning an error slice to
-// the pool scrubs the backing array, so a later Get cannot observe stale error
-// values via the capacity range (which may reference request data).
-func TestErrorSlicePoolClearsBackingArray(t *testing.T) {
-	p := pool.ErrorSlice()
+// TestFreeErrorSliceClearsBackingArray verifies that freeErrorSlice scrubs the
+// entire backing array (up to cap), not just the live length. A returned slice
+// may hold errors that reference request data; leaving stale non-nil elements
+// reachable through the slice's capacity would keep that data alive in the
+// pool's backing storage. This is a white-box test calling freeErrorSlice
+// directly so it does not depend on sync.Pool returning the same backing array.
+func TestFreeErrorSliceClearsBackingArray(t *testing.T) {
+	// Construct a slice with stale, non-nil error elements occupying the full
+	// backing array, then hand it to freeErrorSlice.
+	const n = 4
+	s := make([]error, n, n)
+	for i := range s {
+		s[i] = errors.New("stale error")
+	}
 
-	s := p.Get()
-	require.Equal(t, 0, len(s), "initial slice should have length 0")
+	got := freeErrorSlice(s)
 
-	s = append(s, errors.New("stale error"))
-	require.Equal(t, 1, len(s), "slice length should reflect appended error")
+	require.Equal(t, 0, len(got), "freed slice should have length 0")
+	require.Equal(t, n, cap(got), "freed slice should retain its capacity")
 
-	c := cap(s)
-	p.Put(s)
-
-	s2 := p.Get()
-	require.Equal(t, 0, len(s2), "slice length after Put should be reset to 0")
-
-	// Inspect the full backing array up to its capacity: no stale element must remain.
-	full := s2[:cap(s2)]
-	require.GreaterOrEqual(t, cap(s2), c, "capacity should be retained after reuse")
+	// The entire backing array (up to cap) must be nil. This assertion fails
+	// against a no-clear implementation (e.g. returning s[:0] without clear),
+	// where the stale elements remain reachable via got[:cap(got)].
+	full := got[:cap(got)]
 	for i, e := range full {
 		require.Nil(t, e, "backing array element %d should be cleared", i)
 	}


### PR DESCRIPTION
- `freeErrorSlice` now `clear`s the full backing array (`s[:cap(s)]`) before returning `s[:0]`, so pooled errors that reference request data don't stay reachable in the pool until overwritten — same idiom already used by `freeByteSlice`.
- Internal-only (`internal/pool`); no public API or observable behavior change.