### PR TITLE
avoid full-string rune alloc in alg error

### DIFF
--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -35,26 +35,31 @@ func ErrInvalidKeyAlgorithm() error {
 }
 
 func formatInvalidKeyAlgorithmValue(v string) string {
-	// Find the byte offset just past the maxKeyAlgorithmErrorPreview-th
-	// rune without materializing []rune(v) for the whole string. For an
+	// Collect at most maxKeyAlgorithmErrorPreview decoded runes without
+	// materializing []rune(v) for the whole string. For an
 	// attacker-controllable v this bounds the transient allocation to
-	// the preview window rather than the entire input, while producing a
-	// byte-for-byte identical error string to a full rune-slice cut.
-	count := 0
-	cut := -1
-	for i := range v {
-		if count == maxKeyAlgorithmErrorPreview {
-			cut = i
+	// the preview window rather than the entire input.
+	//
+	// Ranging over a string decodes invalid UTF-8 to utf8.RuneError
+	// (U+FFFD), so the preview is byte-for-byte identical to the naive
+	// string([]rune(v)[:maxKeyAlgorithmErrorPreview]) implementation,
+	// including the U+FFFD substitution for malformed bytes within the
+	// window.
+	preview := make([]rune, 0, maxKeyAlgorithmErrorPreview)
+	truncated := false
+	for _, r := range v {
+		if len(preview) == maxKeyAlgorithmErrorPreview {
+			truncated = true
 			break
 		}
-		count++
+		preview = append(preview, r)
 	}
-	if cut < 0 {
+	if !truncated {
 		// v has maxKeyAlgorithmErrorPreview runes or fewer: render in full.
 		return fmt.Sprintf("%q", v)
 	}
 
-	return fmt.Sprintf("%q", v[:cut]+`...`)
+	return fmt.Sprintf("%q", string(preview)+`...`)
 }
 
 // algorithmKind tags entries in the shared algRegistry so the

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -35,12 +35,26 @@ func ErrInvalidKeyAlgorithm() error {
 }
 
 func formatInvalidKeyAlgorithmValue(v string) string {
-	runes := []rune(v)
-	if len(runes) <= maxKeyAlgorithmErrorPreview {
+	// Find the byte offset just past the maxKeyAlgorithmErrorPreview-th
+	// rune without materializing []rune(v) for the whole string. For an
+	// attacker-controllable v this bounds the transient allocation to
+	// the preview window rather than the entire input, while producing a
+	// byte-for-byte identical error string to a full rune-slice cut.
+	count := 0
+	cut := -1
+	for i := range v {
+		if count == maxKeyAlgorithmErrorPreview {
+			cut = i
+			break
+		}
+		count++
+	}
+	if cut < 0 {
+		// v has maxKeyAlgorithmErrorPreview runes or fewer: render in full.
 		return fmt.Sprintf("%q", v)
 	}
 
-	return fmt.Sprintf("%q", string(runes[:maxKeyAlgorithmErrorPreview])+`...`)
+	return fmt.Sprintf("%q", v[:cut]+`...`)
 }
 
 // algorithmKind tags entries in the shared algRegistry so the

--- a/jwa/jwa_test.go
+++ b/jwa/jwa_test.go
@@ -167,6 +167,18 @@ func TestKeyAlgorithmFrom(t *testing.T) {
 				Input:    strings.Repeat("あ", 1024),
 				Expected: fmt.Sprintf(`invalid key value: %q: invalid key algorithm`, strings.Repeat("あ", 64)+`...`),
 			},
+			{
+				// Invalid UTF-8 bytes within the preview window must be
+				// decoded to U+FFFD before %q quoting, matching the old
+				// string([]rune(v)[:64]) reference. The leading "\xff\xfe"
+				// are two invalid bytes that decode to two U+FFFD runes.
+				Name:  "invalid utf-8 before cutoff is decoded to replacement runes",
+				Input: "\xff\xfe" + strings.Repeat("a", 80),
+				Expected: fmt.Sprintf(
+					`invalid key value: %q: invalid key algorithm`,
+					string([]rune("\xff\xfe"+strings.Repeat("a", 80))[:64])+`...`,
+				),
+			},
 		} {
 			t.Run(tc.Name, func(t *testing.T) {
 				t.Parallel()

--- a/jwa/jwa_test.go
+++ b/jwa/jwa_test.go
@@ -176,7 +176,7 @@ func TestKeyAlgorithmFrom(t *testing.T) {
 				Input: "\xff\xfe" + strings.Repeat("a", 80),
 				Expected: fmt.Sprintf(
 					`invalid key value: %q: invalid key algorithm`,
-					string([]rune("\xff\xfe"+strings.Repeat("a", 80))[:64])+`...`,
+					string([]rune("\xff\xfe" + strings.Repeat("a", 80))[:64])+`...`,
 				),
 			},
 		} {

--- a/jwa/jwa_test.go
+++ b/jwa/jwa_test.go
@@ -131,6 +131,52 @@ func TestKeyAlgorithmFrom(t *testing.T) {
 		require.NotContains(t, err.Error(), input, `error should not echo the full invalid value`)
 	})
 
+	// Pin the exact error string for several input lengths so that the
+	// bounded-allocation preview formatting stays byte-for-byte identical
+	// to the naive []rune(v) implementation.
+	t.Run("exact error string is identical regardless of length", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range []struct {
+			Name     string
+			Input    string
+			Expected string
+		}{
+			{
+				Name:     "short ASCII rendered in full",
+				Input:    "dummy",
+				Expected: `invalid key value: "dummy": invalid key algorithm`,
+			},
+			{
+				Name:     "exactly the preview length rendered in full",
+				Input:    strings.Repeat("a", 64),
+				Expected: fmt.Sprintf(`invalid key value: %q: invalid key algorithm`, strings.Repeat("a", 64)),
+			},
+			{
+				Name:     "one rune over the preview length is truncated",
+				Input:    strings.Repeat("a", 65),
+				Expected: fmt.Sprintf(`invalid key value: %q: invalid key algorithm`, strings.Repeat("a", 64)+`...`),
+			},
+			{
+				Name:     "long ASCII is truncated",
+				Input:    strings.Repeat("a", 1024),
+				Expected: fmt.Sprintf(`invalid key value: %q: invalid key algorithm`, strings.Repeat("a", 64)+`...`),
+			},
+			{
+				Name:     "long multibyte is truncated on rune boundaries",
+				Input:    strings.Repeat("あ", 1024),
+				Expected: fmt.Sprintf(`invalid key value: %q: invalid key algorithm`, strings.Repeat("あ", 64)+`...`),
+			},
+		} {
+			t.Run(tc.Name, func(t *testing.T) {
+				t.Parallel()
+				_, err := jwa.KeyAlgorithmFrom(tc.Input)
+				require.Error(t, err, `creating key algorithm should fail`)
+				require.Equal(t, tc.Expected, err.Error(), `error string must be byte-for-byte identical`)
+			})
+		}
+	})
+
 	t.Run("invalid type preserves type information", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
- `formatInvalidKeyAlgorithmValue` no longer builds `[]rune(v)` over the entire input; it scans only the first preview window of runes, bounding the transient allocation for huge invalid `alg` strings.
- Error string output is byte-for-byte identical for all inputs; tests pin exact output for short, boundary, long-ASCII, and long-multibyte cases.