### PR TITLE
[v4] test jwe rejects UnsupportedKey placeholders

### DIFF
--- a/jwe/BUILD.bazel
+++ b/jwe/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "options_gen_test.go",
         "recipient_headers_test.go",
         "speed_test.go",
+        "unsupported_key_test.go",
         "zip_protected_only_test.go",
     ],
     embed = [":jwe"],

--- a/jwe/BUILD.bazel
+++ b/jwe/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "options_gen_test.go",
         "recipient_headers_test.go",
         "speed_test.go",
+        "unsupported_key_internal_test.go",
         "unsupported_key_test.go",
         "zip_protected_only_test.go",
     ],

--- a/jwe/unsupported_key_internal_test.go
+++ b/jwe/unsupported_key_internal_test.go
@@ -1,0 +1,109 @@
+package jwe
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingKeySink implements jwe.KeySink and remembers every key handed to
+// it, so a test can assert exactly which keys reached the sink. Unlike
+// algKeySink it does nothing with the keys other than record them.
+type recordingKeySink struct {
+	keys []any
+}
+
+func (s *recordingKeySink) Key(_ jwa.KeyEncryptionAlgorithm, key any) {
+	s.keys = append(s.keys, key)
+}
+
+// parsePlaceholderKey parses a single unknown-kty entry in retain mode and
+// returns the resulting jwk.UnsupportedKey placeholder.
+func parsePlaceholderKey(t *testing.T) jwk.UnsupportedKey {
+	t.Helper()
+
+	set, err := jwk.Parse([]byte(`{"keys":[{"kty":"FUTURE","kid":"future-1"}]}`), jwk.WithStrictKeySetParsing(false))
+	require.NoError(t, err, `jwk.Parse in retain mode should succeed`)
+	key, ok := set.Key(0)
+	require.True(t, ok, `set should have one entry`)
+	placeholder, ok := key.(jwk.UnsupportedKey)
+	require.True(t, ok, `the only entry should be an UnsupportedKey placeholder`)
+	require.True(t, jwk.IsUnsupportedKey(placeholder), `placeholder should report IsUnsupportedKey`)
+	require.Error(t, placeholder.Reason(), `placeholder should retain its parse error`)
+	return placeholder
+}
+
+// TestKeySetProviderSkipsUnsupportedKey is a white-box test that drives
+// keySetProvider.FetchKeys directly with a recording KeySink to pin the
+// UnsupportedKey guard in selectKey (jwe/key_provider.go). It deliberately
+// gives the recipient an "alg" header so that, were the guard removed, the
+// placeholder would fall through to the header-alg branch and be sunk — that
+// is exactly the leak this test catches. The existing end-to-end WithKeySet
+// test does not fail if the guard is deleted, because a usable key decrypts
+// first and a downstream jwk.Export guard catches the placeholder-only case.
+func TestKeySetProviderSkipsUnsupportedKey(t *testing.T) {
+	t.Parallel()
+
+	rawPriv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, `generating RSA key should succeed`)
+
+	// A recipient that declares "alg" — this is what would let an
+	// unguarded selectKey sink a placeholder via the header-alg fallback.
+	recipientWithAlg := func(t *testing.T) Recipient {
+		t.Helper()
+		rec := NewRecipient()
+		require.NoError(t, rec.Headers().Set(AlgorithmKey, jwa.RSA_OAEP()), `setting recipient alg should succeed`)
+		return rec
+	}
+
+	t.Run("mixed set sinks only the usable key, never the placeholder", func(t *testing.T) {
+		t.Parallel()
+
+		usable, err := jwk.Import[jwk.Key](rawPriv)
+		require.NoError(t, err, `importing RSA private key should succeed`)
+		require.NoError(t, usable.Set(jwk.AlgorithmKey, jwa.RSA_OAEP()))
+		require.NoError(t, usable.Set(jwk.KeyIDKey, "usable"))
+
+		placeholder := parsePlaceholderKey(t)
+
+		set := jwk.NewSet()
+		require.NoError(t, set.AddKey(usable), `adding usable key should succeed`)
+		require.NoError(t, set.AddKey(placeholder), `adding placeholder should succeed`)
+
+		kp := &keySetProvider{set: set, requireKid: false}
+		sink := &recordingKeySink{}
+		err = kp.FetchKeys(t.Context(), sink, recipientWithAlg(t), NewMessage())
+		require.NoError(t, err, `FetchKeys should succeed when a usable key is present`)
+
+		// The usable key — and only the usable key — must reach the sink.
+		require.Len(t, sink.keys, 1, `exactly one key should reach the sink`)
+		sunk, ok := sink.keys[0].(jwk.Key)
+		require.True(t, ok, `the sunk key should be a jwk.Key`)
+		require.False(t, jwk.IsUnsupportedKey(sunk), `the placeholder must never reach the sink`)
+		for _, k := range sink.keys {
+			if key, ok := k.(jwk.Key); ok {
+				require.False(t, jwk.IsUnsupportedKey(key), `no sunk key may be an UnsupportedKey placeholder`)
+			}
+		}
+	})
+
+	t.Run("placeholder-only set sinks nothing and returns the unsupported reason", func(t *testing.T) {
+		t.Parallel()
+
+		placeholder := parsePlaceholderKey(t)
+
+		set := jwk.NewSet()
+		require.NoError(t, set.AddKey(placeholder), `adding placeholder should succeed`)
+
+		kp := &keySetProvider{set: set, requireKid: false}
+		sink := &recordingKeySink{}
+		err := kp.FetchKeys(t.Context(), sink, recipientWithAlg(t), NewMessage())
+		require.Error(t, err, `FetchKeys must fail when the only key is a placeholder`)
+		require.ErrorIs(t, err, placeholder.Reason(), `error should wrap the placeholder's unsupported reason`)
+		require.Empty(t, sink.keys, `no key may reach the sink`)
+	})
+}

--- a/jwe/unsupported_key_test.go
+++ b/jwe/unsupported_key_test.go
@@ -1,0 +1,129 @@
+package jwe_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/internal/json"
+	"github.com/lestrrat-go/jwx/v4/internal/jwxtest"
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwe"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/stretchr/testify/require"
+)
+
+// An unknown "kty" entry parses (in retain mode) into a jwk.UnsupportedKey
+// placeholder rather than failing the whole set. These tests pin the
+// crypto-isolation invariant: such a placeholder must NEVER reach encryption
+// or decryption key material through any of jwe's key-provider paths
+// (jwe.WithKeySet, jwe.WithKey, or a custom jwe.WithKeyProvider).
+const unsupportedKeyEntry = `{"kty":"FUTURE","kid":"future-1"}`
+
+// parseSetWithPlaceholder builds a JWK set JSON from the given usable key JSON
+// plus one unknown-kty entry, parses it in retain mode, and returns the parsed
+// set together with the retained placeholder.
+func parseSetWithPlaceholder(t *testing.T, usableKeyJSON []byte) (jwk.Set, jwk.UnsupportedKey) {
+	t.Helper()
+
+	setJSON := []byte(`{"keys":[` + string(usableKeyJSON) + `,` + unsupportedKeyEntry + `]}`)
+	set, err := jwk.Parse(setJSON, jwk.WithStrictKeySetParsing(false))
+	require.NoError(t, err, `jwk.Parse in retain mode should succeed`)
+
+	var placeholder jwk.UnsupportedKey
+	for i := range set.Len() {
+		key, ok := set.Key(i)
+		require.True(t, ok, `set.Key(%d) should be present`, i)
+		if uk, ok := key.(jwk.UnsupportedKey); ok {
+			placeholder = uk
+		}
+	}
+	require.NotNil(t, placeholder, `set should retain the unknown entry as an UnsupportedKey placeholder`)
+	require.True(t, jwk.IsUnsupportedKey(placeholder), `placeholder should report IsUnsupportedKey`)
+	require.Error(t, placeholder.Reason(), `placeholder should retain its parse error`)
+	return set, placeholder
+}
+
+func TestUnsupportedKeyRejectedAcrossKeyPaths(t *testing.T) {
+	t.Parallel()
+
+	rawPriv, err := jwxtest.GenerateRsaKey()
+	require.NoError(t, err, `generating RSA key should succeed`)
+
+	// Private JWK is what the decrypting set carries (RSA-OAEP unwrap needs
+	// the private key); marshal it so it can be embedded in the set JSON.
+	privJWK, err := jwk.Import[jwk.Key](rawPriv)
+	require.NoError(t, err, `importing RSA private key should succeed`)
+	require.NoError(t, privJWK.Set(jwk.AlgorithmKey, jwa.RSA_OAEP()))
+	require.NoError(t, privJWK.Set(jwk.KeyIDKey, "usable"))
+	usableKeyJSON, err := json.Marshal(privJWK)
+	require.NoError(t, err, `marshaling usable JWK should succeed`)
+
+	// Encrypt a payload to the usable key so every path below decrypts a
+	// genuine ciphertext.
+	pubJWK, err := jwk.Import[jwk.Key](rawPriv.PublicKey)
+	require.NoError(t, err, `importing RSA public key should succeed`)
+	require.NoError(t, pubJWK.Set(jwk.KeyIDKey, "usable"))
+
+	payload := []byte("super secret encrypted message")
+	ciphertext, err := jwe.Encrypt(payload, jwe.WithKey(jwa.RSA_OAEP(), pubJWK))
+	require.NoError(t, err, `jwe.Encrypt to the usable key should succeed`)
+
+	t.Run("WithKeySet decrypts via the usable key and never the placeholder", func(t *testing.T) {
+		set, _ := parseSetWithPlaceholder(t, usableKeyJSON)
+
+		var used any
+		plaintext, err := jwe.Decrypt(ciphertext,
+			jwe.WithKeySet(set, jwe.WithRequireKid(false)),
+			jwe.WithKeyUsed(&used),
+		)
+		require.NoError(t, err, `jwe.Decrypt should succeed via the usable key`)
+		require.Equal(t, payload, plaintext, `decrypted plaintext should match`)
+
+		usedKey, ok := used.(jwk.Key)
+		require.True(t, ok, `key used should be a jwk.Key`)
+		require.False(t, jwk.IsUnsupportedKey(usedKey), `the placeholder must never be the used key`)
+	})
+
+	t.Run("WithKeySet containing only the placeholder fails with no plaintext", func(t *testing.T) {
+		setJSON := []byte(`{"keys":[` + unsupportedKeyEntry + `]}`)
+		set, err := jwk.Parse(setJSON, jwk.WithStrictKeySetParsing(false))
+		require.NoError(t, err, `jwk.Parse in retain mode should succeed`)
+		key, ok := set.Key(0)
+		require.True(t, ok, `set should have one entry`)
+		placeholder, ok := key.(jwk.UnsupportedKey)
+		require.True(t, ok, `the only entry should be the placeholder`)
+
+		plaintext, err := jwe.Decrypt(ciphertext, jwe.WithKeySet(set, jwe.WithRequireKid(false)))
+		require.Error(t, err, `jwe.Decrypt must fail when the only key is a placeholder`)
+		require.Nil(t, plaintext, `no plaintext must be produced`)
+		require.ErrorIs(t, err, placeholder.Reason(), `error should surface the placeholder's unsupported reason`)
+	})
+
+	t.Run("direct WithKey with the placeholder fails for Decrypt and Encrypt", func(t *testing.T) {
+		_, placeholder := parseSetWithPlaceholder(t, usableKeyJSON)
+
+		plaintext, err := jwe.Decrypt(ciphertext, jwe.WithKey(jwa.RSA_OAEP(), placeholder))
+		require.Error(t, err, `jwe.Decrypt with a placeholder must fail`)
+		require.Nil(t, plaintext, `no plaintext must be produced`)
+		require.ErrorIs(t, err, placeholder.Reason(), `Decrypt error should surface the unsupported reason`)
+
+		encrypted, err := jwe.Encrypt(payload, jwe.WithKey(jwa.RSA_OAEP(), placeholder))
+		require.Error(t, err, `jwe.Encrypt with a placeholder must fail`)
+		require.Nil(t, encrypted, `no ciphertext must be produced`)
+		require.ErrorIs(t, err, placeholder.Reason(), `Encrypt error should surface the unsupported reason`)
+	})
+
+	t.Run("custom KeyProvider that sinks the placeholder fails with no plaintext", func(t *testing.T) {
+		_, placeholder := parseSetWithPlaceholder(t, usableKeyJSON)
+
+		provider := jwe.KeyProviderFunc(func(_ context.Context, sink jwe.KeySink, _ jwe.Recipient, _ *jwe.Message) error {
+			sink.Key(jwa.RSA_OAEP(), placeholder)
+			return nil
+		})
+
+		plaintext, err := jwe.Decrypt(ciphertext, jwe.WithKeyProvider(provider))
+		require.Error(t, err, `jwe.Decrypt via a placeholder-sinking provider must fail`)
+		require.Nil(t, plaintext, `no plaintext must be produced`)
+		require.ErrorIs(t, err, placeholder.Reason(), `error should surface the unsupported reason`)
+	})
+}

--- a/jwe/unsupported_key_test.go
+++ b/jwe/unsupported_key_test.go
@@ -69,6 +69,7 @@ func TestUnsupportedKeyRejectedAcrossKeyPaths(t *testing.T) {
 	require.NoError(t, err, `jwe.Encrypt to the usable key should succeed`)
 
 	t.Run("WithKeySet decrypts via the usable key and never the placeholder", func(t *testing.T) {
+		t.Parallel()
 		set, _ := parseSetWithPlaceholder(t, usableKeyJSON)
 
 		var used any
@@ -85,6 +86,7 @@ func TestUnsupportedKeyRejectedAcrossKeyPaths(t *testing.T) {
 	})
 
 	t.Run("WithKeySet containing only the placeholder fails with no plaintext", func(t *testing.T) {
+		t.Parallel()
 		setJSON := []byte(`{"keys":[` + unsupportedKeyEntry + `]}`)
 		set, err := jwk.Parse(setJSON, jwk.WithStrictKeySetParsing(false))
 		require.NoError(t, err, `jwk.Parse in retain mode should succeed`)
@@ -100,6 +102,7 @@ func TestUnsupportedKeyRejectedAcrossKeyPaths(t *testing.T) {
 	})
 
 	t.Run("direct WithKey with the placeholder fails for Decrypt and Encrypt", func(t *testing.T) {
+		t.Parallel()
 		_, placeholder := parseSetWithPlaceholder(t, usableKeyJSON)
 
 		plaintext, err := jwe.Decrypt(ciphertext, jwe.WithKey(jwa.RSA_OAEP(), placeholder))
@@ -114,6 +117,7 @@ func TestUnsupportedKeyRejectedAcrossKeyPaths(t *testing.T) {
 	})
 
 	t.Run("custom KeyProvider that sinks the placeholder fails with no plaintext", func(t *testing.T) {
+		t.Parallel()
 		_, placeholder := parseSetWithPlaceholder(t, usableKeyJSON)
 
 		provider := jwe.KeyProviderFunc(func(_ context.Context, sink jwe.KeySink, _ jwe.Recipient, _ *jwe.Message) error {


### PR DESCRIPTION
- add regression tests proving a `jwk.UnsupportedKey` placeholder can never reach jwe key material
- covers `WithKeySet`, direct `WithKey` (Decrypt+Encrypt), and custom `WithKeyProvider`
- closes a test gap; existing guards in `key_provider.go` and `jwk.Export` were untested
