### PR TITLE
document ec private scalar not bound to point

### DIFF
--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -529,6 +529,15 @@ func ecdsaValidateKey(k interface {
 	}
 
 	if checkPrivate {
+		// This validates only the length of "d"; it intentionally does NOT
+		// verify that "d" derives the stored public point (d*G == (x, y)). A
+		// mismatch is self-defeating, not exploitable: every operation uses
+		// "d" (ECDSA signs under d*G; ECDH derives the shared secret from d),
+		// while (x, y) is advertised metadata. A key whose (x, y) != d*G
+		// therefore produces signatures/ciphertext that fail to verify/decrypt
+		// against its own advertised public key — it can never make a
+		// verification or decryption wrongly succeed; the inconsistency is
+		// caught at use time. Do NOT add a d*G == (x, y) check here.
 		if priv, ok := k.(keyWithD); ok {
 			if d, ok := priv.D(); !ok || len(d) != keySize {
 				return fmt.Errorf(`invalid "d" length (%d) for curve %q`, len(d), crv.Params().Name)

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -531,16 +531,21 @@ func ecdsaValidateKey(k interface {
 	if checkPrivate {
 		// This validates only the length of "d"; it intentionally does NOT
 		// verify that "d" derives the stored public point (d*G == (x, y)), nor
-		// that the scalar is in range (0 < d < N). Both are self-defeating, not
-		// exploitable: every operation uses "d" (ECDSA signs under d*G; ECDH
-		// derives the shared secret from d), while (x, y) is advertised
-		// metadata. A key whose (x, y) != d*G — or whose scalar is out of range
-		// — therefore produces signatures/ciphertext that fail to verify/decrypt
-		// against its own advertised public key (an out-of-range scalar is
-		// likewise rejected or rendered useless by crypto/ecdsa at sign time).
-		// It can never make a verification or decryption wrongly succeed; the
-		// inconsistency is caught at use time. Do NOT add a d*G == (x, y) or a
-		// 0 < d < N check here.
+		// that the scalar is in canonical range (0 < d < N). Neither omission is
+		// exploitable:
+		//
+		//   - A public point that does not match "d" is self-defeating: every
+		//     operation uses "d" (ECDSA signs under d*G; ECDH derives the shared
+		//     secret from d) while (x, y) is advertised metadata, so the key
+		//     produces signatures/ciphertext that fail to verify/decrypt against
+		//     its own advertised public key. It cannot make a verification or
+		//     decryption wrongly succeed.
+		//   - An out-of-range scalar is reduced mod N by crypto/ecdsa at sign
+		//     time, so it is merely equivalent to its in-range representative
+		//     (benign) — except d ≡ 0 (mod N), which yields a degenerate,
+		//     unusable key. Neither case can make a verification wrongly succeed.
+		//
+		// Do NOT add a d*G == (x, y) or a 0 < d < N check here.
 		if priv, ok := k.(keyWithD); ok {
 			if d, ok := priv.D(); !ok || len(d) != keySize {
 				return fmt.Errorf(`invalid "d" length (%d) for curve %q`, len(d), crv.Params().Name)

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -530,14 +530,17 @@ func ecdsaValidateKey(k interface {
 
 	if checkPrivate {
 		// This validates only the length of "d"; it intentionally does NOT
-		// verify that "d" derives the stored public point (d*G == (x, y)). A
-		// mismatch is self-defeating, not exploitable: every operation uses
-		// "d" (ECDSA signs under d*G; ECDH derives the shared secret from d),
-		// while (x, y) is advertised metadata. A key whose (x, y) != d*G
-		// therefore produces signatures/ciphertext that fail to verify/decrypt
-		// against its own advertised public key — it can never make a
-		// verification or decryption wrongly succeed; the inconsistency is
-		// caught at use time. Do NOT add a d*G == (x, y) check here.
+		// verify that "d" derives the stored public point (d*G == (x, y)), nor
+		// that the scalar is in range (0 < d < N). Both are self-defeating, not
+		// exploitable: every operation uses "d" (ECDSA signs under d*G; ECDH
+		// derives the shared secret from d), while (x, y) is advertised
+		// metadata. A key whose (x, y) != d*G — or whose scalar is out of range
+		// — therefore produces signatures/ciphertext that fail to verify/decrypt
+		// against its own advertised public key (an out-of-range scalar is
+		// likewise rejected or rendered useless by crypto/ecdsa at sign time).
+		// It can never make a verification or decryption wrongly succeed; the
+		// inconsistency is caught at use time. Do NOT add a d*G == (x, y) or a
+		// 0 < d < N check here.
 		if priv, ok := k.(keyWithD); ok {
 			if d, ok := priv.D(); !ok || len(d) != keySize {
 				return fmt.Errorf(`invalid "d" length (%d) for curve %q`, len(d), crv.Params().Name)

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -540,10 +540,13 @@ func ecdsaValidateKey(k interface {
 		//     produces signatures/ciphertext that fail to verify/decrypt against
 		//     its own advertised public key. It cannot make a verification or
 		//     decryption wrongly succeed.
-		//   - An out-of-range scalar is reduced mod N by crypto/ecdsa at sign
-		//     time, so it is merely equivalent to its in-range representative
-		//     (benign) — except d ≡ 0 (mod N), which yields a degenerate,
-		//     unusable key. Neither case can make a verification wrongly succeed.
+		//   - An out-of-range scalar is left for the signing path (crypto/ecdsa)
+		//     to handle as the authority on scalar validity: depending on the Go
+		//     version and key path it either rejects the key or treats the scalar
+		//     as its in-range equivalent. Either way the only outcomes are that
+		//     the key's own operations fail or behave as some in-range key —
+		//     never that an invalid scalar forges a signature or decryption that
+		//     verifies against a key the holder does not legitimately control.
 		//
 		// Do NOT add a d*G == (x, y) or a 0 < d < N check here.
 		if priv, ok := k.(keyWithD); ok {


### PR DESCRIPTION
- document that EC private validate intentionally does not check d·G==(x,y)
- a mismatch only ever fails verify/decrypt against the advertised key (caught at use-time), never wrongly succeeds; comment-only, no behavior change