### PR TITLE
fix misspellings in code comments

### DIFF
--- a/jwe/message.go
+++ b/jwe/message.go
@@ -377,7 +377,7 @@ func (m *Message) UnmarshalJSON(buf []byte) error {
 	if proxy.Headers != nil || len(proxy.EncryptedKey) > 0 {
 		recipient := NewRecipient()
 
-		// `"heders"` could be empty. If that's the case, just skip the
+		// `"headers"` could be empty. If that's the case, just skip the
 		// following unmarshaling step
 		if proxy.Headers != nil {
 			hdrs := NewHeaders()

--- a/jwk/doc.go
+++ b/jwk/doc.go
@@ -29,7 +29,7 @@
 //	jws.Sign([]byte(`...`), jws.WithKey(jwa.RS256, jwkKey))
 //	jwe.Encrypt([]byte(`...`), jwe.WithKey(jwa.RSA_OAEP, jwkKey))
 //
-// See examples/jwk_parse_example_test.go and other files in the exmaples/ directory for more.
+// See examples/jwk_parse_example_test.go and other files in the examples/ directory for more.
 //
 // # Advanced Usage: Registering a custom key type and conversion routines
 //

--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -40,7 +40,7 @@ func (k *okpPrivateKey) KeyKind() KeyKind { return okpKeyKind(k.Crv) }
 // Because this is an elliptic curve based Diffie Hellman protocol, it is also referred to
 // as ECDH.
 //
-// OKP keys are used to represent private/public pairs of thse elliptic curve
+// OKP keys are used to represent private/public pairs of these elliptic curve
 // keys. But note that the name just means Octet Key Pair.
 
 func (k *okpPublicKey) Import(rawKeyIf any) error {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -517,7 +517,7 @@ OUTER:
 // the token.
 //
 // For well-known algorithms with no special considerations (e.g. detached
-// payloads, extra protected heders, etc), this function will automatically
+// payloads, extra protected headers, etc), this function will automatically
 // take the fast path and bypass the jws.Sign() machinery, which improves
 // performance significantly.
 //


### PR DESCRIPTION
v3 backport of #2248.

- `exmaples` → `examples` (jwk/doc.go)
- `thse` → `these` (jwk/okp.go)
- `heders` → `headers` (jwe/message.go, jwt/jwt.go)