### PR TITLE
document okp public key not bound to scalar

### DIFF
--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -474,14 +474,14 @@ func validateOKPKey(key interface {
 
 	if priv, ok := key.(keyWithD); ok {
 		// This validates the length of "d" but intentionally does NOT verify
-		// that the public key "x" is derived from "d". As with EC keys, a
-		// mismatch is self-defeating, not exploitable: Ed25519 signs under d's
-		// real public key and X25519 derives the shared secret from d, while
-		// "x" is advertised metadata. A key whose "x" does not match d's public
-		// key therefore produces signatures/ciphertext that fail to
-		// verify/decrypt against its own advertised "x" — it can never make a
-		// verification or decryption wrongly succeed; the inconsistency is
-		// caught at use time. Do NOT add an "x derives from d" check here.
+		// that the public key "x" is derived from "d". A mismatch is
+		// self-defeating, not exploitable: it can never make a signature
+		// verification or a decryption wrongly succeed. Ed25519 signs under d's
+		// real public key, so a signature fails to verify against a mismatched
+		// advertised "x". X25519 derives the shared secret from "d" (against the
+		// peer's key), so the local "x" is never consulted in the operation and
+		// cannot influence its outcome; "x" is public metadata either way. Do
+		// NOT add an "x derives from d" check here.
 		d, ok := priv.D()
 		if !ok || len(d) == 0 {
 			return fmt.Errorf(`missing "d" field`)

--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -473,6 +473,15 @@ func validateOKPKey(key interface {
 	}
 
 	if priv, ok := key.(keyWithD); ok {
+		// This validates the length of "d" but intentionally does NOT verify
+		// that the public key "x" is derived from "d". As with EC keys, a
+		// mismatch is self-defeating, not exploitable: Ed25519 signs under d's
+		// real public key and X25519 derives the shared secret from d, while
+		// "x" is advertised metadata. A key whose "x" does not match d's public
+		// key therefore produces signatures/ciphertext that fail to
+		// verify/decrypt against its own advertised "x" — it can never make a
+		// verification or decryption wrongly succeed; the inconsistency is
+		// caught at use time. Do NOT add an "x derives from d" check here.
 		d, ok := priv.D()
 		if !ok || len(d) == 0 {
 			return fmt.Errorf(`missing "d" field`)


### PR DESCRIPTION
- document that OKP private validate intentionally does not check that x derives from d
- a mismatch only fails verify/decrypt against the advertised x (caught at use-time), never wrongly succeeds; comment-only, no behavior change