### PR TITLE
add bazel test target for internal/json

### DIFF
--- a/internal/json/BUILD.bazel
+++ b/internal/json/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "json",
@@ -15,4 +15,13 @@ alias(
     name = "go_default_library",
     actual = ":json",
     visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "json_test",
+    srcs = ["registry_test.go"],
+    deps = [
+        ":json",
+        "@com_github_stretchr_testify//require",
+    ],
 )


### PR DESCRIPTION
- internal/json/registry_test.go had no go_test target in BUILD.bazel, so Bazel never ran it (the Go test suite did)
- add the gazelle-generated go_test target; `bazel test //internal/json:json_test` passes