### PR TITLE
use released Go 1.27 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,18 @@ jobs:
         with:
           go-version-file: "go.mod"
           check-latest: true
+      # Mirror of the guard in the Go 1.27 job below. go.mod declares go 1.26.0,
+      # where encoding/json/v2 is still behind GOEXPERIMENT=jsonv2, so this job
+      # must name the experiment. Asserting both halves means neither the probe
+      # in the Makefile nor a toolchain change can quietly flip one of them.
+      # When go.mod moves to 1.27, this expectation becomes the empty string.
+      - name: Verify the jsonv2 experiment is set
+        run: |
+          exp=$(make print-goexperiment)
+          if [ "$exp" != "jsonv2" ]; then
+            echo "::error::expected GOEXPERIMENT=jsonv2 on the go.mod toolchain, got '$exp'"
+            exit 1
+          fi
       - name: Install stringer
         run: go install golang.org/x/tools/cmd/stringer@v0.42.0
       - name: Install jose
@@ -125,10 +137,11 @@ jobs:
           check-latest: true
       - name: Install jose
         run: sudo apt-get install -y --no-install-recommends jose
-      # Go 1.27 ships encoding/json/v2 in the standard library, so this job must
-      # NOT name the jsonv2 experiment; doing so rebuilds the standard library
-      # under a non-default configuration. The Makefile probes the toolchain to
-      # decide, and this step guards that probe against regressing.
+      # Mirror of the guard in the "build" job above. Go 1.27 ships
+      # encoding/json/v2 in the standard library, so this job must NOT name the
+      # jsonv2 experiment; doing so rebuilds the standard library under a
+      # non-default configuration. The Makefile probes the toolchain to decide,
+      # and this step guards that probe against regressing.
       - name: Verify the jsonv2 experiment is not set
         run: |
           exp=$(make print-goexperiment)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,17 @@ jobs:
           check-latest: true
       - name: Install jose
         run: sudo apt-get install -y --no-install-recommends jose
+      # Go 1.27 ships encoding/json/v2 in the standard library, so this job must
+      # NOT name the jsonv2 experiment; doing so rebuilds the standard library
+      # under a non-default configuration. The Makefile probes the toolchain to
+      # decide, and this step guards that probe against regressing.
+      - name: Verify the jsonv2 experiment is not set
+        run: |
+          exp=$(make print-goexperiment)
+          if [ -n "$exp" ]; then
+            echo "::error::expected an empty GOEXPERIMENT on Go 1.27, got '$exp'"
+            exit 1
+          fi
       # -vet=off is required, not a shortcut. go.mod declares go 1.26.0, and
       # under Go 1.27 the encoding/json/v2 and jsontext symbols carry a
       # since-go1.27 API version, so vet's stdversion analyzer rejects every

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,8 @@ jobs:
       - name: Install Go 1.27
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          # Switch to "1.27.x" once Go 1.27 is released.
-          go-version: "1.27.0-rc.3"
+          go-version: "1.27.x"
+          check-latest: true
       - name: Install jose
         run: sudo apt-get install -y --no-install-recommends jose
       # -vet=off is required, not a shortcut. go.mod declares go 1.26.0, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,14 +19,18 @@ This project requires **Go 1.26.0** or later. Check `go.mod` for the exact versi
 
 ## GOEXPERIMENT
 
-v4 depends on `encoding/json/v2` which requires `GOEXPERIMENT=jsonv2`. The Makefile exports this automatically, but any direct `go build`, `go test`, or `go run` invocation **must** set it:
+v4 depends on `encoding/json/v2`, which is behind `GOEXPERIMENT=jsonv2` on Go 1.26 and part of the standard library from Go 1.27 on. The Makefile probes the toolchain and exports the variable only when it is needed, so `make` targets work on both.
+
+A direct `go build`, `go test`, or `go run` invocation on **Go 1.26** must set it:
 
 ```bash
 GOEXPERIMENT=jsonv2 go test ./...
 GOEXPERIMENT=jsonv2 go build ./...
 ```
 
-Without this, builds fail with `build constraints exclude all Go files` errors.
+Without this, Go 1.26 builds fail with `build constraints exclude all Go files` errors.
+
+On **Go 1.27** do not set it. Naming an experiment the toolchain already ships for real rebuilds the standard library under a non-default configuration for no benefit.
 
 ## Module Path vs Physical Layout
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
-.PHONY: generate realclean cover viewcover test lint check_diffs imports tidy jwx fuzz fuzz-jwt fuzz-jws fuzz-jwe fuzz-jwk companion-test
+.PHONY: generate realclean cover viewcover test lint check_diffs imports tidy jwx fuzz fuzz-jwt fuzz-jws fuzz-jwe fuzz-jwk companion-test print-goexperiment
 
+# encoding/json/v2 sits behind GOEXPERIMENT=jsonv2 on Go 1.26 and is part of
+# the standard library from Go 1.27 on. Probe the toolchain rather than
+# hardcoding a version, and leave GOEXPERIMENT alone when the experiment is not
+# needed: naming an experiment the toolchain already ships for real forces the
+# standard library to be rebuilt under a non-default configuration.
+# GOEXPERIMENT is cleared for the probe so a recursive $(MAKE) re-probes
+# honestly instead of seeing the value this file exported.
+ifneq ($(shell GOEXPERIMENT= go list encoding/json/v2 >/dev/null 2>&1 || echo needed),)
 export GOEXPERIMENT := jsonv2
+endif
 
 generate:
 	@go generate
@@ -39,6 +48,11 @@ lint:
 
 check_diffs:
 	./scripts/check-diff.sh
+
+# Reports the GOEXPERIMENT this Makefile settled on for the current toolchain.
+# CI uses it to assert that the Go 1.27 job does not name the jsonv2 experiment.
+print-goexperiment:
+	@echo "$(GOEXPERIMENT)"
 
 imports:
 	goimports -w ./

--- a/agents/docs/testing.md
+++ b/agents/docs/testing.md
@@ -72,6 +72,12 @@ the same reason. Use Go 1.26 for vet and lint until `go.mod` moves to 1.27.
 with vet enabled, and `Test (Go 1.27)` runs the same suite with vet disabled.
 Every other workflow takes its toolchain from `go.mod`.
 
+Each of those two jobs also asserts the experiment its toolchain expects, via
+`make print-goexperiment`. `Test` requires `jsonv2` and `Test (Go 1.27)`
+requires the empty string, so a broken probe cannot quietly flip either one.
+When `go.mod` moves to 1.27, the `Test` job's expectation becomes the empty
+string and `Test (Go 1.27)` goes away with the rest of the shim.
+
 ## Fuzz Tests
 
 ```bash

--- a/agents/docs/testing.md
+++ b/agents/docs/testing.md
@@ -53,8 +53,11 @@ before concluding ML-DSA is untested.
 
 ## Go 1.27
 
-Both Go 1.26 (with `GOEXPERIMENT=jsonv2`) and Go 1.27 build and pass from the
-same source, but Go 1.27 requires `-vet=off`:
+Both Go 1.26 and Go 1.27 build and pass from the same source. Go 1.26 needs
+`GOEXPERIMENT=jsonv2`; Go 1.27 ships `encoding/json/v2` in the standard library
+and must NOT set it. The Makefile probes the toolchain and exports the variable
+only when it is needed, so `make` handles this either way. Go 1.27 does still
+require `-vet=off`:
 
 ```bash
 make test-cmd TESTOPTS=-vet=off   # Go 1.27

--- a/scripts/test-companion.sh
+++ b/scripts/test-companion.sh
@@ -2,7 +2,13 @@
 
 set -euo pipefail
 
-export GOEXPERIMENT=jsonv2
+# encoding/json/v2 sits behind GOEXPERIMENT=jsonv2 on Go 1.26 and is part of the
+# standard library from Go 1.27 on, where naming the experiment would rebuild
+# the standard library under a non-default configuration for no benefit. Probe
+# the toolchain instead of hardcoding a version.
+if ! GOEXPERIMENT= go list encoding/json/v2 >/dev/null 2>&1; then
+	export GOEXPERIMENT=jsonv2
+fi
 
 JWX_ROOT=$(cd "$(dirname "$0")/.."; pwd -P)
 COMPANIONS_YAML="$JWX_ROOT/companions.yaml"


### PR DESCRIPTION
- Go 1.27.0 is out, so the forward-compat job can track the stable series instead of a pinned release candidate.
- Go 1.27 ships encoding/json/v2 in the standard library, so the jsonv2 experiment must not be named on that toolchain.