### PR TITLE
[v4] let per-call WithRejectDuplicateKID override global

### DIFF
--- a/jwk/interface.go
+++ b/jwk/interface.go
@@ -141,7 +141,7 @@ type set struct {
 	dc                  DecodeCtx
 	privateParams       map[string]any
 	maxKeys             int   // scratch cap consumed by UnmarshalJSON; 0 means use global default
-	rejectDuplicateKID  bool  // scratch flag consumed by UnmarshalJSON; false falls back to global
+	rejectDuplicateKID  *bool // scratch tri-state consumed by UnmarshalJSON; nil falls back to global
 	strictKeySetParsing *bool // scratch tri-state consumed by UnmarshalJSON; nil falls back to global
 }
 

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -617,15 +617,17 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 		setter.setMaxKeys(maxK)
 		defer setter.setMaxKeys(0)
 	}
-	if setter, ok := s.(interface{ setRejectDuplicateKID(bool) }); ok && rejectDupKid {
-		setter.setRejectDuplicateKID(true)
-		defer setter.setRejectDuplicateKID(false)
-	}
-	// Unlike rejectDupKid above, the resolved strict value is always
-	// propagated (not only when true): a per-call
-	// WithStrictKeySetParsing(false) must override a global true, so
-	// UnmarshalJSONFrom needs the resolved value, not just a "turn it
+	// Always propagate the resolved value (not only when true): a
+	// per-call WithRejectDuplicateKID(false) must override a global true,
+	// so UnmarshalJSONFrom needs the resolved value, not just a "turn it
 	// on" signal. A nil reset restores the fall-back-to-global state.
+	if setter, ok := s.(interface{ setRejectDuplicateKID(*bool) }); ok {
+		setter.setRejectDuplicateKID(&rejectDupKid)
+		defer setter.setRejectDuplicateKID(nil)
+	}
+	// Same rationale as rejectDupKid above: the resolved strict value is
+	// always propagated so a per-call WithStrictKeySetParsing(false) can
+	// override a global true.
 	if setter, ok := s.(interface{ setStrictKeySetParsing(*bool) }); ok {
 		setter.setStrictKeySetParsing(&strict)
 		defer setter.setStrictKeySetParsing(nil)

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -2842,6 +2842,23 @@ func TestRejectDuplicateKID(t *testing.T) {
 		require.Contains(t, err.Error(), `same-kid`)
 	})
 
+	t.Run("per-call false overrides global true", func(t *testing.T) {
+		require.NoError(t, jwk.Settings(jwk.WithRejectDuplicateKID(true)))
+		t.Cleanup(func() {
+			require.NoError(t, jwk.Settings(jwk.WithRejectDuplicateKID(false)))
+		})
+		set, err := jwk.Parse(dupPayload, jwk.WithRejectDuplicateKID(false))
+		require.NoError(t, err, `per-call WithRejectDuplicateKID(false) must override the global true`)
+		require.Equal(t, 2, set.Len(), `both keys should be in the set`)
+	})
+
+	t.Run("per-call true overrides global false", func(t *testing.T) {
+		require.NoError(t, jwk.Settings(jwk.WithRejectDuplicateKID(false)))
+		_, err := jwk.Parse(dupPayload, jwk.WithRejectDuplicateKID(true))
+		require.Error(t, err, `per-call WithRejectDuplicateKID(true) must override the global false`)
+		require.Contains(t, err.Error(), `same-kid`)
+	})
+
 	t.Run("empty kid entries are ignored", func(t *testing.T) {
 		// Two keys, neither carrying a kid. Reject-duplicates should
 		// still accept — the setting targets explicit duplicates, not

--- a/jwk/set.go
+++ b/jwk/set.go
@@ -209,7 +209,12 @@ func (s *set) setMaxKeys(n int) {
 	s.maxKeys = n
 }
 
-func (s *set) setRejectDuplicateKID(v bool) {
+// setRejectDuplicateKID stores the reject-duplicate-kid value resolved by
+// Parse (global default already merged with any per-call option). A nil
+// pointer means "not resolved" — UnmarshalJSONFrom then falls back to the
+// global setting. The pointer form lets a per-call false override a global
+// true, which a plain bool scratch field cannot express.
+func (s *set) setRejectDuplicateKID(v *bool) {
 	s.rejectDuplicateKID = v
 }
 
@@ -256,7 +261,10 @@ func (s *set) UnmarshalJSONFrom(dec *jsontext.Decoder) error {
 	if maxK <= 0 {
 		maxK = int(maxKeys.Load())
 	}
-	rejectDupKid := s.rejectDuplicateKID || rejectDuplicateKID.Load()
+	rejectDupKid := rejectDuplicateKID.Load()
+	if s.rejectDuplicateKID != nil {
+		rejectDupKid = *s.rejectDuplicateKID
+	}
 	strict := strictKeySetParsing.Load()
 	if s.strictKeySetParsing != nil {
 		strict = *s.strictKeySetParsing


### PR DESCRIPTION
- Per-call `WithRejectDuplicateKID(false)` was ignored under a global `true`.
- Propagate resolved value as `*bool` tri-state, per-call now overrides global.
