### PR TITLE
point ML-DSA doc cache at generated jwa file

### DIFF
--- a/agents/docs/packages.md
+++ b/agents/docs/packages.md
@@ -25,8 +25,8 @@ Algorithm identifiers per RFC 7518. Registry pattern with thread-safe lookup.
 - Per-type API: `New{Type}()`, `Lookup{Type}(name) (T, bool)`, `Register{Type}()`, `Unregister{Type}()`, `{Type}s() []T`
   `Register{Type}()` is process-global; attempts to replace builtin identifiers such as `RS256` return an error.
 - Constructor functions: `ES256()`, `RS256()`, `A128GCM()`, `P256()`, `Ed25519()`, etc.
-- **MLDSA44()**, **MLDSA65()**, **MLDSA87()** — ML-DSA signature algorithms (FIPS 204). Go 1.27 and later only; `jwa/mldsa.go` is `//go:build go1.27` because `crypto/mldsa` lands in Go 1.27. Registered as builtins from `init()`, not from `objects.yml`.
-- Files: `jwa.go`, `mldsa.go` (go1.27) + generated `*_gen.go`
+- **MLDSA44()**, **MLDSA65()**, **MLDSA87()** — ML-DSA signature algorithms (FIPS 204). Go 1.27 and later only; `jwa/signature_go127_gen.go` is `//go:build go1.27` because `crypto/mldsa` lands in Go 1.27. Generated from the three `build_constraint: go1.27` entries in `objects.yml`, and registered as builtins from that file's `init()`.
+- Files: `jwa.go` + generated `*_gen.go` (including `signature_go127_gen.go`, go1.27)
 - Imports: internal/tokens
 
 ## jwk/

--- a/agents/docs/testing.md
+++ b/agents/docs/testing.md
@@ -41,10 +41,11 @@ No feature build tags in v4. Optional features (signature algorithms, base64 bac
 The only build tags in the tree are Go-version constraints, and tests never set
 them; the toolchain selects the files. Two groups exist: the json/v2 sentinel
 shim (`internal/json/skipfunc_pre_go127.go` / `skipfunc_go127.go`), and native
-ML-DSA (`jwa/mldsa.go`, `jwk/mldsa.go`, `jws/mldsa.go` plus their tests, all
-`//go:build go1.27`).
+ML-DSA (`jwa/signature_go127_gen.go`, `jwk/mldsa.go`, `jws/mldsa.go` plus their
+tests, all `//go:build go1.27`).
 
 ML-DSA coverage therefore runs only on Go 1.27: `jwa/mldsa_test.go`,
+`jwa/signature_go127_gen_test.go` (generated; DO NOT EDIT),
 `jwk/mldsa_test.go` (import/export, JWK round-trip, thumbprint, and known-answer
 vectors pinned from a fixed seed), `jws/mldsa_test.go` (sign/verify, parameter-set
 confusion, signer-opts handling), and `jws/mldsa_fuzz_test.go`. On Go 1.26 these


### PR DESCRIPTION
- `jwa/mldsa.go` no longer exists; #2311 replaced it with generated `jwa/signature_go127_gen.go`.
- The cache also claimed ML-DSA is registered outside `objects.yml`, which is now backwards.
