### PR TITLE
add JWE authenticated data option

### DIFF
--- a/.claude/docs/packages.md
+++ b/.claude/docs/packages.md
@@ -73,7 +73,7 @@ JSON Web Encryption per RFC 7516. Encrypt, decrypt, parse.
 - **Decrypt(buf []byte, ...DecryptOption) ([]byte, error)** — decrypt message
 - **Parse(buf []byte, ...ParseOption) (*Message, error)** — parse without decryption
 - Key types: `Message`, `Recipient`, `Headers`, `KeyProvider`, `KeyEncrypter`, `KeyDecrypter`
-- Options: `WithKey()`, `WithKeySet()`, `WithContentEncryption()`, `WithCompress()`, `WithJSON()`, `WithProtectedHeaders()`
+- Options: `WithKey()`, `WithKeySet()`, `WithContentEncryption()`, `WithCompress()`, `WithJSON()`, `WithProtectedHeaders()`, `WithAuthenticateData()`
 - Global/per-call settings: `WithMaxPBES2Count()`, `WithMinPBES2Count()`, `WithMaxDecompressBufferSize()`, `WithMaxRecipients()` (usable in both `Settings()` and `Decrypt()`); `WithCBCBufferSize()`, `WithDisabledKeyAlgorithms(...jwa.KeyEncryptionAlgorithm)` (global only; the latter blocks listed key algorithms in both Encrypt and Decrypt)
 - Error sentinels: `EncryptError()`, `DecryptError()`, `RecipientError()`, `ParseError()`
 - Internal subpackages: `jwe/internal/{aescbc,cipher,concatkdf,content_crypt,keygen}`, `jwe/jwebb`

--- a/Changes
+++ b/Changes
@@ -5,6 +5,13 @@ v3 has many incompatibilities with v2. To see the full list of differences betwe
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
 v3.2.0 UNRELEASED
+  * [jwe] Correct the JSON `"aad"` member so it contains only
+    BASE64URL of the external Additional Authenticated Data, rather than the
+    combined value used as the content-encryption AAD. Add
+    `jwe.WithAuthenticateData` for encrypting JSON JWEs with external AAD;
+    the value is included in the shared AEAD input for all recipients, and
+    compact serialization rejects non-empty external AAD. (#2276, #2278)
+
   * [jwk] Added opt-in retention of unparseable JWK Set entries. Passing
     `jwk.WithStrictKeySetParsing(false)` to `jwk.Parse` (or setting it
     globally via `jwk.Configure`) keeps an entry whose key type is not

--- a/jwe/encrypt_aad_test.go
+++ b/jwe/encrypt_aad_test.go
@@ -1,0 +1,54 @@
+package jwe_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/internal/json"
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwe"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptWithAuthenticateData(t *testing.T) {
+	const payload = "encrypted payload"
+	aad := []byte("external aad")
+	key1 := []byte("01234567890123456789012345678901")
+	key2 := []byte("abcdefghijklmnopqrstuvwxyz123456")
+
+	encrypted, err := jwe.Encrypt(
+		[]byte(payload),
+		jwe.WithJSON(),
+		jwe.WithAuthenticateData(aad),
+		jwe.WithKey(jwa.A256KW(), key1),
+		jwe.WithKey(jwa.A256KW(), key2),
+	)
+	require.NoError(t, err)
+
+	var wire struct {
+		AAD string `json:"aad"`
+	}
+	require.NoError(t, json.Unmarshal(encrypted, &wire))
+	require.Equal(t, base64.RawURLEncoding.EncodeToString(aad), wire.AAD)
+
+	msg, err := jwe.Parse(encrypted)
+	require.NoError(t, err)
+	require.Equal(t, aad, msg.AuthenticatedData())
+
+	for name, key := range map[string][]byte{"first recipient": key1, "second recipient": key2} {
+		t.Run(name, func(t *testing.T) {
+			decrypted, err := jwe.Decrypt(encrypted, jwe.WithKey(jwa.A256KW(), key))
+			require.NoError(t, err)
+			require.Equal(t, []byte(payload), decrypted)
+		})
+	}
+}
+
+func TestEncryptWithAuthenticateDataRejectsCompact(t *testing.T) {
+	_, err := jwe.Encrypt(
+		[]byte("encrypted payload"),
+		jwe.WithAuthenticateData([]byte("external aad")),
+		jwe.WithKey(jwa.A256KW(), []byte("01234567890123456789012345678901")),
+	)
+	require.ErrorContains(t, err, `cannot use compact serialization with external authenticated data`)
+}

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -877,6 +877,7 @@ type encryptContext struct {
 	compression         jwa.CompressionAlgorithm
 	format              int
 	pbes2Count          int
+	authenticatedData   []byte
 	builders            []*recipientBuilder
 	protected           Headers
 	legacyHeaderMerging bool
@@ -897,6 +898,7 @@ func freeEncryptContext(ec *encryptContext) *encryptContext {
 	ec.compression = jwa.NoCompress()
 	ec.format = fmtCompact
 	ec.pbes2Count = 0
+	ec.authenticatedData = nil
 	ec.builders = ec.builders[:0]
 	ec.protected = nil
 	return ec
@@ -949,6 +951,12 @@ func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
 				return err
 			}
 			ec.compression = comp
+		case identAuthenticateData{}:
+			var aad []byte
+			if err := option.Value(&aad); err != nil {
+				return err
+			}
+			ec.authenticatedData = aad
 		case identMergeProtectedHeaders{}:
 			var mp bool
 			if err := option.Value(&mp); err != nil {
@@ -992,6 +1000,10 @@ func (ec *encryptContext) ProcessOptions(options []EncryptOption) error {
 		if ec.format == fmtCompact {
 			return fmt.Errorf(`cannot use compact serialization when multiple recipients exist (check the number of WithKey() argument, or use WithJSON())`)
 		}
+	}
+
+	if len(ec.authenticatedData) > 0 && ec.format == fmtCompact {
+		return fmt.Errorf(`cannot use compact serialization with external authenticated data (use WithJSON())`)
 	}
 
 	if useRawCEK {
@@ -1193,12 +1205,13 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 		}
 	}
 
-	aad, err := protected.Encode()
+	protectedAAD, err := protected.Encode()
 	if err != nil {
 		return nil, fmt.Errorf(`failed to base64 encode protected headers: %w`, err)
 	}
 
-	iv, ciphertext, tag, err := contentcrypt.Encrypt(cek, payload, aad)
+	contentAAD := concatAAD(protectedAAD, base64.Encode(ec.authenticatedData))
+	iv, ciphertext, tag, err := contentcrypt.Encrypt(cek, payload, contentAAD)
 	if err != nil {
 		return nil, fmt.Errorf(`failed to encrypt payload: %w`, err)
 	}
@@ -1207,7 +1220,7 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 	// pre-encoded headers and raw fields, avoiding the full Message
 	// construction and redundant header re-encoding that Compact() does.
 	if ec.format == fmtCompact {
-		return compactSerialize(aad, recipients[0].EncryptedKey(), iv, ciphertext, tag), nil
+		return compactSerialize(protectedAAD, recipients[0].EncryptedKey(), iv, ciphertext, tag), nil
 	}
 
 	msg := msgPool.Get()
@@ -1227,6 +1240,11 @@ func (ec *encryptContext) EncryptMessage(payload []byte, cek []byte) ([]byte, er
 	}
 	if err := msg.Set(TagKey, tag); err != nil {
 		return nil, fmt.Errorf(`failed to set %s: %w`, TagKey, err)
+	}
+	if len(ec.authenticatedData) > 0 {
+		if err := msg.Set(AuthenticatedDataKey, ec.authenticatedData); err != nil {
+			return nil, fmt.Errorf(`failed to set %s: %w`, AuthenticatedDataKey, err)
+		}
 	}
 
 	switch ec.format {

--- a/jwe/options.go
+++ b/jwe/options.go
@@ -1,6 +1,8 @@
 package jwe
 
 import (
+	"bytes"
+
 	"github.com/lestrrat-go/jwx/v3/jwa"
 	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/lestrrat-go/option/v2"
@@ -74,6 +76,16 @@ func WithCritExtension(names ...string) DecryptOption {
 func WithProtectedHeaders(h Headers) EncryptOption {
 	cloned, _ := h.Clone()
 	return &encryptOption{option.New(identProtectedHeaders{}, cloned)}
+}
+
+// WithAuthenticateData specifies the external Additional Authenticated Data
+// to use when encrypting a JSON JWE.
+//
+// The data is copied before it is stored in the option. External Additional
+// Authenticated Data is not supported by compact serialization; pass
+// WithJSON() to select JSON serialization.
+func WithAuthenticateData(aad []byte) EncryptOption {
+	return &encryptOption{option.New(identAuthenticateData{}, bytes.Clone(aad))}
 }
 
 type withKey struct {

--- a/jwe/options.yaml
+++ b/jwe/options.yaml
@@ -60,6 +60,13 @@ options:
     skip_option: true
   - ident: ProtectedHeaders
     skip_option: true
+  - ident: AuthenticateData
+    skip_option: true
+    interface: EncryptOption
+    argument_type: '[]byte'
+    comment: |
+      WithAuthenticateData specifies the external Additional Authenticated Data
+      to use when encrypting a JSON JWE.
   - ident: PerRecipientHeaders
     skip_option: true
   - ident: KeyProvider

--- a/jwe/options_gen.go
+++ b/jwe/options_gen.go
@@ -169,6 +169,7 @@ type withKeySetSuboption struct {
 
 func (*withKeySetSuboption) withKeySetSuboption() {}
 
+type identAuthenticateData struct{}
 type identCBCBufferSize struct{}
 type identCEK struct{}
 type identCompress struct{}
@@ -192,6 +193,10 @@ type identPretty struct{}
 type identProtectedHeaders struct{}
 type identRequireKid struct{}
 type identSerialization struct{}
+
+func (identAuthenticateData) String() string {
+	return "WithAuthenticateData"
+}
 
 func (identCBCBufferSize) String() string {
 	return "WithCBCBufferSize"

--- a/jwe/options_gen_test.go
+++ b/jwe/options_gen_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestOptionIdent(t *testing.T) {
+	require.Equal(t, "WithAuthenticateData", identAuthenticateData{}.String())
 	require.Equal(t, "WithCBCBufferSize", identCBCBufferSize{}.String())
 	require.Equal(t, "WithCEK", identCEK{}.String())
 	require.Equal(t, "WithCompress", identCompress{}.String())


### PR DESCRIPTION
- stack this follow-up on #2276
- add `jwe.WithAuthenticateData` for JSON encryption and shared recipient AAD
- reject compact output and cover multi-recipient encryption and decryption
