### PR TITLE
require empty encrypted_key for direct cek

### DIFF
--- a/jwe/BUILD.bazel
+++ b/jwe/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     name = "jwe_test",
     srcs = [
         "bench_encrypt_test.go",
+        "directcek_test.go",
         "fuzz_test.go",
         "gh402_test.go",
         "headers_nil_test.go",

--- a/jwe/decrypt.go
+++ b/jwe/decrypt.go
@@ -28,6 +28,24 @@ func decryptCEK(alg jwa.KeyEncryptionAlgorithm, key any, msg *Message, recipient
 	algStr := alg.String()
 	recipientKey := recipient.EncryptedKey()
 
+	// Direct-mode key management (RFC 7518 §4.5 "dir" and §4.6 bare ECDH-ES)
+	// derives the CEK without an encrypted key, so the JWE Encrypted Key must
+	// be the empty octet sequence. Enforce this here, before the KeyDecrypter
+	// branch, so a tampered message carrying a stray encrypted_key is rejected
+	// on every path -- including caller-supplied custom decrypters.
+	directMode := jwebb.IsDirect(algStr)
+	if !directMode && jwebb.IsECDHES(algStr) {
+		// ECDH-ES+A*KW (keywrap == true) legitimately carries an encrypted_key;
+		// only bare ECDH-ES is direct. Reuse the same helper the ECDH-ES path
+		// uses to determine keywrap.
+		if _, _, keywrap, err := jwebb.KeyEncryptionECDHESKeySize(algStr, ctx.ctalg.String()); err == nil {
+			directMode = !keywrap
+		}
+	}
+	if directMode && len(recipientKey) != 0 {
+		return nil, fmt.Errorf(`jwe: decrypt key: %q requires an empty encrypted_key`, algStr)
+	}
+
 	if kd, ok := key.(KeyDecrypter); ok {
 		return kd.DecryptKey(alg, recipientKey, recipient, msg)
 	}
@@ -57,11 +75,8 @@ func decryptCEK(alg jwa.KeyEncryptionAlgorithm, key any, msg *Message, recipient
 }
 
 func decryptKeyDirect(recipientKey []byte, alg string, key any) ([]byte, error) {
-	// RFC 7518 §4.5: for "dir" the JWE Encrypted Key must be the empty octet
-	// sequence. Reject a stray non-empty value rather than silently ignoring it.
-	if len(recipientKey) != 0 {
-		return nil, fmt.Errorf(`jwe: decrypt key: %q requires an empty encrypted_key`, alg)
-	}
+	// The empty-encrypted_key invariant for "dir" (RFC 7518 §4.5) is enforced
+	// in decryptCEK ahead of the KeyDecrypter branch, so it covers every path.
 	cek, err := requireByteKey(key, alg)
 	if err != nil {
 		return nil, err
@@ -182,10 +197,9 @@ func decryptKeyECDHES(recipientKey []byte, alg string, ctalg jwa.ContentEncrypti
 
 	// RFC 7518 §4.6: for bare ECDH-ES (keywrap == false) the CEK is derived
 	// directly and the JWE Encrypted Key must be the empty octet sequence.
-	// ECDH-ES+A*KW (keywrap == true) legitimately carries an encrypted_key.
-	if !keywrap && len(recipientKey) != 0 {
-		return nil, fmt.Errorf(`jwe: decrypt key: %q requires an empty encrypted_key`, alg)
-	}
+	// That invariant is enforced in decryptCEK ahead of the KeyDecrypter
+	// branch so it covers every path; ECDH-ES+A*KW legitimately carries an
+	// encrypted_key.
 
 	// Extract ephemeral public key from headers
 	epkV, ok := headers.Field(EphemeralPublicKeyKey)

--- a/jwe/decrypt.go
+++ b/jwe/decrypt.go
@@ -57,6 +57,11 @@ func decryptCEK(alg jwa.KeyEncryptionAlgorithm, key any, msg *Message, recipient
 }
 
 func decryptKeyDirect(recipientKey []byte, alg string, key any) ([]byte, error) {
+	// RFC 7518 §4.5: for "dir" the JWE Encrypted Key must be the empty octet
+	// sequence. Reject a stray non-empty value rather than silently ignoring it.
+	if len(recipientKey) != 0 {
+		return nil, fmt.Errorf(`jwe: decrypt key: %q requires an empty encrypted_key`, alg)
+	}
 	cek, err := requireByteKey(key, alg)
 	if err != nil {
 		return nil, err
@@ -173,6 +178,13 @@ func decryptKeyECDHES(recipientKey []byte, alg string, ctalg jwa.ContentEncrypti
 	derivedAlg, keysize, keywrap, err := jwebb.KeyEncryptionECDHESKeySize(alg, ctalgStr)
 	if err != nil {
 		return nil, fmt.Errorf(`jwe: decrypt key: failed to determine ECDH-ES key size: %w`, err)
+	}
+
+	// RFC 7518 §4.6: for bare ECDH-ES (keywrap == false) the CEK is derived
+	// directly and the JWE Encrypted Key must be the empty octet sequence.
+	// ECDH-ES+A*KW (keywrap == true) legitimately carries an encrypted_key.
+	if !keywrap && len(recipientKey) != 0 {
+		return nil, fmt.Errorf(`jwe: decrypt key: %q requires an empty encrypted_key`, alg)
 	}
 
 	// Extract ephemeral public key from headers

--- a/jwe/directcek_test.go
+++ b/jwe/directcek_test.go
@@ -162,7 +162,7 @@ func TestDirectCEKRequiresEmptyEncryptedKey(t *testing.T) {
 		called := false
 		dec := jwe.KeyDecryptFunc(func(jwa.KeyEncryptionAlgorithm, []byte, jwe.Recipient, *jwe.Message) ([]byte, error) {
 			called = true
-			return nil, nil //nolint:nilnil // exercised only on the rejection path
+			return nil, nil
 		})
 
 		tampered := injectEncryptedKey(t, encrypted)

--- a/jwe/directcek_test.go
+++ b/jwe/directcek_test.go
@@ -1,0 +1,105 @@
+package jwe_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/internal/json"
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwe"
+	"github.com/stretchr/testify/require"
+)
+
+// injectEncryptedKey rewrites a flattened-JSON JWE serialization, replacing
+// the top-level "encrypted_key" member with a non-empty base64url value.
+func injectEncryptedKey(t *testing.T, serialized []byte) []byte {
+	t.Helper()
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(serialized, &m), `unmarshal flattened JWE should succeed`)
+
+	bogus := base64.RawURLEncoding.EncodeToString([]byte("not-empty-bytes"))
+	m["encrypted_key"] = bogus
+
+	out, err := json.Marshal(m)
+	require.NoError(t, err, `marshal tampered JWE should succeed`)
+	return out
+}
+
+func TestDirectCEKRequiresEmptyEncryptedKey(t *testing.T) {
+	t.Parallel()
+
+	plaintext := []byte("the quick brown fox")
+
+	t.Run("dir", func(t *testing.T) {
+		t.Parallel()
+
+		key := make([]byte, 16) // A128GCM CEK
+		_, err := rand.Read(key)
+		require.NoError(t, err, `rand.Read should succeed`)
+
+		encrypted, err := jwe.Encrypt(plaintext,
+			jwe.WithKey(jwa.DIRECT(), key),
+			jwe.WithContentEncryption(jwa.A128GCM()),
+			jwe.WithJSON(),
+		)
+		require.NoError(t, err, `jwe.Encrypt (dir) should succeed`)
+
+		// Valid dir JWE (empty encrypted_key) decrypts.
+		decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.DIRECT(), key))
+		require.NoError(t, err, `jwe.Decrypt (dir) should succeed`)
+		require.Equal(t, plaintext, decrypted)
+
+		// dir JWE with a non-empty encrypted_key injected is rejected.
+		tampered := injectEncryptedKey(t, encrypted)
+		_, err = jwe.Decrypt(tampered, jwe.WithKey(jwa.DIRECT(), key))
+		require.Error(t, err, `jwe.Decrypt (dir, non-empty encrypted_key) should fail`)
+	})
+
+	t.Run("ECDH-ES (bare/direct)", func(t *testing.T) {
+		t.Parallel()
+
+		privkey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err, `ecdsa.GenerateKey should succeed`)
+
+		encrypted, err := jwe.Encrypt(plaintext,
+			jwe.WithKey(jwa.ECDH_ES(), &privkey.PublicKey),
+			jwe.WithContentEncryption(jwa.A128GCM()),
+			jwe.WithJSON(),
+		)
+		require.NoError(t, err, `jwe.Encrypt (ECDH-ES) should succeed`)
+
+		// Valid bare ECDH-ES JWE (empty encrypted_key) decrypts.
+		decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.ECDH_ES(), privkey))
+		require.NoError(t, err, `jwe.Decrypt (ECDH-ES) should succeed`)
+		require.Equal(t, plaintext, decrypted)
+
+		// bare ECDH-ES JWE with a non-empty encrypted_key injected is rejected.
+		tampered := injectEncryptedKey(t, encrypted)
+		_, err = jwe.Decrypt(tampered, jwe.WithKey(jwa.ECDH_ES(), privkey))
+		require.Error(t, err, `jwe.Decrypt (ECDH-ES, non-empty encrypted_key) should fail`)
+	})
+
+	t.Run("ECDH-ES+A128KW (wrapped, control)", func(t *testing.T) {
+		t.Parallel()
+
+		privkey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err, `ecdsa.GenerateKey should succeed`)
+
+		// Wrapped ECDH-ES legitimately carries a non-empty encrypted_key.
+		encrypted, err := jwe.Encrypt(plaintext,
+			jwe.WithKey(jwa.ECDH_ES_A128KW(), &privkey.PublicKey),
+			jwe.WithContentEncryption(jwa.A128GCM()),
+			jwe.WithJSON(),
+		)
+		require.NoError(t, err, `jwe.Encrypt (ECDH-ES+A128KW) should succeed`)
+
+		decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.ECDH_ES_A128KW(), privkey))
+		require.NoError(t, err, `jwe.Decrypt (ECDH-ES+A128KW) should succeed`)
+		require.Equal(t, plaintext, decrypted)
+	})
+}

--- a/jwe/directcek_test.go
+++ b/jwe/directcek_test.go
@@ -102,4 +102,72 @@ func TestDirectCEKRequiresEmptyEncryptedKey(t *testing.T) {
 		require.NoError(t, err, `jwe.Decrypt (ECDH-ES+A128KW) should succeed`)
 		require.Equal(t, plaintext, decrypted)
 	})
+
+	// The empty-encrypted_key invariant for direct modes must hold even when
+	// the caller supplies a custom KeyDecrypter. The guard lives in decryptCEK
+	// ahead of the KeyDecrypter branch, so a tampered (non-empty encrypted_key)
+	// message is rejected before the custom decrypter ever runs.
+	t.Run("dir custom KeyDecrypter", func(t *testing.T) {
+		t.Parallel()
+
+		key := make([]byte, 16) // A128GCM CEK
+		_, err := rand.Read(key)
+		require.NoError(t, err, `rand.Read should succeed`)
+
+		encrypted, err := jwe.Encrypt(plaintext,
+			jwe.WithKey(jwa.DIRECT(), key),
+			jwe.WithContentEncryption(jwa.A128GCM()),
+			jwe.WithJSON(),
+		)
+		require.NoError(t, err, `jwe.Encrypt (dir) should succeed`)
+
+		// A custom decrypter for "dir" returns the supplied key as the CEK.
+		called := false
+		dec := jwe.KeyDecryptFunc(func(_ jwa.KeyEncryptionAlgorithm, _ []byte, _ jwe.Recipient, _ *jwe.Message) ([]byte, error) {
+			called = true
+			return key, nil
+		})
+
+		// Valid dir JWE (empty encrypted_key) decrypts through the custom decrypter.
+		decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.DIRECT(), dec))
+		require.NoError(t, err, `jwe.Decrypt (dir, custom decrypter) should succeed`)
+		require.Equal(t, plaintext, decrypted)
+		require.True(t, called, `custom decrypter should run for a valid dir message`)
+
+		// Tampered dir JWE (non-empty encrypted_key) is rejected before the
+		// custom decrypter is invoked.
+		called = false
+		tampered := injectEncryptedKey(t, encrypted)
+		_, err = jwe.Decrypt(tampered, jwe.WithKey(jwa.DIRECT(), dec))
+		require.Error(t, err, `jwe.Decrypt (dir, non-empty encrypted_key, custom decrypter) should fail`)
+		require.False(t, called, `custom decrypter must not run for a tampered dir message`)
+	})
+
+	t.Run("ECDH-ES (bare) custom KeyDecrypter", func(t *testing.T) {
+		t.Parallel()
+
+		privkey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err, `ecdsa.GenerateKey should succeed`)
+
+		encrypted, err := jwe.Encrypt(plaintext,
+			jwe.WithKey(jwa.ECDH_ES(), &privkey.PublicKey),
+			jwe.WithContentEncryption(jwa.A128GCM()),
+			jwe.WithJSON(),
+		)
+		require.NoError(t, err, `jwe.Encrypt (ECDH-ES) should succeed`)
+
+		// A custom decrypter that delegates to the built-in bare ECDH-ES path
+		// by returning a derived CEK is hard to reproduce here, so just assert
+		// the guard rejects the tampered message before the decrypter runs.
+		called := false
+		dec := jwe.KeyDecryptFunc(func(jwa.KeyEncryptionAlgorithm, []byte, jwe.Recipient, *jwe.Message) ([]byte, error) {
+			called = true
+			return nil, nil //nolint:nilnil // exercised only on the rejection path
+		})
+
+		tampered := injectEncryptedKey(t, encrypted)
+		_, err = jwe.Decrypt(tampered, jwe.WithKey(jwa.ECDH_ES(), dec))
+		require.Error(t, err, `jwe.Decrypt (ECDH-ES, non-empty encrypted_key, custom decrypter) should fail`)
+		require.False(t, called, `custom decrypter must not run for a tampered bare ECDH-ES message`)
+	})
 }


### PR DESCRIPTION
- Reject a non-empty `encrypted_key` for `dir` and bare (direct) `ECDH-ES`; RFC 7518 requires it to be the empty octet sequence, and silently ignoring it allowed serialized malleability.
- Wrapped `ECDH-ES+A*KW` is unaffected (`keywrap == true`) — `encrypted_key` is required there. Direct vs wrapped is distinguished by the `keywrap` bool from `jwebb.KeyEncryptionECDHESKeySize`.
- No exported API change.