### PR TITLE
document jwk alg is informational, not validated

### DIFF
--- a/internal/jwxcodegen/cmd/jwxcodegen/genjwk.go
+++ b/internal/jwxcodegen/cmd/jwxcodegen/genjwk.go
@@ -565,6 +565,12 @@ func generateKeyUnmarshalJSON(o *codegen.Output, kt *KeyType, obj *codegen.Objec
 			o.L("}")
 		} else if f.Type() == "jwa.KeyAlgorithm" {
 			o.L("case %sKey:", f.Name(true))
+			o.L("// The \"alg\" value is stored as-is and is NOT validated against the key")
+			o.L("// type, curve, or key size at parse time. This is intentional: per RFC 7517")
+			o.L("// section 4.4, \"alg\" is an OPTIONAL, informational hint identifying the")
+			o.L("// algorithm intended for use with the key, not a constraint on the key itself.")
+			o.L("// An incompatible \"alg\" is rejected when the key is used in a JOSE operation,")
+			o.L("// not at parse time. Do NOT add parse-time alg-vs-kty validation here.")
 			o.L("var s string")
 			o.L("if err := json.UnmarshalDecode(dec, &s); err != nil {")
 			o.L("return fmt.Errorf(`failed to decode value for key %%s: %%w`, %sKey, err)", f.Name(true))

--- a/internal/jwxcodegen/cmd/jwxcodegen/genjwk.go
+++ b/internal/jwxcodegen/cmd/jwxcodegen/genjwk.go
@@ -565,12 +565,7 @@ func generateKeyUnmarshalJSON(o *codegen.Output, kt *KeyType, obj *codegen.Objec
 			o.L("}")
 		} else if f.Type() == "jwa.KeyAlgorithm" {
 			o.L("case %sKey:", f.Name(true))
-			o.L("// The \"alg\" value is stored as-is and is NOT validated against the key")
-			o.L("// type, curve, or key size at parse time. This is intentional: per RFC 7517")
-			o.L("// section 4.4, \"alg\" is an OPTIONAL, informational hint identifying the")
-			o.L("// algorithm intended for use with the key, not a constraint on the key itself.")
-			o.L("// An incompatible \"alg\" is rejected when the key is used in a JOSE operation,")
-			o.L("// not at parse time. Do NOT add parse-time alg-vs-kty validation here.")
+			o.L("// \"alg\" is an informational hint stored as-is, not validated against the key type here; see [ParseKey] for rationale.")
 			o.L("var s string")
 			o.L("if err := json.UnmarshalDecode(dec, &s); err != nil {")
 			o.L("return fmt.Errorf(`failed to decode value for key %%s: %%w`, %sKey, err)", f.Name(true))

--- a/jwk/akp_gen.go
+++ b/jwk/akp_gen.go
@@ -477,12 +477,7 @@ func (h *akpPublicKey) UnmarshalJSON(buf []byte) error {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
-			// The "alg" value is stored as-is and is NOT validated against the key
-			// type, curve, or key size at parse time. This is intentional: per RFC 7517
-			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
-			// algorithm intended for use with the key, not a constraint on the key itself.
-			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
-			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
+			// "alg" is an informational hint stored as-is, not validated against the key type here; see [ParseKey] for rationale.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)
@@ -1237,12 +1232,7 @@ func (h *akpPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
-			// The "alg" value is stored as-is and is NOT validated against the key
-			// type, curve, or key size at parse time. This is intentional: per RFC 7517
-			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
-			// algorithm intended for use with the key, not a constraint on the key itself.
-			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
-			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
+			// "alg" is an informational hint stored as-is, not validated against the key type here; see [ParseKey] for rationale.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)

--- a/jwk/akp_gen.go
+++ b/jwk/akp_gen.go
@@ -477,6 +477,12 @@ func (h *akpPublicKey) UnmarshalJSON(buf []byte) error {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
+			// The "alg" value is stored as-is and is NOT validated against the key
+			// type, curve, or key size at parse time. This is intentional: per RFC 7517
+			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
+			// algorithm intended for use with the key, not a constraint on the key itself.
+			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
+			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)
@@ -1231,6 +1237,12 @@ func (h *akpPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
+			// The "alg" value is stored as-is and is NOT validated against the key
+			// type, curve, or key size at parse time. This is intentional: per RFC 7517
+			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
+			// algorithm intended for use with the key, not a constraint on the key itself.
+			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
+			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -546,6 +546,12 @@ func (h *ecdsaPublicKey) UnmarshalJSON(buf []byte) error {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
+			// The "alg" value is stored as-is and is NOT validated against the key
+			// type, curve, or key size at parse time. This is intentional: per RFC 7517
+			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
+			// algorithm intended for use with the key, not a constraint on the key itself.
+			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
+			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)
@@ -1409,6 +1415,12 @@ func (h *ecdsaPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
+			// The "alg" value is stored as-is and is NOT validated against the key
+			// type, curve, or key size at parse time. This is intentional: per RFC 7517
+			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
+			// algorithm intended for use with the key, not a constraint on the key itself.
+			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
+			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -546,12 +546,7 @@ func (h *ecdsaPublicKey) UnmarshalJSON(buf []byte) error {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
-			// The "alg" value is stored as-is and is NOT validated against the key
-			// type, curve, or key size at parse time. This is intentional: per RFC 7517
-			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
-			// algorithm intended for use with the key, not a constraint on the key itself.
-			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
-			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
+			// "alg" is an informational hint stored as-is, not validated against the key type here; see [ParseKey] for rationale.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)
@@ -1415,12 +1410,7 @@ func (h *ecdsaPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
-			// The "alg" value is stored as-is and is NOT validated against the key
-			// type, curve, or key size at parse time. This is intentional: per RFC 7517
-			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
-			// algorithm intended for use with the key, not a constraint on the key itself.
-			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
-			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
+			// "alg" is an informational hint stored as-is, not validated against the key type here; see [ParseKey] for rationale.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -367,6 +367,14 @@ func (ctx *setDecodeCtx) IgnoreParseError() bool {
 // are performed for certificate expiration, no checks against missing
 // parameters are performed, etc.
 //
+// In particular, the "alg" value is stored as-is and is NOT validated
+// against the key type, curve, or key size at parse time. This is
+// intentional: per RFC 7517 section 4.4, "alg" is an OPTIONAL,
+// informational hint identifying the algorithm intended for use with the
+// key, not a constraint on the key itself. An incompatible "alg" is
+// rejected when the key is used in a JOSE operation, not at parse time.
+// Parse-time alg-vs-kty validation must NOT be added.
+//
 // Use [ParseKeyAs] when a concrete key subtype (e.g. [RSAPrivateKey],
 // [ECDSAPublicKey]) is required.
 func ParseKey(data []byte, options ...ParseOption) (Key, error) {

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -508,12 +508,7 @@ func (h *okpPublicKey) UnmarshalJSON(buf []byte) error {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
-			// The "alg" value is stored as-is and is NOT validated against the key
-			// type, curve, or key size at parse time. This is intentional: per RFC 7517
-			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
-			// algorithm intended for use with the key, not a constraint on the key itself.
-			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
-			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
+			// "alg" is an informational hint stored as-is, not validated against the key type here; see [ParseKey] for rationale.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)
@@ -1319,12 +1314,7 @@ func (h *okpPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
-			// The "alg" value is stored as-is and is NOT validated against the key
-			// type, curve, or key size at parse time. This is intentional: per RFC 7517
-			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
-			// algorithm intended for use with the key, not a constraint on the key itself.
-			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
-			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
+			// "alg" is an informational hint stored as-is, not validated against the key type here; see [ParseKey] for rationale.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -508,6 +508,12 @@ func (h *okpPublicKey) UnmarshalJSON(buf []byte) error {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
+			// The "alg" value is stored as-is and is NOT validated against the key
+			// type, curve, or key size at parse time. This is intentional: per RFC 7517
+			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
+			// algorithm intended for use with the key, not a constraint on the key itself.
+			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
+			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)
@@ -1313,6 +1319,12 @@ func (h *okpPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
+			// The "alg" value is stored as-is and is NOT validated against the key
+			// type, curve, or key size at parse time. This is intentional: per RFC 7517
+			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
+			// algorithm intended for use with the key, not a constraint on the key itself.
+			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
+			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -517,12 +517,7 @@ func (h *rsaPublicKey) UnmarshalJSON(buf []byte) error {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
-			// The "alg" value is stored as-is and is NOT validated against the key
-			// type, curve, or key size at parse time. This is intentional: per RFC 7517
-			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
-			// algorithm intended for use with the key, not a constraint on the key itself.
-			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
-			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
+			// "alg" is an informational hint stored as-is, not validated against the key type here; see [ParseKey] for rationale.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)
@@ -1527,12 +1522,7 @@ func (h *rsaPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
-			// The "alg" value is stored as-is and is NOT validated against the key
-			// type, curve, or key size at parse time. This is intentional: per RFC 7517
-			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
-			// algorithm intended for use with the key, not a constraint on the key itself.
-			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
-			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
+			// "alg" is an informational hint stored as-is, not validated against the key type here; see [ParseKey] for rationale.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -517,6 +517,12 @@ func (h *rsaPublicKey) UnmarshalJSON(buf []byte) error {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
+			// The "alg" value is stored as-is and is NOT validated against the key
+			// type, curve, or key size at parse time. This is intentional: per RFC 7517
+			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
+			// algorithm intended for use with the key, not a constraint on the key itself.
+			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
+			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)
@@ -1521,6 +1527,12 @@ func (h *rsaPrivateKey) UnmarshalJSON(buf []byte) (retErr error) {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
+			// The "alg" value is stored as-is and is NOT validated against the key
+			// type, curve, or key size at parse time. This is intentional: per RFC 7517
+			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
+			// algorithm intended for use with the key, not a constraint on the key itself.
+			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
+			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -475,6 +475,12 @@ func (h *symmetricKey) UnmarshalJSON(buf []byte) (retErr error) {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
+			// The "alg" value is stored as-is and is NOT validated against the key
+			// type, curve, or key size at parse time. This is intentional: per RFC 7517
+			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
+			// algorithm intended for use with the key, not a constraint on the key itself.
+			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
+			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -475,12 +475,7 @@ func (h *symmetricKey) UnmarshalJSON(buf []byte) (retErr error) {
 				return fmt.Errorf(`invalid kty value for RSAPublicKey (%s)`, val)
 			}
 		case AlgorithmKey:
-			// The "alg" value is stored as-is and is NOT validated against the key
-			// type, curve, or key size at parse time. This is intentional: per RFC 7517
-			// section 4.4, "alg" is an OPTIONAL, informational hint identifying the
-			// algorithm intended for use with the key, not a constraint on the key itself.
-			// An incompatible "alg" is rejected when the key is used in a JOSE operation,
-			// not at parse time. Do NOT add parse-time alg-vs-kty validation here.
+			// "alg" is an informational hint stored as-is, not validated against the key type here; see [ParseKey] for rationale.
 			var s string
 			if err := json.UnmarshalDecode(dec, &s); err != nil {
 				return fmt.Errorf(`failed to decode value for key %s: %w`, AlgorithmKey, err)


### PR DESCRIPTION
- Document (in generated UnmarshalJSON via genjwk.go) that a JWK's `alg` is stored as-is and validated at use-time, not at parse, per RFC 7517 §4.4
- Comment-only; no behavior or API change