### PR TITLE
jws: reject duplicate JOSE header parameter names

### DIFF
--- a/jws/jwsbb/header.go
+++ b/jws/jwsbb/header.go
@@ -81,6 +81,26 @@ func HeaderParse(decoded []byte) Header {
 	if err != nil {
 		return &header{err: err}
 	}
+	// fastjson keeps duplicate object members and Get returns the first;
+	// reject them so the fast path matches jws.Verify.
+	if obj, oerr := v.Object(); oerr == nil {
+		seen := make(map[string]struct{})
+		var dup string
+		obj.Visit(func(key []byte, _ *fastjson.Value) {
+			if dup != "" {
+				return
+			}
+			k := string(key)
+			if _, ok := seen[k]; ok {
+				dup = k
+				return
+			}
+			seen[k] = struct{}{}
+		})
+		if dup != "" {
+			return &header{err: fmt.Errorf(`duplicate header parameter name %q`, dup)}
+		}
+	}
 	return &header{
 		v: v,
 	}

--- a/jws/jwsbb/header_test.go
+++ b/jws/jwsbb/header_test.go
@@ -200,3 +200,30 @@ func TestHeader(t *testing.T) {
 		})
 	})
 }
+
+func TestHeaderParseDuplicateKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("duplicate alg is rejected", func(t *testing.T) {
+		t.Parallel()
+		h := jwsbb.HeaderParse([]byte(`{"alg":"HS256","alg":"none"}`))
+		_, err := jwsbb.HeaderGetString(h, "alg")
+		require.Error(t, err, "duplicate header parameter name should be rejected")
+	})
+
+	t.Run("duplicate via escaped key is rejected", func(t *testing.T) {
+		t.Parallel()
+		// "crit" and "crit" are the same name once unescaped.
+		h := jwsbb.HeaderParse([]byte("{\"\\u0063rit\":[\"b64\"],\"crit\":[\"b64\"]}"))
+		_, err := jwsbb.HeaderGetStringArray(h, "crit")
+		require.Error(t, err, "escaped duplicate header parameter name should be rejected")
+	})
+
+	t.Run("well-formed header is accepted", func(t *testing.T) {
+		t.Parallel()
+		h := jwsbb.HeaderParse([]byte(`{"alg":"HS256","typ":"JWT"}`))
+		alg, err := jwsbb.HeaderGetString(h, "alg")
+		require.NoError(t, err)
+		require.Equal(t, "HS256", alg)
+	})
+}


### PR DESCRIPTION
`HeaderParse` (jwsbb) uses fastjson, which keeps duplicate object members and returns the first on `Get`. So `VerifyCompactFast`, and `jwt.Parse` which uses it, accepted a protected header with duplicate parameter names while `jws.Verify` rejects the same token via `encoding/json/v2`. RFC 7515 section 4 forbids duplicate Header Parameter names.

This rejects duplicates in `HeaderParse` so the fast path agrees with `jws.Verify`. The test in `jws/jwsbb` covers a duplicate `alg`, an escaped-key duplicate, and a well-formed control.

If you would rather keep `HeaderParse` spec-agnostic and scope the check to `VerifyCompactFast`, or align `jws.Verify` to the fast path instead, happy to adjust.

Fixes #2234
