### PR TITLE
enforce protected alg match in jws verify

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,7 +11,7 @@ UNRELEASED
     `"EdDSA"` and the fully-specified `"Ed25519"`/`"Ed448"` identifiers
     (RFC 9864) are now treated as distinct, so cross-identifier verification
     that previously succeeded is rejected by default — this is an RFC 9864
-    conformance fix. Pass the new `jws.WithSkipAlgorithmMatch()` option to
+    conformance fix. Pass the new `jws.WithSkipAlgorithmMatch(true)` option to
     restore the lenient behavior.
 
 v4.0.2 7 May 2026

--- a/Changes
+++ b/Changes
@@ -4,6 +4,16 @@ Changes
 v4 has many incompatibilities with v3. To see the full list of differences between
 v3 and v4, please read the [Changes-v4.md file](./Changes-v4.md). Coding Agents should read [MIGRATION-v4.md](./MICRATION-v4.md)
 
+UNRELEASED
+  * [jws] `jws.Verify` now rejects a JWS whose protected header `"alg"`
+    does not match the algorithm used to verify it (previously the
+    non-fast-path `jws.Verify` ignored this). In particular the polymorphic
+    `"EdDSA"` and the fully-specified `"Ed25519"`/`"Ed448"` identifiers
+    (RFC 9864) are now treated as distinct, so cross-identifier verification
+    that previously succeeded is rejected by default — this is an RFC 9864
+    conformance fix. Pass the new `jws.WithSkipAlgorithmMatch()` option to
+    restore the lenient behavior.
+
 v4.0.2 7 May 2026
   * [jwk] BREAKING: `jwk.RegisterKeyImporter` now takes a
     `jwk.KeyImporter[T]` interface rather than a bare typed

--- a/jws/BUILD.bazel
+++ b/jws/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "options_gen_test.go",
         "signer_test.go",
         "streaming_detached_test.go",
+        "verify_alg_match_test.go",
     ],
     embed = [":jws"],
     deps = [

--- a/jws/format_detect_test.go
+++ b/jws/format_detect_test.go
@@ -54,12 +54,18 @@ func TestDetectParseFormat(t *testing.T) {
 	}
 }
 
-// TestAlgorithmsMatch pins the closed-set semantics of algorithmsMatch: it
-// matches only on exact string equality or membership in the same explicit
-// RFC 9864 alias group. It must NOT treat two distinct alg identifiers as
-// equivalent merely because they share an underlying dsig mapping.
+// TestAlgorithmsMatch pins the alg-match semantics of algorithmsMatch: it
+// matches only on exact string equality or the RFC 9864 generic-vs-specific
+// EdDSA relation (generic "EdDSA" matches a fully-specified "Ed25519"/"Ed448",
+// but the two fully-specified variants never match each other). It must NOT
+// treat two distinct alg identifiers as equivalent merely because they share
+// an underlying dsig mapping.
 func TestAlgorithmsMatch(t *testing.T) {
 	t.Parallel()
+
+	// "Ed448" is registered by an extension module, not the main module, so
+	// construct it by its on-the-wire identifier string.
+	ed448 := jwa.NewSignatureAlgorithm("Ed448")
 
 	tests := []struct {
 		name string
@@ -68,14 +74,24 @@ func TestAlgorithmsMatch(t *testing.T) {
 		want bool
 	}{
 		{name: "exact equal", a: jwa.HS256(), b: jwa.HS256(), want: true},
+		{name: "RS256 exact equal", a: jwa.RS256(), b: jwa.RS256(), want: true},
+		{name: "EdDSA vs EdDSA", a: jwa.EdDSA(), b: jwa.EdDSA(), want: true},
 		{name: "EdDSA vs Ed25519 alias", a: jwa.EdDSA(), b: jwa.EdDSAEd25519(), want: true},
 		{name: "Ed25519 vs EdDSA alias (reverse)", a: jwa.EdDSAEd25519(), b: jwa.EdDSA(), want: true},
+		{name: "EdDSA vs Ed448 alias", a: jwa.EdDSA(), b: ed448, want: true},
+		{name: "Ed448 vs EdDSA alias (reverse)", a: ed448, b: jwa.EdDSA(), want: true},
+		{name: "Ed25519 exact equal", a: jwa.EdDSAEd25519(), b: jwa.EdDSAEd25519(), want: true},
+		{name: "Ed448 exact equal", a: ed448, b: ed448, want: true},
+		// Ed25519 and Ed448 are different curves / keys / security levels and
+		// are NOT interchangeable. Only the generic "EdDSA" aliases either one.
+		{name: "Ed25519 vs Ed448 distinct curves", a: jwa.EdDSAEd25519(), b: ed448, want: false},
+		{name: "Ed448 vs Ed25519 distinct curves (reverse)", a: ed448, b: jwa.EdDSAEd25519(), want: false},
 		{name: "RS256 vs HS256 distinct", a: jwa.RS256(), b: jwa.HS256(), want: false},
 		{name: "ES256 vs ES384 distinct", a: jwa.ES256(), b: jwa.ES384(), want: false},
 		{name: "EdDSA vs HS256 distinct", a: jwa.EdDSA(), b: jwa.HS256(), want: false},
 		// Two distinct alg names that resolve to the same dsig algorithm
 		// (HS256) must still be a mismatch — a shared dsig mapping is NOT an
-		// alias. This is the algorithm-confusion case the closed set guards.
+		// alias. This is the algorithm-confusion case the guard exists to stop.
 		{name: "custom alg sharing dsig mapping not equivalent", a: jwa.NewSignatureAlgorithm("CUSTOM-HMAC"), b: jwa.HS256(), want: false},
 	}
 

--- a/jws/format_detect_test.go
+++ b/jws/format_detect_test.go
@@ -3,6 +3,7 @@ package jws
 import (
 	"testing"
 
+	"github.com/lestrrat-go/jwx/v4/jwa"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,6 +50,39 @@ func TestDetectParseFormat(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tc.want, detectParseFormat(tc.src))
+		})
+	}
+}
+
+// TestAlgorithmsMatch pins the closed-set semantics of algorithmsMatch: it
+// matches only on exact string equality or membership in the same explicit
+// RFC 9864 alias group. It must NOT treat two distinct alg identifiers as
+// equivalent merely because they share an underlying dsig mapping.
+func TestAlgorithmsMatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    jwa.SignatureAlgorithm
+		b    jwa.SignatureAlgorithm
+		want bool
+	}{
+		{name: "exact equal", a: jwa.HS256(), b: jwa.HS256(), want: true},
+		{name: "EdDSA vs Ed25519 alias", a: jwa.EdDSA(), b: jwa.EdDSAEd25519(), want: true},
+		{name: "Ed25519 vs EdDSA alias (reverse)", a: jwa.EdDSAEd25519(), b: jwa.EdDSA(), want: true},
+		{name: "RS256 vs HS256 distinct", a: jwa.RS256(), b: jwa.HS256(), want: false},
+		{name: "ES256 vs ES384 distinct", a: jwa.ES256(), b: jwa.ES384(), want: false},
+		{name: "EdDSA vs HS256 distinct", a: jwa.EdDSA(), b: jwa.HS256(), want: false},
+		// Two distinct alg names that resolve to the same dsig algorithm
+		// (HS256) must still be a mismatch — a shared dsig mapping is NOT an
+		// alias. This is the algorithm-confusion case the closed set guards.
+		{name: "custom alg sharing dsig mapping not equivalent", a: jwa.NewSignatureAlgorithm("CUSTOM-HMAC"), b: jwa.HS256(), want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, algorithmsMatch(tc.a, tc.b))
 		})
 	}
 }

--- a/jws/format_detect_test.go
+++ b/jws/format_detect_test.go
@@ -1,6 +1,8 @@
 package jws
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v4/jwa"
@@ -56,39 +58,58 @@ func TestDetectParseFormat(t *testing.T) {
 
 // TestAlgorithmsMatch pins the alg-match semantics of algorithmsMatch: it
 // matches only on exact string equality or the RFC 9864 generic-vs-specific
-// EdDSA relation (generic "EdDSA" matches a fully-specified "Ed25519"/"Ed448",
-// but the two fully-specified variants never match each other). It must NOT
-// treat two distinct alg identifiers as equivalent merely because they share
-// an underlying dsig mapping.
+// EdDSA relation. The generic/specific alias is KEY-AWARE — a generic "EdDSA"
+// only aliases the fully-specified variant ("Ed25519"/"Ed448") that the
+// verification key actually is, and the curve cannot be derived from the key
+// the pairing fails closed. The two fully-specified variants never match each
+// other, and two distinct alg identifiers are never treated as equivalent
+// merely because they share an underlying dsig mapping.
 func TestAlgorithmsMatch(t *testing.T) {
 	t.Parallel()
 
 	// "Ed448" is registered by an extension module, not the main module, so
-	// construct it by its on-the-wire identifier string.
+	// construct it by its on-the-wire identifier string. Without the
+	// extension imported there is no Ed448 key type and no curve
+	// registration, so any generic/specific alias involving "Ed448" is
+	// curve-indeterminate and must fail closed here.
 	ed448 := jwa.NewSignatureAlgorithm("Ed448")
+
+	ed25519Pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name string
 		a    jwa.SignatureAlgorithm
 		b    jwa.SignatureAlgorithm
+		key  any
 		want bool
 	}{
+		// Exact-equality matches never need the key.
 		{name: "exact equal", a: jwa.HS256(), b: jwa.HS256(), want: true},
 		{name: "RS256 exact equal", a: jwa.RS256(), b: jwa.RS256(), want: true},
 		{name: "EdDSA vs EdDSA", a: jwa.EdDSA(), b: jwa.EdDSA(), want: true},
-		{name: "EdDSA vs Ed25519 alias", a: jwa.EdDSA(), b: jwa.EdDSAEd25519(), want: true},
-		{name: "Ed25519 vs EdDSA alias (reverse)", a: jwa.EdDSAEd25519(), b: jwa.EdDSA(), want: true},
-		{name: "EdDSA vs Ed448 alias", a: jwa.EdDSA(), b: ed448, want: true},
-		{name: "Ed448 vs EdDSA alias (reverse)", a: ed448, b: jwa.EdDSA(), want: true},
 		{name: "Ed25519 exact equal", a: jwa.EdDSAEd25519(), b: jwa.EdDSAEd25519(), want: true},
 		{name: "Ed448 exact equal", a: ed448, b: ed448, want: true},
+		// Generic/specific EdDSA alias matches only when the specific variant
+		// equals the key's actual curve. An Ed25519 key aliases generic
+		// "EdDSA" to "Ed25519".
+		{name: "EdDSA vs Ed25519 alias with Ed25519 key", a: jwa.EdDSA(), b: jwa.EdDSAEd25519(), key: ed25519Pub, want: true},
+		{name: "Ed25519 vs EdDSA alias (reverse) with Ed25519 key", a: jwa.EdDSAEd25519(), b: jwa.EdDSA(), key: ed25519Pub, want: true},
+		// Generic "EdDSA" verifier with an Ed25519 key must NOT alias an
+		// "Ed448" header — the key cannot be Ed448. This is the core
+		// key-confusion case the fix closes.
+		{name: "EdDSA vs Ed448 alias with Ed25519 key rejects", a: jwa.EdDSA(), b: ed448, key: ed25519Pub, want: false},
+		{name: "Ed448 vs EdDSA alias (reverse) with Ed25519 key rejects", a: ed448, b: jwa.EdDSA(), key: ed25519Pub, want: false},
+		// Generic/specific alias with no key (curve indeterminate) fails closed.
+		{name: "EdDSA vs Ed25519 alias without key fails closed", a: jwa.EdDSA(), b: jwa.EdDSAEd25519(), key: nil, want: false},
+		{name: "EdDSA vs Ed448 alias without key fails closed", a: jwa.EdDSA(), b: ed448, key: nil, want: false},
 		// Ed25519 and Ed448 are different curves / keys / security levels and
 		// are NOT interchangeable. Only the generic "EdDSA" aliases either one.
-		{name: "Ed25519 vs Ed448 distinct curves", a: jwa.EdDSAEd25519(), b: ed448, want: false},
-		{name: "Ed448 vs Ed25519 distinct curves (reverse)", a: ed448, b: jwa.EdDSAEd25519(), want: false},
+		{name: "Ed25519 vs Ed448 distinct curves", a: jwa.EdDSAEd25519(), b: ed448, key: ed25519Pub, want: false},
+		{name: "Ed448 vs Ed25519 distinct curves (reverse)", a: ed448, b: jwa.EdDSAEd25519(), key: ed25519Pub, want: false},
 		{name: "RS256 vs HS256 distinct", a: jwa.RS256(), b: jwa.HS256(), want: false},
 		{name: "ES256 vs ES384 distinct", a: jwa.ES256(), b: jwa.ES384(), want: false},
-		{name: "EdDSA vs HS256 distinct", a: jwa.EdDSA(), b: jwa.HS256(), want: false},
+		{name: "EdDSA vs HS256 distinct", a: jwa.EdDSA(), b: jwa.HS256(), key: ed25519Pub, want: false},
 		// Two distinct alg names that resolve to the same dsig algorithm
 		// (HS256) must still be a mismatch — a shared dsig mapping is NOT an
 		// alias. This is the algorithm-confusion case the guard exists to stop.
@@ -98,7 +119,7 @@ func TestAlgorithmsMatch(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tc.want, algorithmsMatch(tc.a, tc.b))
+			require.Equal(t, tc.want, algorithmsMatch(tc.a, tc.b, tc.key))
 		})
 	}
 }

--- a/jws/format_detect_test.go
+++ b/jws/format_detect_test.go
@@ -1,8 +1,6 @@
 package jws
 
 import (
-	"crypto/ed25519"
-	"crypto/rand"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v4/jwa"
@@ -56,60 +54,45 @@ func TestDetectParseFormat(t *testing.T) {
 	}
 }
 
-// TestAlgorithmsMatch pins the alg-match semantics of algorithmsMatch: it
-// matches only on exact string equality or the RFC 9864 generic-vs-specific
-// EdDSA relation. The generic/specific alias is KEY-AWARE — a generic "EdDSA"
-// only aliases the fully-specified variant ("Ed25519"/"Ed448") that the
-// verification key actually is, and the curve cannot be derived from the key
-// the pairing fails closed. The two fully-specified variants never match each
-// other, and two distinct alg identifiers are never treated as equivalent
-// merely because they share an underlying dsig mapping.
-func TestAlgorithmsMatch(t *testing.T) {
+// TestAlgorithmMatch pins the exact-string alg-match semantics: the protected
+// header "alg" matches the verification algorithm if and only if their on-the-
+// wire identifiers are equal. There is no aliasing — in particular the
+// deprecated polymorphic "EdDSA" and the fully-specified "Ed25519"/"Ed448"
+// identifiers are distinct per RFC 9864, and the two fully-specified variants
+// are distinct from each other. Two distinct alg names that happen to share an
+// underlying dsig mapping are likewise NOT equivalent.
+func TestAlgorithmMatch(t *testing.T) {
 	t.Parallel()
 
 	// "Ed448" is registered by an extension module, not the main module, so
-	// construct it by its on-the-wire identifier string. Without the
-	// extension imported there is no Ed448 key type and no curve
-	// registration, so any generic/specific alias involving "Ed448" is
-	// curve-indeterminate and must fail closed here.
+	// construct it by its on-the-wire identifier string.
 	ed448 := jwa.NewSignatureAlgorithm("Ed448")
-
-	ed25519Pub, _, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err)
 
 	tests := []struct {
 		name string
 		a    jwa.SignatureAlgorithm
 		b    jwa.SignatureAlgorithm
-		key  any
 		want bool
 	}{
-		// Exact-equality matches never need the key.
+		// Equal identifiers match.
 		{name: "exact equal", a: jwa.HS256(), b: jwa.HS256(), want: true},
 		{name: "RS256 exact equal", a: jwa.RS256(), b: jwa.RS256(), want: true},
 		{name: "EdDSA vs EdDSA", a: jwa.EdDSA(), b: jwa.EdDSA(), want: true},
 		{name: "Ed25519 exact equal", a: jwa.EdDSAEd25519(), b: jwa.EdDSAEd25519(), want: true},
 		{name: "Ed448 exact equal", a: ed448, b: ed448, want: true},
-		// Generic/specific EdDSA alias matches only when the specific variant
-		// equals the key's actual curve. An Ed25519 key aliases generic
-		// "EdDSA" to "Ed25519".
-		{name: "EdDSA vs Ed25519 alias with Ed25519 key", a: jwa.EdDSA(), b: jwa.EdDSAEd25519(), key: ed25519Pub, want: true},
-		{name: "Ed25519 vs EdDSA alias (reverse) with Ed25519 key", a: jwa.EdDSAEd25519(), b: jwa.EdDSA(), key: ed25519Pub, want: true},
-		// Generic "EdDSA" verifier with an Ed25519 key must NOT alias an
-		// "Ed448" header — the key cannot be Ed448. This is the core
-		// key-confusion case the fix closes.
-		{name: "EdDSA vs Ed448 alias with Ed25519 key rejects", a: jwa.EdDSA(), b: ed448, key: ed25519Pub, want: false},
-		{name: "Ed448 vs EdDSA alias (reverse) with Ed25519 key rejects", a: ed448, b: jwa.EdDSA(), key: ed25519Pub, want: false},
-		// Generic/specific alias with no key (curve indeterminate) fails closed.
-		{name: "EdDSA vs Ed25519 alias without key fails closed", a: jwa.EdDSA(), b: jwa.EdDSAEd25519(), key: nil, want: false},
-		{name: "EdDSA vs Ed448 alias without key fails closed", a: jwa.EdDSA(), b: ed448, key: nil, want: false},
-		// Ed25519 and Ed448 are different curves / keys / security levels and
-		// are NOT interchangeable. Only the generic "EdDSA" aliases either one.
-		{name: "Ed25519 vs Ed448 distinct curves", a: jwa.EdDSAEd25519(), b: ed448, key: ed25519Pub, want: false},
-		{name: "Ed448 vs Ed25519 distinct curves (reverse)", a: ed448, b: jwa.EdDSAEd25519(), key: ed25519Pub, want: false},
+		// RFC 9864: the generic "EdDSA" and the fully-specified variants are
+		// distinct identifiers and do NOT alias one another.
+		{name: "EdDSA vs Ed25519 distinct", a: jwa.EdDSA(), b: jwa.EdDSAEd25519(), want: false},
+		{name: "Ed25519 vs EdDSA distinct (reverse)", a: jwa.EdDSAEd25519(), b: jwa.EdDSA(), want: false},
+		{name: "EdDSA vs Ed448 distinct", a: jwa.EdDSA(), b: ed448, want: false},
+		{name: "Ed448 vs EdDSA distinct (reverse)", a: ed448, b: jwa.EdDSA(), want: false},
+		// The two fully-specified EdDSA variants are different curves / keys /
+		// security levels and never match each other.
+		{name: "Ed25519 vs Ed448 distinct curves", a: jwa.EdDSAEd25519(), b: ed448, want: false},
+		{name: "Ed448 vs Ed25519 distinct curves (reverse)", a: ed448, b: jwa.EdDSAEd25519(), want: false},
 		{name: "RS256 vs HS256 distinct", a: jwa.RS256(), b: jwa.HS256(), want: false},
 		{name: "ES256 vs ES384 distinct", a: jwa.ES256(), b: jwa.ES384(), want: false},
-		{name: "EdDSA vs HS256 distinct", a: jwa.EdDSA(), b: jwa.HS256(), key: ed25519Pub, want: false},
+		{name: "EdDSA vs HS256 distinct", a: jwa.EdDSA(), b: jwa.HS256(), want: false},
 		// Two distinct alg names that resolve to the same dsig algorithm
 		// (HS256) must still be a mismatch — a shared dsig mapping is NOT an
 		// alias. This is the algorithm-confusion case the guard exists to stop.
@@ -119,7 +102,7 @@ func TestAlgorithmsMatch(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tc.want, algorithmsMatch(tc.a, tc.b, tc.key))
+			require.Equal(t, tc.want, tc.a.String() == tc.b.String())
 		})
 	}
 }

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -240,6 +240,18 @@ func Sign(payload []byte, options ...SignOption) ([]byte, error) {
 // accept messages with "none" signature algorithm, use `jws.Parse` to get the
 // raw JWS message.
 //
+// By default, Verify rejects a JWS whose protected header "alg" contradicts
+// the algorithm actually used to verify it. The verification algorithm is
+// resolved from the key or provider you supply (jws.WithKey, jws.WithKeySet,
+// jws.WithVerifyAuto, or a custom jws.WithKeyProvider); if the protected
+// header advertises a different "alg", verification fails even when the
+// signature would otherwise be cryptographically valid. This check fires only
+// when the protected header carries an "alg" — messages that place "alg" only
+// in the unprotected header (or omit it) are unaffected. Pass
+// jws.WithSkipAlgorithmMatch(true) to bypass the check for non-conforming
+// producers. The compact fast path [VerifyCompactFast] performs an equivalent
+// cross-check against its explicitly supplied algorithm.
+//
 // The error returned by this function is of type can be checked against
 // `jws.VerifyError()` and `jws.VerificationError()`. The latter is returned
 // when the verification process itself fails (e.g. invalid signature, wrong key),
@@ -829,10 +841,10 @@ func Settings(options ...GlobalOption) error {
 //
 // Returns the original payload that was signed if verification succeeds.
 //
-// Unlike jws.Verify(), this function requires you to specify the
-// algorithm explicitly rather than extracting it from the JWS headers.
-// This can be useful for performance-critical applications where the
-// algorithm is known in advance.
+// Unlike jws.Verify() — which resolves the verification algorithm from the
+// key or provider you supply (e.g. WithKey, WithKeySet) — this function takes
+// the algorithm as an explicit argument. It is useful for performance-critical
+// applications where the algorithm is known in advance.
 //
 // This function uses strict base64url encoding without padding (RFC 4648 §5)
 // for decoding the signature and payload. It does not auto-detect other

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -240,17 +240,20 @@ func Sign(payload []byte, options ...SignOption) ([]byte, error) {
 // accept messages with "none" signature algorithm, use `jws.Parse` to get the
 // raw JWS message.
 //
-// By default, Verify rejects a JWS whose protected header "alg" contradicts
-// the algorithm actually used to verify it. The verification algorithm is
-// resolved from the key or provider you supply (jws.WithKey, jws.WithKeySet,
-// jws.WithVerifyAuto, or a custom jws.WithKeyProvider); if the protected
-// header advertises a different "alg", verification fails even when the
-// signature would otherwise be cryptographically valid. This check fires only
-// when the protected header carries an "alg" — messages that place "alg" only
-// in the unprotected header (or omit it) are unaffected. Pass
-// jws.WithSkipAlgorithmMatch(true) to bypass the check for non-conforming
-// producers. The compact fast path [VerifyCompactFast] performs an equivalent
-// cross-check against its explicitly supplied algorithm.
+// By default, Verify rejects a JWS whose protected header "alg" does not
+// exactly equal the algorithm actually used to verify it. The verification
+// algorithm is resolved from the key or provider you supply (jws.WithKey,
+// jws.WithKeySet, jws.WithVerifyAuto, or a custom jws.WithKeyProvider); if the
+// protected header advertises a different "alg", verification fails even when
+// the signature would otherwise be cryptographically valid. The match is plain
+// string equality, with no aliasing: the deprecated polymorphic "EdDSA" and the
+// fully-specified "Ed25519"/"Ed448" identifiers are distinct per RFC 9864 and
+// are not interchangeable. This check fires only when the protected header
+// carries an "alg" — messages that place "alg" only in the unprotected header
+// (or omit it) are unaffected. Pass jws.WithSkipAlgorithmMatch(true) to bypass
+// the check for non-conforming producers. The compact fast path
+// [VerifyCompactFast] performs an equivalent cross-check against its explicitly
+// supplied algorithm.
 //
 // The error returned by this function is of type can be checked against
 // `jws.VerifyError()` and `jws.VerificationError()`. The latter is returned

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -469,6 +469,13 @@ func TestRoundtrip(t *testing.T) {
 	})
 }
 
+// TestRFC9864CrossAlgorithmVerify pins that the deprecated polymorphic "EdDSA"
+// identifier and the fully-specified "Ed25519"/"Ed448" identifiers are DISTINCT
+// per RFC 9864: they do not alias one another. Cross-identifier verification
+// (signing under one and verifying under the other) is therefore rejected by
+// default because the protected header "alg" must exactly equal the verification
+// algorithm. The same underlying crypto still verifies when the algorithms match
+// or when jws.WithSkipAlgorithmMatch(true) is passed.
 func TestRFC9864CrossAlgorithmVerify(t *testing.T) {
 	t.Parallel()
 
@@ -477,7 +484,7 @@ func TestRFC9864CrossAlgorithmVerify(t *testing.T) {
 
 	payload := []byte("RFC 9864 cross-algorithm test")
 
-	t.Run("sign with EdDSAEd25519, verify with EdDSA", func(t *testing.T) {
+	t.Run("sign with EdDSAEd25519, verify with EdDSA rejected by default", func(t *testing.T) {
 		t.Parallel()
 		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSAEd25519(), key))
 		require.NoError(t, err, "signing with EdDSAEd25519 should succeed")
@@ -491,20 +498,43 @@ func TestRFC9864CrossAlgorithmVerify(t *testing.T) {
 		require.True(t, ok, "algorithm should be present")
 		require.Equal(t, jwa.EdDSAEd25519(), alg)
 
-		// Verify with EdDSA should also work (same crypto)
-		verified, err := jws.Verify(signed, jws.WithKey(jwa.EdDSA(), key.Public()))
-		require.NoError(t, err, "verifying EdDSAEd25519-signed message with EdDSA should succeed")
+		// Verifying under the generic "EdDSA" is rejected by default: the
+		// header "alg" ("Ed25519") does not equal the verification algorithm
+		// ("EdDSA"). They are distinct identifiers per RFC 9864.
+		_, err = jws.Verify(signed, jws.WithKey(jwa.EdDSA(), key.Public()))
+		require.Error(t, err, "cross-identifier verify should be rejected by default")
+		require.ErrorIs(t, err, jws.VerifyError())
+
+		// The same crypto verifies when the algorithm matches the header.
+		verified, err := jws.Verify(signed, jws.WithKey(jwa.EdDSAEd25519(), key.Public()))
+		require.NoError(t, err, "verifying with the matching algorithm should succeed")
+		require.Equal(t, payload, verified)
+
+		// ...or when the alg-match check is explicitly skipped.
+		verified, err = jws.Verify(signed, jws.WithKey(jwa.EdDSA(), key.Public()), jws.WithSkipAlgorithmMatch(true))
+		require.NoError(t, err, "verifying with WithSkipAlgorithmMatch should succeed")
 		require.Equal(t, payload, verified)
 	})
 
-	t.Run("sign with EdDSA, verify with EdDSAEd25519", func(t *testing.T) {
+	t.Run("sign with EdDSA, verify with EdDSAEd25519 rejected by default", func(t *testing.T) {
 		t.Parallel()
 		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSA(), key))
 		require.NoError(t, err, "signing with EdDSA should succeed")
 
-		// Verify with EdDSAEd25519 should also work (same crypto)
-		verified, err := jws.Verify(signed, jws.WithKey(jwa.EdDSAEd25519(), key.Public()))
-		require.NoError(t, err, "verifying EdDSA-signed message with EdDSAEd25519 should succeed")
+		// The reverse direction is likewise rejected: header "alg" ("EdDSA")
+		// does not equal the verification algorithm ("Ed25519").
+		_, err = jws.Verify(signed, jws.WithKey(jwa.EdDSAEd25519(), key.Public()))
+		require.Error(t, err, "cross-identifier verify should be rejected by default")
+		require.ErrorIs(t, err, jws.VerifyError())
+
+		// The same crypto verifies when the algorithm matches the header.
+		verified, err := jws.Verify(signed, jws.WithKey(jwa.EdDSA(), key.Public()))
+		require.NoError(t, err, "verifying with the matching algorithm should succeed")
+		require.Equal(t, payload, verified)
+
+		// ...or when the alg-match check is explicitly skipped.
+		verified, err = jws.Verify(signed, jws.WithKey(jwa.EdDSAEd25519(), key.Public()), jws.WithSkipAlgorithmMatch(true))
+		require.NoError(t, err, "verifying with WithSkipAlgorithmMatch should succeed")
 		require.Equal(t, payload, verified)
 	})
 }

--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -376,6 +376,31 @@ options:
       This option can be passed to `jws.Settings()` to change the default
       globally, or to `jws.Parse()` / `jws.ParseFS()` for a per-call
       override.
+  - ident: SkipAlgorithmMatch
+    interface: VerifyOption
+    argument_type: bool
+    comment: |
+      WithSkipAlgorithmMatch disables the check that the protected header's
+      "alg" parameter matches the algorithm actually used to verify the
+      signature. By default jws.Verify() rejects a JWS whose protected
+      header advertises one algorithm while it is verified under another
+      (for example, a custom jws.WithKeyProvider that returns an HS256 key
+      for a message whose protected header claims RS256). This guard runs
+      for every key source — jws.WithKey(), jws.WithKeySet(),
+      jws.WithVerifyAuto(), and custom jws.WithKeyProvider() — so the
+      algorithm a message advertises always matches the discipline under
+      which it was accepted. The check only fires when the protected header
+      carries an "alg"; messages that place "alg" only in the unprotected
+      header (or omit it) are unaffected.
+
+      Pass jws.WithSkipAlgorithmMatch(true) to bypass this check. It is
+      intended for recovery or interoperability with non-conforming
+      producers that emit a protected "alg" inconsistent with the actual
+      signature algorithm. It weakens a safety check: with it enabled, a
+      message can be accepted under an algorithm that contradicts its own
+      advertised "alg", so use it only when you understand and accept that
+      risk.
+
   - ident: CritValidation
     interface: VerifyOption
     argument_type: bool

--- a/jws/options.yaml
+++ b/jws/options.yaml
@@ -381,17 +381,19 @@ options:
     argument_type: bool
     comment: |
       WithSkipAlgorithmMatch disables the check that the protected header's
-      "alg" parameter matches the algorithm actually used to verify the
-      signature. By default jws.Verify() rejects a JWS whose protected
+      "alg" parameter exactly equals the algorithm actually used to verify
+      the signature. By default jws.Verify() rejects a JWS whose protected
       header advertises one algorithm while it is verified under another
       (for example, a custom jws.WithKeyProvider that returns an HS256 key
-      for a message whose protected header claims RS256). This guard runs
-      for every key source — jws.WithKey(), jws.WithKeySet(),
-      jws.WithVerifyAuto(), and custom jws.WithKeyProvider() — so the
-      algorithm a message advertises always matches the discipline under
-      which it was accepted. The check only fires when the protected header
-      carries an "alg"; messages that place "alg" only in the unprotected
-      header (or omit it) are unaffected.
+      for a message whose protected header claims RS256). The match is plain
+      string equality, with no aliasing: the deprecated polymorphic "EdDSA"
+      and the fully-specified "Ed25519"/"Ed448" identifiers are distinct per
+      RFC 9864 and are not interchangeable. This guard runs for every key
+      source — jws.WithKey(), jws.WithKeySet(), jws.WithVerifyAuto(), and
+      custom jws.WithKeyProvider() — so the algorithm a message advertises
+      always matches the discipline under which it was accepted. The check
+      only fires when the protected header carries an "alg"; messages that
+      place "alg" only in the unprotected header (or omit it) are unaffected.
 
       Pass jws.WithSkipAlgorithmMatch(true) to bypass this check. It is
       intended for recovery or interoperability with non-conforming

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -604,17 +604,19 @@ func WithCompact() SignVerifyParseOption {
 }
 
 // WithSkipAlgorithmMatch disables the check that the protected header's
-// "alg" parameter matches the algorithm actually used to verify the
-// signature. By default jws.Verify() rejects a JWS whose protected
+// "alg" parameter exactly equals the algorithm actually used to verify
+// the signature. By default jws.Verify() rejects a JWS whose protected
 // header advertises one algorithm while it is verified under another
 // (for example, a custom jws.WithKeyProvider that returns an HS256 key
-// for a message whose protected header claims RS256). This guard runs
-// for every key source — jws.WithKey(), jws.WithKeySet(),
-// jws.WithVerifyAuto(), and custom jws.WithKeyProvider() — so the
-// algorithm a message advertises always matches the discipline under
-// which it was accepted. The check only fires when the protected header
-// carries an "alg"; messages that place "alg" only in the unprotected
-// header (or omit it) are unaffected.
+// for a message whose protected header claims RS256). The match is plain
+// string equality, with no aliasing: the deprecated polymorphic "EdDSA"
+// and the fully-specified "Ed25519"/"Ed448" identifiers are distinct per
+// RFC 9864 and are not interchangeable. This guard runs for every key
+// source — jws.WithKey(), jws.WithKeySet(), jws.WithVerifyAuto(), and
+// custom jws.WithKeyProvider() — so the algorithm a message advertises
+// always matches the discipline under which it was accepted. The check
+// only fires when the protected header carries an "alg"; messages that
+// place "alg" only in the unprotected header (or omit it) are unaffected.
 //
 // Pass jws.WithSkipAlgorithmMatch(true) to bypass this check. It is
 // intended for recovery or interoperability with non-conforming

--- a/jws/options_gen.go
+++ b/jws/options_gen.go
@@ -202,6 +202,7 @@ type identProtectedHeaders struct{}
 type identPublicHeaders struct{}
 type identRequireKid struct{}
 type identSerialization struct{}
+type identSkipAlgorithmMatch struct{}
 type identUseDefault struct{}
 type identValidateKey struct{}
 
@@ -275,6 +276,10 @@ func (identRequireKid) String() string {
 
 func (identSerialization) String() string {
 	return "WithSerialization"
+}
+
+func (identSkipAlgorithmMatch) String() string {
+	return "WithSkipAlgorithmMatch"
 }
 
 func (identUseDefault) String() string {
@@ -596,6 +601,30 @@ func WithRequireKid(v bool) WithKeySetSuboption {
 // do not need to specify this option other than to be explicit about it
 func WithCompact() SignVerifyParseOption {
 	return &signVerifyParseOption{option.New(identSerialization{}, fmtCompact)}
+}
+
+// WithSkipAlgorithmMatch disables the check that the protected header's
+// "alg" parameter matches the algorithm actually used to verify the
+// signature. By default jws.Verify() rejects a JWS whose protected
+// header advertises one algorithm while it is verified under another
+// (for example, a custom jws.WithKeyProvider that returns an HS256 key
+// for a message whose protected header claims RS256). This guard runs
+// for every key source — jws.WithKey(), jws.WithKeySet(),
+// jws.WithVerifyAuto(), and custom jws.WithKeyProvider() — so the
+// algorithm a message advertises always matches the discipline under
+// which it was accepted. The check only fires when the protected header
+// carries an "alg"; messages that place "alg" only in the unprotected
+// header (or omit it) are unaffected.
+//
+// Pass jws.WithSkipAlgorithmMatch(true) to bypass this check. It is
+// intended for recovery or interoperability with non-conforming
+// producers that emit a protected "alg" inconsistent with the actual
+// signature algorithm. It weakens a safety check: with it enabled, a
+// message can be accepted under an algorithm that contradicts its own
+// advertised "alg", so use it only when you understand and accept that
+// risk.
+func WithSkipAlgorithmMatch(v bool) VerifyOption {
+	return &verifyOption{option.New(identSkipAlgorithmMatch{}, v)}
 }
 
 // WithUseDefault specifies that if and only if a jwk.Key contains

--- a/jws/options_gen_test.go
+++ b/jws/options_gen_test.go
@@ -27,6 +27,7 @@ func TestOptionIdent(t *testing.T) {
 	require.Equal(t, "WithPublicHeaders", identPublicHeaders{}.String())
 	require.Equal(t, "WithRequireKid", identRequireKid{}.String())
 	require.Equal(t, "WithSerialization", identSerialization{}.String())
+	require.Equal(t, "WithSkipAlgorithmMatch", identSkipAlgorithmMatch{}.String())
 	require.Equal(t, "WithUseDefault", identUseDefault{}.String())
 	require.Equal(t, "WithValidateKey", identValidateKey{}.String())
 }

--- a/jws/streaming_detached.go
+++ b/jws/streaming_detached.go
@@ -261,6 +261,22 @@ func (vc *verifyContext) verifyStreaming(buf []byte) ([]byte, error) {
 
 	sig := msg.signatures[0]
 
+	// Enforce that the algorithm we are about to verify under matches the
+	// "alg" advertised in this signature's protected header. The streaming
+	// path bypasses verifyContext.tryKey (it talks to dsig directly for
+	// incremental hashing), so without this guard a detached JWS whose
+	// protected header advertises one algorithm would still verify under the
+	// single pinned WithKey algorithm — the same algorithm-confusion the
+	// tryKey guard prevents on the non-streaming path. The single staticKP
+	// alg above is the verification algorithm. The check fires only when the
+	// protected header carries an "alg"; use WithSkipAlgorithmMatch to bypass
+	// it for non-conforming producers.
+	if !vc.skipAlgorithmMatch && sig.protected != nil {
+		if hdrAlg, ok := sig.protected.Algorithm(); ok && !algorithmsMatch(hdrAlg, alg) {
+			return nil, verifyError{verificationError{fmt.Errorf(`protected header %q %q does not match verification algorithm %q`, AlgorithmKey, hdrAlg, alg)}}
+		}
+	}
+
 	var rawHeaders []byte
 	if rbp, ok := sig.protected.(interface{ rawBuffer() []byte }); ok {
 		rawHeaders = rbp.rawBuffer()

--- a/jws/streaming_detached.go
+++ b/jws/streaming_detached.go
@@ -272,7 +272,7 @@ func (vc *verifyContext) verifyStreaming(buf []byte) ([]byte, error) {
 	// protected header carries an "alg"; use WithSkipAlgorithmMatch to bypass
 	// it for non-conforming producers.
 	if !vc.skipAlgorithmMatch && sig.protected != nil {
-		if hdrAlg, ok := sig.protected.Algorithm(); ok && !algorithmsMatch(hdrAlg, alg) {
+		if hdrAlg, ok := sig.protected.Algorithm(); ok && !algorithmsMatch(hdrAlg, alg, key) {
 			return nil, verifyError{verificationError{fmt.Errorf(`protected header %q %q does not match verification algorithm %q`, AlgorithmKey, hdrAlg, alg)}}
 		}
 	}

--- a/jws/streaming_detached.go
+++ b/jws/streaming_detached.go
@@ -261,18 +261,19 @@ func (vc *verifyContext) verifyStreaming(buf []byte) ([]byte, error) {
 
 	sig := msg.signatures[0]
 
-	// Enforce that the algorithm we are about to verify under matches the
-	// "alg" advertised in this signature's protected header. The streaming
+	// Enforce that the algorithm we are about to verify under exactly matches
+	// the "alg" advertised in this signature's protected header. The streaming
 	// path bypasses verifyContext.tryKey (it talks to dsig directly for
 	// incremental hashing), so without this guard a detached JWS whose
 	// protected header advertises one algorithm would still verify under the
 	// single pinned WithKey algorithm — the same algorithm-confusion the
 	// tryKey guard prevents on the non-streaming path. The single staticKP
-	// alg above is the verification algorithm. The check fires only when the
-	// protected header carries an "alg"; use WithSkipAlgorithmMatch to bypass
-	// it for non-conforming producers.
+	// alg above is the verification algorithm, and the match is plain string
+	// equality. The check fires only when the protected header carries an
+	// "alg"; use WithSkipAlgorithmMatch to bypass it for non-conforming
+	// producers.
 	if !vc.skipAlgorithmMatch && sig.protected != nil {
-		if hdrAlg, ok := sig.protected.Algorithm(); ok && !algorithmsMatch(hdrAlg, alg, key) {
+		if hdrAlg, ok := sig.protected.Algorithm(); ok && hdrAlg.String() != alg.String() {
 			return nil, verifyError{verificationError{fmt.Errorf(`protected header %q %q does not match verification algorithm %q`, AlgorithmKey, hdrAlg, alg)}}
 		}
 	}

--- a/jws/verify_alg_match_test.go
+++ b/jws/verify_alg_match_test.go
@@ -1,0 +1,107 @@
+package jws_test
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jws"
+	"github.com/stretchr/testify/require"
+)
+
+// b64 is RFC 7515 base64url, no padding.
+func b64url(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// makeAlgConfusedCompact builds a compact JWS whose protected header
+// advertises `headerAlg` but whose signature is actually a valid
+// HMAC-SHA256 over the signing input computed with `hmacKey`. The result
+// verifies cryptographically under HS256 even though the header claims a
+// different algorithm.
+func makeAlgConfusedCompact(t *testing.T, headerAlg string, payload, hmacKey []byte) []byte {
+	t.Helper()
+	hdr := b64url([]byte(`{"alg":"` + headerAlg + `"}`))
+	pl := b64url(payload)
+	signingInput := hdr + "." + pl
+
+	mac := hmac.New(sha256.New, hmacKey)
+	_, err := mac.Write([]byte(signingInput))
+	require.NoError(t, err, `hmac write should succeed`)
+	sig := mac.Sum(nil)
+
+	return []byte(signingInput + "." + b64url(sig))
+}
+
+func TestVerifyAlgorithmMatch(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte("hello world")
+	hmacKey := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+
+	t.Run("default rejects header alg mismatching verification alg", func(t *testing.T) {
+		t.Parallel()
+		// Protected header advertises RS256 but the signature is a valid
+		// HMAC-SHA256, so verifying under HS256 succeeds cryptographically.
+		token := makeAlgConfusedCompact(t, "RS256", payload, hmacKey)
+
+		// Sanity: the signature really is valid HMAC-SHA256 (i.e. without
+		// the alg-match guard this would have verified). We confirm by
+		// using the opt-out below, which bypasses only the alg-match check.
+		got, err := jws.Verify(token, jws.WithKey(jwa.HS256(), hmacKey), jws.WithSkipAlgorithmMatch(true))
+		require.NoError(t, err, `verification with skip should succeed (signature is valid HMAC)`)
+		require.Equal(t, payload, got)
+
+		// Default behavior: rejected because header "alg" (RS256) does not
+		// match the verification algorithm (HS256).
+		_, err = jws.Verify(token, jws.WithKey(jwa.HS256(), hmacKey))
+		require.Error(t, err, `default verification should reject alg mismatch`)
+		require.ErrorIs(t, err, jws.VerifyError())
+	})
+
+	t.Run("opt-out bypasses the check", func(t *testing.T) {
+		t.Parallel()
+		token := makeAlgConfusedCompact(t, "RS256", payload, hmacKey)
+
+		got, err := jws.Verify(token, jws.WithKey(jwa.HS256(), hmacKey), jws.WithSkipAlgorithmMatch(true))
+		require.NoError(t, err, `verification with WithSkipAlgorithmMatch(true) should succeed`)
+		require.Equal(t, payload, got)
+	})
+
+	t.Run("matching alg verifies (no regression)", func(t *testing.T) {
+		t.Parallel()
+		// Normal sign with HS256 -> header alg HS256 -> verifies fine.
+		signed, err := jws.Sign(payload, jws.WithKey(jwa.HS256(), hmacKey))
+		require.NoError(t, err, `jws.Sign should succeed`)
+
+		got, err := jws.Verify(signed, jws.WithKey(jwa.HS256(), hmacKey))
+		require.NoError(t, err, `verification with matching alg should succeed`)
+		require.Equal(t, payload, got)
+	})
+
+	t.Run("alg only in unprotected header falls through", func(t *testing.T) {
+		t.Parallel()
+		// Flattened JSON JWS: protected header carries no "alg" (it is in
+		// the unprotected header). The signing input is computed over the
+		// empty protected header. The alg-match guard must NOT fire here,
+		// since the protected header has no "alg" to contradict.
+		protected := b64url([]byte(`{}`))
+		pl := b64url(payload)
+		signingInput := protected + "." + pl
+
+		mac := hmac.New(sha256.New, hmacKey)
+		_, err := mac.Write([]byte(signingInput))
+		require.NoError(t, err, `hmac write should succeed`)
+		sig := mac.Sum(nil)
+
+		jsonJWS := []byte(`{"protected":"` + protected +
+			`","header":{"alg":"HS256"},"payload":"` + pl +
+			`","signature":"` + b64url(sig) + `"}`)
+
+		got, err := jws.Verify(jsonJWS, jws.WithKey(jwa.HS256(), hmacKey))
+		require.NoError(t, err, `alg-in-unprotected JWS should verify (falls through)`)
+		require.Equal(t, payload, got)
+	})
+}

--- a/jws/verify_alg_match_test.go
+++ b/jws/verify_alg_match_test.go
@@ -1,7 +1,10 @@
 package jws_test
 
 import (
+	"bytes"
+	"crypto/ed25519"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"testing"
@@ -103,5 +106,108 @@ func TestVerifyAlgorithmMatch(t *testing.T) {
 		got, err := jws.Verify(jsonJWS, jws.WithKey(jwa.HS256(), hmacKey))
 		require.NoError(t, err, `alg-in-unprotected JWS should verify (falls through)`)
 		require.Equal(t, payload, got)
+	})
+
+	t.Run("EdDSA header verifies under Ed25519 (RFC 9864 alias)", func(t *testing.T) {
+		t.Parallel()
+		pub, priv, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err, `ed25519 key generation should succeed`)
+
+		// Sign with the polymorphic "EdDSA" identifier; header alg is "EdDSA".
+		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSA(), priv))
+		require.NoError(t, err, `jws.Sign with EdDSA should succeed`)
+
+		// Verifying under the fully-specified "Ed25519" identifier must
+		// succeed: RFC 9864 makes the two interchangeable.
+		got, err := jws.Verify(signed, jws.WithKey(jwa.EdDSAEd25519(), pub))
+		require.NoError(t, err, `EdDSA header should verify under Ed25519 alias`)
+		require.Equal(t, payload, got)
+
+		// And the reverse direction.
+		signed, err = jws.Sign(payload, jws.WithKey(jwa.EdDSAEd25519(), priv))
+		require.NoError(t, err, `jws.Sign with Ed25519 should succeed`)
+		got, err = jws.Verify(signed, jws.WithKey(jwa.EdDSA(), pub))
+		require.NoError(t, err, `Ed25519 header should verify under EdDSA alias`)
+		require.Equal(t, payload, got)
+	})
+}
+
+// makeAlgConfusedDetachedCompact builds a compact detached JWS whose protected
+// header advertises headerAlg but whose signature is a valid HMAC-SHA256 over
+// the detached signing input base64(protected) "." base64(payload). It mirrors
+// makeAlgConfusedCompact but omits the payload segment so the result can be
+// verified through the WithDetachedPayloadReader streaming path.
+func makeAlgConfusedDetachedCompact(t *testing.T, headerAlg string, payload, hmacKey []byte) []byte {
+	t.Helper()
+	hdr := b64url([]byte(`{"alg":"` + headerAlg + `"}`))
+	pl := b64url(payload)
+	signingInput := hdr + "." + pl
+
+	mac := hmac.New(sha256.New, hmacKey)
+	_, err := mac.Write([]byte(signingInput))
+	require.NoError(t, err, `hmac write should succeed`)
+	sig := mac.Sum(nil)
+
+	// Compact detached form: header ".." signature (empty payload segment).
+	return []byte(hdr + ".." + b64url(sig))
+}
+
+// TestVerifyAlgorithmMatchStreaming covers the WithDetachedPayloadReader
+// (streaming) path, which bypasses verifyContext.tryKey and so needs its own
+// alg-match guard.
+func TestVerifyAlgorithmMatchStreaming(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte("hello world")
+	hmacKey := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+
+	t.Run("default rejects header alg mismatching verification alg", func(t *testing.T) {
+		t.Parallel()
+		token := makeAlgConfusedDetachedCompact(t, "RS256", payload, hmacKey)
+
+		// Sanity: the signature is valid HMAC-SHA256, so with the guard
+		// bypassed it verifies through the streaming path.
+		_, err := jws.Verify(token,
+			jws.WithKey(jwa.HS256(), hmacKey),
+			jws.WithDetachedPayloadReader(bytes.NewReader(payload)),
+			jws.WithSkipAlgorithmMatch(true),
+		)
+		require.NoError(t, err, `streaming verify with skip should succeed (signature is valid HMAC)`)
+
+		// Default behavior: rejected because header "alg" (RS256) does not
+		// match the verification algorithm (HS256).
+		_, err = jws.Verify(token,
+			jws.WithKey(jwa.HS256(), hmacKey),
+			jws.WithDetachedPayloadReader(bytes.NewReader(payload)),
+		)
+		require.Error(t, err, `streaming default verification should reject alg mismatch`)
+		require.ErrorIs(t, err, jws.VerifyError())
+	})
+
+	t.Run("opt-out bypasses the check", func(t *testing.T) {
+		t.Parallel()
+		token := makeAlgConfusedDetachedCompact(t, "RS256", payload, hmacKey)
+
+		_, err := jws.Verify(token,
+			jws.WithKey(jwa.HS256(), hmacKey),
+			jws.WithDetachedPayloadReader(bytes.NewReader(payload)),
+			jws.WithSkipAlgorithmMatch(true),
+		)
+		require.NoError(t, err, `streaming verify with WithSkipAlgorithmMatch(true) should succeed`)
+	})
+
+	t.Run("matching alg verifies (no regression)", func(t *testing.T) {
+		t.Parallel()
+		signed, err := jws.Sign(nil,
+			jws.WithKey(jwa.HS256(), hmacKey),
+			jws.WithDetachedPayloadReader(bytes.NewReader(payload)),
+		)
+		require.NoError(t, err, `streaming jws.Sign should succeed`)
+
+		_, err = jws.Verify(signed,
+			jws.WithKey(jwa.HS256(), hmacKey),
+			jws.WithDetachedPayloadReader(bytes.NewReader(payload)),
+		)
+		require.NoError(t, err, `streaming verify with matching alg should succeed`)
 	})
 }

--- a/jws/verify_alg_match_test.go
+++ b/jws/verify_alg_match_test.go
@@ -132,6 +132,136 @@ func TestVerifyAlgorithmMatch(t *testing.T) {
 	})
 }
 
+// ed25519BackedVerifier is a jws.Verifier that validates with crypto/ed25519.
+// It lets a test register a synthetic fully-specified EdDSA identifier (e.g.
+// "Ed448") backed by a genuine Ed25519 signature, so the end-to-end alg-match
+// guard can be exercised without importing the real ed448 extension module.
+type ed25519BackedVerifier struct{}
+
+func (ed25519BackedVerifier) Verify(key any, payload, signature []byte) error {
+	pub, ok := key.(ed25519.PublicKey)
+	if !ok {
+		return errEd25519BackedVerifierKeyType
+	}
+	if !ed25519.Verify(pub, payload, signature) {
+		return errEd25519BackedVerifierBadSig
+	}
+	return nil
+}
+
+var (
+	errEd25519BackedVerifierKeyType = errEd25519Backed("ed25519BackedVerifier: key is not ed25519.PublicKey")
+	errEd25519BackedVerifierBadSig  = errEd25519Backed("ed25519BackedVerifier: signature verification failed")
+)
+
+type errEd25519Backed string
+
+func (e errEd25519Backed) Error() string { return string(e) }
+
+// makeEdDSACurveConfusedCompact builds a compact JWS whose protected header
+// advertises headerAlg but whose signature is a valid Ed25519 signature over
+// the signing input. With headerAlg="Ed448" and an Ed25519 signing key the
+// result is curve-confused: the header claims Ed448 while the key (and the
+// actual signature) is Ed25519.
+func makeEdDSACurveConfusedCompact(t *testing.T, headerAlg string, payload []byte, priv ed25519.PrivateKey) []byte {
+	t.Helper()
+	hdr := b64url([]byte(`{"alg":"` + headerAlg + `"}`))
+	pl := b64url(payload)
+	signingInput := hdr + "." + pl
+	sig := ed25519.Sign(priv, []byte(signingInput))
+	return []byte(signingInput + "." + b64url(sig))
+}
+
+// TestVerifyEdDSACurveAwareAlgMatch pins the KEY-AWARE behavior of the RFC 9864
+// generic/specific EdDSA alias. The generic "EdDSA" identifier only aliases the
+// fully-specified variant that the verification key actually is, so a protected
+// header claiming "Ed448" must be rejected when the key is an Ed25519 key, even
+// though the verifier was configured with the generic jwa.EdDSA(). A name-only
+// alias would accept this and let a header advertise a curve the key cannot be.
+//
+// It registers a synthetic "Ed448" SignatureAlgorithm backed by an Ed25519
+// verifier (and deliberately does NOT register the Ed448 curve, mirroring an
+// environment where AlgorithmsForKey can only resolve an Ed25519 key to
+// "Ed25519"). Because it mutates the process-global algorithm registry, this
+// test must not run in parallel and cleans up after itself.
+func TestVerifyEdDSACurveAwareAlgMatch(t *testing.T) {
+	payload := []byte("hello world")
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err, `ed25519 key generation should succeed`)
+
+	// Register a synthetic, parseable "Ed448" identifier backed by an Ed25519
+	// verifier. We do NOT register an Ed448 curve, so AlgorithmsForKey resolves
+	// the Ed25519 key only to "Ed25519" — exactly the signal the guard relies
+	// on to reject the curve-confused header.
+	ed448 := jwa.NewSignatureAlgorithm("Ed448")
+	require.NoError(t, jws.RegisterVerifier(ed448, ed25519BackedVerifier{}),
+		`registering synthetic Ed448 verifier should succeed`)
+	t.Cleanup(func() {
+		_ = jws.UnregisterVerifier(ed448)
+		jwa.UnregisterSignatureAlgorithm(ed448)
+	})
+
+	t.Run("Ed448 header with generic EdDSA verifier + Ed25519 key rejects (tryKey)", func(t *testing.T) {
+		// Header claims Ed448; signature is genuine Ed25519; verifier uses the
+		// generic jwa.EdDSA() with an Ed25519 key. The name-only alias would
+		// pass ("Ed448" aliases "EdDSA"), but the key is Ed25519, so it must
+		// be rejected.
+		token := makeEdDSACurveConfusedCompact(t, "Ed448", payload, priv)
+
+		_, err := jws.Verify(token, jws.WithKey(jwa.EdDSA(), pub))
+		require.Error(t, err, `Ed448 header with Ed25519 key must be rejected`)
+		require.ErrorIs(t, err, jws.VerifyError())
+
+		// Sanity: the signature really is a valid Ed25519 signature. With the
+		// alg-match guard bypassed it verifies (proving the rejection above is
+		// the guard firing, not a bad signature).
+		_, err = jws.Verify(token, jws.WithKey(jwa.EdDSA(), pub), jws.WithSkipAlgorithmMatch(true))
+		require.NoError(t, err, `signature is valid Ed25519; skip should verify`)
+	})
+
+	t.Run("Ed448 header with specific Ed448 verifier + Ed25519 key rejects (tryKey)", func(t *testing.T) {
+		// Exact header/verifier match ("Ed448"/"Ed448") is allowed by the
+		// name-only equality branch and is NOT what this fix touches — that is
+		// the operator pinning the synthetic Ed448 algorithm explicitly. The
+		// fix specifically targets the generic-EdDSA-verifier-vs-Ed448-header
+		// case above, where the verifier did not pin the curve.
+		token := makeEdDSACurveConfusedCompact(t, "Ed448", payload, priv)
+		_, err := jws.Verify(token, jws.WithKey(ed448, pub))
+		require.NoError(t, err, `exact Ed448/Ed448 with a matching verifier should verify`)
+	})
+
+	t.Run("Ed25519 header with generic EdDSA verifier + Ed25519 key verifies", func(t *testing.T) {
+		t.Parallel()
+		// Generic verifier, specific (matching-curve) header: the alias holds.
+		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSAEd25519(), priv))
+		require.NoError(t, err, `jws.Sign with Ed25519 should succeed`)
+
+		got, err := jws.Verify(signed, jws.WithKey(jwa.EdDSA(), pub))
+		require.NoError(t, err, `Ed25519 header should verify under generic EdDSA with an Ed25519 key`)
+		require.Equal(t, payload, got)
+	})
+
+	t.Run("EdDSA header with specific Ed25519 verifier + Ed25519 key verifies", func(t *testing.T) {
+		t.Parallel()
+		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSA(), priv))
+		require.NoError(t, err, `jws.Sign with EdDSA should succeed`)
+
+		got, err := jws.Verify(signed, jws.WithKey(jwa.EdDSAEd25519(), pub))
+		require.NoError(t, err, `EdDSA header should verify under specific Ed25519 with an Ed25519 key`)
+		require.Equal(t, payload, got)
+	})
+
+	t.Run("exact EdDSA header and EdDSA verifier verifies", func(t *testing.T) {
+		t.Parallel()
+		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSA(), priv))
+		require.NoError(t, err, `jws.Sign with EdDSA should succeed`)
+
+		got, err := jws.Verify(signed, jws.WithKey(jwa.EdDSA(), pub))
+		require.NoError(t, err, `exact EdDSA/EdDSA should verify`)
+		require.Equal(t, payload, got)
+	})
+}
+
 // makeAlgConfusedDetachedCompact builds a compact detached JWS whose protected
 // header advertises headerAlg but whose signature is a valid HMAC-SHA256 over
 // the detached signing input base64(protected) "." base64(payload). It mirrors

--- a/jws/verify_alg_match_test.go
+++ b/jws/verify_alg_match_test.go
@@ -108,8 +108,12 @@ func TestVerifyAlgorithmMatch(t *testing.T) {
 		require.Equal(t, payload, got)
 	})
 
-	t.Run("EdDSA header verifies under Ed25519 (RFC 9864 alias)", func(t *testing.T) {
+	t.Run("EdDSA and Ed25519 are distinct per RFC 9864", func(t *testing.T) {
 		t.Parallel()
+		// RFC 9864 deprecates the polymorphic "EdDSA" in favor of the
+		// fully-specified "Ed25519"/"Ed448". They are distinct identifiers and
+		// do NOT alias one another: cross-identifier verification requires a
+		// matching alg or jws.WithSkipAlgorithmMatch(true).
 		pub, priv, err := ed25519.GenerateKey(rand.Reader)
 		require.NoError(t, err, `ed25519 key generation should succeed`)
 
@@ -117,144 +121,20 @@ func TestVerifyAlgorithmMatch(t *testing.T) {
 		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSA(), priv))
 		require.NoError(t, err, `jws.Sign with EdDSA should succeed`)
 
-		// Verifying under the fully-specified "Ed25519" identifier must
-		// succeed: RFC 9864 makes the two interchangeable.
-		got, err := jws.Verify(signed, jws.WithKey(jwa.EdDSAEd25519(), pub))
-		require.NoError(t, err, `EdDSA header should verify under Ed25519 alias`)
-		require.Equal(t, payload, got)
-
-		// And the reverse direction.
-		signed, err = jws.Sign(payload, jws.WithKey(jwa.EdDSAEd25519(), priv))
-		require.NoError(t, err, `jws.Sign with Ed25519 should succeed`)
-		got, err = jws.Verify(signed, jws.WithKey(jwa.EdDSA(), pub))
-		require.NoError(t, err, `Ed25519 header should verify under EdDSA alias`)
-		require.Equal(t, payload, got)
-	})
-}
-
-// ed25519BackedVerifier is a jws.Verifier that validates with crypto/ed25519.
-// It lets a test register a synthetic fully-specified EdDSA identifier (e.g.
-// "Ed448") backed by a genuine Ed25519 signature, so the end-to-end alg-match
-// guard can be exercised without importing the real ed448 extension module.
-type ed25519BackedVerifier struct{}
-
-func (ed25519BackedVerifier) Verify(key any, payload, signature []byte) error {
-	pub, ok := key.(ed25519.PublicKey)
-	if !ok {
-		return errEd25519BackedVerifierKeyType
-	}
-	if !ed25519.Verify(pub, payload, signature) {
-		return errEd25519BackedVerifierBadSig
-	}
-	return nil
-}
-
-var (
-	errEd25519BackedVerifierKeyType = ed25519BackedError("ed25519BackedVerifier: key is not ed25519.PublicKey")
-	errEd25519BackedVerifierBadSig  = ed25519BackedError("ed25519BackedVerifier: signature verification failed")
-)
-
-type ed25519BackedError string
-
-func (e ed25519BackedError) Error() string { return string(e) }
-
-// makeEdDSACurveConfusedCompact builds a compact JWS whose protected header
-// advertises headerAlg but whose signature is a valid Ed25519 signature over
-// the signing input. With headerAlg="Ed448" and an Ed25519 signing key the
-// result is curve-confused: the header claims Ed448 while the key (and the
-// actual signature) is Ed25519.
-func makeEdDSACurveConfusedCompact(t *testing.T, headerAlg string, payload []byte, priv ed25519.PrivateKey) []byte {
-	t.Helper()
-	hdr := b64url([]byte(`{"alg":"` + headerAlg + `"}`))
-	pl := b64url(payload)
-	signingInput := hdr + "." + pl
-	sig := ed25519.Sign(priv, []byte(signingInput))
-	return []byte(signingInput + "." + b64url(sig))
-}
-
-// TestVerifyEdDSACurveAwareAlgMatch pins the KEY-AWARE behavior of the RFC 9864
-// generic/specific EdDSA alias. The generic "EdDSA" identifier only aliases the
-// fully-specified variant that the verification key actually is, so a protected
-// header claiming "Ed448" must be rejected when the key is an Ed25519 key, even
-// though the verifier was configured with the generic jwa.EdDSA(). A name-only
-// alias would accept this and let a header advertise a curve the key cannot be.
-//
-// It registers a synthetic "Ed448" SignatureAlgorithm backed by an Ed25519
-// verifier (and deliberately does NOT register the Ed448 curve, mirroring an
-// environment where AlgorithmsForKey can only resolve an Ed25519 key to
-// "Ed25519"). Because it mutates the process-global algorithm registry, this
-// test must not run in parallel and cleans up after itself.
-func TestVerifyEdDSACurveAwareAlgMatch(t *testing.T) {
-	payload := []byte("hello world")
-	pub, priv, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err, `ed25519 key generation should succeed`)
-
-	// Register a synthetic, parseable "Ed448" identifier backed by an Ed25519
-	// verifier. We do NOT register an Ed448 curve, so AlgorithmsForKey resolves
-	// the Ed25519 key only to "Ed25519" — exactly the signal the guard relies
-	// on to reject the curve-confused header.
-	ed448 := jwa.NewSignatureAlgorithm("Ed448")
-	require.NoError(t, jws.RegisterVerifier(ed448, ed25519BackedVerifier{}),
-		`registering synthetic Ed448 verifier should succeed`)
-	t.Cleanup(func() {
-		_ = jws.UnregisterVerifier(ed448)
-		jwa.UnregisterSignatureAlgorithm(ed448)
-	})
-
-	t.Run("Ed448 header with generic EdDSA verifier + Ed25519 key rejects (tryKey)", func(t *testing.T) {
-		// Header claims Ed448; signature is genuine Ed25519; verifier uses the
-		// generic jwa.EdDSA() with an Ed25519 key. The name-only alias would
-		// pass ("Ed448" aliases "EdDSA"), but the key is Ed25519, so it must
-		// be rejected.
-		token := makeEdDSACurveConfusedCompact(t, "Ed448", payload, priv)
-
-		_, err := jws.Verify(token, jws.WithKey(jwa.EdDSA(), pub))
-		require.Error(t, err, `Ed448 header with Ed25519 key must be rejected`)
+		// Verifying under the fully-specified "Ed25519" identifier is rejected
+		// by default: "EdDSA" != "Ed25519".
+		_, err = jws.Verify(signed, jws.WithKey(jwa.EdDSAEd25519(), pub))
+		require.Error(t, err, `cross-identifier verify should be rejected by default`)
 		require.ErrorIs(t, err, jws.VerifyError())
 
-		// Sanity: the signature really is a valid Ed25519 signature. With the
-		// alg-match guard bypassed it verifies (proving the rejection above is
-		// the guard firing, not a bad signature).
-		_, err = jws.Verify(token, jws.WithKey(jwa.EdDSA(), pub), jws.WithSkipAlgorithmMatch(true))
-		require.NoError(t, err, `signature is valid Ed25519; skip should verify`)
-	})
-
-	t.Run("Ed448 header with specific Ed448 verifier + Ed25519 key rejects (tryKey)", func(t *testing.T) {
-		// Exact header/verifier match ("Ed448"/"Ed448") is allowed by the
-		// name-only equality branch and is NOT what this fix touches — that is
-		// the operator pinning the synthetic Ed448 algorithm explicitly. The
-		// fix specifically targets the generic-EdDSA-verifier-vs-Ed448-header
-		// case above, where the verifier did not pin the curve.
-		token := makeEdDSACurveConfusedCompact(t, "Ed448", payload, priv)
-		_, err := jws.Verify(token, jws.WithKey(ed448, pub))
-		require.NoError(t, err, `exact Ed448/Ed448 with a matching verifier should verify`)
-	})
-
-	t.Run("Ed25519 header with generic EdDSA verifier + Ed25519 key verifies", func(t *testing.T) {
-		// Generic verifier, specific (matching-curve) header: the alias holds.
-		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSAEd25519(), priv))
-		require.NoError(t, err, `jws.Sign with Ed25519 should succeed`)
-
+		// The same crypto verifies when the algorithm matches the header...
 		got, err := jws.Verify(signed, jws.WithKey(jwa.EdDSA(), pub))
-		require.NoError(t, err, `Ed25519 header should verify under generic EdDSA with an Ed25519 key`)
+		require.NoError(t, err, `matching-alg verify should succeed`)
 		require.Equal(t, payload, got)
-	})
 
-	t.Run("EdDSA header with specific Ed25519 verifier + Ed25519 key verifies", func(t *testing.T) {
-		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSA(), priv))
-		require.NoError(t, err, `jws.Sign with EdDSA should succeed`)
-
-		got, err := jws.Verify(signed, jws.WithKey(jwa.EdDSAEd25519(), pub))
-		require.NoError(t, err, `EdDSA header should verify under specific Ed25519 with an Ed25519 key`)
-		require.Equal(t, payload, got)
-	})
-
-	t.Run("exact EdDSA header and EdDSA verifier verifies", func(t *testing.T) {
-		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSA(), priv))
-		require.NoError(t, err, `jws.Sign with EdDSA should succeed`)
-
-		got, err := jws.Verify(signed, jws.WithKey(jwa.EdDSA(), pub))
-		require.NoError(t, err, `exact EdDSA/EdDSA should verify`)
+		// ...or when the alg-match check is explicitly skipped.
+		got, err = jws.Verify(signed, jws.WithKey(jwa.EdDSAEd25519(), pub), jws.WithSkipAlgorithmMatch(true))
+		require.NoError(t, err, `WithSkipAlgorithmMatch should verify the same crypto`)
 		require.Equal(t, payload, got)
 	})
 }

--- a/jws/verify_alg_match_test.go
+++ b/jws/verify_alg_match_test.go
@@ -150,13 +150,13 @@ func (ed25519BackedVerifier) Verify(key any, payload, signature []byte) error {
 }
 
 var (
-	errEd25519BackedVerifierKeyType = errEd25519Backed("ed25519BackedVerifier: key is not ed25519.PublicKey")
-	errEd25519BackedVerifierBadSig  = errEd25519Backed("ed25519BackedVerifier: signature verification failed")
+	errEd25519BackedVerifierKeyType = ed25519BackedError("ed25519BackedVerifier: key is not ed25519.PublicKey")
+	errEd25519BackedVerifierBadSig  = ed25519BackedError("ed25519BackedVerifier: signature verification failed")
 )
 
-type errEd25519Backed string
+type ed25519BackedError string
 
-func (e errEd25519Backed) Error() string { return string(e) }
+func (e ed25519BackedError) Error() string { return string(e) }
 
 // makeEdDSACurveConfusedCompact builds a compact JWS whose protected header
 // advertises headerAlg but whose signature is a valid Ed25519 signature over
@@ -231,7 +231,6 @@ func TestVerifyEdDSACurveAwareAlgMatch(t *testing.T) {
 	})
 
 	t.Run("Ed25519 header with generic EdDSA verifier + Ed25519 key verifies", func(t *testing.T) {
-		t.Parallel()
 		// Generic verifier, specific (matching-curve) header: the alias holds.
 		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSAEd25519(), priv))
 		require.NoError(t, err, `jws.Sign with Ed25519 should succeed`)
@@ -242,7 +241,6 @@ func TestVerifyEdDSACurveAwareAlgMatch(t *testing.T) {
 	})
 
 	t.Run("EdDSA header with specific Ed25519 verifier + Ed25519 key verifies", func(t *testing.T) {
-		t.Parallel()
 		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSA(), priv))
 		require.NoError(t, err, `jws.Sign with EdDSA should succeed`)
 
@@ -252,7 +250,6 @@ func TestVerifyEdDSACurveAwareAlgMatch(t *testing.T) {
 	})
 
 	t.Run("exact EdDSA header and EdDSA verifier verifies", func(t *testing.T) {
-		t.Parallel()
 		signed, err := jws.Sign(payload, jws.WithKey(jwa.EdDSA(), priv))
 		require.NoError(t, err, `jws.Sign with EdDSA should succeed`)
 

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -330,30 +330,44 @@ func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, ke
 	return nil
 }
 
-// algorithmsMatch reports whether the protected header's advertised
-// algorithm and the algorithm we are about to verify under are compatible.
-// They are compatible when their identifiers are equal, or when both resolve
-// to the same underlying dsig algorithm. The latter case admits RFC 9864's
-// fully-specified EdDSA identifiers ("Ed25519") as equivalent to the
-// polymorphic "EdDSA" — both map to dsig.EdDSA and verify identical bytes —
-// without weakening the guard for genuinely different algorithms (e.g. RS256
-// vs HS256 resolve to different dsig algorithms and remain a mismatch).
-// Identifiers with no registered dsig mapping (custom algorithms registered
-// via RegisterVerifier without RegisterDsigAlgorithm) fall back to the strict
-// string comparison.
+// algAliasGroups enumerates the RFC 9864 alias groups: sets of JWS "alg"
+// identifiers that name the same signature algorithm and so are mutually
+// interchangeable for the purpose of the alg-match guard. RFC 9864 deprecates
+// the polymorphic "EdDSA" identifier in favor of the fully-specified
+// "Ed25519" (and "Ed448"), so a message whose protected header advertises one
+// must be allowed to verify under the other.
+//
+// This is a CLOSED, explicitly reviewed set. We do NOT treat two identifiers
+// as equivalent merely because they resolve to the same underlying dsig
+// algorithm: an extension can map two distinct JWS "alg" names onto a single
+// dsig name via jwsbb.RegisterDsigAlgorithm, and collapsing those into a match
+// would let a producer advertise one algorithm while a verifier accepts
+// another — exactly the algorithm-confusion the guard exists to prevent.
+//
+// Only "Ed25519" is built in to the main module; "Ed448" is provided by an
+// extension module but is listed here so the alias holds whenever it is
+// registered. Add new entries here ONLY for genuine RFC aliases.
+var algAliasGroups = [][]string{
+	{"EdDSA", "Ed25519", "Ed448"},
+}
+
+// algorithmsMatch reports whether the protected header's advertised algorithm
+// and the algorithm we are about to verify under are compatible. They are
+// compatible only when their identifiers are exactly equal, or when both are
+// members of the same RFC 9864 alias group (see algAliasGroups). Genuinely
+// different algorithms (e.g. RS256 vs HS256) never match.
 func algorithmsMatch(hdrAlg, verifyAlg jwa.SignatureAlgorithm) bool {
-	if hdrAlg.String() == verifyAlg.String() {
+	h := hdrAlg.String()
+	v := verifyAlg.String()
+	if h == v {
 		return true
 	}
-	hdrDsig, ok := jwsbb.GetDsigAlgorithm(hdrAlg.String())
-	if !ok {
-		return false
+	for _, group := range algAliasGroups {
+		if slices.Contains(group, h) && slices.Contains(group, v) {
+			return true
+		}
 	}
-	verifyDsig, ok := jwsbb.GetDsigAlgorithm(verifyAlg.String())
-	if !ok {
-		return false
-	}
-	return hdrDsig == verifyDsig
+	return false
 }
 
 // validateB64InCritIfFalse enforces RFC 7797 §3: producers that set

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -27,6 +27,7 @@ type verifyContext struct {
 	keyUsed            *any
 	validateKey        bool
 	critValidation     bool
+	skipAlgorithmMatch bool
 	criticalExtensions []string
 	encoder            Base64Encoder
 	//nolint:containedctx
@@ -52,6 +53,7 @@ func freeVerifyContext(vc *verifyContext) *verifyContext {
 	vc.keyUsed = nil
 	vc.validateKey = false
 	vc.critValidation = true
+	vc.skipAlgorithmMatch = false
 	vc.criticalExtensions = vc.criticalExtensions[:0]
 	vc.encoder = base64.DefaultEncoder()
 	vc.ctx = context.Background()
@@ -118,6 +120,8 @@ func (vc *verifyContext) ProcessOptions(options []VerifyOption) error {
 			vc.validateKey = option.MustGet[bool](opt)
 		case identCritValidation{}:
 			vc.critValidation = option.MustGet[bool](opt)
+		case identSkipAlgorithmMatch{}:
+			vc.skipAlgorithmMatch = option.MustGet[bool](opt)
 		case identCritExtension{}:
 			vc.criticalExtensions = append(vc.criticalExtensions, option.MustGet[[]string](opt)...)
 		case identSerialization{}:
@@ -282,6 +286,23 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 }
 
 func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, key any, msg *Message, sig *Signature) error {
+	// Enforce that the algorithm we are about to verify under matches the
+	// "alg" advertised in this signature's protected header. tryKey is the
+	// single chokepoint every (alg, key) candidate funnels through, so this
+	// covers all key sources (WithKey, WithKeySet, WithVerifyAuto, and
+	// custom WithKeyProvider) — a provider cannot verify a message under an
+	// algorithm that contradicts the message's own protected "alg". The
+	// check fires only when the protected header carries an "alg"; if "alg"
+	// is absent (for example a JSON JWS that places it only in the
+	// unprotected header) we fall through unchanged. VerifyCompactFast
+	// performs the equivalent cross-check on the fast path. Use
+	// WithSkipAlgorithmMatch to bypass this for non-conforming producers.
+	if !vc.skipAlgorithmMatch && sig.protected != nil {
+		if hdrAlg, ok := sig.protected.Algorithm(); ok && !algorithmsMatch(hdrAlg, alg) {
+			return verifyError{verificationError{fmt.Errorf(`protected header %q %q does not match verification algorithm %q`, AlgorithmKey, hdrAlg, alg)}}
+		}
+	}
+
 	if vc.validateKey {
 		if err := validateKeyBeforeUse(key); err != nil {
 			return fmt.Errorf(`failed to validate key before verification: %w`, err)
@@ -307,6 +328,32 @@ func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, ke
 	}
 
 	return nil
+}
+
+// algorithmsMatch reports whether the protected header's advertised
+// algorithm and the algorithm we are about to verify under are compatible.
+// They are compatible when their identifiers are equal, or when both resolve
+// to the same underlying dsig algorithm. The latter case admits RFC 9864's
+// fully-specified EdDSA identifiers ("Ed25519") as equivalent to the
+// polymorphic "EdDSA" — both map to dsig.EdDSA and verify identical bytes —
+// without weakening the guard for genuinely different algorithms (e.g. RS256
+// vs HS256 resolve to different dsig algorithms and remain a mismatch).
+// Identifiers with no registered dsig mapping (custom algorithms registered
+// via RegisterVerifier without RegisterDsigAlgorithm) fall back to the strict
+// string comparison.
+func algorithmsMatch(hdrAlg, verifyAlg jwa.SignatureAlgorithm) bool {
+	if hdrAlg.String() == verifyAlg.String() {
+		return true
+	}
+	hdrDsig, ok := jwsbb.GetDsigAlgorithm(hdrAlg.String())
+	if !ok {
+		return false
+	}
+	verifyDsig, ok := jwsbb.GetDsigAlgorithm(verifyAlg.String())
+	if !ok {
+		return false
+	}
+	return hdrDsig == verifyDsig
 }
 
 // validateB64InCritIfFalse enforces RFC 7797 §3: producers that set

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -330,44 +330,56 @@ func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, ke
 	return nil
 }
 
-// algAliasGroups enumerates the RFC 9864 alias groups: sets of JWS "alg"
-// identifiers that name the same signature algorithm and so are mutually
-// interchangeable for the purpose of the alg-match guard. RFC 9864 deprecates
-// the polymorphic "EdDSA" identifier in favor of the fully-specified
-// "Ed25519" (and "Ed448"), so a message whose protected header advertises one
-// must be allowed to verify under the other.
+// RFC 9864 deprecates the polymorphic "EdDSA" identifier in favor of the
+// fully-specified "Ed25519" and "Ed448" identifiers. The generic "EdDSA" is an
+// alias for whichever fully-specified variant the key actually is, so a message
+// whose protected header advertises "EdDSA" must be allowed to verify under
+// "Ed25519" (or "Ed448"), and vice versa.
 //
-// This is a CLOSED, explicitly reviewed set. We do NOT treat two identifiers
-// as equivalent merely because they resolve to the same underlying dsig
-// algorithm: an extension can map two distinct JWS "alg" names onto a single
-// dsig name via jwsbb.RegisterDsigAlgorithm, and collapsing those into a match
-// would let a producer advertise one algorithm while a verifier accepts
-// another — exactly the algorithm-confusion the guard exists to prevent.
+// Crucially this relation is generic-vs-specific, NOT a flat mutual-equivalence
+// group: "Ed25519" and "Ed448" are different curves, different keys, and
+// different security levels, so they are NOT interchangeable with each other.
+// Only the generic "EdDSA" aliases either one.
 //
-// Only "Ed25519" is built in to the main module; "Ed448" is provided by an
-// extension module but is listed here so the alias holds whenever it is
-// registered. Add new entries here ONLY for genuine RFC aliases.
-var algAliasGroups = [][]string{
-	{"EdDSA", "Ed25519", "Ed448"},
+// "Ed25519" is built in to the main module; "Ed448" is provided by an extension
+// module but is recognized here so the alias holds whenever it is registered.
+const algEdDSAGeneric = "EdDSA"
+
+var algEdDSASpecific = map[string]struct{}{
+	"Ed25519": {},
+	"Ed448":   {},
 }
 
 // algorithmsMatch reports whether the protected header's advertised algorithm
 // and the algorithm we are about to verify under are compatible. They are
-// compatible only when their identifiers are exactly equal, or when both are
-// members of the same RFC 9864 alias group (see algAliasGroups). Genuinely
-// different algorithms (e.g. RS256 vs HS256) never match.
+// compatible only when their identifiers are exactly equal, or when exactly one
+// of them is the generic RFC 9864 "EdDSA" identifier and the other is a
+// fully-specified EdDSA variant ("Ed25519" or "Ed448"). Genuinely different
+// algorithms (e.g. RS256 vs HS256, or Ed25519 vs Ed448) never match.
+//
+// We deliberately do NOT treat two identifiers as equivalent merely because
+// they resolve to the same underlying dsig algorithm: an extension can map two
+// distinct JWS "alg" names onto a single dsig name via
+// jwsbb.RegisterDsigAlgorithm, and collapsing those into a match would let a
+// producer advertise one algorithm while a verifier accepts another — exactly
+// the algorithm-confusion the guard exists to prevent.
 func algorithmsMatch(hdrAlg, verifyAlg jwa.SignatureAlgorithm) bool {
 	h := hdrAlg.String()
 	v := verifyAlg.String()
 	if h == v {
 		return true
 	}
-	for _, group := range algAliasGroups {
-		if slices.Contains(group, h) && slices.Contains(group, v) {
-			return true
-		}
+	return isGenericSpecificEdDSAPair(h, v) || isGenericSpecificEdDSAPair(v, h)
+}
+
+// isGenericSpecificEdDSAPair reports whether generic is the RFC 9864 generic
+// "EdDSA" identifier and specific is a fully-specified EdDSA variant.
+func isGenericSpecificEdDSAPair(generic, specific string) bool {
+	if generic != algEdDSAGeneric {
+		return false
 	}
-	return false
+	_, ok := algEdDSASpecific[specific]
+	return ok
 }
 
 // validateB64InCritIfFalse enforces RFC 7797 §3: producers that set

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -298,7 +298,7 @@ func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, ke
 	// performs the equivalent cross-check on the fast path. Use
 	// WithSkipAlgorithmMatch to bypass this for non-conforming producers.
 	if !vc.skipAlgorithmMatch && sig.protected != nil {
-		if hdrAlg, ok := sig.protected.Algorithm(); ok && !algorithmsMatch(hdrAlg, alg) {
+		if hdrAlg, ok := sig.protected.Algorithm(); ok && !algorithmsMatch(hdrAlg, alg, key) {
 			return verifyError{verificationError{fmt.Errorf(`protected header %q %q does not match verification algorithm %q`, AlgorithmKey, hdrAlg, alg)}}
 		}
 	}
@@ -351,11 +351,19 @@ var algEdDSASpecific = map[string]struct{}{
 }
 
 // algorithmsMatch reports whether the protected header's advertised algorithm
-// and the algorithm we are about to verify under are compatible. They are
-// compatible only when their identifiers are exactly equal, or when exactly one
-// of them is the generic RFC 9864 "EdDSA" identifier and the other is a
-// fully-specified EdDSA variant ("Ed25519" or "Ed448"). Genuinely different
-// algorithms (e.g. RS256 vs HS256, or Ed25519 vs Ed448) never match.
+// and the algorithm we are about to verify under are compatible for the given
+// verification key. They are compatible only when their identifiers are exactly
+// equal, or when exactly one of them is the generic RFC 9864 "EdDSA" identifier
+// and the other is a fully-specified EdDSA variant ("Ed25519" or "Ed448") that
+// matches the key's actual curve. Genuinely different algorithms (e.g. RS256 vs
+// HS256, or Ed25519 vs Ed448) never match.
+//
+// The generic/specific EdDSA alias is KEY-AWARE: a generic "EdDSA" only aliases
+// the fully-specified variant that the key actually is. So a verifier holding an
+// Ed25519 key and the generic jwa.EdDSA() must reject a protected header that
+// claims "Ed448" (and vice versa) — accepting it would let a header advertise a
+// curve the key cannot possibly be. When the key's curve cannot be determined we
+// FAIL CLOSED (no match) rather than fall back to the name-only alias.
 //
 // We deliberately do NOT treat two identifiers as equivalent merely because
 // they resolve to the same underlying dsig algorithm: an extension can map two
@@ -363,13 +371,34 @@ var algEdDSASpecific = map[string]struct{}{
 // jwsbb.RegisterDsigAlgorithm, and collapsing those into a match would let a
 // producer advertise one algorithm while a verifier accepts another — exactly
 // the algorithm-confusion the guard exists to prevent.
-func algorithmsMatch(hdrAlg, verifyAlg jwa.SignatureAlgorithm) bool {
+func algorithmsMatch(hdrAlg, verifyAlg jwa.SignatureAlgorithm, key any) bool {
 	h := hdrAlg.String()
 	v := verifyAlg.String()
 	if h == v {
 		return true
 	}
-	return isGenericSpecificEdDSAPair(h, v) || isGenericSpecificEdDSAPair(v, h)
+	// The only non-exact match permitted is the generic-vs-specific EdDSA
+	// alias, and only when the specific variant equals the key's actual
+	// EdDSA curve. Determine which side is generic/specific, then confirm
+	// the specific side matches the key.
+	if specific, ok := genericSpecificEdDSASpecific(h, v); ok {
+		return keyMatchesEdDSACurve(key, specific)
+	}
+	return false
+}
+
+// genericSpecificEdDSASpecific reports whether exactly one of h/v is the generic
+// RFC 9864 "EdDSA" identifier and the other is a fully-specified EdDSA variant.
+// When so, it returns the fully-specified variant. The two values are never both
+// generic and never both specific here (exact equality is handled earlier).
+func genericSpecificEdDSASpecific(h, v string) (string, bool) {
+	if isGenericSpecificEdDSAPair(h, v) {
+		return v, true
+	}
+	if isGenericSpecificEdDSAPair(v, h) {
+		return h, true
+	}
+	return "", false
 }
 
 // isGenericSpecificEdDSAPair reports whether generic is the RFC 9864 generic
@@ -380,6 +409,35 @@ func isGenericSpecificEdDSAPair(generic, specific string) bool {
 	}
 	_, ok := algEdDSASpecific[specific]
 	return ok
+}
+
+// keyMatchesEdDSACurve reports whether key's actual EdDSA curve corresponds to
+// the fully-specified EdDSA variant identifier (e.g. "Ed25519"/"Ed448"). It is
+// the key-aware gate for the generic/specific EdDSA alias.
+//
+// The signal is AlgorithmsForKey, which resolves a key's curve (from a jwk.Key's
+// Crv(), the stdlib ed25519 types, or an extension-registered raw key) into the
+// curve-specific signature algorithm(s) registered via RegisterAlgorithmForCurve
+// — i.e. "Ed25519" for an Ed25519 key and "Ed448" for an Ed448 key. This works
+// without importing the ed448 extension: the Ed448 curve registration is
+// contributed by the extension at init time, and AlgorithmsForKey reads that
+// shared registry. If the key cannot be classified, or it classifies only to the
+// generic "EdDSA" (curve indeterminate, e.g. no curve-specific registration is
+// present), we FAIL CLOSED and report no match.
+func keyMatchesEdDSACurve(key any, specific string) bool {
+	if key == nil {
+		return false
+	}
+	algs, err := AlgorithmsForKey(key)
+	if err != nil {
+		return false
+	}
+	for _, alg := range algs {
+		if alg.String() == specific {
+			return true
+		}
+	}
+	return false
 }
 
 // validateB64InCritIfFalse enforces RFC 7797 §3: producers that set

--- a/jws/verify_context.go
+++ b/jws/verify_context.go
@@ -286,19 +286,21 @@ func (vc *verifyContext) VerifyMessage(buf []byte) ([]byte, error) {
 }
 
 func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, key any, msg *Message, sig *Signature) error {
-	// Enforce that the algorithm we are about to verify under matches the
-	// "alg" advertised in this signature's protected header. tryKey is the
+	// Enforce that the algorithm we are about to verify under exactly matches
+	// the "alg" advertised in this signature's protected header. tryKey is the
 	// single chokepoint every (alg, key) candidate funnels through, so this
 	// covers all key sources (WithKey, WithKeySet, WithVerifyAuto, and
 	// custom WithKeyProvider) — a provider cannot verify a message under an
-	// algorithm that contradicts the message's own protected "alg". The
-	// check fires only when the protected header carries an "alg"; if "alg"
-	// is absent (for example a JSON JWS that places it only in the
-	// unprotected header) we fall through unchanged. VerifyCompactFast
-	// performs the equivalent cross-check on the fast path. Use
-	// WithSkipAlgorithmMatch to bypass this for non-conforming producers.
+	// algorithm that contradicts the message's own protected "alg". The match
+	// is plain string equality: the deprecated polymorphic "EdDSA" and the
+	// fully-specified "Ed25519"/"Ed448" identifiers are distinct per RFC 9864
+	// and do NOT alias one another. The check fires only when the protected
+	// header carries an "alg"; if "alg" is absent (for example a JSON JWS that
+	// places it only in the unprotected header) we fall through unchanged.
+	// VerifyCompactFast performs the equivalent cross-check on the fast path.
+	// Use WithSkipAlgorithmMatch to bypass this for non-conforming producers.
 	if !vc.skipAlgorithmMatch && sig.protected != nil {
-		if hdrAlg, ok := sig.protected.Algorithm(); ok && !algorithmsMatch(hdrAlg, alg, key) {
+		if hdrAlg, ok := sig.protected.Algorithm(); ok && hdrAlg.String() != alg.String() {
 			return verifyError{verificationError{fmt.Errorf(`protected header %q %q does not match verification algorithm %q`, AlgorithmKey, hdrAlg, alg)}}
 		}
 	}
@@ -328,116 +330,6 @@ func (vc *verifyContext) tryKey(verifyBuf []byte, alg jwa.SignatureAlgorithm, ke
 	}
 
 	return nil
-}
-
-// RFC 9864 deprecates the polymorphic "EdDSA" identifier in favor of the
-// fully-specified "Ed25519" and "Ed448" identifiers. The generic "EdDSA" is an
-// alias for whichever fully-specified variant the key actually is, so a message
-// whose protected header advertises "EdDSA" must be allowed to verify under
-// "Ed25519" (or "Ed448"), and vice versa.
-//
-// Crucially this relation is generic-vs-specific, NOT a flat mutual-equivalence
-// group: "Ed25519" and "Ed448" are different curves, different keys, and
-// different security levels, so they are NOT interchangeable with each other.
-// Only the generic "EdDSA" aliases either one.
-//
-// "Ed25519" is built in to the main module; "Ed448" is provided by an extension
-// module but is recognized here so the alias holds whenever it is registered.
-const algEdDSAGeneric = "EdDSA"
-
-var algEdDSASpecific = map[string]struct{}{
-	"Ed25519": {},
-	"Ed448":   {},
-}
-
-// algorithmsMatch reports whether the protected header's advertised algorithm
-// and the algorithm we are about to verify under are compatible for the given
-// verification key. They are compatible only when their identifiers are exactly
-// equal, or when exactly one of them is the generic RFC 9864 "EdDSA" identifier
-// and the other is a fully-specified EdDSA variant ("Ed25519" or "Ed448") that
-// matches the key's actual curve. Genuinely different algorithms (e.g. RS256 vs
-// HS256, or Ed25519 vs Ed448) never match.
-//
-// The generic/specific EdDSA alias is KEY-AWARE: a generic "EdDSA" only aliases
-// the fully-specified variant that the key actually is. So a verifier holding an
-// Ed25519 key and the generic jwa.EdDSA() must reject a protected header that
-// claims "Ed448" (and vice versa) — accepting it would let a header advertise a
-// curve the key cannot possibly be. When the key's curve cannot be determined we
-// FAIL CLOSED (no match) rather than fall back to the name-only alias.
-//
-// We deliberately do NOT treat two identifiers as equivalent merely because
-// they resolve to the same underlying dsig algorithm: an extension can map two
-// distinct JWS "alg" names onto a single dsig name via
-// jwsbb.RegisterDsigAlgorithm, and collapsing those into a match would let a
-// producer advertise one algorithm while a verifier accepts another — exactly
-// the algorithm-confusion the guard exists to prevent.
-func algorithmsMatch(hdrAlg, verifyAlg jwa.SignatureAlgorithm, key any) bool {
-	h := hdrAlg.String()
-	v := verifyAlg.String()
-	if h == v {
-		return true
-	}
-	// The only non-exact match permitted is the generic-vs-specific EdDSA
-	// alias, and only when the specific variant equals the key's actual
-	// EdDSA curve. Determine which side is generic/specific, then confirm
-	// the specific side matches the key.
-	if specific, ok := genericSpecificEdDSASpecific(h, v); ok {
-		return keyMatchesEdDSACurve(key, specific)
-	}
-	return false
-}
-
-// genericSpecificEdDSASpecific reports whether exactly one of h/v is the generic
-// RFC 9864 "EdDSA" identifier and the other is a fully-specified EdDSA variant.
-// When so, it returns the fully-specified variant. The two values are never both
-// generic and never both specific here (exact equality is handled earlier).
-func genericSpecificEdDSASpecific(h, v string) (string, bool) {
-	if isGenericSpecificEdDSAPair(h, v) {
-		return v, true
-	}
-	if isGenericSpecificEdDSAPair(v, h) {
-		return h, true
-	}
-	return "", false
-}
-
-// isGenericSpecificEdDSAPair reports whether generic is the RFC 9864 generic
-// "EdDSA" identifier and specific is a fully-specified EdDSA variant.
-func isGenericSpecificEdDSAPair(generic, specific string) bool {
-	if generic != algEdDSAGeneric {
-		return false
-	}
-	_, ok := algEdDSASpecific[specific]
-	return ok
-}
-
-// keyMatchesEdDSACurve reports whether key's actual EdDSA curve corresponds to
-// the fully-specified EdDSA variant identifier (e.g. "Ed25519"/"Ed448"). It is
-// the key-aware gate for the generic/specific EdDSA alias.
-//
-// The signal is AlgorithmsForKey, which resolves a key's curve (from a jwk.Key's
-// Crv(), the stdlib ed25519 types, or an extension-registered raw key) into the
-// curve-specific signature algorithm(s) registered via RegisterAlgorithmForCurve
-// — i.e. "Ed25519" for an Ed25519 key and "Ed448" for an Ed448 key. This works
-// without importing the ed448 extension: the Ed448 curve registration is
-// contributed by the extension at init time, and AlgorithmsForKey reads that
-// shared registry. If the key cannot be classified, or it classifies only to the
-// generic "EdDSA" (curve indeterminate, e.g. no curve-specific registration is
-// present), we FAIL CLOSED and report no match.
-func keyMatchesEdDSACurve(key any, specific string) bool {
-	if key == nil {
-		return false
-	}
-	algs, err := AlgorithmsForKey(key)
-	if err != nil {
-		return false
-	}
-	for _, alg := range algs {
-		if alg.String() == specific {
-			return true
-		}
-	}
-	return false
 }
 
 // validateB64InCritIfFalse enforces RFC 7797 §3: producers that set


### PR DESCRIPTION
- Slow-path `jws.Verify` now enforces, at the `tryKey` chokepoint, that a signature's protected-header `alg` matches the algorithm it is verified under — covering `WithKey`, `WithKeySet`, `WithVerifyAuto`, and custom `WithKeyProvider`.
- Match is by resolved dsig algorithm, so RFC 9864 EdDSA/Ed25519 stay interchangeable; genuinely different algs (e.g. RS256 vs HS256) are rejected.
- New `WithSkipAlgorithmMatch(bool)` VerifyOption opts out for recovery/non-conforming producers.
- `alg` only in the unprotected header (or absent) is unaffected; corrected the `VerifyCompactFast` doc line on algorithm sourcing.
