### PR TITLE
docs: point jwkcache references to jwkfetch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,7 @@ Read linked doc BEFORE working in that area. No exceptions.
 | Understanding package relationships, imports | `agents/docs/dependencies.md` |
 | Working with errors, error handling patterns | `agents/docs/error-formatting.md` |
 | Code generation, options pattern, extension points, JSON/base64 backends | `agents/docs/internals.md` |
-| Extension modules (ES256K, Ed448, ML-DSA, ML-KEM, X448, compsig, asmbase64, jwkcache) | `docs/10-extensions.md` |
+| Extension modules (ES256K, Ed448, ML-DSA, ML-KEM, X448, compsig, asmbase64, jwkfetch) | `docs/10-extensions.md` |
 | Companion modules, CI templates, `/jwx-companion-bulk` | `agents/docs/companions.md` |
 | Reverse-syncing action versions from companion workflows into templates | `agents/docs/companion-template-sync.md` |
 | Cutting a release / tagging a new version | `agents/docs/release.md` |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you are migrating from `github.com/lestrrat-go/jwx/v3`, see [`MIGRATION.md`](
 | **Opinionated, uniform API** | Everything is symmetric and follows a standard convention: `jws.Parse`/`Verify`/`Sign`, `jwe.Parse`/`Encrypt`/`Decrypt`. Arguments are organized as explicit required parameters and optional `WithXXXX()` style options. |
 | **Post-quantum cryptography** | Supports ML-KEM, ML-DSA, and HPKE. |
 | **Extension module architecture** | Opt-in features via extension modules. See [Extension Modules](docs/10-extensions.md). |
-| **JWK Caching** | [`jwkcache`](https://github.com/jwx-go/jwkcache) extension to always keep a JWKS up-to-date. |
+| **JWK Caching** | [`jwkfetch`](https://github.com/jwx-go/jwkfetch) extension to always keep a JWKS up-to-date. |
 | **Bazel Support** | [Bazel](https://bazel.build)-ready. |
 
 # SYNOPSIS
@@ -235,7 +235,7 @@ to specify alternate structs to parse objects with custom fields)
 In the end I think it comes down to your usage pattern, and priorities.
 Some general guidelines that come to mind are:
 
-* If you want a single library to handle everything JWx, such as using JWE, JWK, JWS, handling [auto-refreshing JWKs](https://github.com/jwx-go/jwkcache), use this module.
+* If you want a single library to handle everything JWx, such as using JWE, JWK, JWS, handling [auto-refreshing JWKs](https://github.com/jwx-go/jwkfetch), use this module.
 * If you want to honor all possible custom fields transparently, use this module.
 * If you want a standardized clean API, use this module.
 

--- a/agents/docs/companions.md
+++ b/agents/docs/companions.md
@@ -3,7 +3,7 @@
 ## Overview
 
 Extension modules under `github.com/jwx-go/*` (asmbase64, compsig, ed448, es256k, examples,
-jwkcache, jwxmigrate, mlkem, mldsa, reddy-pqchpke, x448, benchmarks) are managed as "companion modules." They live in
+jwkfetch, jwxfilter, jwxmigrate, mlkem, mldsa, reddy-pqchpke, x448, benchmarks) are managed as "companion modules." They live in
 separate repos but share CI workflows, dependabot config, and development tooling.
 
 ## House style: `init()` and Register\* failures

--- a/agents/docs/packages.md
+++ b/agents/docs/packages.md
@@ -41,7 +41,7 @@ JSON Web Keys per RFC 7517. Key representation, parsing, import/export, caching.
 - **AssignKeyID(key Key, ...AssignKeyIDOption) error** — compute and set kid via thumbprint
 - PEM output moved to `jwkbb.EncodePEM(keys ...any)`; unwrap via `jwk.Export[any]` / `jwk.ExportAll[any]` first
 - Global options: `WithStrictKeyUsage(bool)`, `WithMinRSAModulusBits(int)`, `WithMinRSAPublicExponent(int)`, `WithMaxKeys(int)` (also accepted as a per-call `ParseOption`; caps `"keys"` array + PEM block count at 1000 by default)
-- JWKS caching moved to `github.com/jwx-go/jwkcache` — see [Extension Modules](../../docs/10-extensions.md)
+- HTTP JWK Set retrieval + caching moved to `github.com/jwx-go/jwkfetch` — see [Extension Modules](../../docs/10-extensions.md)
 - Key interfaces: `Key`, `Set`, `RSAPublicKey`, `RSAPrivateKey`, `ECDSAPublicKey`, `ECDSAPrivateKey`, `OKPPublicKey`, `OKPPrivateKey`, `SymmetricKey`, `AKPPublicKey`, `AKPPrivateKey` (post-quantum, used by mldsa/mlkem extensions)
 - Extension: `RegisterCustomField[T]()`, `RegisterCustomDecoder[T]()`, `RegisterKeyParser()`, `RegisterKeyImporter()`, `RegisterKeyExporter()`
 - Error sentinels: `ImportError()`, `ParseError()`, `WhitelistError()`, `ContinueError()`


### PR DESCRIPTION
- jwkcache is superseded by jwkfetch in v4 (jwkcache/v4 never had a stable release)
- update stale refs in README, AGENTS.md, agents/docs/companions.md, agents/docs/packages.md to jwkfetch
- companions.md list now matches companions.yaml (drop jwkcache, add jwkfetch + jwxfilter)
- historical migration/design-doc mentions of jwkcache left intact