### PR TITLE
error on nil curve and oversized d at import

### DIFF
--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -103,6 +103,19 @@ func (k *ecdsaPrivateKey) Import(rawKey *ecdsa.PrivateKey) error {
 		return fmt.Errorf(`jwk: %w`, err)
 	}
 
+	// validateECDSAPoint guarantees a non-nil Curve. Bound D the same way
+	// the X/Y coordinates are bounded: AllocECPointBuffer writes D into a
+	// fixed-size buffer via big.Int.FillBytes, which panics on oversized
+	// input. A valid private scalar is in [1, n-1], so reject non-positive
+	// or over-wide values here.
+	bits := rawKey.Curve.Params().BitSize
+	if rawKey.D.Sign() <= 0 {
+		return fmt.Errorf(`jwk: invalid ECDSA private key: d must be a positive scalar`)
+	}
+	if rawKey.D.BitLen() > bits {
+		return fmt.Errorf(`jwk: invalid ECDSA private key: d is %d bits, exceeds curve %q field size of %d bits`, rawKey.D.BitLen(), rawKey.Curve.Params().Name, bits)
+	}
+
 	xbuf := ecutil.AllocECPointBuffer(rawKey.PublicKey.X, rawKey.Curve)
 	ybuf := ecutil.AllocECPointBuffer(rawKey.PublicKey.Y, rawKey.Curve)
 	dbuf := ecutil.AllocECPointBuffer(rawKey.D, rawKey.Curve)
@@ -169,6 +182,13 @@ func buildECDSAPublicKey(alg jwa.EllipticCurveAlgorithm, xbuf, ybuf []byte) (*ec
 // failing closed is preferable to silently accepting unvalidated
 // points.
 func validateECDSAPoint(crv elliptic.Curve, x, y *big.Int) error {
+	// A nil curve has no field parameters; every check below dereferences
+	// crv.Params(), so guard here to avoid a nil-pointer panic on
+	// hand-crafted keys with an unset Curve.
+	if crv == nil {
+		return fmt.Errorf(`invalid ECDSA key: nil curve`)
+	}
+
 	if x.Sign() == 0 && y.Sign() == 0 {
 		return fmt.Errorf(`invalid ECDSA public key: identity point is not a valid public key`)
 	}

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -3,6 +3,7 @@ package jwk_test
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"testing"
@@ -155,5 +156,46 @@ func TestECDSAImportRejectsInvalidPoints(t *testing.T) {
 		require.Error(t, err, `jwk.Import must reject the identity point`)
 		require.ErrorIs(t, err, jwk.ImportError(), `Import error should be classified as jwk.ImportError`)
 		require.True(t, errors.Is(err, jwk.ImportError()), `errors.Is should match jwk.ImportError`)
+	})
+}
+
+// TestECDSAImportMalformedRawKey asserts that jwk.Import returns an error
+// (and does not panic) for hand-crafted ecdsa key structs with a nil curve
+// or an out-of-range D scalar, both of which previously panicked inside the
+// underlying crypto primitives (Curve.Params() nil deref and
+// big.Int.FillBytes on an oversized D).
+func TestECDSAImportMalformedRawKey(t *testing.T) {
+	t.Run("nil curve public key", func(t *testing.T) {
+		raw := &ecdsa.PublicKey{Curve: nil, X: big.NewInt(1), Y: big.NewInt(1)}
+		_, err := jwk.Import[jwk.Key](raw)
+		require.Error(t, err, `Import must reject a nil-curve public key without panicking`)
+	})
+
+	t.Run("nil curve private key", func(t *testing.T) {
+		raw := &ecdsa.PrivateKey{
+			PublicKey: ecdsa.PublicKey{Curve: nil, X: big.NewInt(1), Y: big.NewInt(1)},
+			D:         big.NewInt(1),
+		}
+		_, err := jwk.Import[jwk.Key](raw)
+		require.Error(t, err, `Import must reject a nil-curve private key without panicking`)
+	})
+
+	t.Run("oversized D private key", func(t *testing.T) {
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err, `failed to generate P-256 key`)
+		// Replace D with a scalar far larger than the curve field so that
+		// AllocECPointBuffer -> big.Int.FillBytes would panic if unguarded.
+		priv.D = new(big.Int).Lsh(big.NewInt(1), 4096)
+		_, err = jwk.Import[jwk.Key](priv)
+		require.Error(t, err, `Import must reject an oversized D without panicking`)
+	})
+
+	t.Run("valid generated key imports", func(t *testing.T) {
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err, `failed to generate P-256 key`)
+		_, err = jwk.Import[jwk.Key](priv)
+		require.NoError(t, err, `Import must accept a valid generated key`)
+		_, err = jwk.Import[jwk.Key](&priv.PublicKey)
+		require.NoError(t, err, `Import must accept a valid generated public key`)
 	})
 }

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -83,6 +83,12 @@ func init() {
 //
 // Import validates the populated JWK before returning it. Malformed raw
 // keys fail at import time instead of being returned for later validation.
+//
+// Import expects well-formed raw keys, such as those produced by the
+// standard library generators (e.g. ecdsa.GenerateKey, rsa.GenerateKey)
+// or by parsing an encoded key. Hand-crafting raw key structs with
+// internally inconsistent or out-of-range fields is not supported and may
+// cause the underlying crypto primitives to panic; avoid doing so.
 func Import[T Key](raw any) (T, error) {
 	var zero T
 	key, err := doImport(raw)


### PR DESCRIPTION
- jwk.Import: nil-curve ecdsa keys now return an error instead of panicking in validateECDSAPoint
- jwk.Import: bound private-key D scalar before AllocECPointBuffer to prevent a FillBytes panic on oversized D
- document that Import expects well-formed raw keys; hand-crafted out-of-range structs may panic in crypto primitives