### PR TITLE
[v3] fix per-call reject-dup-kid override

### DIFF
--- a/jwk/interface.go
+++ b/jwk/interface.go
@@ -126,7 +126,7 @@ type set struct {
 	dc                  DecodeCtx
 	privateParams       map[string]any
 	maxKeys             int   // scratch cap consumed by UnmarshalJSON; 0 means use global default
-	rejectDuplicateKID  bool  // scratch flag consumed by UnmarshalJSON; false falls back to global
+	rejectDuplicateKID  *bool // scratch override consumed by UnmarshalJSON; nil falls back to global
 	strictKeySetParsing *bool // scratch override consumed by UnmarshalJSON; nil falls back to global
 }
 

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -485,9 +485,13 @@ func Parse(src []byte, options ...ParseOption) (Set, error) {
 		setter.setMaxKeys(maxK)
 		defer setter.setMaxKeys(0)
 	}
-	if setter, ok := s.(interface{ setRejectDuplicateKID(bool) }); ok && rejectDupKid {
-		setter.setRejectDuplicateKID(true)
-		defer setter.setRejectDuplicateKID(false)
+	// Propagate the resolved reject-duplicate-KID flag. A pointer
+	// distinguishes "not set by Parse" (nil → Set.UnmarshalJSON uses the
+	// global default) from an explicit per-call true/false, so a per-call
+	// false overrides a global true.
+	if setter, ok := s.(interface{ setRejectDuplicateKID(*bool) }); ok {
+		setter.setRejectDuplicateKID(&rejectDupKid)
+		defer setter.setRejectDuplicateKID(nil)
 	}
 	// Propagate the resolved strict flag. A pointer distinguishes "not
 	// set by Parse" (nil → Set.UnmarshalJSON uses the global default of

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -3106,6 +3106,20 @@ func TestRejectDuplicateKID(t *testing.T) {
 		require.Contains(t, err.Error(), `same-kid`)
 	})
 
+	t.Run("per-call false overrides global true", func(t *testing.T) {
+		jwk.Configure(jwk.WithRejectDuplicateKID(true))
+		defer jwk.Configure(jwk.WithRejectDuplicateKID(false))
+		set, err := jwk.Parse(dupPayload, jwk.WithRejectDuplicateKID(false))
+		require.NoError(t, err, `per-call false must override global true`)
+		require.Equal(t, 2, set.Len())
+	})
+
+	t.Run("per-call true overrides global default", func(t *testing.T) {
+		_, err := jwk.Parse(dupPayload, jwk.WithRejectDuplicateKID(true))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `same-kid`)
+	})
+
 	t.Run("empty kid entries are ignored", func(t *testing.T) {
 		noKidA, err := jwxtest.GenerateSymmetricJwk()
 		require.NoError(t, err)

--- a/jwk/set.go
+++ b/jwk/set.go
@@ -211,7 +211,7 @@ func (s *set) setMaxKeys(n int) {
 	s.maxKeys = n
 }
 
-func (s *set) setRejectDuplicateKID(v bool) {
+func (s *set) setRejectDuplicateKID(v *bool) {
 	s.rejectDuplicateKID = v
 }
 
@@ -245,7 +245,10 @@ func (s *set) UnmarshalJSON(data []byte) error {
 	if maxK <= 0 {
 		maxK = int(maxKeys.Load())
 	}
-	rejectDupKid := s.rejectDuplicateKID || rejectDuplicateKID.Load()
+	rejectDupKid := rejectDuplicateKID.Load()
+	if s.rejectDuplicateKID != nil {
+		rejectDupKid = *s.rejectDuplicateKID
+	}
 	strict := strictKeySetParsing.Load()
 	if s.strictKeySetParsing != nil {
 		strict = *s.strictKeySetParsing


### PR DESCRIPTION
- per-call `WithRejectDuplicateKID(false)` now overrides a global true
- `set.rejectDuplicateKID` is now a `*bool` override, mirroring `strictKeySetParsing`
- v3 backport; default behavior unchanged
