### PR TITLE
fix WithPedantic doc: typ is not checked

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -453,7 +453,7 @@ OUTER:
 				if state != _JwsVerifySkipped {
 					payload = v
 
-					// We only check for cty and typ if the pedantic flag is enabled
+					// We only check for cty (to detect nested JWTs) if the pedantic flag is enabled
 					if !ctx.pedantic {
 						continue
 					}

--- a/jwt/options.yaml
+++ b/jwt/options.yaml
@@ -216,7 +216,10 @@ options:
     argument_type: bool
     comment: |
       WithPedantic enables pedantic mode for parsing JWTs. Currently this only
-      applies to checking for the correct `typ` and/or `cty` when necessary.
+      applies to detecting nested JWTs via the `cty` (content type) header and
+      rejecting payloads that are not recognizable as a JWT. The `typ` header is
+      not inspected: it is OPTIONAL per RFC 7519 §5.1, so its absence or value is
+      not treated as an error.
   - ident: EncryptOption
     interface: EncryptOption
     argument_type: jwe.EncryptOption

--- a/jwt/options_gen.go
+++ b/jwt/options_gen.go
@@ -411,7 +411,10 @@ func WithNumericDateParsePrecision(v int) GlobalOption {
 }
 
 // WithPedantic enables pedantic mode for parsing JWTs. Currently this only
-// applies to checking for the correct `typ` and/or `cty` when necessary.
+// applies to detecting nested JWTs via the `cty` (content type) header and
+// rejecting payloads that are not recognizable as a JWT. The `typ` header is
+// not inspected: it is OPTIONAL per RFC 7519 §5.1, so its absence or value is
+// not treated as an error.
 func WithPedantic(v bool) ParseOption {
 	return &parseOption{option.New(identPedantic{}, v)}
 }


### PR DESCRIPTION
- WithPedantic documented checking `typ` and/or `cty`, but only `cty` (nested-JWT detection) is implemented
- correct the godoc and the stale inline comment to reflect actual behavior; `typ` is OPTIONAL per RFC 7519 §5.1
- doc/comment-only, regenerated options_gen.go; no behavior change