### PR TITLE
docs: fix typos in comments (exmaples, thse, heders)

### DIFF
--- a/jwk/doc.go
+++ b/jwk/doc.go
@@ -33,7 +33,7 @@
 //	jws.Sign([]byte(`...`), jws.WithKey(jwa.RS256, jwkKey))
 //	jwe.Encrypt([]byte(`...`), jwe.WithKey(jwa.RSA_OAEP, jwkKey))
 //
-// See examples/jwk_parse_example_test.go and other files in the exmaples/ directory for more.
+// See examples/jwk_parse_example_test.go and other files in the examples/ directory for more.
 //
 // # Registering a custom key type
 //

--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -57,7 +57,7 @@ func (k *okpPrivateKey) KeyKind() KeyKind { return okpKeyKind(k.Crv) }
 // Because this is an elliptic curve based Diffie Hellman protocol, it is also referred to
 // as ECDH.
 //
-// OKP keys are used to represent private/public pairs of thse elliptic curve
+// OKP keys are used to represent private/public pairs of these elliptic curve
 // keys. But note that the name just means Octet Key Pair.
 
 func (k *okpPublicKey) Import(rawKeyIf any) error {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -548,7 +548,7 @@ OUTER:
 // the token.
 //
 // For well-known algorithms with no special considerations (e.g. detached
-// payloads, extra protected heders, etc), this function will automatically
+// payloads, extra protected headers, etc), this function will automatically
 // take the fast path and bypass the jws.Sign() machinery, which improves
 // performance significantly.
 //


### PR DESCRIPTION
Fix three typos in Go doc comments:

- `jwk/doc.go`: `exmaples` → `examples`
- `jwk/okp.go`: `thse` → `these`
- `jwt/jwt.go`: `heders` → `headers`

No functional change — comment text only.