### PR TITLE
document slow-path alg handling in jws verify

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -260,6 +260,11 @@ func Sign(payload []byte, options ...SignOption) ([]byte, error) {
 // staticKeyProvider and keySetProvider do not consult ctx inside
 // FetchKeys themselves (their backing data is already in memory) — see
 // the [WithContext] godoc for the full per-layer breakdown.
+//
+// Note: unlike VerifyCompactFast, Verify does not require the protected
+// header's "alg" to be present or to equal the algorithm used to verify
+// (that algorithm is determined by the key or provider you supply). Use
+// VerifyCompactFast if you need that strict header check.
 func Verify(buf []byte, options ...VerifyOption) ([]byte, error) {
 	vc := verifyContextPool.Get()
 	defer verifyContextPool.Put(vc)
@@ -829,10 +834,10 @@ func Settings(options ...GlobalOption) error {
 //
 // Returns the original payload that was signed if verification succeeds.
 //
-// Unlike jws.Verify(), this function requires you to specify the
-// algorithm explicitly rather than extracting it from the JWS headers.
-// This can be useful for performance-critical applications where the
-// algorithm is known in advance.
+// Unlike jws.Verify() — which resolves the verification algorithm from the
+// key or provider you supply (e.g. WithKey, WithKeySet) — this function takes
+// the algorithm as an explicit argument. It is useful for performance-critical
+// applications where the algorithm is known in advance.
 //
 // This function uses strict base64url encoding without padding (RFC 4648 §5)
 // for decoding the signature and payload. It does not auto-detect other

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -261,10 +261,13 @@ func Sign(payload []byte, options ...SignOption) ([]byte, error) {
 // FetchKeys themselves (their backing data is already in memory) — see
 // the [WithContext] godoc for the full per-layer breakdown.
 //
-// Note: unlike VerifyCompactFast, Verify does not require the protected
-// header's "alg" to be present or to equal the algorithm used to verify
-// (that algorithm is determined by the key or provider you supply). Use
-// VerifyCompactFast if you need that strict header check.
+// Note: Verify performs no global check that the protected header's "alg"
+// equals the algorithm used to verify (unlike VerifyCompactFast). The
+// verification algorithm is determined by the key or provider you supply,
+// and providers differ in how they treat the header "alg": WithKey ignores
+// it entirely, while WithVerifyAuto requires a protected "alg" and matches
+// it during key routing. If you need the header "alg" strictly enforced,
+// use VerifyCompactFast.
 func Verify(buf []byte, options ...VerifyOption) ([]byte, error) {
 	vc := verifyContextPool.Get()
 	defer verifyContextPool.Put(vc)

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -281,6 +281,18 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 	return nil, makeVerifyError(`could not verify message using any of the signatures or keys: %w`, errors.Join(errs...))
 }
 
+// tryKey intentionally does NOT compare the protected header's "alg" to alg
+// (the algorithm used to verify). The verification algorithm is always supplied
+// by the key provider: WithKey pins it to the caller's alg, while
+// WithKeySet/WithVerifyAuto take it from the JWK's "alg" or the key's
+// AlgorithmsForKey capability set, using the header "alg" only to route to a
+// candidate key. The attacker-controlled header can therefore never introduce
+// an algorithm the chosen key is not already authorized to produce —
+// validateAlgorithmForKey (jws.go) enforces (alg,key) compatibility at option
+// time. The absence of a header-vs-verifier "alg" check here is thus
+// intentional and cosmetic, NOT an algorithm-confusion vulnerability; do not
+// "fix" it by rejecting header/alg mismatches. VerifyCompactFast is the strict
+// counterpart for callers who want the header "alg" enforced.
 func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, key any, msg *Message, sig *Signature) error {
 	if vc.validateKey {
 		if err := validateKeyBeforeUse(key); err != nil {

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -281,18 +281,23 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 	return nil, makeVerifyError(`could not verify message using any of the signatures or keys: %w`, errors.Join(errs...))
 }
 
-// tryKey intentionally does NOT compare the protected header's "alg" to alg
-// (the algorithm used to verify). The verification algorithm is always supplied
-// by the key provider: WithKey pins it to the caller's alg, while
-// WithKeySet/WithVerifyAuto take it from the JWK's "alg" or the key's
-// AlgorithmsForKey capability set, using the header "alg" only to route to a
-// candidate key. The attacker-controlled header can therefore never introduce
-// an algorithm the chosen key is not already authorized to produce —
-// validateAlgorithmForKey (jws.go) enforces (alg,key) compatibility at option
-// time. The absence of a header-vs-verifier "alg" check here is thus
-// intentional and cosmetic, NOT an algorithm-confusion vulnerability; do not
-// "fix" it by rejecting header/alg mismatches. VerifyCompactFast is the strict
-// counterpart for callers who want the header "alg" enforced.
+// tryKey verifies using alg — the algorithm supplied by the key provider
+// for this (alg, key) pair — and intentionally does NOT compare alg to the
+// protected header's "alg".
+//
+// For the built-in providers the algorithm is pinned independently of the
+// untrusted header: WithKey uses the caller-supplied alg; WithKeySet and
+// WithVerifyAuto use the JWK's "alg" or the key's AlgorithmsForKey set and
+// consult the header "alg" only to select/route a candidate key. A custom
+// WithKeyProvider supplies its own (alg, key) pairs and is responsible for
+// not adopting an unsafe algorithm from the untrusted header.
+//
+// validateAlgorithmForKey checks (alg, key) compatibility for an explicit
+// WithKey at option-processing time (and VerifyCompactFast cross-checks the
+// header); provider-emitted pairs are not re-validated here, but a
+// mismatched (alg, key) still fails because verification dispatches strictly
+// on alg (e.g. an RSA verifier rejects a non-RSA key). So the lack of a
+// header-vs-alg check here is intentional, not an algorithm-confusion hole.
 func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, key any, msg *Message, sig *Signature) error {
 	if vc.validateKey {
 		if err := validateKeyBeforeUse(key); err != nil {


### PR DESCRIPTION
- document that jws.Verify (slow path) intentionally does not enforce header alg == verifier alg; verifier alg comes from key/provider
- correct misleading VerifyCompactFast godoc line about where the algorithm comes from
- add maintainer comment on verifyContext.tryKey explaining the omission is intentional, not an algorithm-confusion bug
- doc-only; no behavior or signature change