### PR TITLE
show fetch failure cause via error sink

### DIFF
--- a/examples/jwk_cache_waitready_example_test.go
+++ b/examples/jwk_cache_waitready_example_test.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/lestrrat-go/httprc/v3"
+	"github.com/lestrrat-go/httprc/v3/errsink"
 	"github.com/lestrrat-go/jwx/v3/jwk"
 )
 
@@ -26,8 +28,10 @@ import (
 // When the deadline expires the URL stays registered and the cache keeps
 // refreshing it in the background, so the returned error is wrapped in
 // `httprc.ErrNotReady()` to distinguish it from a registration that never
-// happened. The underlying fetch errors are reported to the error sink
-// configured with `httprc.WithErrorSink()`.
+// happened. That error says the first fetch has not landed, but not why. The
+// reason is delivered to the error sink configured with
+// `httprc.WithErrorSink()`, which is where every background fetch failure of
+// the cache is reported.
 func Example_jwk_cache_waitready() {
 	const jwks = `{"keys":[{"crv":"P-256","kid":"example-key","kty":"EC","x":"qwwx4vRPSqtIZXXZapWX3ffw8TFOiJJ0VEtTDhQr4gg","y":"704TQDA5YCeyj60FZehEbNsypCCiK65g5OWD9NTy5iE"}]}`
 
@@ -46,7 +50,18 @@ func Example_jwk_cache_waitready() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	c, err := jwk.NewCache(ctx, httprc.NewClient())
+	// Collect the background fetch failures so we can report them below. A
+	// real application would more likely log them, for which
+	// `errsink.NewSlog()` is provided.
+	fetchErrs := make(chan error, 1)
+	c, err := jwk.NewCache(ctx, httprc.NewClient(
+		httprc.WithErrorSink(errsink.NewFunc(func(_ context.Context, err error) {
+			select {
+			case fetchErrs <- err:
+			default: // already holding one; the sink must never block the cache
+			}
+		})),
+	))
 	if err != nil {
 		fmt.Printf("failed to create cache: %s\n", err)
 		return
@@ -60,6 +75,18 @@ func Example_jwk_cache_waitready() {
 	err = c.Register(regCtx, srv.URL, jwk.WithWaitReady(true))
 	fmt.Printf("registered and ready: %t\n", err == nil)
 	fmt.Printf("registered but first fetch pending: %t\n", errors.Is(err, httprc.ErrNotReady()))
+
+	// The error from `Register` does not carry the HTTP failure that caused
+	// it, so read the cause from the sink. The URL below is a random
+	// `httptest` address, and is rewritten to a fixed one only to keep the
+	// output of this example stable.
+	select {
+	case fetchErr := <-fetchErrs:
+		fmt.Printf("cause reported to the sink: %s\n",
+			strings.ReplaceAll(fetchErr.Error(), srv.URL, `https://jwks.example/keys`))
+	case <-time.After(5 * time.Second):
+		fmt.Print("cause reported to the sink: none\n")
+	}
 
 	// `httprc.ErrNotReady()` is recoverable: the caller can start serving the
 	// traffic that does not need the JWKS yet instead of aborting startup.
@@ -80,6 +107,7 @@ func Example_jwk_cache_waitready() {
 	// OUTPUT:
 	// registered and ready: false
 	// registered but first fetch pending: true
+	// cause reported to the sink: httprc.Resource.Sync: unexpected status code (status code=500, url="https://jwks.example/keys")
 	// keys available while the endpoint is down: false
 	// keys available after the endpoint recovers: 1
 }


### PR DESCRIPTION
- Follow up #2343: `httprc.ErrNotReady()` does not say why the first fetch failed.
- Show `httprc.WithErrorSink()` with `errsink.NewFunc` as the place the cause surfaces.
