### PR TITLE
reset private claims on token unmarshal

### DIFF
--- a/internal/jwxcodegen/cmd/jwxcodegen/genjwt.go
+++ b/internal/jwxcodegen/cmd/jwxcodegen/genjwt.go
@@ -359,6 +359,7 @@ func generateTokenUnmarshalJSON(o *codegen.Output, obj *codegen.Object) {
 	for _, f := range fields {
 		o.L("t.%s = nil", f.Name(false))
 	}
+	o.L("clear(t.privateClaims)")
 
 	o.L("dec := json.NewDecoder(bytes.NewReader(buf))")
 	o.L("tok, err := dec.ReadToken()")

--- a/jwt/openid/openid_test.go
+++ b/jwt/openid/openid_test.go
@@ -841,3 +841,20 @@ func TestWithBase64Encoder(t *testing.T) {
 		require.NoError(t, err, `jwt.Parse should succeed`)
 	})
 }
+
+func TestUnmarshalResetsPrivateClaims(t *testing.T) {
+	t.Parallel()
+	tok := openid.New()
+	require.NoError(t, json.Unmarshal([]byte(`{"role":"admin","sub":"x"}`), tok))
+	v, ok := tok.Field("role")
+	require.True(t, ok, `role claim should be present after first unmarshal`)
+	require.Equal(t, "admin", v)
+
+	// Reuse the same token instance for a payload that omits "role".
+	require.NoError(t, json.Unmarshal([]byte(`{"sub":"y"}`), tok))
+	_, ok = tok.Field("role")
+	require.False(t, ok, `stale private claim "role" must be cleared on reuse`)
+	sub, ok := tok.Subject()
+	require.True(t, ok, `sub claim should be present after second unmarshal`)
+	require.Equal(t, "y", sub)
+}

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -938,6 +938,7 @@ func (t *stdToken) UnmarshalJSON(buf []byte) error {
 	t.updatedAt = nil
 	t.website = nil
 	t.zoneinfo = nil
+	clear(t.privateClaims)
 	dec := json.NewDecoder(bytes.NewReader(buf))
 	tok, err := dec.ReadToken()
 	if err != nil {

--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -173,7 +173,8 @@ options:
     argument_type: Token
     comment: |
       WithToken specifies the token instance in which the resulting JWT is stored
-      when parsing JWT tokens
+      when parsing JWT tokens. The supplied token is fully reset (all claims,
+      including private claims, are cleared) before the parsed token is stored into it.
   - ident: Validate
     interface: ParseOption
     argument_type: bool

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -475,7 +475,8 @@ func WithStrictStringClaims(v bool) ParseOption {
 }
 
 // WithToken specifies the token instance in which the resulting JWT is stored
-// when parsing JWT tokens
+// when parsing JWT tokens. The supplied token is fully reset (all claims,
+// including private claims, are cleared) before the parsed token is stored into it.
 func WithToken(v Token) ParseOption {
 	return &parseOption{option.New(identToken{}, v)}
 }

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -376,6 +376,7 @@ func (t *stdToken) UnmarshalJSON(buf []byte) error {
 	t.jwtID = nil
 	t.notBefore = nil
 	t.subject = nil
+	clear(t.privateClaims)
 	dec := json.NewDecoder(bytes.NewReader(buf))
 	tok, err := dec.ReadToken()
 	if err != nil {

--- a/jwt/token_test.go
+++ b/jwt/token_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lestrrat-go/jwx/v4/internal/json"
 
+	"github.com/lestrrat-go/jwx/v4/jwa"
 	"github.com/lestrrat-go/jwx/v4/jwt"
 	"github.com/stretchr/testify/require"
 )
@@ -247,5 +248,56 @@ func TestToken(t *testing.T) {
 			require.True(t, ok, `tok.Field(%s) should succeed`, k)
 			require.NoError(t, newtok.Set(k, v), `newtok.Set should succeed`)
 		}
+	})
+}
+
+func TestUnmarshalResetsPrivateClaims(t *testing.T) {
+	t.Parallel()
+	t.Run("direct UnmarshalJSON", func(t *testing.T) {
+		t.Parallel()
+		tok := jwt.New()
+		require.NoError(t, json.Unmarshal([]byte(`{"role":"admin","sub":"x"}`), tok))
+		v, ok := tok.Field("role")
+		require.True(t, ok, `role claim should be present after first unmarshal`)
+		require.Equal(t, "admin", v)
+
+		// Reuse the same token instance for a payload that omits "role".
+		require.NoError(t, json.Unmarshal([]byte(`{"sub":"y"}`), tok))
+		_, ok = tok.Field("role")
+		require.False(t, ok, `stale private claim "role" must be cleared on reuse`)
+		sub, ok := tok.Subject()
+		require.True(t, ok, `sub claim should be present after second unmarshal`)
+		require.Equal(t, "y", sub)
+	})
+	t.Run("Parse with WithToken", func(t *testing.T) {
+		t.Parallel()
+		key := []byte("0123456789abcdef")
+
+		t1 := jwt.New()
+		require.NoError(t, t1.Set("role", "admin"))
+		require.NoError(t, t1.Set(jwt.SubjectKey, "x"))
+		signed1, err := jwt.Sign(t1, jwt.WithKey(jwa.HS256(), key))
+		require.NoError(t, err, `jwt.Sign should succeed`)
+
+		t2 := jwt.New()
+		require.NoError(t, t2.Set(jwt.SubjectKey, "y"))
+		signed2, err := jwt.Sign(t2, jwt.WithKey(jwa.HS256(), key))
+		require.NoError(t, err, `jwt.Sign should succeed`)
+
+		dst := jwt.New()
+		_, err = jwt.Parse(signed1, jwt.WithKey(jwa.HS256(), key), jwt.WithToken(dst))
+		require.NoError(t, err, `jwt.Parse should succeed`)
+		v, ok := dst.Field("role")
+		require.True(t, ok, `role claim should be present after first parse`)
+		require.Equal(t, "admin", v)
+
+		// Reuse the same destination token for a payload without "role".
+		_, err = jwt.Parse(signed2, jwt.WithKey(jwa.HS256(), key), jwt.WithToken(dst))
+		require.NoError(t, err, `jwt.Parse should succeed`)
+		_, ok = dst.Field("role")
+		require.False(t, ok, `stale private claim "role" must be cleared on reuse`)
+		sub, ok := dst.Subject()
+		require.True(t, ok, `sub claim should be present after second parse`)
+		require.Equal(t, "y", sub)
 	})
 }


### PR DESCRIPTION
- clear `privateClaims` in generated `UnmarshalJSON` (jwt + openid) so reused token instances no longer carry stale private claims across parses
- note in `jwt.WithToken` doc that the supplied token is fully reset before storing the parsed result