### PR TITLE
chore: run jwkfetch in companion test sweep

### DIFF
--- a/companions.yaml
+++ b/companions.yaml
@@ -24,7 +24,6 @@ modules:
   - name: jwkfetch
     repo: git@github.com:jwx-go/jwkfetch.git
     branch: develop/v4
-    runtests: false
   - name: jwxfilter
     repo: git@github.com:jwx-go/jwxfilter.git
     branch: develop/v4


### PR DESCRIPTION
- Drop the stale `runtests: false` from the `jwkfetch` entry in `companions.yaml` so `scripts/test-companion.sh` (and the companion CI) actually run its tests.
- The flag was a new-module placeholder added when jwkfetch was extracted (#1820) and never flipped back. The repo now has an httptest-based suite (no live network) that passes offline — verified against `develop/v4` via `go.work`.
