### PR TITLE
Fix build under Go 1.27 (json/v2.SkipFunc removal)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,9 @@ Use `github.com/stretchr/testify/require` for assertions (not `assert`).
 
 ## Build Tags
 
-No build tags in v4. Optional features (signature algorithms, backend replacements) are provided as extension modules under [`github.com/jwx-go`](https://github.com/jwx-go). See [Extension Modules](docs/10-extensions.md) for the full list.
+No feature build tags in v4. Optional features (signature algorithms, backend replacements) are provided as extension modules under [`github.com/jwx-go`](https://github.com/jwx-go). See [Extension Modules](docs/10-extensions.md) for the full list.
+
+The one exception is a Go-version compatibility shim: `internal/json/skipfunc_pre_go127.go` and `internal/json/skipfunc_go127.go` pick the json/v2 "skip this value" sentinel, which Go 1.27 renamed from `json/v2.SkipFunc` to `errors.ErrUnsupported`. Do not add feature build tags alongside it.
 
 ## Quick Reference: Common Modifications
 

--- a/Changes
+++ b/Changes
@@ -11,6 +11,12 @@ UNRELEASED
     `jwe.WithAuthenticateData` for encrypting JSON JWEs with external AAD;
     the value is included in the shared AEAD input for all recipients, and
     compact serialization rejects non-empty external AAD. (#2275, #2277)
+  * Fix the build under Go 1.27. Go 1.27 removed `encoding/json/v2.SkipFunc`
+    and gave its role to `errors.ErrUnsupported`, which broke compilation of
+    `internal/json` for anyone on the new toolchain. The sentinel is now
+    selected by a Go-version build tag, so both Go 1.26 (with
+    `GOEXPERIMENT=jsonv2`) and Go 1.27 build from the same source. No public
+    API or behavior change.
 
 v4.2.0 24 July 2026
   * [jwk] `jwk.Parse` (and `Set.UnmarshalJSON`) no longer fails an entire

--- a/agents/docs/internals.md
+++ b/agents/docs/internals.md
@@ -107,7 +107,14 @@ rejects the registration.
 
 ## JSON Backend
 
-Uses `encoding/json/v2` exclusively (no build-tag switching).
+Uses `encoding/json/v2` exclusively (no build-tag switching between backends).
+
+One Go-version build tag does live inside `internal/json`: the sentinel a custom
+unmarshaler returns to decline a value is `json/v2.SkipFunc` up to Go 1.26 and
+`errors.ErrUnsupported` from Go 1.27 on. `skipfunc_pre_go127.go` /
+`skipfunc_go127.go` bind it to `errSkipFunc` so the rest of the package does not
+have to care. This is a compatibility shim, not a backend switch — delete it
+once the module requires Go 1.27.
 
 Internal `internal/json` package provides the abstraction. Custom field registry (`json.Registry`) enables type-safe deserialization of extension fields.
 

--- a/agents/docs/testing.md
+++ b/agents/docs/testing.md
@@ -36,7 +36,12 @@ Environment variables:
 
 ## Build Tags for Tests
 
-No build tags in v4. Optional features (signature algorithms, base64 backend) are activated via side-effect imports of [extension modules](../docs/10-extensions.md).
+No feature build tags in v4. Optional features (signature algorithms, base64 backend) are activated via side-effect imports of [extension modules](../docs/10-extensions.md).
+
+The only build tags in the tree are the Go-version constraints on
+`internal/json/skipfunc_pre_go127.go` / `skipfunc_go127.go`. Tests never set
+them: both Go 1.26 (with `GOEXPERIMENT=jsonv2`) and Go 1.27 build and pass
+as-is.
 
 ## Fuzz Tests
 

--- a/internal/json/BUILD.bazel
+++ b/internal/json/BUILD.bazel
@@ -5,6 +5,8 @@ go_library(
     srcs = [
         "json.go",
         "registry.go",
+        "skipfunc_go127.go",
+        "skipfunc_pre_go127.go",
     ],
     importpath = "github.com/lestrrat-go/jwx/v4/internal/json",
     visibility = ["//:__subpackages__"],

--- a/internal/json/registry.go
+++ b/internal/json/registry.go
@@ -70,7 +70,9 @@ func (dec *TypedDecoder[T]) Decode(data []byte) (any, error) {
 var useNumberUnmarshalers = jsonv2.WithUnmarshalers(
 	jsonv2.UnmarshalFromFunc(func(dec *jsontext.Decoder, val *any) error {
 		if dec.PeekKind() != '0' {
-			return jsonv2.SkipFunc
+			// the sentinel is spelled differently before and after go1.27;
+			// see skipfunc_go127.go / skipfunc_pre_go127.go
+			return errSkipFunc
 		}
 		raw, err := dec.ReadValue()
 		if err != nil {

--- a/internal/json/skipfunc_go127.go
+++ b/internal/json/skipfunc_go127.go
@@ -1,0 +1,15 @@
+//go:build go1.27
+
+package json
+
+import (
+	"errors"
+)
+
+// errSkipFunc is the sentinel a marshal/unmarshal function returns to decline
+// handling a value, so that the next applicable function (or the default
+// behavior) is used instead.
+//
+// Go 1.27 removed json/v2.SkipFunc and gave the role to errors.ErrUnsupported,
+// which json/v2 now matches with errors.Is rather than by identity.
+var errSkipFunc = errors.ErrUnsupported

--- a/internal/json/skipfunc_pre_go127.go
+++ b/internal/json/skipfunc_pre_go127.go
@@ -1,0 +1,15 @@
+//go:build !go1.27
+
+package json
+
+import (
+	jsonv2 "encoding/json/v2"
+)
+
+// errSkipFunc is the sentinel a marshal/unmarshal function returns to decline
+// handling a value, so that the next applicable function (or the default
+// behavior) is used instead.
+//
+// Go 1.26 spells it json/v2.SkipFunc and compares it by identity
+// (`err == SkipFunc`), so it has to be returned verbatim.
+var errSkipFunc = jsonv2.SkipFunc


### PR DESCRIPTION
Go 1.27 removed encoding/json/v2.SkipFunc and handed its role to errors.ErrUnsupported: json/v2 now decides whether a custom marshal or unmarshal function declined a value with errors.Is(err, errors.ErrUnsupported) instead of the identity comparison err == SkipFunc.

ref:

- https://github.com/golang/go/issues/74324
- https://go-review.googlesource.com/c/go/+/745041
- https://pkg.go.dev/encoding/json/v2@go1.27rc3

internal/json referenced jsonv2.SkipFunc directly, so v4 fails to compile for anyone on Go 1.27:

    internal/json/registry.go:73:18: undefined: jsonv2.SkipFunc

No single expression satisfies both toolchains. Go 1.26 compares the sentinel by identity, so it has to be SkipFunc verbatim, and that identifier no longer exists in 1.27. Bind it to errSkipFunc behind a Go-version build tag instead, keeping go.mod at go 1.26.0 so existing users are unaffected. The shim can be deleted once the module requires Go 1.27.

---

Should I include the CI configuration for 1.27 in this pull request? It’s still in the RC stage, so it might be a bit premature.