### PR TITLE
release json registry lock before decoder call

### DIFF
--- a/internal/json/registry.go
+++ b/internal/json/registry.go
@@ -143,10 +143,15 @@ func (r *Registry) Unregister(name string) {
 // given field name. If no decoder is registered, the raw value is decoded
 // into any.
 func (r *Registry) Decode(name string, raw RawMessage) (any, error) {
+	// Snapshot the decoder under the read lock, then release the lock before
+	// invoking it. The user-supplied decoder may re-entrantly call
+	// Register/Unregister on this same registry (which take a write lock), and
+	// holding the read lock across the call would deadlock (RLock -> Lock).
 	r.mu.RLock()
-	defer r.mu.RUnlock()
+	ctr, ok := r.ctrs[name]
+	r.mu.RUnlock()
 
-	if ctr, ok := r.ctrs[name]; ok {
+	if ok {
 		v, err := ctr.Decode([]byte(raw))
 		if err != nil {
 			return nil, fmt.Errorf(`failed to decode field %s: %w`, name, err)

--- a/internal/json/registry_test.go
+++ b/internal/json/registry_test.go
@@ -1,0 +1,44 @@
+package json_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v4/internal/json"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegistryDecodeReentrant ensures that a registered decoder may call
+// Register/Unregister on the same registry during Decode without deadlocking.
+// Decode must not hold the registry lock while invoking the user-supplied
+// decoder.
+func TestRegistryDecodeReentrant(t *testing.T) {
+	t.Parallel()
+
+	reg := json.NewRegistry()
+
+	// This decoder re-entrantly mutates the same registry during Decode.
+	// Before the fix, Decode held an RLock across this call, and the
+	// Register/Unregister calls (which take a write Lock) would deadlock.
+	json.RegisterCustomDecoder(reg, "field", json.CustomDecodeFunc[string](func(data []byte) (string, error) {
+		reg.Register("other", "")
+		reg.Unregister("other")
+		return string(data), nil
+	}))
+
+	done := make(chan struct{})
+	var v any
+	var err error
+	go func() {
+		defer close(done)
+		v, err = reg.Decode("field", json.RawMessage(`"hello"`))
+	}()
+
+	select {
+	case <-done:
+		require.NoError(t, err)
+		require.Equal(t, `"hello"`, v)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Decode deadlocked: registered decoder could not re-entrantly mutate the registry")
+	}
+}


### PR DESCRIPTION
- `internal/json` `Registry.Decode` held the read lock across the user-supplied decoder call; a decoder that re-entrantly calls `Register`/`Unregister` on the same registry deadlocked (RLock -> Lock).
- Snapshot the decoder under the read lock, release it, then invoke. Internal-only; no public API or behavior change for non-re-entrant usage.