### PR TITLE
handle nil clock and validator in validate

### DIFF
--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -80,6 +80,8 @@ options:
     comment: |
       WithClock specifies the `Clock` to be used when verifying
       exp, iat and nbf claims.
+
+      If v is nil, the default clock (the system clock, time.Now) is used.
   - ident: Context
     interface: ValidateOption
     argument_type: context.Context
@@ -233,7 +235,9 @@ options:
     argument_type: Validator
     comment: |
      WithValidator validates the token with the given Validator.
-      
+
+     Passing a nil Validator causes Validate to return an error.
+
      For example, in order to validate tokens that are only valid during August, you would write
       
       validator := jwt.ValidatorFunc(func(_ context.Context, t jwt.Token) error {

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -289,6 +289,8 @@ func WithBase64Encoder(v jws.Base64Encoder) SignParseOption {
 
 // WithClock specifies the `Clock` to be used when verifying
 // exp, iat and nbf claims.
+//
+// If v is nil, the default clock (the system clock, time.Now) is used.
 func WithClock(v Clock) ValidateOption {
 	return &validateOption{option.New(identClock{}, v)}
 }
@@ -507,6 +509,8 @@ func WithValidate(v bool) ParseOption {
 }
 
 // WithValidator validates the token with the given Validator.
+//
+// Passing a nil Validator causes Validate to return an error.
 //
 // For example, in order to validate tokens that are only valid during August, you would write
 //

--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -20,6 +20,21 @@ func (f ClockFunc) Now() time.Time {
 	return f()
 }
 
+// isNilValue reports whether v is nil, including a typed-nil interface value
+// that wraps a nil pointer (or other nilable kind). A plain `== nil` check
+// misses the latter because the interface itself is non-nil.
+func isNilValue(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Func, reflect.Map, reflect.Slice, reflect.Chan:
+		return rv.IsNil()
+	}
+	return false
+}
+
 func isSupportedTimeClaim(c string) error {
 	switch c {
 	case ExpirationKey, IssuedAtKey, NotBeforeKey:
@@ -66,7 +81,8 @@ func Validate(t Token, options ...ValidateOption) error {
 	ctx := context.Background()
 	trunc := getDefaultTruncation()
 
-	var clock Clock = ClockFunc(time.Now)
+	var defaultClock Clock = ClockFunc(time.Now)
+	clock := defaultClock
 	var skew time.Duration
 	var baseValidators = []Validator{
 		IsIssuedAtValid(),
@@ -81,10 +97,16 @@ func Validate(t Token, options ...ValidateOption) error {
 		switch o.Ident() {
 		case identClock{}:
 			// A nil Clock falls back to the default clock (the system
-			// clock, time.Now) already assigned above, so only override
-			// when a non-nil Clock was supplied. This avoids a panic in
-			// clock.Now().
-			if c, ok := option.Get[Clock](o); ok && c != nil {
+			// clock, time.Now). WithClock(nil) stores an untyped nil, so
+			// option.Get reports ok=false; a typed-nil interface wrapping a
+			// nil pointer reports ok=true but isNilValue catches it. In both
+			// cases reset to the default so a later WithClock(nil) undoes an
+			// earlier custom clock, matching the documented behavior and
+			// avoiding a panic in clock.Now().
+			c, ok := option.Get[Clock](o)
+			if !ok || isNilValue(c) {
+				clock = defaultClock
+			} else {
 				clock = c
 			}
 		case identAcceptableSkew{}:
@@ -101,10 +123,11 @@ func Validate(t Token, options ...ValidateOption) error {
 		case identCollectErrors{}:
 			collectErrors = option.MustGet[bool](o)
 		case identValidator{}:
-			// A nil Validator would panic when its Validate method is
-			// called, so reject it up front with a clear error.
+			// A nil Validator (including a typed-nil interface wrapping a
+			// nil pointer) would panic when its Validate method is called,
+			// so reject it up front with a clear error.
 			v, ok := option.Get[Validator](o)
-			if !ok || v == nil {
+			if !ok || isNilValue(v) {
 				return validateErrorf(`jwt.WithValidator: nil Validator`)
 			}
 			switch v := v.(type) {

--- a/jwt/validate.go
+++ b/jwt/validate.go
@@ -80,7 +80,13 @@ func Validate(t Token, options ...ValidateOption) error {
 	for _, o := range options {
 		switch o.Ident() {
 		case identClock{}:
-			clock = option.MustGet[Clock](o)
+			// A nil Clock falls back to the default clock (the system
+			// clock, time.Now) already assigned above, so only override
+			// when a non-nil Clock was supplied. This avoids a panic in
+			// clock.Now().
+			if c, ok := option.Get[Clock](o); ok && c != nil {
+				clock = c
+			}
 		case identAcceptableSkew{}:
 			skew = option.MustGet[time.Duration](o)
 			if skew < 0 {
@@ -95,7 +101,12 @@ func Validate(t Token, options ...ValidateOption) error {
 		case identCollectErrors{}:
 			collectErrors = option.MustGet[bool](o)
 		case identValidator{}:
-			v := option.MustGet[Validator](o)
+			// A nil Validator would panic when its Validate method is
+			// called, so reject it up front with a clear error.
+			v, ok := option.Get[Validator](o)
+			if !ok || v == nil {
+				return validateErrorf(`jwt.WithValidator: nil Validator`)
+			}
 			switch v := v.(type) {
 			case *isInTimeRange:
 				if v.c1 != "" {

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -1047,3 +1047,43 @@ func TestValidateDefaultOrderMatchesSlowPath(t *testing.T) {
 	require.ErrorIs(t, errFast, jwt.InvalidIssuedAtError{},
 		`fast path must report iat error first too (symmetry with slow path)`)
 }
+
+func TestValidateNilClock(t *testing.T) {
+	t.Parallel()
+
+	// A nil Clock must fall back to the default clock (time.Now) instead
+	// of panicking.
+	valid, err := jwt.NewBuilder().
+		Expiration(time.Now().Add(time.Hour)).
+		Build()
+	require.NoError(t, err, `jwt.NewBuilder should succeed`)
+
+	require.NotPanics(t, func() {
+		err = jwt.Validate(valid, jwt.WithClock(nil))
+	}, `Validate with nil clock must not panic`)
+	require.NoError(t, err, `not-yet-expired token must validate with nil clock`)
+
+	expired, err := jwt.NewBuilder().
+		Expiration(time.Now().Add(-time.Hour)).
+		Build()
+	require.NoError(t, err, `jwt.NewBuilder should succeed`)
+
+	require.NotPanics(t, func() {
+		err = jwt.Validate(expired, jwt.WithClock(nil))
+	}, `Validate with nil clock must not panic`)
+	require.ErrorIs(t, err, jwt.TokenExpiredError{},
+		`expired token must fail with TokenExpiredError under nil (default) clock`)
+}
+
+func TestValidateNilValidator(t *testing.T) {
+	t.Parallel()
+
+	tok, err := jwt.NewBuilder().Build()
+	require.NoError(t, err, `jwt.NewBuilder should succeed`)
+
+	var err2 error
+	require.NotPanics(t, func() {
+		err2 = jwt.Validate(tok, jwt.WithValidator(nil))
+	}, `Validate with nil validator must not panic`)
+	require.Error(t, err2, `Validate with nil validator must return an error`)
+}

--- a/jwt/validate_test.go
+++ b/jwt/validate_test.go
@@ -1073,7 +1073,40 @@ func TestValidateNilClock(t *testing.T) {
 	}, `Validate with nil clock must not panic`)
 	require.ErrorIs(t, err, jwt.TokenExpiredError{},
 		`expired token must fail with TokenExpiredError under nil (default) clock`)
+
+	// A later WithClock(nil) must reset to the default clock, undoing an
+	// earlier custom clock (documented behavior). Use a clock fixed far in
+	// the future: under it the not-yet-expired token would read as expired,
+	// so a clean validation proves the default clock won the reset.
+	future := jwt.ClockFunc(func() time.Time { return time.Now().Add(100 * time.Hour) })
+	require.NotPanics(t, func() {
+		err = jwt.Validate(valid, jwt.WithClock(future), jwt.WithClock(nil))
+	}, `Validate with custom-then-nil clock must not panic`)
+	require.NoError(t, err,
+		`WithClock(nil) after a custom clock must reset to the default clock`)
+
+	// A typed-nil Clock (an interface value wrapping a nil pointer) must
+	// also fall back to the default clock instead of panicking.
+	var typedNil jwt.Clock = (*nilClock)(nil)
+	require.NotPanics(t, func() {
+		err = jwt.Validate(valid, jwt.WithClock(typedNil))
+	}, `Validate with typed-nil clock must not panic`)
+	require.NoError(t, err,
+		`typed-nil clock must fall back to the default clock`)
 }
+
+// nilClock is a concrete Clock type used to construct typed-nil interface
+// values in tests. Its Now method is never expected to be reached.
+type nilClock struct{}
+
+func (*nilClock) Now() time.Time { return time.Time{} }
+
+// nilValidator is a concrete Validator type used to construct typed-nil
+// interface values in tests. Its Validate method is never expected to be
+// reached.
+type nilValidator struct{}
+
+func (*nilValidator) Validate(context.Context, jwt.Token) error { return nil }
 
 func TestValidateNilValidator(t *testing.T) {
 	t.Parallel()
@@ -1086,4 +1119,12 @@ func TestValidateNilValidator(t *testing.T) {
 		err2 = jwt.Validate(tok, jwt.WithValidator(nil))
 	}, `Validate with nil validator must not panic`)
 	require.Error(t, err2, `Validate with nil validator must return an error`)
+
+	// A typed-nil Validator (an interface wrapping a nil pointer) must also
+	// be rejected with the nil-validator error rather than panicking later.
+	var typedNil jwt.Validator = (*nilValidator)(nil)
+	require.NotPanics(t, func() {
+		err2 = jwt.Validate(tok, jwt.WithValidator(typedNil))
+	}, `Validate with typed-nil validator must not panic`)
+	require.Error(t, err2, `Validate with typed-nil validator must return an error`)
 }


### PR DESCRIPTION
- jwt.WithClock(nil) now falls back to the default clock (time.Now) instead of panicking
- jwt.WithValidator(nil) now returns an error from Validate instead of panicking
- documented the nil behavior on both options