### PR TITLE
add JWE authenticated data option

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,14 @@ Changes
 v4 has many incompatibilities with v3. To see the full list of differences between
 v3 and v4, please read the [Changes-v4.md file](./Changes-v4.md). Coding Agents should read [MIGRATION-v4.md](./MICRATION-v4.md)
 
+UNRELEASED
+  * [jwe] Correct the JSON `"aad"` member so it contains only
+    BASE64URL of the external Additional Authenticated Data, rather than the
+    combined value used as the content-encryption AAD. Add
+    `jwe.WithAuthenticateData` for encrypting JSON JWEs with external AAD;
+    the value is included in the shared AEAD input for all recipients, and
+    compact serialization rejects non-empty external AAD. (#2275, #2277)
+
 v4.2.0 24 July 2026
   * [jwk] `jwk.Parse` (and `Set.UnmarshalJSON`) no longer fails an entire
     JWK Set when a single entry in the "keys" array cannot be parsed. By

--- a/agents/docs/packages.md
+++ b/agents/docs/packages.md
@@ -77,7 +77,7 @@ JSON Web Encryption per RFC 7516. Encrypt, decrypt, parse.
 - **Parse(buf []byte, ...ParseOption) (*Message, error)** — parse without decryption
 - **Settings(options ...GlobalOption)** — configure global jwe settings
 - Key types: `Message`, `Recipient`, `Headers`, `KeyProvider`, `KeyEncrypter`, `KeyDecrypter`
-- Options: `WithKey()`, `WithKeySet()`, `WithContentEncryption()`, `WithCompress()`, `WithJSON()`, `WithProtectedHeaders()`
+- Options: `WithKey()`, `WithKeySet()`, `WithContentEncryption()`, `WithCompress()`, `WithJSON()`, `WithProtectedHeaders()`, `WithAuthenticateData()`
 - Global/per-call settings: `WithMaxPBES2Count()`, `WithMinPBES2Count()`, `WithMaxDecompressBufferSize()`, `WithMaxRecipients()` (usable in both `Settings()` and `Decrypt()`); `WithCBCBufferSize()`, `WithDisabledKeyAlgorithms(...jwa.KeyEncryptionAlgorithm)` (global only; the latter blocks listed key algorithms in both Encrypt and Decrypt)
 - Error sentinels: `EncryptError()`, `DecryptError()`, `HPKEError()`, `RecipientError()`, `ParseError()`
 - Internal subpackages: `jwe/internal/{aescbc,cipher,concatkdf,content_crypt,keygen}`, `jwe/jwebb` — building blocks including HPKE extension interfaces (`HPKEKeyEncrypter`, `HPKEKeyDecrypter`), custom HPKE encrypt/decrypt bridges (`KeyEncryptHPKECustom`, `KeyDecryptHPKECustom`), and dynamic algorithm registration (`RegisterHPKEAlgorithm`)

--- a/jwe/encrypt_aad_test.go
+++ b/jwe/encrypt_aad_test.go
@@ -1,0 +1,54 @@
+package jwe_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/internal/json"
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwe"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptWithAuthenticateData(t *testing.T) {
+	const payload = "encrypted payload"
+	var aad = []byte("external aad")
+	key1 := []byte("01234567890123456789012345678901")
+	key2 := []byte("abcdefghijklmnopqrstuvwxyz123456")
+
+	encrypted, err := jwe.Encrypt(
+		[]byte(payload),
+		jwe.WithJSON(),
+		jwe.WithAuthenticateData(aad),
+		jwe.WithKey(jwa.A256KW(), key1),
+		jwe.WithKey(jwa.A256KW(), key2),
+	)
+	require.NoError(t, err)
+
+	var wire struct {
+		AAD string `json:"aad"`
+	}
+	require.NoError(t, json.Unmarshal(encrypted, &wire))
+	require.Equal(t, base64.RawURLEncoding.EncodeToString(aad), wire.AAD)
+
+	msg, err := jwe.Parse(encrypted)
+	require.NoError(t, err)
+	require.Equal(t, aad, msg.AuthenticatedData())
+
+	for name, key := range map[string][]byte{"first recipient": key1, "second recipient": key2} {
+		t.Run(name, func(t *testing.T) {
+			decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.A256KW(), key))
+			require.NoError(t, err)
+			require.Equal(t, []byte(payload), decrypted)
+		})
+	}
+}
+
+func TestEncryptWithAuthenticateDataRejectsCompact(t *testing.T) {
+	_, err := jwe.Encrypt(
+		[]byte("encrypted payload"),
+		jwe.WithAuthenticateData([]byte("external aad")),
+		jwe.WithKey(jwa.A256KW(), []byte("01234567890123456789012345678901")),
+	)
+	require.ErrorContains(t, err, `cannot use compact serialization with external authenticated data`)
+}

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -797,13 +797,14 @@ func (dc *decryptContext) decryptContent(msg *Message, alg jwa.KeyEncryptionAlgo
 
 // encryptContext holds the state during JWE encryption, similar to JWS signContext
 type encryptContext struct {
-	calg        jwa.ContentEncryptionAlgorithm
-	compression jwa.CompressionAlgorithm
-	format      int
-	pbes2Count  int
-	builders    []*recipientBuilder
-	protected   Headers
-	builderBuf  [1]recipientBuilder // inline storage for common single-recipient case
+	calg              jwa.ContentEncryptionAlgorithm
+	compression       jwa.CompressionAlgorithm
+	format            int
+	pbes2Count        int
+	authenticatedData []byte
+	builders          []*recipientBuilder
+	protected         Headers
+	builderBuf        [1]recipientBuilder // inline storage for common single-recipient case
 }
 
 var encryptContextPool = pool.New(allocEncryptContext, freeEncryptContext)
@@ -821,6 +822,7 @@ func freeEncryptContext(ec *encryptContext) *encryptContext {
 	ec.compression = jwa.NoCompress()
 	ec.format = fmtCompact
 	ec.pbes2Count = 0
+	ec.authenticatedData = nil
 	ec.builders = ec.builders[:0]
 	ec.protected = nil
 	ec.builderBuf[0] = recipientBuilder{}
@@ -864,6 +866,8 @@ func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
 			ec.calg = option.MustGet[jwa.ContentEncryptionAlgorithm](opt)
 		case identCompress{}:
 			ec.compression = option.MustGet[jwa.CompressionAlgorithm](opt)
+		case identAuthenticateData{}:
+			ec.authenticatedData = option.MustGet[[]byte](opt)
 		case identMergeProtectedHeaders{}:
 			mergeProtected = option.MustGet[bool](opt)
 		case identProtectedHeaders{}:
@@ -890,6 +894,10 @@ func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
 		if ec.format == fmtCompact {
 			return fmt.Errorf(`cannot use compact serialization when multiple recipients exist (check the number of WithKey() argument, or use WithJSON())`)
 		}
+	}
+
+	if len(ec.authenticatedData) > 0 && ec.format == fmtCompact {
+		return fmt.Errorf(`cannot use compact serialization with external authenticated data (use WithJSON())`)
 	}
 
 	if useRawCEK {
@@ -1082,12 +1090,13 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 		}
 	}
 
-	aad, err := protected.Encode()
+	protectedAAD, err := protected.Encode()
 	if err != nil {
 		return nil, fmt.Errorf(`failed to base64 encode protected headers: %w`, err)
 	}
 
-	iv, ciphertext, tag, err := contentcrypt.Encrypt(cek, payload, aad)
+	contentAAD := concatAAD(protectedAAD, base64.Encode(ec.authenticatedData))
+	iv, ciphertext, tag, err := contentcrypt.Encrypt(cek, payload, contentAAD)
 	if err != nil {
 		return nil, fmt.Errorf(`failed to encrypt payload: %w`, err)
 	}
@@ -1097,7 +1106,7 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 	// were copied into protected above), so we can build the compact
 	// serialization directly from the raw parts.
 	if ec.format == fmtCompact {
-		return jwebb.JoinCompact(base64.DefaultEncoder(), aad, recipients[0].EncryptedKey(), iv, ciphertext, tag), nil
+		return jwebb.JoinCompact(base64.DefaultEncoder(), protectedAAD, recipients[0].EncryptedKey(), iv, ciphertext, tag), nil
 	}
 
 	msg := msgPool.Get()
@@ -1117,6 +1126,11 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 	}
 	if err := msg.Set(TagKey, tag); err != nil {
 		return nil, fmt.Errorf(`failed to set %s: %w`, TagKey, err)
+	}
+	if len(ec.authenticatedData) > 0 {
+		if err := msg.Set(AuthenticatedDataKey, ec.authenticatedData); err != nil {
+			return nil, fmt.Errorf(`failed to set %s: %w`, AuthenticatedDataKey, err)
+		}
 	}
 
 	switch ec.format {

--- a/jwe/message.go
+++ b/jwe/message.go
@@ -228,20 +228,16 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 		fields = append(fields, jsonKV{Key: InitializationVectorKey, Value: v})
 	}
 
-	var encodedProtectedHeaders []byte
 	if h := m.ProtectedHeaders(); h != nil {
 		v, err := h.Encode()
 		if err != nil {
 			return nil, fmt.Errorf(`failed to encode protected headers: %w`, err)
 		}
 
-		encodedProtectedHeaders = v
-		if len(encodedProtectedHeaders) <= 2 { // '{}'
-			encodedProtectedHeaders = nil
-		} else {
+		if len(v) > 2 { // '{}'
 			fields = append(fields, jsonKV{
 				Key:   ProtectedHeadersKey,
-				Value: fmt.Sprintf("%q", encodedProtectedHeaders),
+				Value: fmt.Sprintf("%q", v),
 			})
 		}
 	}

--- a/jwe/message.go
+++ b/jwe/message.go
@@ -247,12 +247,14 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 	}
 
 	if aad := m.AuthenticatedData(); len(aad) > 0 {
-		aad = base64.Encode(aad)
-		if encodedProtectedHeaders != nil {
-			aad = concatAAD(encodedProtectedHeaders, aad)
-		}
-
-		v, err := marshalField(aad)
+		// RFC 7516 §7.2.1: the "aad" member is BASE64URL(JWE AAD) — the
+		// external Additional Authenticated Data on its own. The protected
+		// header is prepended to the AAD only when building the AEAD input
+		// (concatAAD, in the encrypt/decrypt paths), never in the serialized
+		// member. Encode to a base64url string like the ciphertext/iv/tag
+		// members above so marshalField does not base64-encode the raw bytes
+		// a second time (which also used the padded std alphabet).
+		v, err := marshalField(base64.EncodeToString(aad))
 		if err != nil {
 			return nil, fmt.Errorf(`failed to encode %s field: %w`, AuthenticatedDataKey, err)
 		}

--- a/jwe/message_test.go
+++ b/jwe/message_test.go
@@ -1,6 +1,8 @@
 package jwe_test
 
 import (
+	"encoding/base64"
+	"fmt"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v4/internal/json"
@@ -8,6 +10,47 @@ import (
 
 	"github.com/lestrrat-go/jwx/v4/jwe"
 )
+
+// TestJWEJSONAADRoundTrip pins RFC 7516 §7.2.1 — the "aad" member of the JWE
+// JSON Serialization is BASE64URL(JWE AAD): the external Additional
+// Authenticated Data alone, base64url-encoded with no padding. It must NOT
+// carry the "protected header '.' aad" concatenation (that form is only the
+// AEAD input, per §5.1/§5.2 step 14), and it must not be base64-encoded a
+// second time. Before the fix, MarshalJSON emitted
+// base64std(protectedB64 + "." + base64url(aad)), so a message carrying an
+// external aad did not survive Parse -> json.Marshal -> Parse: the aad was
+// silently corrupted (the lenient decoder accepts the mangled value without
+// error).
+func TestJWEJSONAADRoundTrip(t *testing.T) {
+	extAAD := []byte("external-aad")
+	// RFC 7516 §7.2.1: aad member == BASE64URL(JWE AAD).
+	wantAADMember := base64.RawURLEncoding.EncodeToString(extAAD)
+	protected := base64.RawURLEncoding.EncodeToString([]byte(`{"enc":"A128GCM"}`))
+	src := fmt.Sprintf(
+		`{"protected":%q,"encrypted_key":"","iv":"aXZpdml2aXZpdml2","ciphertext":"Y3Q","tag":"dGFn","aad":%q}`,
+		protected, wantAADMember,
+	)
+
+	msg, err := jwe.Parse([]byte(src))
+	require.NoError(t, err, `jwe.Parse should succeed`)
+	require.Equal(t, extAAD, msg.AuthenticatedData(), `parsed aad should be the external AAD`)
+
+	buf, err := json.Marshal(msg)
+	require.NoError(t, err, `json.Marshal should succeed`)
+
+	var got map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(buf, &got), `re-parse of serialized message should succeed`)
+	var gotAAD string
+	require.NoError(t, json.Unmarshal(got["aad"], &gotAAD), `aad member should be a JSON string`)
+	require.Equal(t, wantAADMember, gotAAD,
+		`serialized "aad" member must be BASE64URL(JWE AAD) per RFC 7516 §7.2.1`)
+
+	// The message must survive a full Parse -> Marshal -> Parse cycle.
+	msg2, err := jwe.Parse(buf)
+	require.NoError(t, err, `re-parse of the serialized message should succeed`)
+	require.Equal(t, extAAD, msg2.AuthenticatedData(),
+		`external AAD must be preserved across a serialization round trip`)
+}
 
 func TestRecipient(t *testing.T) {
 	t.Run("JSON Marshaling", func(t *testing.T) {

--- a/jwe/options.go
+++ b/jwe/options.go
@@ -1,6 +1,8 @@
 package jwe
 
 import (
+	"bytes"
+
 	"github.com/lestrrat-go/jwx/v4/jwa"
 	"github.com/lestrrat-go/jwx/v4/jwk"
 	"github.com/lestrrat-go/option/v3"
@@ -79,6 +81,16 @@ func WithCritExtension(names ...string) DecryptOption {
 func WithProtectedHeaders(h Headers) EncryptOption {
 	cloned, _ := h.Clone()
 	return &encryptOption{option.New(identProtectedHeaders{}, cloned)}
+}
+
+// WithAuthenticateData specifies the external Additional Authenticated Data
+// to use when encrypting a JSON JWE.
+//
+// The data is copied before it is stored in the option. External Additional
+// Authenticated Data is not supported by compact serialization; pass
+// WithJSON() to select JSON serialization.
+func WithAuthenticateData(aad []byte) EncryptOption {
+	return &encryptOption{option.New(identAuthenticateData{}, bytes.Clone(aad))}
 }
 
 type withKey struct {

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -55,6 +55,13 @@ options:
     skip_option: true
   - ident: ProtectedHeaders
     skip_option: true
+  - ident: AuthenticateData
+    skip_option: true
+    interface: EncryptOption
+    argument_type: '[]byte'
+    comment: |
+      WithAuthenticateData specifies the external Additional Authenticated Data
+      to use when encrypting a JSON JWE.
   - ident: PerRecipientHeaders
     skip_option: true
   - ident: KeyProvider

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -156,6 +156,7 @@ type withKeySetSuboption struct {
 
 func (*withKeySetSuboption) withKeySetSuboption() {}
 
+type identAuthenticateData struct{}
 type identCBCBufferSize struct{}
 type identCEK struct{}
 type identCompress struct{}
@@ -177,6 +178,10 @@ type identPretty struct{}
 type identProtectedHeaders struct{}
 type identRequireKid struct{}
 type identSerialization struct{}
+
+func (identAuthenticateData) String() string {
+	return "WithAuthenticateData"
+}
 
 func (identCBCBufferSize) String() string {
 	return "WithCBCBufferSize"

--- a/jwe/options_gen_test.go
+++ b/jwe/options_gen_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestOptionIdent(t *testing.T) {
+	require.Equal(t, "WithAuthenticateData", identAuthenticateData{}.String())
 	require.Equal(t, "WithCBCBufferSize", identCBCBufferSize{}.String())
 	require.Equal(t, "WithCEK", identCEK{}.String())
 	require.Equal(t, "WithCompress", identCompress{}.String())


### PR DESCRIPTION
- stack this follow-up on #2275
- add `jwe.WithAuthenticateData` for JSON encryption and shared recipient AAD
- reject compact output and cover multi-recipient encryption and decryption
