### PR TITLE
fix build under Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,47 @@ jobs:
           fi
       - name: Check difference between generation code and commit code
         run: make check_diffs
+
+  # Guards the Go 1.27 compatibility shim in internal/json. Nothing else in CI
+  # compiles skipfunc_go127.go, because every other workflow takes its toolchain
+  # from go.mod (the 1.26 line).
+  #
+  # This is a separate job rather than a go-version matrix on "build" above,
+  # because the two toolchains do not run the same steps. `make generate`,
+  # `make tidy`, `make check_diffs` and the coverage report each need exactly
+  # one toolchain and produce nothing useful on a second, and `-vet=off` below
+  # must not apply to the go.mod toolchain. A matrix would need `if:` guards on
+  # most of the steps, and it would force `build` to hardcode a Go version
+  # instead of reading go.mod, so CI would no longer test what go.mod declares.
+  # Once go.mod moves to 1.27 the shim and `-vet=off` both go away, the two
+  # jobs become identical, and a matrix becomes the better shape.
+  build-next:
+    runs-on: ubuntu-latest
+    name: "Test (Go 1.27)"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Cache Go modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go1.27-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go1.27-
+      - name: Install Go 1.27
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          # Switch to "1.27.x" once Go 1.27 is released.
+          go-version: "1.27.0-rc.3"
+      - name: Install jose
+        run: sudo apt-get install -y --no-install-recommends jose
+      # -vet=off is required, not a shortcut. go.mod declares go 1.26.0, and
+      # under Go 1.27 the encoding/json/v2 and jsontext symbols carry a
+      # since-go1.27 API version, so vet's stdversion analyzer rejects every
+      # file that uses them ("requires go1.27 or later (file is go1.26)").
+      # The Go 1.26 job above runs the full vet suite. Drop this flag when
+      # go.mod moves to 1.27.
+      - name: Test
+        run: make test-cmd TESTOPTS=-vet=off

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,9 @@ Use `github.com/stretchr/testify/require` for assertions (not `assert`).
 
 ## Build Tags
 
-No build tags in v4. Optional features (signature algorithms, backend replacements) are provided as extension modules under [`github.com/jwx-go`](https://github.com/jwx-go). See [Extension Modules](docs/10-extensions.md) for the full list.
+No feature build tags in v4. Optional features (signature algorithms, backend replacements) are provided as extension modules under [`github.com/jwx-go`](https://github.com/jwx-go). See [Extension Modules](docs/10-extensions.md) for the full list.
+
+The one exception is a Go-version compatibility shim: `internal/json/skipfunc_pre_go127.go` and `internal/json/skipfunc_go127.go` pick the json/v2 "skip this value" sentinel, which Go 1.27 renamed from `json/v2.SkipFunc` to `errors.ErrUnsupported`. Do not add feature build tags alongside it.
 
 ## Quick Reference: Common Modifications
 

--- a/Changes
+++ b/Changes
@@ -11,6 +11,12 @@ UNRELEASED
     `jwe.WithAuthenticateData` for encrypting JSON JWEs with external AAD;
     the value is included in the shared AEAD input for all recipients, and
     compact serialization rejects non-empty external AAD. (#2275, #2277)
+  * Fix the build under Go 1.27. Go 1.27 removed `encoding/json/v2.SkipFunc`
+    and gave its role to `errors.ErrUnsupported`, which broke compilation of
+    `internal/json` for anyone on the new toolchain. The sentinel is now
+    selected by a Go-version build tag, so both Go 1.26 (with
+    `GOEXPERIMENT=jsonv2`) and Go 1.27 build from the same source. No public
+    API or behavior change.
 
 v4.2.0 24 July 2026
   * [jwk] `jwk.Parse` (and `Set.UnmarshalJSON`) no longer fails an entire

--- a/agents/docs/internals.md
+++ b/agents/docs/internals.md
@@ -107,7 +107,14 @@ rejects the registration.
 
 ## JSON Backend
 
-Uses `encoding/json/v2` exclusively (no build-tag switching).
+Uses `encoding/json/v2` exclusively (no build-tag switching between backends).
+
+One Go-version build tag does live inside `internal/json`: the sentinel a custom
+unmarshaler returns to decline a value is `json/v2.SkipFunc` up to Go 1.26 and
+`errors.ErrUnsupported` from Go 1.27 on. `skipfunc_pre_go127.go` /
+`skipfunc_go127.go` bind it to `errSkipFunc` so the rest of the package does not
+have to care. This is a compatibility shim, not a backend switch — delete it
+once the module requires Go 1.27.
 
 Internal `internal/json` package provides the abstraction. Custom field registry (`json.Registry`) enables type-safe deserialization of extension fields.
 

--- a/agents/docs/testing.md
+++ b/agents/docs/testing.md
@@ -40,8 +40,25 @@ No feature build tags in v4. Optional features (signature algorithms, base64 bac
 
 The only build tags in the tree are the Go-version constraints on
 `internal/json/skipfunc_pre_go127.go` / `skipfunc_go127.go`. Tests never set
-them: both Go 1.26 (with `GOEXPERIMENT=jsonv2`) and Go 1.27 build and pass
-as-is.
+them; the toolchain selects the file.
+
+## Go 1.27
+
+Both Go 1.26 (with `GOEXPERIMENT=jsonv2`) and Go 1.27 build and pass from the
+same source, but Go 1.27 requires `-vet=off`:
+
+```bash
+make test-cmd TESTOPTS=-vet=off   # Go 1.27
+```
+
+`go.mod` declares `go 1.26.0`, so under Go 1.27 vet's `stdversion` analyzer
+rejects every file that uses `encoding/json/v2` or `jsontext` (`requires go1.27
+or later (file is go1.26)`). `go vet ./...` and `make lint` fail on Go 1.27 for
+the same reason. Use Go 1.26 for vet and lint until `go.mod` moves to 1.27.
+
+`.github/workflows/ci.yml` covers both: the `Test` job uses the go.mod toolchain
+with vet enabled, and `Test (Go 1.27)` runs the same suite with vet disabled.
+Every other workflow takes its toolchain from `go.mod`.
 
 ## Fuzz Tests
 

--- a/agents/docs/testing.md
+++ b/agents/docs/testing.md
@@ -36,7 +36,12 @@ Environment variables:
 
 ## Build Tags for Tests
 
-No build tags in v4. Optional features (signature algorithms, base64 backend) are activated via side-effect imports of [extension modules](../docs/10-extensions.md).
+No feature build tags in v4. Optional features (signature algorithms, base64 backend) are activated via side-effect imports of [extension modules](../docs/10-extensions.md).
+
+The only build tags in the tree are the Go-version constraints on
+`internal/json/skipfunc_pre_go127.go` / `skipfunc_go127.go`. Tests never set
+them: both Go 1.26 (with `GOEXPERIMENT=jsonv2`) and Go 1.27 build and pass
+as-is.
 
 ## Fuzz Tests
 

--- a/internal/json/BUILD.bazel
+++ b/internal/json/BUILD.bazel
@@ -5,6 +5,8 @@ go_library(
     srcs = [
         "json.go",
         "registry.go",
+        "skipfunc_go127.go",
+        "skipfunc_pre_go127.go",
     ],
     importpath = "github.com/lestrrat-go/jwx/v4/internal/json",
     visibility = ["//:__subpackages__"],

--- a/internal/json/registry.go
+++ b/internal/json/registry.go
@@ -70,7 +70,9 @@ func (dec *TypedDecoder[T]) Decode(data []byte) (any, error) {
 var useNumberUnmarshalers = jsonv2.WithUnmarshalers(
 	jsonv2.UnmarshalFromFunc(func(dec *jsontext.Decoder, val *any) error {
 		if dec.PeekKind() != '0' {
-			return jsonv2.SkipFunc
+			// the sentinel is spelled differently before and after go1.27;
+			// see skipfunc_go127.go / skipfunc_pre_go127.go
+			return errSkipFunc
 		}
 		raw, err := dec.ReadValue()
 		if err != nil {

--- a/internal/json/skipfunc_go127.go
+++ b/internal/json/skipfunc_go127.go
@@ -1,0 +1,15 @@
+//go:build go1.27
+
+package json
+
+import (
+	"errors"
+)
+
+// errSkipFunc is the sentinel a marshal/unmarshal function returns to decline
+// handling a value, so that the next applicable function (or the default
+// behavior) is used instead.
+//
+// Go 1.27 removed json/v2.SkipFunc and gave the role to errors.ErrUnsupported,
+// which json/v2 now matches with errors.Is rather than by identity.
+var errSkipFunc = errors.ErrUnsupported

--- a/internal/json/skipfunc_pre_go127.go
+++ b/internal/json/skipfunc_pre_go127.go
@@ -1,0 +1,15 @@
+//go:build !go1.27
+
+package json
+
+import (
+	jsonv2 "encoding/json/v2"
+)
+
+// errSkipFunc is the sentinel a marshal/unmarshal function returns to decline
+// handling a value, so that the next applicable function (or the default
+// behavior) is used instead.
+//
+// Go 1.26 spells it json/v2.SkipFunc and compares it by identity
+// (`err == SkipFunc`), so it has to be returned verbatim.
+var errSkipFunc = jsonv2.SkipFunc


### PR DESCRIPTION
- Supersedes #2297, whose commit is included here unchanged.
- Go 1.27 removed `encoding/json/v2.SkipFunc`; a build tag picks the sentinel, keeping `go.mod` at 1.26.
- Adds a `Test (Go 1.27)` job, needing `-vet=off` while `go.mod` still says 1.26.
