### PR TITLE
strip inherited jsonv2 on Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,14 @@ jobs:
             echo "::error::expected an empty GOEXPERIMENT on Go 1.27, got '$exp'"
             exit 1
           fi
+          # The probe must also drop a jsonv2 the caller already exported. A
+          # developer who set it for Go 1.26 keeps it in their environment
+          # across the toolchain upgrade, and it would otherwise survive here.
+          exp=$(GOEXPERIMENT=jsonv2 make print-goexperiment)
+          if [ -n "$exp" ]; then
+            echo "::error::expected the probe to drop an inherited jsonv2 on Go 1.27, got '$exp'"
+            exit 1
+          fi
       # -vet=off is required, not a shortcut. go.mod declares go 1.26.0, and
       # under Go 1.27 the encoding/json/v2 and jsontext symbols carry a
       # since-go1.27 API version, so vet's stdversion analyzer rejects every

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This project requires **Go 1.26.0** or later. Check `go.mod` for the exact versi
 
 ## GOEXPERIMENT
 
-v4 depends on `encoding/json/v2`, which is behind `GOEXPERIMENT=jsonv2` on Go 1.26 and part of the standard library from Go 1.27 on. The Makefile probes the toolchain and exports the variable only when it is needed, so `make` targets work on both.
+v4 depends on `encoding/json/v2`, which is behind `GOEXPERIMENT=jsonv2` on Go 1.26 and part of the standard library from Go 1.27 on. The Makefile probes the toolchain and rewrites `GOEXPERIMENT` to match it, adding `jsonv2` on Go 1.26 and removing it on Go 1.27, so `make` targets work on both even when your shell already exports the variable. Experiments other than `jsonv2` are left alone. `scripts/test-companion.sh` carries the same probe.
 
 A direct `go build`, `go test`, or `go run` invocation on **Go 1.26** must set it:
 

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,27 @@
 
 # encoding/json/v2 sits behind GOEXPERIMENT=jsonv2 on Go 1.26 and is part of
 # the standard library from Go 1.27 on. Probe the toolchain rather than
-# hardcoding a version, and leave GOEXPERIMENT alone when the experiment is not
-# needed: naming an experiment the toolchain already ships for real forces the
-# standard library to be rebuilt under a non-default configuration.
-# GOEXPERIMENT is cleared for the probe so a recursive $(MAKE) re-probes
-# honestly instead of seeing the value this file exported.
+# hardcoding a version, and do not name the experiment when the toolchain
+# already ships it for real: that forces the standard library to be rebuilt
+# under a non-default configuration.
+#
+# Both branches rewrite GOEXPERIMENT instead of only setting it, because the
+# caller may have exported it. On Go 1.27 an inherited jsonv2 would otherwise
+# survive and trigger the very rebuild this probe exists to avoid. Experiments
+# other than jsonv2 are always preserved, and the result is idempotent, so a
+# recursive $(MAKE) that inherits it lands on the same value. GOEXPERIMENT is
+# cleared for the probe itself so that recursion re-probes the toolchain
+# honestly instead of reading back what this file exported.
+GOEXPERIMENT_COMMA := ,
+GOEXPERIMENT_EMPTY :=
+GOEXPERIMENT_SPACE := $(GOEXPERIMENT_EMPTY) $(GOEXPERIMENT_EMPTY)
+GOEXPERIMENT_OTHERS := $(strip $(filter-out jsonv2,$(subst $(GOEXPERIMENT_COMMA),$(GOEXPERIMENT_SPACE),$(GOEXPERIMENT))))
+GOEXPERIMENT_REST := $(subst $(GOEXPERIMENT_SPACE),$(GOEXPERIMENT_COMMA),$(GOEXPERIMENT_OTHERS))
+
 ifneq ($(shell GOEXPERIMENT= go list encoding/json/v2 >/dev/null 2>&1 || echo needed),)
-export GOEXPERIMENT := jsonv2
+export GOEXPERIMENT := $(if $(GOEXPERIMENT_REST),$(GOEXPERIMENT_REST)$(GOEXPERIMENT_COMMA))jsonv2
+else
+export GOEXPERIMENT := $(GOEXPERIMENT_REST)
 endif
 
 generate:

--- a/agents/docs/testing.md
+++ b/agents/docs/testing.md
@@ -55,9 +55,10 @@ before concluding ML-DSA is untested.
 
 Both Go 1.26 and Go 1.27 build and pass from the same source. Go 1.26 needs
 `GOEXPERIMENT=jsonv2`; Go 1.27 ships `encoding/json/v2` in the standard library
-and must NOT set it. The Makefile probes the toolchain and exports the variable
-only when it is needed, so `make` handles this either way. Go 1.27 does still
-require `-vet=off`:
+and must NOT set it. The Makefile probes the toolchain and rewrites
+`GOEXPERIMENT` to match, adding `jsonv2` on Go 1.26 and stripping it on Go 1.27,
+so `make` handles this either way even when the variable is already exported.
+Go 1.27 does still require `-vet=off`:
 
 ```bash
 make test-cmd TESTOPTS=-vet=off   # Go 1.27

--- a/scripts/test-companion.sh
+++ b/scripts/test-companion.sh
@@ -6,8 +6,26 @@ set -euo pipefail
 # standard library from Go 1.27 on, where naming the experiment would rebuild
 # the standard library under a non-default configuration for no benefit. Probe
 # the toolchain instead of hardcoding a version.
-if ! GOEXPERIMENT= go list encoding/json/v2 >/dev/null 2>&1; then
-	export GOEXPERIMENT=jsonv2
+#
+# Both branches rewrite GOEXPERIMENT instead of only setting it, because the
+# caller may have exported it. On Go 1.27 an inherited jsonv2 would otherwise
+# survive and trigger the very rebuild this probe exists to avoid. Experiments
+# other than jsonv2 are preserved. Mirrors the probe at the top of the Makefile.
+goexperiment_rest=""
+if [ -n "${GOEXPERIMENT:-}" ]; then
+	IFS=',' read -ra goexperiment_parts <<<"$GOEXPERIMENT"
+	for part in "${goexperiment_parts[@]}"; do
+		if [ -z "$part" ] || [ "$part" = jsonv2 ]; then
+			continue
+		fi
+		goexperiment_rest="${goexperiment_rest:+$goexperiment_rest,}$part"
+	done
+fi
+
+if GOEXPERIMENT= go list encoding/json/v2 >/dev/null 2>&1; then
+	export GOEXPERIMENT="$goexperiment_rest"
+else
+	export GOEXPERIMENT="${goexperiment_rest:+$goexperiment_rest,}jsonv2"
 fi
 
 JWX_ROOT=$(cd "$(dirname "$0")/.."; pwd -P)


### PR DESCRIPTION
- The probe only ever set `GOEXPERIMENT`, so a jsonv2 already in the shell survived on Go 1.27.
- That silently rebuilt the standard library, which is exactly what the probe exists to avoid.
- Both branches now rewrite the value and preserve experiments other than jsonv2.
