### PR TITLE
fix: reject duplicate JOSE headers on fast path

### DIFF
--- a/agents/docs/dependencies.md
+++ b/agents/docs/dependencies.md
@@ -16,7 +16,7 @@ Composition Layer
 
 Processing Layer
   jws → jwa, jwk, cert, internal/{base64,json,pool,tokens}
-       → jws/jwsbb
+       → jws/jwsbb, jws/internal/jwsbb
   jwe → jwa, jwk, cert, transform, internal/{base64,json,pool,tokens}
        → jwe/internal/{aescbc,cipher,concatkdf,content_crypt,keygen}
        → jwe/jwebb
@@ -54,5 +54,5 @@ Leaf Packages (no internal deps)
 |------------|---------|---------|
 | `lestrrat-go/dsig` | jws/jwsbb | Digital signature primitives (HMAC, RSA, ECDSA, EdDSA) |
 | `lestrrat-go/option/v3` | all packages | Functional options pattern |
-| `valyala/fastjson` | jws/jwsbb, jwk/jwkbb | Fast JSON header / object peek |
+| `valyala/fastjson` | jws/internal/jwsbb, jwk/jwkbb | Fast JSON header / object peek |
 | `golang.org/x/crypto` | jwe | Extended crypto (PBKDF2, etc.) |

--- a/agents/docs/error-formatting.md
+++ b/agents/docs/error-formatting.md
@@ -74,6 +74,7 @@ Only `jwt.UnknownPayloadTypeError()` remains a sentinel function (no struct type
 | `jws` | `ParseError()` | Parse failed |
 | `jws` | `ErrCritPresent()` | `VerifyCompactFast` refused a `crit`-bearing protected header (use `jws.Verify`) |
 | `jws` | `ErrB64Present()` | `VerifyCompactFast` refused a `b64`-bearing protected header (use `jws.Verify`) |
+| `jws` | `ErrNonMinimalHeader()` | `VerifyCompactFast` refused a protected header outside the fast-path minimal shape — alg×1 + optional single typ/kid/cty, no escapes/duplicates/extras (use `jws.Verify`) |
 | `jws` | `ErrUnclassifiableKey()` | `AlgorithmsForKey` couldn't classify the key shape (Import failed, kty not registered, or key-agreement-only key like ecdh) |
 | `jwe` | `EncryptError()` | Encryption failed |
 | `jwe` | `DecryptError()` | Decryption failed |

--- a/agents/docs/packages.md
+++ b/agents/docs/packages.md
@@ -63,7 +63,7 @@ JSON Web Signatures per RFC 7515. Sign, verify, parse.
 - Global/per-call settings: `WithMaxSignatures()` (usable in both `Settings()` and `Parse()`/`ReadFile()`)
 - Registration: `RegisterSigner()`, `RegisterVerifier()`, `AlgorithmsForKey()`, `RegisterAlgorithmForKeyType()`, `RegisterAlgorithmForCurve()`
 - Error sentinels: `SignError()`, `VerifyError()`, `VerificationError()`, `ParseError()`
-- Sub-package: `jws/jwsbb` — compact serialization, signing, verification building blocks
+- Sub-package: `jws/jwsbb` — compact serialization, signing, verification building blocks. The fastjson-backed `Header` probe (`HeaderParse`/`HeaderGet*`/`HeaderHas`) is a thin facade over `jws/internal/jwsbb`, which holds the implementation plus jwx-internal-only helpers not re-exported by the facade (e.g. `HeaderForEach`, the header-key enumerator used by `VerifyCompactFast`'s minimal-shape gate)
 - Files: `jws.go`, `message.go`, `signer.go`, `verifier.go`, `headers.go`, `interface.go`, `errors.go`, `options.go`, `key_provider.go`, `sign_context.go`, `verify_context.go`, `streaming_detached.go`
 - Imports: jwa, jwk, cert, internal/{base64,json,pool,tokens}
 

--- a/agents/docs/packages.md
+++ b/agents/docs/packages.md
@@ -63,7 +63,7 @@ JSON Web Signatures per RFC 7515. Sign, verify, parse.
 - Global/per-call settings: `WithMaxSignatures()` (usable in both `Settings()` and `Parse()`/`ReadFile()`)
 - Registration: `RegisterSigner()`, `RegisterVerifier()`, `AlgorithmsForKey()`, `RegisterAlgorithmForKeyType()`, `RegisterAlgorithmForCurve()`
 - Error sentinels: `SignError()`, `VerifyError()`, `VerificationError()`, `ParseError()`
-- Sub-package: `jws/jwsbb` — compact serialization, signing, verification building blocks. The fastjson-backed `Header` probe (`HeaderParse`/`HeaderGet*`/`HeaderHas`) is a thin facade over `jws/internal/jwsbb`, which holds the implementation plus jwx-internal-only helpers not re-exported by the facade (e.g. `HeaderForEach`, the header-key enumerator used by `VerifyCompactFast`'s minimal-shape gate)
+- Sub-package: `jws/jwsbb` — compact serialization, signing, verification building blocks. The fastjson-backed `Header` probe (`HeaderParse`/`HeaderGet*`/`HeaderHas`) is a thin facade over `jws/internal/jwsbb`, which holds the implementation plus jwx-internal-only helpers not re-exported by the facade (e.g. `HeaderForEachKey`, the header-key enumerator used by `VerifyCompactFast`'s minimal-shape gate)
 - Files: `jws.go`, `message.go`, `signer.go`, `verifier.go`, `headers.go`, `interface.go`, `errors.go`, `options.go`, `key_provider.go`, `sign_context.go`, `verify_context.go`, `streaming_detached.go`
 - Imports: jwa, jwk, cert, internal/{base64,json,pool,tokens}
 

--- a/jws/BUILD.bazel
+++ b/jws/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//internal/tokens",
         "//jwa",
         "//jwk",
+        "//jws/internal/jwsbb",
         "//jws/jwsbb",
         "@com_github_lestrrat_go_dsig//:dsig",
         "@com_github_lestrrat_go_option_v3//:option",

--- a/jws/errors.go
+++ b/jws/errors.go
@@ -30,7 +30,10 @@ var errNonMinimalHeader = errors.New(`VerifyCompactFast: protected header is not
 // an unknown or key-source parameter, an escaped key, or the more specific
 // "crit"/"b64" cases (see ErrCritPresent / ErrB64Present, which both match
 // this sentinel too). Treat it as "the fast path declined this header; retry
-// through jws.Verify". The error also matches jws.VerifyError().
+// through jws.Verify". Errors returned from VerifyCompactFast that wrap this
+// sentinel additionally match jws.VerifyError() (they are wrapped in
+// verifyError at the return site); the bare sentinel value returned here does
+// not.
 func ErrNonMinimalHeader() error {
 	return errNonMinimalHeader
 }
@@ -46,8 +49,9 @@ func ErrNonMinimalHeader() error {
 var errCritPresent = fmt.Errorf(`%w (header contains "crit")`, errNonMinimalHeader)
 
 // ErrCritPresent returns the sentinel error returned by VerifyCompactFast
-// when the protected header contains a "crit" list. The returned error also
-// matches jws.ErrNonMinimalHeader() (the umbrella refusal) and
+// when the protected header contains a "crit" list. This sentinel itself also
+// matches jws.ErrNonMinimalHeader() (it wraps the umbrella refusal). Errors
+// returned from VerifyCompactFast that wrap it additionally match
 // jws.VerifyError() (the general class), so callers can branch at whatever
 // granularity fits.
 func ErrCritPresent() error {
@@ -69,8 +73,9 @@ func ErrCritPresent() error {
 var errB64Present = fmt.Errorf(`%w (header contains "b64")`, errNonMinimalHeader)
 
 // ErrB64Present returns the sentinel error returned by VerifyCompactFast when
-// the protected header contains a "b64" entry. The returned error also
-// matches jws.ErrNonMinimalHeader() (the umbrella refusal) and
+// the protected header contains a "b64" entry. This sentinel itself also
+// matches jws.ErrNonMinimalHeader() (it wraps the umbrella refusal). Errors
+// returned from VerifyCompactFast that wrap it additionally match
 // jws.VerifyError() (the general class).
 func ErrB64Present() error {
 	return errB64Present

--- a/jws/errors.go
+++ b/jws/errors.go
@@ -5,70 +5,75 @@ import (
 	"fmt"
 )
 
-// errCritPresent is returned by VerifyCompactFast when the protected
-// header carries a "crit" list. The fast path cannot enforce RFC 7515
-// §4.1.11 (it has no WithCritExtension allowlist), so it refuses rather
-// than silently accepting. The sentinel is wrapped in verifyError at the
-// return site so the resulting error matches BOTH errors.Is(err,
-// jws.ErrCritPresent()) (the specific reason) AND errors.Is(err,
-// jws.VerifyError()) (the general class), letting callers choose the
-// classification granularity that fits their code path.
-var errCritPresent = errors.New("VerifyCompactFast: protected header contains \"crit\"; use jws.Verify")
-
-// ErrCritPresent returns the sentinel error returned by VerifyCompactFast
-// when the protected header contains a "crit" list. The error returned
-// from VerifyCompactFast also matches jws.VerifyError(), so callers that
-// only branch on the general class still classify the refusal correctly.
-func ErrCritPresent() error {
-	return errCritPresent
-}
-
-// errB64Present is returned by VerifyCompactFast when the protected
-// header carries a "b64" entry (typically b64=false per RFC 7797). The
-// fast path assumes the default b64=true encoding for both the
-// signing-input reconstruction and the post-verify payload decode; a
-// b64=false message signed under non-conformant rules (b64 not declared
-// in "crit") would otherwise verify cryptographically while returning
-// a decoded payload that differs from the producer's intent. Refusing
-// here defers such messages to jws.Verify, which has the
-// WithDetachedPayload and WithCritExtension machinery to handle b64=false
-// correctly. As with errCritPresent, the sentinel is wrapped in
-// verifyError at the return site so the resulting error matches both
-// errors.Is(err, jws.ErrB64Present()) and errors.Is(err, jws.VerifyError()).
-var errB64Present = errors.New("VerifyCompactFast: protected header contains \"b64\"; use jws.Verify")
-
-// ErrB64Present returns the sentinel error returned by VerifyCompactFast
-// when the protected header contains a "b64" entry. The error returned
-// from VerifyCompactFast also matches jws.VerifyError(), so callers that
-// only branch on the general class still classify the refusal correctly.
-func ErrB64Present() error {
-	return errB64Present
-}
-
-// errNonMinimalHeader is returned by VerifyCompactFast when the protected
-// header is not in the minimal shape the fast path handles: "alg" present
-// exactly once, an optional single "typ"/"kid"/"cty", no JSON escape
-// sequences, and no other parameters. fastjson (used by the fast path) keeps
-// duplicate object members and resolves them first-wins, whereas
+// errNonMinimalHeader is the umbrella sentinel for every VerifyCompactFast
+// header refusal: the protected header is not in the minimal shape the fast
+// path handles ("alg" exactly once, an optional single "typ"/"kid"/"cty", no
+// JSON escape sequences, and no other parameters). fastjson (used by the fast
+// path) keeps duplicate object members and resolves them first-wins, whereas
 // encoding/json/v2 (used by jws.Verify) rejects duplicate names outright — so
 // a header carrying a duplicate, a nested object, an unknown or key-source
 // parameter, or an escaped key could be read differently by the two paths
 // (see issue #2234). Refusing such headers defers them to jws.Verify, whose
 // strict, recursive duplicate rejection and full header handling are the
-// authoritative behavior. As with errCritPresent, the sentinel is wrapped in
-// verifyError at the return site so the resulting error matches both
-// errors.Is(err, jws.ErrNonMinimalHeader()) and errors.Is(err, jws.VerifyError()).
+// authoritative behavior.
+//
+// The crit and b64 refusals (errCritPresent, errB64Present) are specific
+// reasons that wrap this sentinel, so a single errors.Is(err,
+// jws.ErrNonMinimalHeader()) check classifies every fast-path header refusal,
+// while errors.Is(err, jws.ErrCritPresent()) still identifies the precise
+// cause. The sentinel is wrapped in verifyError at the return site, so the
+// resulting error also matches errors.Is(err, jws.VerifyError()).
 var errNonMinimalHeader = errors.New(`VerifyCompactFast: protected header is not in the fast-path minimal shape; use jws.Verify`)
 
-// ErrNonMinimalHeader returns the sentinel error returned by
-// VerifyCompactFast when the protected header is outside the minimal shape
-// the fast path handles (see ErrCritPresent for the analogous crit refusal).
-// The error returned from VerifyCompactFast also matches jws.VerifyError(),
-// so callers that only branch on the general class still classify the refusal
-// correctly. Callers that wrap VerifyCompactFast should treat this like
-// ErrCritPresent: fall through to jws.Verify.
+// ErrNonMinimalHeader returns the umbrella sentinel that VerifyCompactFast
+// returns for every protected-header refusal: a duplicate, a nested object,
+// an unknown or key-source parameter, an escaped key, or the more specific
+// "crit"/"b64" cases (see ErrCritPresent / ErrB64Present, which both match
+// this sentinel too). Treat it as "the fast path declined this header; retry
+// through jws.Verify". The error also matches jws.VerifyError().
 func ErrNonMinimalHeader() error {
 	return errNonMinimalHeader
+}
+
+// errCritPresent is the specific case of errNonMinimalHeader where the
+// protected header carries a "crit" list. The fast path cannot enforce
+// RFC 7515 §4.1.11 (it has no WithCritExtension allowlist), so it refuses
+// rather than silently accepting. It wraps errNonMinimalHeader, so the
+// returned error matches errors.Is(err, jws.ErrCritPresent()) (the specific
+// reason), errors.Is(err, jws.ErrNonMinimalHeader()) (the umbrella), and —
+// via the verifyError wrapper at the return site — errors.Is(err,
+// jws.VerifyError()) (the general class).
+var errCritPresent = fmt.Errorf(`%w (header contains "crit")`, errNonMinimalHeader)
+
+// ErrCritPresent returns the sentinel error returned by VerifyCompactFast
+// when the protected header contains a "crit" list. The returned error also
+// matches jws.ErrNonMinimalHeader() (the umbrella refusal) and
+// jws.VerifyError() (the general class), so callers can branch at whatever
+// granularity fits.
+func ErrCritPresent() error {
+	return errCritPresent
+}
+
+// errB64Present is the specific case of errNonMinimalHeader where the
+// protected header carries a "b64" entry (typically b64=false per RFC 7797).
+// The fast path assumes the default b64=true encoding for both the
+// signing-input reconstruction and the post-verify payload decode; a
+// b64=false message signed under non-conformant rules (b64 not declared in
+// "crit") would otherwise verify cryptographically while returning a decoded
+// payload that differs from the producer's intent. Refusing here defers such
+// messages to jws.Verify, which has the WithDetachedPayload and
+// WithCritExtension machinery to handle b64=false correctly. Like
+// errCritPresent it wraps errNonMinimalHeader and is wrapped in verifyError at
+// the return site, so it matches ErrB64Present(), ErrNonMinimalHeader(), and
+// VerifyError().
+var errB64Present = fmt.Errorf(`%w (header contains "b64")`, errNonMinimalHeader)
+
+// ErrB64Present returns the sentinel error returned by VerifyCompactFast when
+// the protected header contains a "b64" entry. The returned error also
+// matches jws.ErrNonMinimalHeader() (the umbrella refusal) and
+// jws.VerifyError() (the general class).
+func ErrB64Present() error {
+	return errB64Present
 }
 
 // errUnclassifiableKey is the common sentinel for AlgorithmsForKey

--- a/jws/errors.go
+++ b/jws/errors.go
@@ -45,6 +45,32 @@ func ErrB64Present() error {
 	return errB64Present
 }
 
+// errNonMinimalHeader is returned by VerifyCompactFast when the protected
+// header is not in the minimal shape the fast path handles: "alg" present
+// exactly once, an optional single "typ"/"kid"/"cty", no JSON escape
+// sequences, and no other parameters. fastjson (used by the fast path) keeps
+// duplicate object members and resolves them first-wins, whereas
+// encoding/json/v2 (used by jws.Verify) rejects duplicate names outright — so
+// a header carrying a duplicate, a nested object, an unknown or key-source
+// parameter, or an escaped key could be read differently by the two paths
+// (see issue #2234). Refusing such headers defers them to jws.Verify, whose
+// strict, recursive duplicate rejection and full header handling are the
+// authoritative behavior. As with errCritPresent, the sentinel is wrapped in
+// verifyError at the return site so the resulting error matches both
+// errors.Is(err, jws.ErrNonMinimalHeader()) and errors.Is(err, jws.VerifyError()).
+var errNonMinimalHeader = errors.New(`VerifyCompactFast: protected header is not in the fast-path minimal shape; use jws.Verify`)
+
+// ErrNonMinimalHeader returns the sentinel error returned by
+// VerifyCompactFast when the protected header is outside the minimal shape
+// the fast path handles (see ErrCritPresent for the analogous crit refusal).
+// The error returned from VerifyCompactFast also matches jws.VerifyError(),
+// so callers that only branch on the general class still classify the refusal
+// correctly. Callers that wrap VerifyCompactFast should treat this like
+// ErrCritPresent: fall through to jws.Verify.
+func ErrNonMinimalHeader() error {
+	return errNonMinimalHeader
+}
+
 // errUnclassifiableKey is the common sentinel for AlgorithmsForKey
 // failures: the key shape cannot be matched to any registered key type
 // for signing. Three different code paths land here — Import-failed,

--- a/jws/internal/jwsbb/BUILD.bazel
+++ b/jws/internal/jwsbb/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "jwsbb",
+    srcs = ["header.go"],
+    importpath = "github.com/lestrrat-go/jwx/v4/jws/internal/jwsbb",
+    visibility = ["//jws:__subpackages__"],
+    deps = [
+        "//internal/base64",
+        "@com_github_valyala_fastjson//:fastjson",
+    ],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":jwsbb",
+    visibility = ["//jws:__subpackages__"],
+)
+
+go_test(
+    name = "jwsbb_test",
+    srcs = ["header_test.go"],
+    deps = [
+        ":jwsbb",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/jws/internal/jwsbb/header.go
+++ b/jws/internal/jwsbb/header.go
@@ -1,13 +1,42 @@
+// Package jwsbb holds the implementation of the jws/jwsbb building blocks.
+//
+// The public, end-user-facing API lives in github.com/lestrrat-go/jwx/v4/jws/jwsbb,
+// which is a thin facade over this package. Symbols that should be usable by
+// jwx-internal code but NOT exposed to end users (e.g. HeaderForEach) live
+// here and are simply not re-exported by the facade.
 package jwsbb
 
 import (
-	impl "github.com/lestrrat-go/jwx/v4/jws/internal/jwsbb"
+	"fmt"
+
+	"github.com/lestrrat-go/jwx/v4/internal/base64"
+	"github.com/valyala/fastjson"
 )
 
-// This file is a thin public facade over jws/internal/jwsbb. The header probe
-// implementation lives in the internal package so that jwx-internal-only
-// helpers (e.g. HeaderForEach) can be shared across the module without being
-// exposed to end users. Everything below simply re-exports the internal API.
+type headerNotFoundError struct {
+	key string
+}
+
+func (e headerNotFoundError) Error() string {
+	return fmt.Sprintf(`jwsbb: header "%s" not found`, e.key)
+}
+
+func (e headerNotFoundError) Is(target error) bool {
+	switch target.(type) {
+	case headerNotFoundError, *headerNotFoundError:
+		// If the target is a headerNotFoundError or a pointer to it, we
+		// consider it a match
+		return true
+	default:
+		return false
+	}
+}
+
+// ErrHeaderNotFound returns an error that can be passed to `errors.Is` to check if the error is
+// the result of the field not being found
+func ErrHeaderNotFound() error {
+	return headerNotFoundError{}
+}
 
 // Header is an object that allows you to access the JWS header in a quick and
 // dirty way. It does not verify anything, it does not know anything about what
@@ -15,26 +44,36 @@ import (
 // But when you need to access the JWS header for that one field that you
 // need, this is the object you want to use.
 //
-// As of this writing, Header cannot be used from concurrent goroutines.
+// As of this writing, HeaderParser cannot be used from concurrent goroutines.
 // You will need to create a new instance for each goroutine that needs to parse a JWS header.
 // Also, in general values obtained from this object should only be used
 // while the Header object is still in scope.
 //
 // This type is experimental and may change or be removed in the future.
-type Header = impl.Header
-
-// ErrHeaderNotFound returns an error that can be passed to `errors.Is` to check if the error is
-// the result of the field not being found.
-func ErrHeaderNotFound() error {
-	return impl.ErrHeaderNotFound()
+type Header interface {
+	// I'm hiding this behind an interface so that users won't accidentally
+	// rely on the underlying json handler implementation, nor the concrete
+	// type name that jwsbb provides, as we may choose a different one in the future.
+	jwsbbHeader()
 }
+
+type header struct {
+	v   *fastjson.Value
+	err error
+}
+
+func (h *header) jwsbbHeader() {}
 
 // HeaderParseCompact parses a JWS header from a compact serialization format.
 // You will need to call HeaderGet* functions to extract the values from the header.
 //
 // This function is experimental and may change or be removed in the future.
 func HeaderParseCompact(buf []byte) Header {
-	return impl.HeaderParseCompact(buf)
+	decoded, err := base64.Decode(buf)
+	if err != nil {
+		return &header{err: err}
+	}
+	return HeaderParse(decoded)
 }
 
 // HeaderParse parses a JWS header from a byte slice containing the decoded JSON.
@@ -43,7 +82,60 @@ func HeaderParseCompact(buf []byte) Header {
 // Unlike HeaderParseCompact, this function does not perform any base64 decoding.
 // This function is experimental and may change or be removed in the future.
 func HeaderParse(decoded []byte) Header {
-	return impl.HeaderParse(decoded)
+	var p fastjson.Parser
+	v, err := p.ParseBytes(decoded)
+	if err != nil {
+		return &header{err: err}
+	}
+	return &header{
+		v: v,
+	}
+}
+
+// HeaderForEach calls fn once for each top-level parameter name in the
+// parsed header, in document order. Duplicate parameter names are reported
+// once per occurrence, so callers can detect duplicates. The name slice
+// passed to fn is only valid for the duration of the call; do not retain it.
+//
+// An error is returned if the header failed to parse or does not decode to a
+// JSON object.
+//
+// This enumeration primitive exists so that jwx-internal callers which need
+// RFC-level header rules — e.g. rejecting duplicate parameter names per
+// RFC 7515 §4, or restricting a fast path to a known set of parameters — can
+// enforce those rules themselves. HeaderParse stays deliberately spec-agnostic
+// (see the [Header] doc): the policy lives in the caller, not in this generic,
+// shared field-probe. It is deliberately NOT re-exported by the public jwsbb
+// facade — enumerating raw header parameter names is a jwx-internal concern,
+// not an end-user one.
+func HeaderForEach(h Header, fn func(name []byte)) error {
+	//nolint:forcetypeassert
+	hh := h.(*header) // we _know_ this can't be another type
+	if hh.err != nil {
+		return hh.err
+	}
+	obj, err := hh.v.Object()
+	if err != nil {
+		return err
+	}
+	obj.Visit(func(key []byte, _ *fastjson.Value) {
+		fn(key)
+	})
+	return nil
+}
+
+func headerGet(h Header, key string) (*fastjson.Value, error) {
+	//nolint:forcetypeassert
+	hh := h.(*header) // we _know_ this can't be another type
+	if hh.err != nil {
+		return nil, hh.err
+	}
+
+	v := hh.v.Get(key)
+	if v == nil {
+		return nil, headerNotFoundError{key: key}
+	}
+	return v, nil
 }
 
 // HeaderGetString returns the string value for the given key from the JWS header.
@@ -52,7 +144,17 @@ func HeaderParse(decoded []byte) Header {
 //
 // This function is experimental and may change or be removed in the future.
 func HeaderGetString(h Header, key string) (string, error) {
-	return impl.HeaderGetString(h, key)
+	v, err := headerGet(h, key)
+	if err != nil {
+		return "", err
+	}
+
+	sb, err := v.StringBytes()
+	if err != nil {
+		return "", err
+	}
+
+	return string(sb), nil
 }
 
 // HeaderGetBool returns the boolean value for the given key from the JWS header.
@@ -61,7 +163,11 @@ func HeaderGetString(h Header, key string) (string, error) {
 //
 // This function is experimental and may change or be removed in the future.
 func HeaderGetBool(h Header, key string) (bool, error) {
-	return impl.HeaderGetBool(h, key)
+	v, err := headerGet(h, key)
+	if err != nil {
+		return false, err
+	}
+	return v.Bool()
 }
 
 // HeaderGetFloat64 returns the float64 value for the given key from the JWS header.
@@ -70,7 +176,11 @@ func HeaderGetBool(h Header, key string) (bool, error) {
 //
 // This function is experimental and may change or be removed in the future.
 func HeaderGetFloat64(h Header, key string) (float64, error) {
-	return impl.HeaderGetFloat64(h, key)
+	v, err := headerGet(h, key)
+	if err != nil {
+		return 0, err
+	}
+	return v.Float64()
 }
 
 // HeaderGetInt returns the int value for the given key from the JWS header.
@@ -79,7 +189,11 @@ func HeaderGetFloat64(h Header, key string) (float64, error) {
 //
 // This function is experimental and may change or be removed in the future.
 func HeaderGetInt(h Header, key string) (int, error) {
-	return impl.HeaderGetInt(h, key)
+	v, err := headerGet(h, key)
+	if err != nil {
+		return 0, err
+	}
+	return v.Int()
 }
 
 // HeaderGetInt64 returns the int64 value for the given key from the JWS header.
@@ -88,7 +202,11 @@ func HeaderGetInt(h Header, key string) (int, error) {
 //
 // This function is experimental and may change or be removed in the future.
 func HeaderGetInt64(h Header, key string) (int64, error) {
-	return impl.HeaderGetInt64(h, key)
+	v, err := headerGet(h, key)
+	if err != nil {
+		return 0, err
+	}
+	return v.Int64()
 }
 
 // HeaderGetStringBytes returns the JSON string bytes for the given key
@@ -104,14 +222,20 @@ func HeaderGetInt64(h Header, key string) (int64, error) {
 //
 // This function is experimental and may change or be removed in the future.
 func HeaderGetStringBytes(h Header, key string) ([]byte, error) {
-	return impl.HeaderGetStringBytes(h, key)
+	v, err := headerGet(h, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return v.StringBytes()
 }
 
 // HeaderHas returns true if the given key exists in the JWS header.
 //
 // This function is experimental and may change or be removed in the future.
 func HeaderHas(h Header, key string) bool {
-	return impl.HeaderHas(h, key)
+	_, err := headerGet(h, key)
+	return err == nil
 }
 
 // HeaderGetStringArray returns a string array for the given key from the JWS header.
@@ -120,7 +244,25 @@ func HeaderHas(h Header, key string) bool {
 //
 // This function is experimental and may change or be removed in the future.
 func HeaderGetStringArray(h Header, key string) ([]string, error) {
-	return impl.HeaderGetStringArray(h, key)
+	v, err := headerGet(h, key)
+	if err != nil {
+		return nil, err
+	}
+
+	arr, err := v.Array()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]string, len(arr))
+	for i, item := range arr {
+		sb, err := item.StringBytes()
+		if err != nil {
+			return nil, err
+		}
+		result[i] = string(sb)
+	}
+	return result, nil
 }
 
 // HeaderGetUint returns the uint value for the given key from the JWS header.
@@ -129,7 +271,11 @@ func HeaderGetStringArray(h Header, key string) ([]string, error) {
 //
 // This function is experimental and may change or be removed in the future.
 func HeaderGetUint(h Header, key string) (uint, error) {
-	return impl.HeaderGetUint(h, key)
+	v, err := headerGet(h, key)
+	if err != nil {
+		return 0, err
+	}
+	return v.Uint()
 }
 
 // HeaderGetUint64 returns the uint64 value for the given key from the JWS header.
@@ -138,5 +284,10 @@ func HeaderGetUint(h Header, key string) (uint, error) {
 //
 // This function is experimental and may change or be removed in the future.
 func HeaderGetUint64(h Header, key string) (uint64, error) {
-	return impl.HeaderGetUint64(h, key)
+	v, err := headerGet(h, key)
+	if err != nil {
+		return 0, err
+	}
+
+	return v.Uint64()
 }

--- a/jws/internal/jwsbb/header.go
+++ b/jws/internal/jwsbb/header.go
@@ -2,7 +2,7 @@
 //
 // The public, end-user-facing API lives in github.com/lestrrat-go/jwx/v4/jws/jwsbb,
 // which is a thin facade over this package. Symbols that should be usable by
-// jwx-internal code but NOT exposed to end users (e.g. HeaderForEach) live
+// jwx-internal code but NOT exposed to end users (e.g. HeaderForEachKey) live
 // here and are simply not re-exported by the facade.
 package jwsbb
 
@@ -92,7 +92,7 @@ func HeaderParse(decoded []byte) Header {
 	}
 }
 
-// HeaderForEach calls fn once for each top-level parameter name in the
+// HeaderForEachKey calls fn once for each top-level parameter name in the
 // parsed header, in document order. Duplicate parameter names are reported
 // once per occurrence, so callers can detect duplicates. The name slice
 // passed to fn is only valid for the duration of the call; do not retain it.
@@ -108,7 +108,7 @@ func HeaderParse(decoded []byte) Header {
 // shared field-probe. It is deliberately NOT re-exported by the public jwsbb
 // facade — enumerating raw header parameter names is a jwx-internal concern,
 // not an end-user one.
-func HeaderForEach(h Header, fn func(name []byte)) error {
+func HeaderForEachKey(h Header, fn func(name []byte)) error {
 	//nolint:forcetypeassert
 	hh := h.(*header) // we _know_ this can't be another type
 	if hh.err != nil {

--- a/jws/internal/jwsbb/header.go
+++ b/jws/internal/jwsbb/header.go
@@ -44,7 +44,7 @@ func ErrHeaderNotFound() error {
 // But when you need to access the JWS header for that one field that you
 // need, this is the object you want to use.
 //
-// As of this writing, HeaderParser cannot be used from concurrent goroutines.
+// As of this writing, Header cannot be used from concurrent goroutines.
 // You will need to create a new instance for each goroutine that needs to parse a JWS header.
 // Also, in general values obtained from this object should only be used
 // while the Header object is still in scope.

--- a/jws/internal/jwsbb/header_test.go
+++ b/jws/internal/jwsbb/header_test.go
@@ -1,0 +1,32 @@
+package jwsbb_test
+
+import (
+	"testing"
+
+	jwsbb "github.com/lestrrat-go/jwx/v4/jws/internal/jwsbb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeaderForEach(t *testing.T) {
+	t.Run("enumerates parameter names in order including duplicates", func(t *testing.T) {
+		h := jwsbb.HeaderParse([]byte(`{"alg":"HS256","typ":"JWT","alg":"none"}`))
+		var got []string
+		require.NoError(t, jwsbb.HeaderForEach(h, func(name []byte) {
+			got = append(got, string(name))
+		}))
+		// fastjson keeps duplicate object members, so both "alg" entries are
+		// reported in document order — this is what lets a caller detect a
+		// duplicate parameter name.
+		require.Equal(t, []string{"alg", "typ", "alg"}, got)
+	})
+
+	t.Run("returns error for malformed JSON", func(t *testing.T) {
+		h := jwsbb.HeaderParse([]byte(`{not valid`))
+		require.Error(t, jwsbb.HeaderForEach(h, func([]byte) {}))
+	})
+
+	t.Run("returns error when the header is not a JSON object", func(t *testing.T) {
+		h := jwsbb.HeaderParse([]byte(`"just a string"`))
+		require.Error(t, jwsbb.HeaderForEach(h, func([]byte) {}))
+	})
+}

--- a/jws/internal/jwsbb/header_test.go
+++ b/jws/internal/jwsbb/header_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHeaderForEach(t *testing.T) {
+func TestHeaderForEachKey(t *testing.T) {
 	t.Run("enumerates parameter names in order including duplicates", func(t *testing.T) {
 		h := jwsbb.HeaderParse([]byte(`{"alg":"HS256","typ":"JWT","alg":"none"}`))
 		var got []string
-		require.NoError(t, jwsbb.HeaderForEach(h, func(name []byte) {
+		require.NoError(t, jwsbb.HeaderForEachKey(h, func(name []byte) {
 			got = append(got, string(name))
 		}))
 		// fastjson keeps duplicate object members, so both "alg" entries are
@@ -22,11 +22,11 @@ func TestHeaderForEach(t *testing.T) {
 
 	t.Run("returns error for malformed JSON", func(t *testing.T) {
 		h := jwsbb.HeaderParse([]byte(`{not valid`))
-		require.Error(t, jwsbb.HeaderForEach(h, func([]byte) {}))
+		require.Error(t, jwsbb.HeaderForEachKey(h, func([]byte) {}))
 	})
 
 	t.Run("returns error when the header is not a JSON object", func(t *testing.T) {
 		h := jwsbb.HeaderParse([]byte(`"just a string"`))
-		require.Error(t, jwsbb.HeaderForEach(h, func([]byte) {}))
+		require.Error(t, jwsbb.HeaderForEachKey(h, func([]byte) {}))
 	})
 }

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -1021,8 +1021,8 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	// can diverge from encoding/json/v2 (which jws.Verify uses). Rather than
 	// reason about that, defer any escape-bearing header to jws.Verify. The
 	// header parameter names the fast path handles (alg/typ/kid/cty) never
-	// require escaping, so this refuses nothing a conformant minimal producer
-	// would emit.
+	// require escaping; an escape in a value (e.g. a "kid" containing a quote
+	// or a control char) is simply deferred to jws.Verify, which handles it.
 	if bytes.IndexByte(decodedHdr, '\\') >= 0 {
 		return nil, verifyError{fmt.Errorf(`%w (header contains a JSON escape sequence)`, errNonMinimalHeader)}
 	}

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -986,9 +986,14 @@ func Settings(options ...GlobalOption) error {
 // jws.Verify uses encoding/json/v2, which rejects duplicate names outright.
 // Limiting the fast path to the minimal shape — and deferring everything else
 // to jws.Verify, whose strict, recursive header handling is authoritative —
-// guarantees the two entry points agree on which messages they accept (see
-// issue #2234). Like the crit refusal, ErrNonMinimalHeader means "retry
-// through jws.Verify".
+// makes the two entry points agree on duplicate-name and header-shape handling
+// (see issue #2234). It is not a byte-for-byte mirror, though: the fast parser
+// does not reproduce all of encoding/json/v2's in-string validation, so a
+// header whose "typ"/"kid"/"cty" string value contains e.g. a raw control
+// character or invalid UTF-8 is accepted here but rejected by jws.Verify. The
+// signature is always verified, so this is a parser-strictness nuance, not a
+// bypass; for byte-for-byte parity call jws.Verify. Like the crit refusal,
+// ErrNonMinimalHeader means "retry through jws.Verify".
 func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]byte, error) {
 	if err := validateAlgorithmForKey(alg, key); err != nil {
 		return nil, makeVerifyError(`%w`, err)
@@ -1083,6 +1088,7 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	// path is both cheaper and more complete than making the parser spec-aware.
 	var algN, typN, kidN, ctyN, others int
 	var firstOther string
+	var haveOther bool
 	if err := jwsbbi.HeaderForEachKey(parsedHdr, func(name []byte) {
 		switch string(name) {
 		case AlgorithmKey:
@@ -1094,8 +1100,12 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 		case ContentTypeKey:
 			ctyN++
 		default:
-			if firstOther == "" {
+			if !haveOther {
+				// Capture the first unknown parameter for the diagnostic.
+				// Use a bool sentinel (not firstOther == "") so a literal
+				// empty-string key is still reported as the first one.
 				firstOther = string(name)
+				haveOther = true
 			}
 			others++
 		}

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -1021,7 +1021,7 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	}
 
 	// Header probing uses the jwx-internal jwsbb package directly: the
-	// enumeration primitive (HeaderForEach) the minimal-shape gate below needs
+	// enumeration primitive (HeaderForEachKey) the minimal-shape gate below needs
 	// is intentionally not part of the public jwsbb facade.
 	parsedHdr := jwsbbi.HeaderParse(decodedHdr)
 
@@ -1080,7 +1080,7 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	// Gating on shape and handing anything unusual to the authoritative slow
 	// path is both cheaper and more complete than making the parser spec-aware.
 	var algN, typN, kidN, ctyN, others int
-	if err := jwsbbi.HeaderForEach(parsedHdr, func(name []byte) {
+	if err := jwsbbi.HeaderForEachKey(parsedHdr, func(name []byte) {
 		switch string(name) {
 		case AlgorithmKey:
 			algN++

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -964,6 +964,18 @@ func Settings(options ...GlobalOption) error {
 // Detached-payload callers must use jws.Verify with jws.WithDetachedPayload
 // regardless, since VerifyCompactFast has no way to accept a detached
 // payload.
+//
+// VerifyCompactFast only handles a minimal protected header: "alg" exactly
+// once, an optional single "typ"/"kid"/"cty", no JSON escape sequences, and
+// no other parameters. fastjson (used here) keeps duplicate object members
+// and resolves them first-wins, whereas encoding/json/v2 (used by jws.Verify)
+// rejects duplicate names — so a header with a duplicate, a nested object, an
+// unknown or key-source parameter, or an escaped key could be read
+// differently by the two paths (see issue #2234). Such headers are refused
+// with jws.ErrNonMinimalHeader(); like the crit refusal, callers should treat
+// it as "retry through jws.Verify", whose strict, recursive header handling
+// is authoritative. A missing "alg" is reported via the alg cross-check
+// above, not this refusal.
 func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]byte, error) {
 	if err := validateAlgorithmForKey(alg, key); err != nil {
 		return nil, makeVerifyError(`%w`, err)
@@ -977,7 +989,27 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 		return nil, makeVerifyError("failed to split compact: %w", err)
 	}
 
-	parsedHdr := jwsbb.HeaderParseCompact(hdr)
+	// Decode the protected header ourselves (rather than via
+	// HeaderParseCompact) so we can inspect the raw JSON for escape
+	// sequences before parsing it.
+	decodedHdr, err := base64.Decode(hdr)
+	if err != nil {
+		return nil, makeVerifyError("failed to decode protected header: %w", err)
+	}
+
+	// Refuse any protected header containing a JSON escape sequence. For
+	// literal keys fastjson resolves duplicates first-wins deterministically,
+	// but for *escaped* keys its resolution becomes order/state-dependent and
+	// can diverge from encoding/json/v2 (which jws.Verify uses). Rather than
+	// reason about that, defer any escape-bearing header to jws.Verify. The
+	// header parameter names the fast path handles (alg/typ/kid/cty) never
+	// require escaping, so this refuses nothing a conformant minimal producer
+	// would emit.
+	if bytes.IndexByte(decodedHdr, '\\') >= 0 {
+		return nil, verifyError{errNonMinimalHeader}
+	}
+
+	parsedHdr := jwsbb.HeaderParse(decodedHdr)
 
 	// Refuse crit-bearing messages: the fast path has no WithCritExtension
 	// allowlist, so accepting them would silently violate RFC 7515 §4.1.11.
@@ -1000,8 +1032,60 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	// / WithCritExtension machinery to handle b64=false correctly. As with
 	// the crit refusal above, the sentinel is wrapped in verifyError so the
 	// same error matches both jws.ErrB64Present() and jws.VerifyError().
-	if jwsbb.HeaderHas(parsedHdr, "b64") {
+	if jwsbb.HeaderHas(parsedHdr, B64Key) {
 		return nil, verifyError{errB64Present}
+	}
+
+	// Minimal-shape gate. fastjson keeps duplicate object members and resolves
+	// them first-wins, whereas encoding/json/v2 (jws.Verify) rejects duplicate
+	// names — so a header with a duplicate or otherwise unusual parameter
+	// could be read differently by the two paths (issue #2234). The fast path
+	// therefore only handles the common minimal shape: "alg" exactly once, an
+	// optional single "typ"/"kid"/"cty", and nothing else. Anything outside
+	// that — a duplicate, a nested object, an unknown or key-source parameter
+	// — is deferred to jws.Verify via errNonMinimalHeader, where json/v2's
+	// strict recursive duplicate rejection and full header handling apply. A
+	// *missing* "alg" is left to the cross-check below so the caller still
+	// gets the specific diagnostic.
+	//
+	// Why gate-here-and-defer rather than teach the header parser to reject
+	// duplicates itself:
+	//   - The jwsbb header parser is deliberately spec-agnostic: it is a
+	//     generic, reusable field-probe (shared with other call sites) that
+	//     "does not care about the JWS specification". Baking RFC 7515 §4
+	//     header rules into it would break that contract and silently change
+	//     behavior for every other consumer.
+	//   - A duplicate check inside the parser runs on *every* parse and needs
+	//     a per-call set/map allocation, taxing the very hot path the fast
+	//     path exists to keep cheap. The shape gate here is a single key sweep
+	//     with fixed counters — allocation-free.
+	//   - A parser-level top-level dedup would still miss *nested* duplicate
+	//     names; deferring unusual headers to jws.Verify inherits json/v2's
+	//     strict *recursive* rejection for free, so the two paths agree on
+	//     more than just the top level.
+	// Gating on shape and handing anything unusual to the authoritative slow
+	// path is both cheaper and more complete than making the parser spec-aware.
+	var algN, typN, kidN, ctyN, others int
+	if err := jwsbb.HeaderForEach(parsedHdr, func(name []byte) {
+		switch string(name) {
+		case AlgorithmKey:
+			algN++
+		case TypeKey:
+			typN++
+		case KeyIDKey:
+			kidN++
+		case ContentTypeKey:
+			ctyN++
+		default:
+			others++
+		}
+	}); err != nil {
+		// Header is not a JSON object (or failed to parse); let jws.Verify
+		// produce the authoritative error.
+		return nil, verifyError{errNonMinimalHeader}
+	}
+	if others > 0 || algN > 1 || typN > 1 || kidN > 1 || ctyN > 1 {
+		return nil, verifyError{errNonMinimalHeader}
 	}
 
 	// Cross-check the protected header "alg" against the caller-supplied

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -56,6 +56,7 @@ import (
 	"github.com/lestrrat-go/jwx/v4/internal/tokens"
 	"github.com/lestrrat-go/jwx/v4/jwa"
 	"github.com/lestrrat-go/jwx/v4/jwk"
+	jwsbbi "github.com/lestrrat-go/jwx/v4/jws/internal/jwsbb"
 	"github.com/lestrrat-go/jwx/v4/jws/jwsbb"
 )
 
@@ -1019,7 +1020,10 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 		return nil, verifyError{errNonMinimalHeader}
 	}
 
-	parsedHdr := jwsbb.HeaderParse(decodedHdr)
+	// Header probing uses the jwx-internal jwsbb package directly: the
+	// enumeration primitive (HeaderForEach) the minimal-shape gate below needs
+	// is intentionally not part of the public jwsbb facade.
+	parsedHdr := jwsbbi.HeaderParse(decodedHdr)
 
 	// Refuse crit-bearing messages: the fast path has no WithCritExtension
 	// allowlist, so accepting them would silently violate RFC 7515 §4.1.11.
@@ -1028,7 +1032,7 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	// The sentinel is wrapped in verifyError so the same error also matches
 	// errors.Is(err, jws.VerifyError()) — fast-path refusals are a verify
 	// error, just one with a more specific classification available.
-	if jwsbb.HeaderHas(parsedHdr, CriticalKey) {
+	if jwsbbi.HeaderHas(parsedHdr, CriticalKey) {
 		return nil, verifyError{errCritPresent}
 	}
 
@@ -1042,7 +1046,7 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	// / WithCritExtension machinery to handle b64=false correctly. As with
 	// the crit refusal above, the sentinel is wrapped in verifyError so the
 	// same error matches both jws.ErrB64Present() and jws.VerifyError().
-	if jwsbb.HeaderHas(parsedHdr, B64Key) {
+	if jwsbbi.HeaderHas(parsedHdr, B64Key) {
 		return nil, verifyError{errB64Present}
 	}
 
@@ -1076,7 +1080,7 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	// Gating on shape and handing anything unusual to the authoritative slow
 	// path is both cheaper and more complete than making the parser spec-aware.
 	var algN, typN, kidN, ctyN, others int
-	if err := jwsbb.HeaderForEach(parsedHdr, func(name []byte) {
+	if err := jwsbbi.HeaderForEach(parsedHdr, func(name []byte) {
 		switch string(name) {
 		case AlgorithmKey:
 			algN++
@@ -1104,7 +1108,7 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	// advertises and the discipline under which we verify is the sort of
 	// silent divergence that downstream code (e.g. JWT consumers) should
 	// not be asked to re-discover on its own.
-	hdrAlg, err := jwsbb.HeaderGetString(parsedHdr, AlgorithmKey)
+	hdrAlg, err := jwsbbi.HeaderGetString(parsedHdr, AlgorithmKey)
 	if err != nil {
 		return nil, verifyError{verificationError{fmt.Errorf(`jws.Verify: failed to extract %q from protected header: %w`, AlgorithmKey, err)}}
 	}

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -965,17 +965,27 @@ func Settings(options ...GlobalOption) error {
 // regardless, since VerifyCompactFast has no way to accept a detached
 // payload.
 //
-// VerifyCompactFast only handles a minimal protected header: "alg" exactly
-// once, an optional single "typ"/"kid"/"cty", no JSON escape sequences, and
-// no other parameters. fastjson (used here) keeps duplicate object members
-// and resolves them first-wins, whereas encoding/json/v2 (used by jws.Verify)
-// rejects duplicate names — so a header with a duplicate, a nested object, an
-// unknown or key-source parameter, or an escaped key could be read
-// differently by the two paths (see issue #2234). Such headers are refused
-// with jws.ErrNonMinimalHeader(); like the crit refusal, callers should treat
-// it as "retry through jws.Verify", whose strict, recursive header handling
-// is authoritative. A missing "alg" is reported via the alg cross-check
-// above, not this refusal.
+// VerifyCompactFast only handles a "minimal" protected header. It proceeds
+// with verification only when ALL of the following hold; otherwise it refuses
+// with jws.ErrNonMinimalHeader() and the caller should retry through
+// jws.Verify:
+//
+//   - "alg" is present exactly once (a missing "alg" is reported separately,
+//     via the cross-check described above, not as ErrNonMinimalHeader);
+//   - "typ", "kid", and "cty" each appear at most once;
+//   - no other parameter is present — this excludes "crit" and "b64" (which
+//     have their own dedicated refusals, see above), key-source parameters
+//     such as "jwk"/"jku"/"x5u"/"x5c", and any unknown parameter;
+//   - the header contains no JSON escape sequences.
+//
+// The restriction exists because the fast path reads the header with a parser
+// that keeps duplicate object members and resolves them first-wins, whereas
+// jws.Verify uses encoding/json/v2, which rejects duplicate names outright.
+// Limiting the fast path to the minimal shape — and deferring everything else
+// to jws.Verify, whose strict, recursive header handling is authoritative —
+// guarantees the two entry points agree on which messages they accept (see
+// issue #2234). Like the crit refusal, ErrNonMinimalHeader means "retry
+// through jws.Verify".
 func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]byte, error) {
 	if err := validateAlgorithmForKey(alg, key); err != nil {
 		return nil, makeVerifyError(`%w`, err)

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -974,6 +974,8 @@ func Settings(options ...GlobalOption) error {
 //   - "alg" is present exactly once (a missing "alg" is reported separately,
 //     via the cross-check described above, not as ErrNonMinimalHeader);
 //   - "typ", "kid", and "cty" each appear at most once;
+//   - "typ", "kid", and "cty", when present, have JSON string values (a
+//     non-string value, which jws.Verify rejects, is refused here too);
 //   - no other parameter is present — this excludes "crit" and "b64" (which
 //     have their own dedicated refusals, see above), key-source parameters
 //     such as "jwk"/"jku"/"x5u"/"x5c", and any unknown parameter;
@@ -1120,6 +1122,29 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 			reason = `duplicate "cty"`
 		}
 		return nil, verifyError{fmt.Errorf(`%w (%s)`, errNonMinimalHeader, reason)}
+	}
+
+	// The optional descriptive parameters must be JSON strings, matching what
+	// jws.Verify's typed encoding/json/v2 header decode accepts. Without this,
+	// a genuinely-signed header like {"alg":"HS256","typ":123} would pass the
+	// name-count gate here yet be rejected by jws.Verify — the same fast/slow
+	// divergence the gate exists to prevent. HeaderGetStringBytes reports a
+	// non-string value without copying it, so this stays allocation-free; only
+	// headers that actually carry typ/kid/cty pay the (negligible) lookup.
+	if typN == 1 {
+		if _, err := jwsbbi.HeaderGetStringBytes(parsedHdr, TypeKey); err != nil {
+			return nil, verifyError{fmt.Errorf(`%w (non-string "typ")`, errNonMinimalHeader)}
+		}
+	}
+	if kidN == 1 {
+		if _, err := jwsbbi.HeaderGetStringBytes(parsedHdr, KeyIDKey); err != nil {
+			return nil, verifyError{fmt.Errorf(`%w (non-string "kid")`, errNonMinimalHeader)}
+		}
+	}
+	if ctyN == 1 {
+		if _, err := jwsbbi.HeaderGetStringBytes(parsedHdr, ContentTypeKey); err != nil {
+			return nil, verifyError{fmt.Errorf(`%w (non-string "cty")`, errNonMinimalHeader)}
+		}
 	}
 
 	// Cross-check the protected header "alg" against the caller-supplied

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -1017,7 +1017,7 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	// require escaping, so this refuses nothing a conformant minimal producer
 	// would emit.
 	if bytes.IndexByte(decodedHdr, '\\') >= 0 {
-		return nil, verifyError{errNonMinimalHeader}
+		return nil, verifyError{fmt.Errorf(`%w (header contains a JSON escape sequence)`, errNonMinimalHeader)}
 	}
 
 	// Header probing uses the jwx-internal jwsbb package directly: the
@@ -1080,6 +1080,7 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 	// Gating on shape and handing anything unusual to the authoritative slow
 	// path is both cheaper and more complete than making the parser spec-aware.
 	var algN, typN, kidN, ctyN, others int
+	var firstOther string
 	if err := jwsbbi.HeaderForEachKey(parsedHdr, func(name []byte) {
 		switch string(name) {
 		case AlgorithmKey:
@@ -1091,15 +1092,34 @@ func VerifyCompactFast(key any, compact []byte, alg jwa.SignatureAlgorithm) ([]b
 		case ContentTypeKey:
 			ctyN++
 		default:
+			if firstOther == "" {
+				firstOther = string(name)
+			}
 			others++
 		}
 	}); err != nil {
-		// Header is not a JSON object (or failed to parse); let jws.Verify
+		// Header failed to parse or is not a JSON object; let jws.Verify
 		// produce the authoritative error.
-		return nil, verifyError{errNonMinimalHeader}
+		return nil, verifyError{fmt.Errorf(`%w (protected header is not a valid JSON object)`, errNonMinimalHeader)}
 	}
+	// Refuse, naming the specific trigger so the refusal is debuggable. The
+	// error still wraps errNonMinimalHeader, so errors.Is classification
+	// (ErrNonMinimalHeader / VerifyError) is unchanged.
 	if others > 0 || algN > 1 || typN > 1 || kidN > 1 || ctyN > 1 {
-		return nil, verifyError{errNonMinimalHeader}
+		var reason string
+		switch {
+		case others > 0:
+			reason = fmt.Sprintf(`unexpected protected header parameter %q`, firstOther)
+		case algN > 1:
+			reason = `duplicate "alg"`
+		case typN > 1:
+			reason = `duplicate "typ"`
+		case kidN > 1:
+			reason = `duplicate "kid"`
+		default: // ctyN > 1
+			reason = `duplicate "cty"`
+		}
+		return nil, verifyError{fmt.Errorf(`%w (%s)`, errNonMinimalHeader, reason)}
 	}
 
 	// Cross-check the protected header "alg" against the caller-supplied

--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -600,17 +600,22 @@ func TestVerifyCompactFastMinimalHeaderShape(t *testing.T) {
 		}
 	})
 
-	t.Run("crit and b64 keep their specific sentinels", func(t *testing.T) {
-		// crit/b64 headers are also non-minimal, but their dedicated refusal
-		// sentinels must keep matching: callers (and the jwt crit fallback)
-		// branch on them specifically.
+	t.Run("crit and b64 are specific cases of the umbrella sentinel", func(t *testing.T) {
+		// crit/b64 are specific reasons that wrap ErrNonMinimalHeader: their
+		// dedicated sentinels must keep matching (callers branch on them
+		// specifically), and they must ALSO match the umbrella so a single
+		// ErrNonMinimalHeader check classifies every fast-path header refusal.
 		critCompact := signHS256Compact(key, `{"alg":"HS256","crit":["x"]}`)
 		_, err := jws.VerifyCompactFast(key, critCompact, jwa.HS256())
-		require.ErrorIs(t, err, jws.ErrCritPresent())
+		require.ErrorIs(t, err, jws.ErrCritPresent(), `specific crit sentinel must match`)
+		require.ErrorIs(t, err, jws.ErrNonMinimalHeader(), `crit must also match the umbrella`)
+		require.NotErrorIs(t, err, jws.ErrB64Present(), `crit must not match the b64 sentinel`)
 
 		b64Compact := signHS256Compact(key, `{"alg":"HS256","b64":true}`)
 		_, err = jws.VerifyCompactFast(key, b64Compact, jwa.HS256())
-		require.ErrorIs(t, err, jws.ErrB64Present())
+		require.ErrorIs(t, err, jws.ErrB64Present(), `specific b64 sentinel must match`)
+		require.ErrorIs(t, err, jws.ErrNonMinimalHeader(), `b64 must also match the umbrella`)
+		require.NotErrorIs(t, err, jws.ErrCritPresent(), `b64 must not match the crit sentinel`)
 	})
 
 	t.Run("missing alg keeps the alg-specific diagnostic", func(t *testing.T) {

--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -581,14 +581,17 @@ func TestVerifyCompactFastMinimalHeaderShape(t *testing.T) {
 	})
 
 	t.Run("non-minimal shapes are refused with ErrNonMinimalHeader", func(t *testing.T) {
-		for _, tc := range []struct{ name, hdr string }{
-			{"duplicate alg", `{"alg":"HS256","alg":"none"}`},
-			{"duplicate typ", `{"alg":"HS256","typ":"JWT","typ":"JWT"}`},
-			{"unknown parameter", `{"alg":"HS256","x5t":"abc"}`},
-			{"key-source parameter", `{"alg":"HS256","jwk":{"kty":"oct"}}`},
-			{"nested duplicate", `{"alg":"HS256","extra":[{"a":1,"a":2}]}`},
-			{"escaped key", "{\"\\u0061lg\":\"HS256\"}"},
-			{"escaped duplicate", "{\"alg\":\"HS256\",\"\\u0061lg\":\"none\"}"},
+		// wantMsg is a substring the refusal error must name, so the umbrella
+		// stays debuggable (the caller can see WHICH rule fired, not just that
+		// the header was non-minimal).
+		for _, tc := range []struct{ name, hdr, wantMsg string }{
+			{"duplicate alg", `{"alg":"HS256","alg":"none"}`, `duplicate "alg"`},
+			{"duplicate typ", `{"alg":"HS256","typ":"JWT","typ":"JWT"}`, `duplicate "typ"`},
+			{"unknown parameter", `{"alg":"HS256","x5t":"abc"}`, `"x5t"`},
+			{"key-source parameter", `{"alg":"HS256","jwk":{"kty":"oct"}}`, `"jwk"`},
+			{"nested duplicate", `{"alg":"HS256","extra":[{"a":1,"a":2}]}`, `"extra"`},
+			{"escaped key", "{\"\\u0061lg\":\"HS256\"}", `escape sequence`},
+			{"escaped duplicate", "{\"alg\":\"HS256\",\"\\u0061lg\":\"none\"}", `escape sequence`},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				compact := signHS256Compact(key, tc.hdr)
@@ -596,6 +599,7 @@ func TestVerifyCompactFastMinimalHeaderShape(t *testing.T) {
 				require.Error(t, err)
 				require.ErrorIs(t, err, jws.ErrNonMinimalHeader(), `specific sentinel must match`)
 				require.ErrorIs(t, err, jws.VerifyError(), `refusal must also match jws.VerifyError() class`)
+				require.ErrorContains(t, err, tc.wantMsg, `refusal must name the specific trigger`)
 			})
 		}
 	})

--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -622,6 +622,20 @@ func TestVerifyCompactFastMinimalHeaderShape(t *testing.T) {
 		require.NotErrorIs(t, err, jws.ErrCritPresent(), `b64 must not match the crit sentinel`)
 	})
 
+	t.Run("bare sentinels wrap the umbrella but not VerifyError", func(t *testing.T) {
+		// Documents the precise errors.Is lattice for the SENTINEL VALUES
+		// themselves (as distinct from errors returned by VerifyCompactFast):
+		// crit/b64 wrap ErrNonMinimalHeader via %w, so the bare sentinels match
+		// the umbrella; but the verifyError wrapper is applied only at the
+		// VerifyCompactFast return site, so the bare sentinels do NOT match
+		// VerifyError.
+		require.ErrorIs(t, jws.ErrCritPresent(), jws.ErrNonMinimalHeader(), `bare crit sentinel wraps the umbrella`)
+		require.ErrorIs(t, jws.ErrB64Present(), jws.ErrNonMinimalHeader(), `bare b64 sentinel wraps the umbrella`)
+		require.NotErrorIs(t, jws.ErrCritPresent(), jws.VerifyError(), `bare crit sentinel is not a verifyError`)
+		require.NotErrorIs(t, jws.ErrB64Present(), jws.VerifyError(), `bare b64 sentinel is not a verifyError`)
+		require.NotErrorIs(t, jws.ErrNonMinimalHeader(), jws.VerifyError(), `bare umbrella sentinel is not a verifyError`)
+	})
+
 	t.Run("missing alg keeps the alg-specific diagnostic", func(t *testing.T) {
 		// A missing "alg" is a malformed compact JWS (RFC 7515 §4.1.1), not a
 		// defer-to-jws.Verify case. The gate must let the alg cross-check

--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -538,6 +538,93 @@ func TestVerifyCompactFastRefusalsMatchVerifyError(t *testing.T) {
 	})
 }
 
+// signHS256Compact hand-assembles an HS256 compact JWS with an arbitrary
+// protected header (JSON) over a fixed "payload", so tests can exercise
+// header shapes that jws.Sign would never emit — duplicate parameters, JSON
+// escapes, extra fields.
+func signHS256Compact(key []byte, hdrJSON string) []byte {
+	signingInput := base64.RawURLEncoding.EncodeToString([]byte(hdrJSON)) + "." +
+		base64.RawURLEncoding.EncodeToString([]byte("payload"))
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(signingInput))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return []byte(signingInput + "." + sig)
+}
+
+// TestVerifyCompactFastMinimalHeaderShape documents the fast path's
+// minimal-shape gate (issue #2234). VerifyCompactFast uses fastjson, which
+// keeps duplicate object members and resolves them first-wins, while
+// jws.Verify uses encoding/json/v2, which rejects duplicate names. Without a
+// gate the two entry points disagreed: a duplicate-"alg" header verified on
+// the fast path but was rejected by jws.Verify. The fast path now only
+// handles a minimal header — "alg" exactly once, an optional single
+// "typ"/"kid"/"cty", no JSON escapes, nothing else — and refuses everything
+// else with jws.ErrNonMinimalHeader so callers defer it to jws.Verify.
+func TestVerifyCompactFastMinimalHeaderShape(t *testing.T) {
+	key := jwxtest.GenerateSymmetricKey()
+
+	t.Run("minimal shapes take the fast path", func(t *testing.T) {
+		for _, hdr := range []string{
+			`{"alg":"HS256"}`,
+			`{"alg":"HS256","typ":"JWT"}`,
+			`{"alg":"HS256","kid":"key-1"}`,
+			`{"alg":"HS256","typ":"JWT","kid":"key-1"}`,
+			`{"alg":"HS256","cty":"example"}`,
+		} {
+			t.Run(hdr, func(t *testing.T) {
+				compact := signHS256Compact(key, hdr)
+				payload, err := jws.VerifyCompactFast(key, compact, jwa.HS256())
+				require.NoError(t, err, `minimal header must verify on the fast path`)
+				require.Equal(t, []byte("payload"), payload)
+			})
+		}
+	})
+
+	t.Run("non-minimal shapes are refused with ErrNonMinimalHeader", func(t *testing.T) {
+		for _, tc := range []struct{ name, hdr string }{
+			{"duplicate alg", `{"alg":"HS256","alg":"none"}`},
+			{"duplicate typ", `{"alg":"HS256","typ":"JWT","typ":"JWT"}`},
+			{"unknown parameter", `{"alg":"HS256","x5t":"abc"}`},
+			{"key-source parameter", `{"alg":"HS256","jwk":{"kty":"oct"}}`},
+			{"nested duplicate", `{"alg":"HS256","extra":[{"a":1,"a":2}]}`},
+			{"escaped key", "{\"\\u0061lg\":\"HS256\"}"},
+			{"escaped duplicate", "{\"alg\":\"HS256\",\"\\u0061lg\":\"none\"}"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				compact := signHS256Compact(key, tc.hdr)
+				_, err := jws.VerifyCompactFast(key, compact, jwa.HS256())
+				require.Error(t, err)
+				require.ErrorIs(t, err, jws.ErrNonMinimalHeader(), `specific sentinel must match`)
+				require.ErrorIs(t, err, jws.VerifyError(), `refusal must also match jws.VerifyError() class`)
+			})
+		}
+	})
+
+	t.Run("crit and b64 keep their specific sentinels", func(t *testing.T) {
+		// crit/b64 headers are also non-minimal, but their dedicated refusal
+		// sentinels must keep matching: callers (and the jwt crit fallback)
+		// branch on them specifically.
+		critCompact := signHS256Compact(key, `{"alg":"HS256","crit":["x"]}`)
+		_, err := jws.VerifyCompactFast(key, critCompact, jwa.HS256())
+		require.ErrorIs(t, err, jws.ErrCritPresent())
+
+		b64Compact := signHS256Compact(key, `{"alg":"HS256","b64":true}`)
+		_, err = jws.VerifyCompactFast(key, b64Compact, jwa.HS256())
+		require.ErrorIs(t, err, jws.ErrB64Present())
+	})
+
+	t.Run("missing alg keeps the alg-specific diagnostic", func(t *testing.T) {
+		// A missing "alg" is a malformed compact JWS (RFC 7515 §4.1.1), not a
+		// defer-to-jws.Verify case. The gate must let the alg cross-check
+		// report it so the caller still gets the specific error.
+		compact := signHS256Compact(key, `{"typ":"JWT"}`)
+		_, err := jws.VerifyCompactFast(key, compact, jwa.HS256())
+		require.Error(t, err)
+		require.NotErrorIs(t, err, jws.ErrNonMinimalHeader())
+		require.ErrorContains(t, err, `"alg"`)
+	})
+}
+
 // TestMessageMarshalJSONHonorsB64False documents that Message.MarshalJSON
 // must NOT re-base64-encode the payload when the protected header carries
 // b64=false. The parser path (UnmarshalJSON) stores raw bytes in m.payload

--- a/jws/jws_crit_test.go
+++ b/jws/jws_crit_test.go
@@ -592,6 +592,9 @@ func TestVerifyCompactFastMinimalHeaderShape(t *testing.T) {
 			{"nested duplicate", `{"alg":"HS256","extra":[{"a":1,"a":2}]}`, `"extra"`},
 			{"escaped key", "{\"\\u0061lg\":\"HS256\"}", `escape sequence`},
 			{"escaped duplicate", "{\"alg\":\"HS256\",\"\\u0061lg\":\"none\"}", `escape sequence`},
+			{"non-string typ", `{"alg":"HS256","typ":123}`, `non-string "typ"`},
+			{"non-string kid", `{"alg":"HS256","kid":123}`, `non-string "kid"`},
+			{"non-string cty", `{"alg":"HS256","cty":{"x":1}}`, `non-string "cty"`},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				compact := signHS256Compact(key, tc.hdr)

--- a/jws/jwsbb/BUILD.bazel
+++ b/jws/jwsbb/BUILD.bazel
@@ -21,8 +21,8 @@ go_library(
         "//internal/ecutil",
         "//internal/keyconv",
         "//internal/tokens",
+        "//jws/internal/jwsbb",
         "@com_github_lestrrat_go_dsig//:dsig",
-        "@com_github_valyala_fastjson//:fastjson",
     ],
 )
 

--- a/jws/jwsbb/header.go
+++ b/jws/jwsbb/header.go
@@ -86,6 +86,38 @@ func HeaderParse(decoded []byte) Header {
 	}
 }
 
+// HeaderForEach calls fn once for each top-level parameter name in the
+// parsed header, in document order. Duplicate parameter names are reported
+// once per occurrence, so callers can detect duplicates. The name slice
+// passed to fn is only valid for the duration of the call; do not retain it.
+//
+// An error is returned if the header failed to parse or does not decode to a
+// JSON object.
+//
+// This enumeration primitive exists so that callers which need RFC-level
+// header rules — e.g. rejecting duplicate parameter names per RFC 7515 §4, or
+// restricting a fast path to a known set of parameters — can enforce those
+// rules themselves. HeaderParse stays deliberately spec-agnostic (see the
+// [Header] doc): the policy lives in the caller, not in this generic,
+// shared field-probe.
+//
+// This function is experimental and may change or be removed in the future.
+func HeaderForEach(h Header, fn func(name []byte)) error {
+	//nolint:forcetypeassert
+	hh := h.(*header) // we _know_ this can't be another type
+	if hh.err != nil {
+		return hh.err
+	}
+	obj, err := hh.v.Object()
+	if err != nil {
+		return err
+	}
+	obj.Visit(func(key []byte, _ *fastjson.Value) {
+		fn(key)
+	})
+	return nil
+}
+
 func headerGet(h Header, key string) (*fastjson.Value, error) {
 	//nolint:forcetypeassert
 	hh := h.(*header) // we _know_ this can't be another type

--- a/jws/jwsbb/header.go
+++ b/jws/jwsbb/header.go
@@ -6,7 +6,7 @@ import (
 
 // This file is a thin public facade over jws/internal/jwsbb. The header probe
 // implementation lives in the internal package so that jwx-internal-only
-// helpers (e.g. HeaderForEach) can be shared across the module without being
+// helpers (e.g. HeaderForEachKey) can be shared across the module without being
 // exposed to end users. Everything below simply re-exports the internal API.
 
 // Header is an object that allows you to access the JWS header in a quick and

--- a/jws/jwsbb/header_test.go
+++ b/jws/jwsbb/header_test.go
@@ -200,27 +200,3 @@ func TestHeader(t *testing.T) {
 		})
 	})
 }
-
-func TestHeaderForEach(t *testing.T) {
-	t.Run("enumerates parameter names in order including duplicates", func(t *testing.T) {
-		h := jwsbb.HeaderParse([]byte(`{"alg":"HS256","typ":"JWT","alg":"none"}`))
-		var got []string
-		require.NoError(t, jwsbb.HeaderForEach(h, func(name []byte) {
-			got = append(got, string(name))
-		}))
-		// fastjson keeps duplicate object members, so both "alg" entries are
-		// reported in document order — this is what lets a caller detect a
-		// duplicate parameter name.
-		require.Equal(t, []string{"alg", "typ", "alg"}, got)
-	})
-
-	t.Run("returns error for malformed JSON", func(t *testing.T) {
-		h := jwsbb.HeaderParse([]byte(`{not valid`))
-		require.Error(t, jwsbb.HeaderForEach(h, func([]byte) {}))
-	})
-
-	t.Run("returns error when the header is not a JSON object", func(t *testing.T) {
-		h := jwsbb.HeaderParse([]byte(`"just a string"`))
-		require.Error(t, jwsbb.HeaderForEach(h, func([]byte) {}))
-	})
-}

--- a/jws/jwsbb/header_test.go
+++ b/jws/jwsbb/header_test.go
@@ -200,3 +200,27 @@ func TestHeader(t *testing.T) {
 		})
 	})
 }
+
+func TestHeaderForEach(t *testing.T) {
+	t.Run("enumerates parameter names in order including duplicates", func(t *testing.T) {
+		h := jwsbb.HeaderParse([]byte(`{"alg":"HS256","typ":"JWT","alg":"none"}`))
+		var got []string
+		require.NoError(t, jwsbb.HeaderForEach(h, func(name []byte) {
+			got = append(got, string(name))
+		}))
+		// fastjson keeps duplicate object members, so both "alg" entries are
+		// reported in document order — this is what lets a caller detect a
+		// duplicate parameter name.
+		require.Equal(t, []string{"alg", "typ", "alg"}, got)
+	})
+
+	t.Run("returns error for malformed JSON", func(t *testing.T) {
+		h := jwsbb.HeaderParse([]byte(`{not valid`))
+		require.Error(t, jwsbb.HeaderForEach(h, func([]byte) {}))
+	})
+
+	t.Run("returns error when the header is not a JSON object", func(t *testing.T) {
+		h := jwsbb.HeaderParse([]byte(`"just a string"`))
+		require.Error(t, jwsbb.HeaderForEach(h, func([]byte) {}))
+	})
+}

--- a/jwt/BUILD.bazel
+++ b/jwt/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     name = "jwt_test",
     srcs = [
         "bench_parse_test.go",
+        "fastpath_header_test.go",
         "fastpath_test.go",
         "fuzz_test.go",
         "jwt_crit_test.go",

--- a/jwt/fastpath_header_test.go
+++ b/jwt/fastpath_header_test.go
@@ -59,4 +59,20 @@ func TestParseDuplicateHeaderParameters(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, "alice", sub)
 	})
+
+	t.Run("non-string typ rejected by every entry point", func(t *testing.T) {
+		// A genuinely-signed header with a non-string "typ" is rejected by
+		// jws.Verify (json/v2 typed decode); the fast path must agree rather
+		// than accept it, or jwt.Parse would be laxer than jws.Verify.
+		badTyp := signHS256Compact(key, `{"alg":"HS256","typ":123}`, payload)
+
+		_, err := jws.Verify(badTyp, jws.WithKey(jwa.HS256(), key))
+		require.Error(t, err, `jws.Verify must reject a non-string typ`)
+
+		_, err = jws.VerifyCompactFast(key, badTyp, jwa.HS256())
+		require.Error(t, err, `jws.VerifyCompactFast must reject a non-string typ`)
+
+		_, err = jwt.Parse(badTyp, jwt.WithKey(jwa.HS256(), key), jwt.WithValidate(false))
+		require.Error(t, err, `jwt.Parse must reject a non-string typ`)
+	})
 }

--- a/jwt/fastpath_header_test.go
+++ b/jwt/fastpath_header_test.go
@@ -1,0 +1,62 @@
+package jwt_test
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jws"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/stretchr/testify/require"
+)
+
+func signHS256Compact(key []byte, hdrJSON, payload string) []byte {
+	signingInput := base64.RawURLEncoding.EncodeToString([]byte(hdrJSON)) + "." +
+		base64.RawURLEncoding.EncodeToString([]byte(payload))
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(signingInput))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return []byte(signingInput + "." + sig)
+}
+
+// TestParseDuplicateHeaderParameters is the regression test for issue #2234.
+// jwt.Parse takes the VerifyCompactFast fast path, which (via fastjson)
+// accepted a protected header carrying a duplicate "alg" — a header that
+// jws.Verify (encoding/json/v2) rejects. The fast path now defers any
+// non-minimal header to jws.Verify, so jws.Verify, jws.VerifyCompactFast and
+// jwt.Parse agree: the duplicate is rejected, the well-formed control is
+// accepted.
+func TestParseDuplicateHeaderParameters(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+	payload := `{"sub":"alice"}`
+
+	dup := signHS256Compact(key, `{"alg":"HS256","alg":"none"}`, payload)
+	control := signHS256Compact(key, `{"alg":"HS256","typ":"JWT"}`, payload)
+
+	t.Run("duplicate alg rejected by every entry point", func(t *testing.T) {
+		_, err := jws.Verify(dup, jws.WithKey(jwa.HS256(), key))
+		require.Error(t, err, `jws.Verify must reject duplicate alg`)
+
+		_, err = jws.VerifyCompactFast(key, dup, jwa.HS256())
+		require.Error(t, err, `jws.VerifyCompactFast must reject duplicate alg`)
+
+		_, err = jwt.Parse(dup, jwt.WithKey(jwa.HS256(), key), jwt.WithValidate(false))
+		require.Error(t, err, `jwt.Parse must reject duplicate alg`)
+	})
+
+	t.Run("well-formed control accepted by every entry point", func(t *testing.T) {
+		_, err := jws.Verify(control, jws.WithKey(jwa.HS256(), key))
+		require.NoError(t, err)
+
+		_, err = jws.VerifyCompactFast(key, control, jwa.HS256())
+		require.NoError(t, err)
+
+		tok, err := jwt.Parse(control, jwt.WithKey(jwa.HS256(), key), jwt.WithValidate(false))
+		require.NoError(t, err)
+		sub, ok := tok.Subject()
+		require.True(t, ok)
+		require.Equal(t, "alice", sub)
+	})
+}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -155,9 +155,17 @@ func ParseString(s string, options ...ParseOption) (Token, error) {
 // `jws.VerifyCompactFast` for the exact shape), and any other header —
 // including one carrying duplicate, unknown, or key-source parameters,
 // `crit`, or `b64` — is automatically reverified through the full
-// `jws.Verify` path. The accept/reject outcome is identical either way; only
-// performance differs. In particular a protected header with duplicate
-// parameter names is rejected, matching `jws.Verify`.
+// `jws.Verify` path, so it is never accepted more leniently than `jws.Verify`
+// would. In particular a protected header with duplicate parameter names is
+// rejected, matching `jws.Verify`.
+//
+// The fast path is not a perfect mirror of `jws.Verify`'s header parsing: it
+// checks parameter *names*, not value types, so it can accept a narrow set of
+// unusual-but-genuinely-signed minimal headers that a full `jws.Verify` parse
+// would reject — e.g. a non-string `typ`/`kid`/`cty` value. The signature is
+// always verified, so this is a parser-strictness difference, not a security
+// bypass; if you need byte-for-byte `jws.Verify` header validation, call
+// `jws.Verify` directly.
 func Parse(s []byte, options ...ParseOption) (Token, error) {
 	tok, err := parseBytes(s, options...)
 	if err != nil {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -336,11 +336,12 @@ func verifyJWS(ctx *parseCtx, payload []byte) ([]byte, int, error) {
 			if err == nil {
 				return verified, peekJWSNestedState(ctx, payload), nil
 			}
-			// VerifyCompactFast refuses crit-bearing and non-minimal
-			// headers; on those sentinels, fall through to jws.Verify
-			// below so the full validateCritical rule set and json/v2's
-			// strict header handling (e.g. duplicate-name rejection) apply.
-			if !errors.Is(err, jws.ErrCritPresent()) && !errors.Is(err, jws.ErrNonMinimalHeader()) {
+			// VerifyCompactFast refuses any header outside its minimal
+			// shape (crit and b64 are specific cases of this); on that
+			// umbrella sentinel, fall through to jws.Verify below so the
+			// full validateCritical rule set and json/v2's strict header
+			// handling (e.g. duplicate-name rejection) apply.
+			if !errors.Is(err, jws.ErrNonMinimalHeader()) {
 				// The fast path uses strict base64url (RFC 7515).
 				// On a strict-decode failure, surface a diagnosis
 				// first ("input is not strict RFC 7515 base64url")

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -162,12 +162,12 @@ func ParseString(s string, options ...ParseOption) (Token, error) {
 // The fast path is a close but not byte-for-byte mirror of `jws.Verify`'s
 // header parsing. It validates parameter names and that `alg`/`typ`/`kid`/`cty`
 // are JSON strings, so the common divergences — duplicate names, non-string
-// scalar values — are rejected, matching `jws.Verify`. A residual gap remains
-// only for value-level leniency the fast JSON parser tolerates but
-// `encoding/json/v2` does not (e.g. certain control characters inside a JSON
-// string); for byte-for-byte `jws.Verify` header validation, call `jws.Verify`
-// directly. The signature is always verified, so any residual difference is a
-// parser-strictness nuance, not a security bypass.
+// values — are rejected, matching `jws.Verify`. A residual gap remains only
+// for value-level leniency the fast JSON parser tolerates but
+// `encoding/json/v2` does not (e.g. a raw control character or invalid UTF-8
+// inside a JSON string value); for byte-for-byte `jws.Verify` header
+// validation, call `jws.Verify` directly. The signature is always verified, so
+// any residual difference is a parser-strictness nuance, not a security bypass.
 func Parse(s []byte, options ...ParseOption) (Token, error) {
 	tok, err := parseBytes(s, options...)
 	if err != nil {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -145,6 +145,19 @@ func ParseString(s string, options ...ParseOption) (Token, error) {
 // ParseOptions control parsing and verification behavior, and
 // ValidateOptions are passed to `Validate()` when automatic validation is
 // enabled.
+//
+// For the common case — a single `jwt.WithKey()` naming a concrete signature
+// algorithm (no per-key suboptions), over a compact JWS — Parse verifies
+// through an internal fast path (see `jws.VerifyCompactFast`) that avoids
+// fully materializing the JWS message. This fast path is transparent: it
+// applies only to a minimal protected header (`alg` once, an optional single
+// `typ`/`kid`/`cty`, nothing else, no JSON escapes — see
+// `jws.VerifyCompactFast` for the exact shape), and any other header —
+// including one carrying duplicate, unknown, or key-source parameters,
+// `crit`, or `b64` — is automatically reverified through the full
+// `jws.Verify` path. The accept/reject outcome is identical either way; only
+// performance differs. In particular a protected header with duplicate
+// parameter names is rejected, matching `jws.Verify`.
 func Parse(s []byte, options ...ParseOption) (Token, error) {
 	tok, err := parseBytes(s, options...)
 	if err != nil {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -159,13 +159,15 @@ func ParseString(s string, options ...ParseOption) (Token, error) {
 // would. In particular a protected header with duplicate parameter names is
 // rejected, matching `jws.Verify`.
 //
-// The fast path is not a perfect mirror of `jws.Verify`'s header parsing: it
-// checks parameter *names*, not value types, so it can accept a narrow set of
-// unusual-but-genuinely-signed minimal headers that a full `jws.Verify` parse
-// would reject — e.g. a non-string `typ`/`kid`/`cty` value. The signature is
-// always verified, so this is a parser-strictness difference, not a security
-// bypass; if you need byte-for-byte `jws.Verify` header validation, call
-// `jws.Verify` directly.
+// The fast path is a close but not byte-for-byte mirror of `jws.Verify`'s
+// header parsing. It validates parameter names and that `alg`/`typ`/`kid`/`cty`
+// are JSON strings, so the common divergences — duplicate names, non-string
+// scalar values — are rejected, matching `jws.Verify`. A residual gap remains
+// only for value-level leniency the fast JSON parser tolerates but
+// `encoding/json/v2` does not (e.g. certain control characters inside a JSON
+// string); for byte-for-byte `jws.Verify` header validation, call `jws.Verify`
+// directly. The signature is always verified, so any residual difference is a
+// parser-strictness nuance, not a security bypass.
 func Parse(s []byte, options ...ParseOption) (Token, error) {
 	tok, err := parseBytes(s, options...)
 	if err != nil {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -323,10 +323,11 @@ func verifyJWS(ctx *parseCtx, payload []byte) ([]byte, int, error) {
 			if err == nil {
 				return verified, peekJWSNestedState(ctx, payload), nil
 			}
-			// VerifyCompactFast refuses crit-bearing messages; on
-			// that sentinel, fall through to jws.Verify below so
-			// the full validateCritical rule set applies.
-			if !errors.Is(err, jws.ErrCritPresent()) {
+			// VerifyCompactFast refuses crit-bearing and non-minimal
+			// headers; on those sentinels, fall through to jws.Verify
+			// below so the full validateCritical rule set and json/v2's
+			// strict header handling (e.g. duplicate-name rejection) apply.
+			if !errors.Is(err, jws.ErrCritPresent()) && !errors.Is(err, jws.ErrNonMinimalHeader()) {
 				// The fast path uses strict base64url (RFC 7515).
 				// On a strict-decode failure, surface a diagnosis
 				// first ("input is not strict RFC 7515 base64url")

--- a/jwt/parse_fast.go
+++ b/jwt/parse_fast.go
@@ -75,13 +75,14 @@ func tryFastPath(ctx *fastParseCtx, data []byte, options []ParseOption) bool {
 func parseCompactFast(data []byte, ctx *fastParseCtx) (Token, error) {
 	payload, err := jws.VerifyCompactFast(ctx.key, data, ctx.alg)
 	if err != nil {
-		// VerifyCompactFast refuses crit-bearing and non-minimal headers.
-		// jwt.Parse must not be laxer than jws.Verify, so fall through to
-		// the full jws.Verify path: it enforces validateCritical with the
+		// VerifyCompactFast refuses any header outside its minimal shape
+		// (crit and b64 are specific cases of this umbrella). jwt.Parse must
+		// not be laxer than jws.Verify, so fall through to the full
+		// jws.Verify path: it enforces validateCritical with the
 		// default-strict (empty) WithCritExtension allowlist, plus json/v2's
 		// strict header decoding (e.g. duplicate-name rejection, issue
 		// #2234) that the fast path's minimal-shape gate defers to it.
-		if errors.Is(err, jws.ErrCritPresent()) || errors.Is(err, jws.ErrNonMinimalHeader()) {
+		if errors.Is(err, jws.ErrNonMinimalHeader()) {
 			return parseCompactSlowFallback(data, ctx)
 		}
 		// The fast path uses strict base64url (RFC 7515). On a

--- a/jwt/parse_fast.go
+++ b/jwt/parse_fast.go
@@ -75,12 +75,14 @@ func tryFastPath(ctx *fastParseCtx, data []byte, options []ParseOption) bool {
 func parseCompactFast(data []byte, ctx *fastParseCtx) (Token, error) {
 	payload, err := jws.VerifyCompactFast(ctx.key, data, ctx.alg)
 	if err != nil {
-		// VerifyCompactFast refuses crit-bearing messages. jwt.Parse
-		// must not be laxer than jws.Verify, so fall through to the
-		// full jws.Verify path which enforces validateCritical with
-		// the default-strict (empty) WithCritExtension allowlist.
-		if errors.Is(err, jws.ErrCritPresent()) {
-			return parseCompactCritFallback(data, ctx)
+		// VerifyCompactFast refuses crit-bearing and non-minimal headers.
+		// jwt.Parse must not be laxer than jws.Verify, so fall through to
+		// the full jws.Verify path: it enforces validateCritical with the
+		// default-strict (empty) WithCritExtension allowlist, plus json/v2's
+		// strict header decoding (e.g. duplicate-name rejection, issue
+		// #2234) that the fast path's minimal-shape gate defers to it.
+		if errors.Is(err, jws.ErrCritPresent()) || errors.Is(err, jws.ErrNonMinimalHeader()) {
+			return parseCompactSlowFallback(data, ctx)
 		}
 		// The fast path uses strict base64url (RFC 7515). On a
 		// strict-decode failure, surface a diagnosis first ("input
@@ -111,12 +113,14 @@ func parseCompactFast(data []byte, ctx *fastParseCtx) (Token, error) {
 	return token, nil
 }
 
-// parseCompactCritFallback routes a fast-path-eligible input through
-// jws.Verify so the full RFC 7515 §4.1.11 "crit" rule set applies.
-// Reached only when the protected header actually contains "crit" (or
-// fails to split), so the extra cost is limited to adversarial / RFC 7797
+// parseCompactSlowFallback routes a fast-path-eligible input through
+// jws.Verify so the full RFC 7515 rule set applies: the §4.1.11 "crit"
+// handling, and json/v2's strict header decoding (duplicate-name rejection
+// etc.) that the fast path's minimal-shape gate defers here. Reached only
+// when the protected header actually contains "crit", is non-minimal, or
+// fails to split, so the extra cost is limited to adversarial / unusual
 // inputs.
-func parseCompactCritFallback(data []byte, ctx *fastParseCtx) (Token, error) {
+func parseCompactSlowFallback(data []byte, ctx *fastParseCtx) (Token, error) {
 	payload, err := jws.Verify(data, jws.WithCompact(), jws.WithKey(ctx.alg, ctx.key))
 	if err != nil {
 		return nil, parseErrorf(`jwt.Parse`, `%w`, err)


### PR DESCRIPTION
- `jws.VerifyCompactFast` / `jwt.Parse` fast path now only verifies a *minimal* protected header — `alg` once + optional single string-valued `typ`/`kid`/`cty`, no JSON escapes, no duplicate/extra parameters — and defers everything else to `jws.Verify`. Fixes #2234: duplicate (and non-string-valued) JOSE header parameters were accepted on the fast path but rejected by `jws.Verify`.
- New `jws.ErrNonMinimalHeader()` umbrella sentinel; the `crit`/`b64` refusals wrap it (one `errors.Is` classifies any fast-path header refusal), and refusal errors name the specific trigger.
- Header-probe implementation moved to `jws/internal/jwsbb`; `jws/jwsbb` is now a thin public facade (the `HeaderForEachKey` enumerator stays jwx-internal). Bazel BUILD files updated.
- Alternative to #2235: keeps `jwsbb.HeaderParse` spec-agnostic, the gate is allocation-free, and nested duplicates are caught via the slow path. A residual value-level gap (raw control chars / invalid UTF-8 inside a `typ`/`kid`/`cty` string value — key names and `alg` are not affected) is documented in the godocs; the signature is always verified, so it is a parser-strictness nuance, not a bypass.
