### PR TITLE
[v3] fix curve inference claim in docs

### DIFF
--- a/jws/internal/keyalg/keyalg.go
+++ b/jws/internal/keyalg/keyalg.go
@@ -112,10 +112,18 @@ func KeyTypesFor(alg jwa.SignatureAlgorithm) []jwa.KeyType {
 // purposes, as this is the only usage where one may need to dynamically
 // figure out which method to use.
 //
-// When the key's curve can be determined (via [jwk.Key] Crv() method or
-// inferred from the raw Go type), curve-specific algorithms registered via
+// When the key's curve is known, algorithms registered for that curve via
 // [RegisterForCurve] are combined with key-type-level algorithms to
-// produce a more precise result.
+// produce a more precise result. The curve is known for a [jwk.Key] that
+// has a Crv() method, for raw ed25519 keys, and for any raw key that
+// reaches the [jwk.Import] fallback below.
+//
+// ECDSA is the exception. A raw [ecdsa.PublicKey] or [ecdsa.PrivateKey] is
+// classified by key type alone and its Curve field is never read. No
+// builtin registration binds P-256, P-384, or P-521 to an algorithm
+// either, so every EC key reports the full ES* list no matter which curve
+// it sits on. RFC 7518 Section 3.4 is stricter than that; jws.Sign
+// enforces it only when the caller passes jws.WithStrictECDSA(true).
 //
 // Accepted key shapes (resolved in order):
 //

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -561,10 +561,18 @@ func RegisterAlgorithmForCurve(crv jwa.EllipticCurveAlgorithm, alg jwa.Signature
 // for verification purposes, as this is the only usage where one may need
 // dynamically figure out which method to use.
 //
-// When the key's curve can be determined (via [jwk.Key] Crv() method or
-// inferred from the raw Go type), curve-specific algorithms registered via
+// When the key's curve is known, algorithms registered for that curve via
 // [RegisterAlgorithmForCurve] are combined with key-type-level algorithms
-// to produce a more precise result.
+// to produce a more precise result. The curve is known for a [jwk.Key]
+// that has a Crv() method, for raw ed25519 keys, and for any raw key that
+// reaches the [jwk.Import] fallback below.
+//
+// ECDSA is the exception. A raw [ecdsa.PublicKey] or [ecdsa.PrivateKey] is
+// classified by key type alone and its Curve field is never read. No
+// builtin registration binds P-256, P-384, or P-521 to an algorithm
+// either, so every EC key reports the full ES* list no matter which curve
+// it sits on. RFC 7518 Section 3.4 is stricter than that; see
+// [WithStrictECDSA] for enforcing it when signing.
 //
 // Accepted key shapes (resolved in order):
 //


### PR DESCRIPTION
- Curve inference from a raw Go type happens for ed25519 only, not for `*ecdsa` keys as the docs claimed.
- No builtin registration binds P-256/P-384/P-521, so every EC key reports the full ES* list.
- Points readers at `WithStrictECDSA` for the RFC 7518 3.4 check on the sign side.
