### PR TITLE
jwe: serialize the JSON "aad" member as BASE64URL(JWE AAD)

### DIFF
--- a/jwe/message.go
+++ b/jwe/message.go
@@ -247,12 +247,14 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 	}
 
 	if aad := m.AuthenticatedData(); len(aad) > 0 {
-		aad = base64.Encode(aad)
-		if encodedProtectedHeaders != nil {
-			aad = concatAAD(encodedProtectedHeaders, aad)
-		}
-
-		v, err := marshalField(aad)
+		// RFC 7516 §7.2.1: the "aad" member is BASE64URL(JWE AAD) — the
+		// external Additional Authenticated Data on its own. The protected
+		// header is prepended to the AAD only when building the AEAD input
+		// (concatAAD, in the encrypt/decrypt paths), never in the serialized
+		// member. Encode to a base64url string like the ciphertext/iv/tag
+		// members above so marshalField does not base64-encode the raw bytes
+		// a second time (which also used the padded std alphabet).
+		v, err := marshalField(base64.EncodeToString(aad))
 		if err != nil {
 			return nil, fmt.Errorf(`failed to encode %s field: %w`, AuthenticatedDataKey, err)
 		}

--- a/jwe/message_test.go
+++ b/jwe/message_test.go
@@ -1,6 +1,8 @@
 package jwe_test
 
 import (
+	"encoding/base64"
+	"fmt"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v4/internal/json"
@@ -8,6 +10,47 @@ import (
 
 	"github.com/lestrrat-go/jwx/v4/jwe"
 )
+
+// TestJWEJSONAADRoundTrip pins RFC 7516 §7.2.1 — the "aad" member of the JWE
+// JSON Serialization is BASE64URL(JWE AAD): the external Additional
+// Authenticated Data alone, base64url-encoded with no padding. It must NOT
+// carry the "protected header '.' aad" concatenation (that form is only the
+// AEAD input, per §5.1/§5.2 step 14), and it must not be base64-encoded a
+// second time. Before the fix, MarshalJSON emitted
+// base64std(protectedB64 + "." + base64url(aad)), so a message carrying an
+// external aad did not survive Parse -> json.Marshal -> Parse: the aad was
+// silently corrupted (the lenient decoder accepts the mangled value without
+// error).
+func TestJWEJSONAADRoundTrip(t *testing.T) {
+	extAAD := []byte("external-aad")
+	// RFC 7516 §7.2.1: aad member == BASE64URL(JWE AAD).
+	wantAADMember := base64.RawURLEncoding.EncodeToString(extAAD)
+	protected := base64.RawURLEncoding.EncodeToString([]byte(`{"enc":"A128GCM"}`))
+	src := fmt.Sprintf(
+		`{"protected":%q,"encrypted_key":"","iv":"aXZpdml2aXZpdml2","ciphertext":"Y3Q","tag":"dGFn","aad":%q}`,
+		protected, wantAADMember,
+	)
+
+	msg, err := jwe.Parse([]byte(src))
+	require.NoError(t, err, `jwe.Parse should succeed`)
+	require.Equal(t, extAAD, msg.AuthenticatedData(), `parsed aad should be the external AAD`)
+
+	buf, err := json.Marshal(msg)
+	require.NoError(t, err, `json.Marshal should succeed`)
+
+	var got map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(buf, &got), `re-parse of serialized message should succeed`)
+	var gotAAD string
+	require.NoError(t, json.Unmarshal(got["aad"], &gotAAD), `aad member should be a JSON string`)
+	require.Equal(t, wantAADMember, gotAAD,
+		`serialized "aad" member must be BASE64URL(JWE AAD) per RFC 7516 §7.2.1`)
+
+	// The message must survive a full Parse -> Marshal -> Parse cycle.
+	msg2, err := jwe.Parse(buf)
+	require.NoError(t, err, `re-parse of the serialized message should succeed`)
+	require.Equal(t, extAAD, msg2.AuthenticatedData(),
+		`external AAD must be preserved across a serialization round trip`)
+}
 
 func TestRecipient(t *testing.T) {
 	t.Run("JSON Marshaling", func(t *testing.T) {


### PR DESCRIPTION
`Message.MarshalJSON` writes the JSON `"aad"` member as `base64std(protected_header + "." + BASE64URL(aad))` instead of `BASE64URL(JWE AAD)`. RFC 7516 §7.2.1 defines the member as the external Additional Authenticated Data on its own, base64url-encoded; the protected-header concatenation belongs only to the AEAD input (§5.1/§5.2 step 14), which the encrypt and decrypt paths already build separately with `concatAAD`.

Two things are wrong in the emitted member:

- the protected-header segment and `.` are prepended, and
- `aad` is passed to `marshalField` as a `[]byte`, so `json.Marshal` base64-encodes it a second time, in the padded std alphabet — sibling members `ciphertext`/`iv`/`tag` pass a string from `base64.EncodeToString`, so only `aad` is affected.

A JWE JSON message that carries an external `aad` (as produced by any RFC-compliant library) therefore does not survive `jwe.Parse` -> `json.Marshal` -> `jwe.Parse`: the aad decodes to the wrong value with no error, because the lenient decoder accepts the mangled string. `jwe.Encrypt` has no aad option, so the trigger is the parse-then-reserialize / forward path, not encrypt.

This is the semantic sibling of the `MarshalJSON` aad block touched in #1794 — that change fixed slice aliasing in the same spot but left the value itself wrong.

What changed:

- `Message.MarshalJSON` encodes `aad` as a base64url string, like the other members, with no protected-header prefix.
- added `TestJWEJSONAADRoundTrip`, pinning the RFC 7516 §7.2.1 member value and the `Parse` -> `Marshal` -> `Parse` round trip.

Checked (`GOEXPERIMENT=jsonv2`, go 1.26.4):

- `go test ./jwe/...` — pass; `TestJWEJSONAADRoundTrip` fails before the change (`aad` member is `ZXlKbGJt...==`), passes after.
- `go test ./...` — pass.
- `go vet ./jwe/`, `gofmt -l` — clean.
