### PR TITLE
apply jwt settings only when supplied

### DIFF
--- a/jwt/BUILD.bazel
+++ b/jwt/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "jwt_crit_test.go",
         "jwt_test.go",
         "options_gen_test.go",
+        "settings_test.go",
         "structured_errors_test.go",
         "token_options_test.go",
         "token_test.go",

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -26,9 +26,12 @@ var muSettings sync.Mutex
 var defaultTruncation atomic.Int64
 
 // Settings controls global settings that are specific to JWTs.
+//
+// Each call adjusts only the options explicitly provided; settings that are
+// not specified are left unchanged from their previous value.
 func Settings(options ...GlobalOption) error {
-	var flattenAudience bool
-	var parsePedantic bool
+	var flattenAudience *bool
+	var parsePedantic *bool
 	var parsePrecision = types.MaxPrecision + 1  // illegal value, so we can detect nothing was set
 	var formatPrecision = types.MaxPrecision + 1 // illegal value, so we can detect nothing was set
 	truncation := time.Duration(-1)
@@ -37,9 +40,11 @@ func Settings(options ...GlobalOption) error {
 		case identTruncation{}:
 			truncation = option.MustGet[time.Duration](opt)
 		case identFlattenAudience{}:
-			flattenAudience = option.MustGet[bool](opt)
+			b := option.MustGet[bool](opt)
+			flattenAudience = &b
 		case identNumericDateParsePedantic{}:
-			parsePedantic = option.MustGet[bool](opt)
+			b := option.MustGet[bool](opt)
+			parsePedantic = &b
 		case identNumericDateParsePrecision{}:
 			v := option.MustGet[int](opt)
 			if v < 0 || v > int(types.MaxPrecision) {
@@ -66,17 +71,17 @@ func Settings(options ...GlobalOption) error {
 		types.FormatPrecision.Store(formatPrecision)
 	}
 
-	{
+	if parsePedantic != nil {
 		var newVal uint32
-		if parsePedantic {
+		if *parsePedantic {
 			newVal = 1
 		}
 		types.Pedantic.Store(newVal)
 	}
 
-	{
+	if flattenAudience != nil {
 		opts := TokenOptionSet(defaultOptions.Load())
-		if flattenAudience {
+		if *flattenAudience {
 			opts.Enable(FlattenAudience)
 		} else {
 			opts.Disable(FlattenAudience)

--- a/jwt/settings_test.go
+++ b/jwt/settings_test.go
@@ -1,0 +1,56 @@
+package jwt_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/stretchr/testify/require"
+)
+
+// rfc3339DateToken is a raw JSON token whose "nbf" claim is encoded as an
+// RFC3339 timestamp rather than epoch seconds. When the global pedantic flag
+// is OFF, the lenient parser accepts it; when pedantic is ON, parsing fails.
+const rfc3339DateToken = `{"nbf":"2020-01-01T00:00:00Z"}`
+
+// pedanticEnabled reports whether the global numeric-date pedantic flag is
+// currently in effect, observed behaviorally: a token carrying an RFC3339
+// "nbf" only fails to parse when pedantic mode is enabled.
+func pedanticEnabled(t *testing.T) bool {
+	t.Helper()
+	_, err := jwt.ParseInsecure([]byte(rfc3339DateToken))
+	return err != nil
+}
+
+// TestSettingsNoClobber verifies that each jwt.Settings call adjusts only the
+// options explicitly provided and leaves previously-set, unspecified settings
+// untouched.
+func TestSettingsNoClobber(t *testing.T) {
+	// Settings mutates process-global state. Capture nothing fancy; just
+	// restore the package defaults when we are done so we do not pollute
+	// other tests.
+	defer func() {
+		require.NoError(t, jwt.Settings(
+			jwt.WithNumericDateParsePedantic(false),
+			jwt.WithFlattenAudience(false),
+		))
+	}()
+
+	t.Run("pedantic survives unrelated flatten-audience call", func(t *testing.T) {
+		require.NoError(t, jwt.Settings(jwt.WithNumericDateParsePedantic(true)))
+		require.True(t, pedanticEnabled(t), `pedantic should be enabled`)
+
+		// An unrelated Settings call must not reset pedantic.
+		require.NoError(t, jwt.Settings(jwt.WithFlattenAudience(true)))
+		require.True(t, pedanticEnabled(t), `pedantic should still be enabled after unrelated Settings call`)
+		require.True(t, jwt.DefaultOptionSet().IsEnabled(jwt.FlattenAudience), `flatten audience should be enabled`)
+	})
+
+	t.Run("flatten-audience survives unrelated pedantic call", func(t *testing.T) {
+		require.NoError(t, jwt.Settings(jwt.WithFlattenAudience(true)))
+		require.True(t, jwt.DefaultOptionSet().IsEnabled(jwt.FlattenAudience), `flatten audience should be enabled`)
+
+		// An unrelated Settings call must not reset flatten audience.
+		require.NoError(t, jwt.Settings(jwt.WithNumericDateParsePedantic(false)))
+		require.True(t, jwt.DefaultOptionSet().IsEnabled(jwt.FlattenAudience), `flatten audience should still be enabled after unrelated Settings call`)
+	})
+}


### PR DESCRIPTION
- jwt.Settings stored `parsePedantic` and `flattenAudience` unconditionally, so any later unrelated Settings call reset a previously-set value
- use pointer sentinels so each call applies only the options explicitly provided, matching the existing truncation/precision idiom
- Settings doc note: each call leaves unspecified settings unchanged