### PR TITLE
validate use field at jwk parse time

### DIFF
--- a/internal/jwxcodegen/cmd/jwxcodegen/genjwk.go
+++ b/internal/jwxcodegen/cmd/jwxcodegen/genjwk.go
@@ -543,7 +543,22 @@ func generateKeyUnmarshalJSON(o *codegen.Output, kt *KeyType, obj *codegen.Objec
 	o.L("}")
 
 	for _, f := range obj.Fields() {
-		if f.Type() == "string" {
+		if f.Name(false) == "keyUsage" {
+			// "use" must honor the strictKeyUsage allowlist at parse time, so
+			// route the decoded value through KeyUsageType.Accept instead of
+			// assigning the raw string directly.
+			o.L("case %sKey:", f.Name(true))
+			o.L("val, err := json.ReadNextStringToken(dec, h.dc)")
+			o.L("if err != nil {")
+			o.L("return fmt.Errorf(`failed to decode value for key %%s: %%w`, %sKey, err)", f.Name(true))
+			o.L("}")
+			o.L("var acceptor KeyUsageType")
+			o.L("if err := acceptor.Accept(val); err != nil {")
+			o.L("return fmt.Errorf(`failed to decode value for key %%s: %%w`, %sKey, err)", f.Name(true))
+			o.L("}")
+			o.L("tmp := acceptor.String()")
+			o.L("h.%s = &tmp", f.Name(false))
+		} else if f.Type() == "string" {
 			o.L("case %sKey:", f.Name(true))
 			o.L("if err := json.AssignNextStringToken(&h.%s, dec, h.dc); err != nil {", f.Name(false))
 			o.L("return fmt.Errorf(`failed to decode value for key %%s: %%w`, %sKey, err)", f.Name(true))

--- a/jwk/BUILD.bazel
+++ b/jwk/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "options_gen_test.go",
         "probe_bench_test.go",
         "set_test.go",
+        "usage_parse_test.go",
         "x5c_test.go",
     ],
     data = glob(["testdata/**"]),

--- a/jwk/akp_gen.go
+++ b/jwk/akp_gen.go
@@ -497,9 +497,16 @@ func (h *akpPublicKey) UnmarshalJSON(buf []byte) error {
 			}
 			h.keyOps = &decoded
 		case KeyUsageKey:
-			if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
+			val, err := json.ReadNextStringToken(dec, h.dc)
+			if err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 			}
+			var acceptor KeyUsageType
+			if err := acceptor.Accept(val); err != nil {
+				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
+			}
+			tmp := acceptor.String()
+			h.keyUsage = &tmp
 		case AKPPubKey:
 			if err := json.AssignNextBytesToken(&h.pub, dec); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AKPPubKey, err)
@@ -1244,9 +1251,16 @@ func (h *akpPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 			}
 			h.keyOps = &decoded
 		case KeyUsageKey:
-			if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
+			val, err := json.ReadNextStringToken(dec, h.dc)
+			if err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 			}
+			var acceptor KeyUsageType
+			if err := acceptor.Accept(val); err != nil {
+				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
+			}
+			tmp := acceptor.String()
+			h.keyUsage = &tmp
 		case AKPPrivKey:
 			if err := json.AssignNextBytesToken(&h.priv, dec); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AKPPrivKey, err)

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -572,9 +572,16 @@ func (h *ecdsaPublicKey) UnmarshalJSON(buf []byte) error {
 			}
 			h.keyOps = &decoded
 		case KeyUsageKey:
-			if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
+			val, err := json.ReadNextStringToken(dec, h.dc)
+			if err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 			}
+			var acceptor KeyUsageType
+			if err := acceptor.Accept(val); err != nil {
+				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
+			}
+			tmp := acceptor.String()
+			h.keyUsage = &tmp
 		case ECDSAXKey:
 			if err := json.AssignNextBytesToken(&h.x, dec); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, ECDSAXKey, err)
@@ -1432,9 +1439,16 @@ func (h *ecdsaPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 			}
 			h.keyOps = &decoded
 		case KeyUsageKey:
-			if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
+			val, err := json.ReadNextStringToken(dec, h.dc)
+			if err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 			}
+			var acceptor KeyUsageType
+			if err := acceptor.Accept(val); err != nil {
+				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
+			}
+			tmp := acceptor.String()
+			h.keyUsage = &tmp
 		case ECDSAXKey:
 			if err := json.AssignNextBytesToken(&h.x, dec); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, ECDSAXKey, err)

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -534,9 +534,16 @@ func (h *okpPublicKey) UnmarshalJSON(buf []byte) error {
 			}
 			h.keyOps = &decoded
 		case KeyUsageKey:
-			if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
+			val, err := json.ReadNextStringToken(dec, h.dc)
+			if err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 			}
+			var acceptor KeyUsageType
+			if err := acceptor.Accept(val); err != nil {
+				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
+			}
+			tmp := acceptor.String()
+			h.keyUsage = &tmp
 		case OKPXKey:
 			if err := json.AssignNextBytesToken(&h.x, dec); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, OKPXKey, err)
@@ -1336,9 +1343,16 @@ func (h *okpPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 			}
 			h.keyOps = &decoded
 		case KeyUsageKey:
-			if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
+			val, err := json.ReadNextStringToken(dec, h.dc)
+			if err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 			}
+			var acceptor KeyUsageType
+			if err := acceptor.Accept(val); err != nil {
+				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
+			}
+			tmp := acceptor.String()
+			h.keyUsage = &tmp
 		case OKPXKey:
 			if err := json.AssignNextBytesToken(&h.x, dec); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, OKPXKey, err)

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -541,9 +541,16 @@ func (h *rsaPublicKey) UnmarshalJSON(buf []byte) error {
 			}
 			h.keyOps = &decoded
 		case KeyUsageKey:
-			if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
+			val, err := json.ReadNextStringToken(dec, h.dc)
+			if err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 			}
+			var acceptor KeyUsageType
+			if err := acceptor.Accept(val); err != nil {
+				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
+			}
+			tmp := acceptor.String()
+			h.keyUsage = &tmp
 		case RSANKey:
 			if err := json.AssignNextBytesToken(&h.n, dec); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, RSANKey, err)
@@ -1550,9 +1557,16 @@ func (h *rsaPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 			}
 			h.keyOps = &decoded
 		case KeyUsageKey:
-			if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
+			val, err := json.ReadNextStringToken(dec, h.dc)
+			if err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 			}
+			var acceptor KeyUsageType
+			if err := acceptor.Accept(val); err != nil {
+				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
+			}
+			tmp := acceptor.String()
+			h.keyUsage = &tmp
 		case RSANKey:
 			if err := json.AssignNextBytesToken(&h.n, dec); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, RSANKey, err)

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -495,9 +495,16 @@ func (h *symmetricKey) UnmarshalJSON(buf []byte) (retErr error) {
 			}
 			h.keyOps = &decoded
 		case KeyUsageKey:
-			if err := json.AssignNextStringToken(&h.keyUsage, dec, h.dc); err != nil {
+			val, err := json.ReadNextStringToken(dec, h.dc)
+			if err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
 			}
+			var acceptor KeyUsageType
+			if err := acceptor.Accept(val); err != nil {
+				return fmt.Errorf(`failed to decode value for key %s: %w`, KeyUsageKey, err)
+			}
+			tmp := acceptor.String()
+			h.keyUsage = &tmp
 		case SymmetricOctetsKey:
 			if err := json.AssignNextBytesToken(&h.octets, dec); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, SymmetricOctetsKey, err)

--- a/jwk/usage_parse_test.go
+++ b/jwk/usage_parse_test.go
@@ -1,0 +1,47 @@
+package jwk_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyUsageValidationAtParse(t *testing.T) {
+	// strictKeyUsage is a process-global toggle. Ensure it is restored to its
+	// default (strict on) after each subtest that mutates it.
+	restoreStrict := func(t *testing.T) {
+		t.Helper()
+		require.NoError(t, jwk.Settings(jwk.WithStrictKeyUsage(true)))
+	}
+
+	t.Run("invalid use rejected by default (symmetric)", func(t *testing.T) {
+		_, err := jwk.ParseKey([]byte(`{"kty":"oct","k":"AQ","use":"admin"}`))
+		require.Error(t, err, `parsing an unregistered "use" value should fail by default`)
+	})
+
+	t.Run("invalid use rejected by default (RSA)", func(t *testing.T) {
+		const src = `{"kty":"RSA","n":"sXchDaQebHnPiGvyDOAT4saGEUetSyo9MKLOoWFsueri23bOdgWp4Dy1WlUzewbgBHod5pcM9H5UAqAn3MJA1pCe7d7-Ut2K46_5g","e":"AQAB","use":"admin"}`
+		_, err := jwk.ParseKey([]byte(src))
+		require.Error(t, err, `parsing an unregistered "use" value should fail by default`)
+	})
+
+	t.Run("invalid use accepted when strict disabled", func(t *testing.T) {
+		require.NoError(t, jwk.Settings(jwk.WithStrictKeyUsage(false)))
+		defer restoreStrict(t)
+
+		key, err := jwk.ParseKey([]byte(`{"kty":"oct","k":"AQ","use":"admin"}`))
+		require.NoError(t, err, `parsing should succeed when strict key usage is disabled`)
+		usage, ok := key.KeyUsage()
+		require.True(t, ok)
+		require.Equal(t, "admin", usage)
+	})
+
+	t.Run("valid use accepted by default", func(t *testing.T) {
+		key, err := jwk.ParseKey([]byte(`{"kty":"oct","k":"AQ","use":"sig"}`))
+		require.NoError(t, err, `parsing a registered "use" value should succeed`)
+		usage, ok := key.KeyUsage()
+		require.True(t, ok)
+		require.Equal(t, "sig", usage)
+	})
+}


### PR DESCRIPTION
- route the "use" field through `KeyUsageType.Accept` in the generated `UnmarshalJSON`, honoring `WithStrictKeyUsage` (previously the parse path bypassed the allowlist)
- regenerated all key types (rsa, ecdsa, okp, akp, symmetric); `key_ops` decoding unchanged