### PR TITLE
make GOEXPERIMENT conditional on Go 1.26

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -32,7 +32,7 @@ Text output labels each finding as `(auto)` or `(manual)`, with migration notes 
 ## Prerequisites
 
 - Go 1.26.0 or later
-- Set `GOEXPERIMENT=jsonv2` in your build environment
+- On Go 1.26 only: set `GOEXPERIMENT=jsonv2` in your build environment. Go 1.27 ships `encoding/json/v2` in the standard library, so leave `GOEXPERIMENT` unset there.
 - Update `go.mod`: change module requirement to `github.com/lestrrat-go/jwx/v4`
 
 ## Quick Reference
@@ -559,10 +559,11 @@ These changes cannot be mechanically transformed and need human judgment:
    require github.com/lestrrat-go/jwx/v4 v4.x.x
    ```
 
-2. Set environment variable:
+2. Set environment variable, **on Go 1.26 only**:
    ```bash
    export GOEXPERIMENT=jsonv2
    ```
+   Go 1.27 ships `encoding/json/v2` in the standard library. Leave `GOEXPERIMENT` unset there: naming an experiment the toolchain already ships rebuilds the standard library under a non-default configuration for no benefit.
 
 3. Remove build tags from commands:
    ```bash

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ If you are using this module in your product or your company, please add your pr
 # Requirements
 
 * Go 1.26 or later
-* `GOEXPERIMENT=jsonv2`
+* `GOEXPERIMENT=jsonv2`, **on Go 1.26 only**
+
+v4 uses `encoding/json/v2`, which sits behind `GOEXPERIMENT=jsonv2` on Go 1.26 and is part of the standard library from Go 1.27 on. On Go 1.27 leave `GOEXPERIMENT` unset: naming an experiment the toolchain already ships rebuilds the standard library under a non-default configuration for no benefit.
 
 # Install
 
@@ -186,7 +188,7 @@ Additionally supported via the main module or [extension modules](docs/10-extens
 | Specification | Support |
 |---------------|---------|
 | [FIPS 203](https://csrc.nist.gov/pubs/fips/203/final) (ML-KEM) | JWE key encapsulation via [`github.com/jwx-go/mlkem`](https://github.com/jwx-go/mlkem): ML-KEM-768, ML-KEM-1024, hybrid variants (draft-ietf-jose-pqc-kem) |
-| [FIPS 204](https://csrc.nist.gov/pubs/fips/204/final) (ML-DSA) | JWS signatures via [`github.com/jwx-go/mldsa`](https://github.com/jwx-go/mldsa) |
+| [FIPS 204](https://csrc.nist.gov/pubs/fips/204/final) (ML-DSA) | JWS signatures: native from Go 1.27 on, via [`github.com/jwx-go/mldsa`](https://github.com/jwx-go/mldsa) on Go 1.26 ([details](docs/10-extensions.md#which-implementation-you-get)) |
 
 
 ## History

--- a/agents/plugin-tests/SELF-TEST.md
+++ b/agents/plugin-tests/SELF-TEST.md
@@ -49,8 +49,13 @@ WORKDIR="$(mktemp -d)"
 cd "$WORKDIR"
 go mod init example.com/jwx-self-test/case-N
 # write main.go with all required imports + func main() so it links
-GOEXPERIMENT=jsonv2 go mod tidy
-GOEXPERIMENT=jsonv2 go build ./...
+# encoding/json/v2 is behind GOEXPERIMENT=jsonv2 on Go 1.26 and in the standard
+# library from Go 1.27 on. Probe the toolchain instead of hardcoding a version.
+if ! GOEXPERIMENT= go list encoding/json/v2 >/dev/null 2>&1; then
+	export GOEXPERIMENT=jsonv2
+fi
+go mod tidy
+go build ./...
 ```
 
 The test passes a case only when `go build` exits 0. A successful build proves:

--- a/agents/plugin/skills/guide/SKILL.md
+++ b/agents/plugin/skills/guide/SKILL.md
@@ -34,7 +34,7 @@ When the user's question goes beyond the patterns in this skill (custom claim ty
 ## Prerequisites
 
 - **Go 1.26+** is required. v4 uses generics features and stdlib additions (`errors.AsType[T]`) that are new in 1.26.
-- **`GOEXPERIMENT=jsonv2`** must be set for every `go build`/`go test`/`go run` because v4 depends on `encoding/json/v2`. Without it, builds fail with `build constraints exclude all Go files`.
+- **`GOEXPERIMENT=jsonv2`** must be set on Go 1.26 for every `go build`/`go test`/`go run`, because v4 depends on `encoding/json/v2`. Without it → builds fail with `build constraints exclude all Go files`. NEVER set it on Go 1.27+ → `encoding/json/v2` is in the standard library there, and naming the experiment rebuilds the standard library under a non-default configuration.
 
 Sub-package map:
 
@@ -245,6 +245,8 @@ For algorithm and HPKE modules: **import for side effects** (`import _ "..."`). 
 ### What to do when the user asks about post-quantum or non-default algorithms
 
 Default jwx supports the common RFC 7518 algorithms (RS*, PS*, ES*, HS*, EdDSA, A*GCM, RSA-OAEP-*, etc.) out of the box. For everything in the tables above, the user must add the companion module to their `go.mod` *and* import it for side effects. If a user reports an `algorithm not registered` or similar error for ES256K/Ed448/ML-DSA/ML-KEM/X448, they almost certainly missed the side-effect import.
+
+ML-DSA is the one exception, and it depends on the toolchain. From Go 1.27 on, `crypto/mldsa` is in the standard library, so jwx registers `jwa.MLDSA44()`/`MLDSA65()`/`MLDSA87()` natively and no companion module or side-effect import is needed. On Go 1.26 the algorithms are not registered at all, and `github.com/jwx-go/mldsa/v4` is still required. Canonical owner: `docs/10-extensions.md`, section "Which implementation you get".
 
 ## Errors
 

--- a/docs/design/v4-json-v2-migration.md
+++ b/docs/design/v4-json-v2-migration.md
@@ -45,9 +45,11 @@ MarshalJSON templates changed:
 
 ### Build requirements
 
-During development: `GOEXPERIMENT=jsonv2` must be set for all `go build`, `go test`, `go generate` commands. The Makefile exports this automatically.
+On Go 1.26: `GOEXPERIMENT=jsonv2` must be set for all `go build`, `go test`, `go generate` commands. The Makefile probes the toolchain and exports it only when it is needed.
 
-v4 will ship when json/v2 graduates to default in a future Go release.
+On Go 1.27 and later: `encoding/json/v2` is part of the standard library, and `GOEXPERIMENT` must be left unset.
+
+This section is the only part of this document that tracks current state; the rest records the v3 → v4 decision as it was made. `AGENTS.md` is the canonical owner of the build requirement.
 
 ## Migration guide (v3 → v4)
 

--- a/jwx.go
+++ b/jwx.go
@@ -14,15 +14,18 @@
 //
 // # Requirements
 //
-// v4 uses the experimental encoding/json/v2 API, so consumers must build
-// with:
+// v4 requires Go 1.26.0 or later (see go.mod for the exact minimum) and uses
+// the encoding/json/v2 API. Whether that needs extra build configuration
+// depends on the toolchain:
 //
-//   - Go 1.26.0 or later (see go.mod for the exact minimum)
-//   - GOEXPERIMENT=jsonv2 set in the environment for every `go build`,
-//     `go test`, `go run`, and `go generate` invocation
-//
-// Without GOEXPERIMENT=jsonv2 the Go toolchain reports
-// `build constraints exclude all Go files` and the module will not build.
+//   - Go 1.27 and later ship encoding/json/v2 in the standard library. Build
+//     normally and leave GOEXPERIMENT unset. Naming an experiment the
+//     toolchain already ships rebuilds the standard library under a
+//     non-default configuration for no benefit.
+//   - Go 1.26 keeps encoding/json/v2 behind GOEXPERIMENT=jsonv2, which must be
+//     set for every `go build`, `go test`, `go run`, and `go generate`
+//     invocation. Without it the toolchain reports `build constraints exclude
+//     all Go files` and the module will not build.
 //
 // Examples are stored in a separate Go module (to avoid adding
 // dependencies to this module), and thus does not appear in the


### PR DESCRIPTION
- `GOEXPERIMENT=jsonv2` is a Go 1.26 requirement only; setting it on Go 1.27 rebuilds the stdlib.
- `jwx.go` wrongly claimed the build fails without it on every version.
- README's ML-DSA row omitted the native Go 1.27 path.
