### PR TITLE
[v4] escape JSON object member names on output

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,25 @@ v4 has many incompatibilities with v3. To see the full list of differences betwe
 v3 and v4, please read the [Changes-v4.md file](./Changes-v4.md). Coding Agents should read [MIGRATION-v4.md](./MICRATION-v4.md)
 
 UNRELEASED
+  * [jwt][jws][jwe][jwk] Custom claim, header, and JWK field names are now
+    JSON-escaped on output. Previously a name was written between the quotes
+    as is, so a name containing `"` could close its own member and add
+    members the application never set. For example, calling `Set` with the
+    name `x":0,"admin` produced a signed token containing `"admin":true`.
+    Every name now yields exactly one member, and names that need no
+    escaping serialize exactly as before. A name that is not valid UTF-8 now
+    fails serialization instead of being written raw.
+
+    If your application accepts custom names from callers, an exact-match
+    allowlist was never affected. A blocklist of reserved names, or an
+    allowlist by namespace prefix, could be bypassed by this defect. Both are
+    reasonable designs; the bug was in the serializer. Prefer an exact-match
+    allowlist, and if you accept a prefix, require the rest of the name to be
+    a plain identifier.
+
+    Fixed in v4.4.1 and v3.2.1. v2, v1, and v0 contain the same code and are
+    unmaintained; see SECURITY.md. (GHSA-4cf7-xm37-g63h)
+
   * [jws] Added `jws.WithStrictECDSA(bool)`, a `jws.Sign` option that rejects
     anything RFC 7518 forbids for an ECDSA signature. Today that is Section
     3.4's binding of ES256 to P-256, ES384 to P-384, and ES512 to P-521, so

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,21 @@
 
 ## Supported Versions
 
-Most recent two major versions will receive security updates
+Security fixes are published for the versions marked below. The
+[State of support](https://github.com/lestrrat-go/jwx/discussions/1079)
+discussion is the canonical, up-to-date statement; this table summarizes it.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| v4.x.x   | :white_check_mark: (preview) |
-| v3.x.x   | :white_check_mark: |
-| v2.x.x   | :white_check_mark: |
-| < v2.0.0 | :x:                |
+| v4.x.x   | :white_check_mark: Current release |
+| v3.x.x   | :white_check_mark: Previous release; receives regular fixes |
+| v2.x.x   | :x: Unmaintained. Do not use |
+| v1.x.x   | :x: Unmaintained. Do not use |
+| < v1.0.0 | :x: Unmaintained. Do not use |
+
+Unmaintained versions receive no fixes of any kind, including for issues
+already fixed in a supported version. Each advisory names the versions that
+carry the fix; a version not named there stays affected.
 
 ## Reporting a Vulnerability
 

--- a/agents/docs/dependencies.md
+++ b/agents/docs/dependencies.md
@@ -32,7 +32,8 @@ Leaf Packages (no internal deps)
   jwa → internal/tokens
   cert → internal/{base64,tokens}
   transform → (stdlib only)
-  internal/{base64,json,ecutil,pool,tokens}
+  internal/json → internal/{base64,tokens}
+  internal/{base64,ecutil,pool,tokens}
 ```
 
 ## Package Import Summary

--- a/internal/json/BUILD.bazel
+++ b/internal/json/BUILD.bazel
@@ -10,7 +10,10 @@ go_library(
     ],
     importpath = "github.com/lestrrat-go/jwx/v4/internal/json",
     visibility = ["//:__subpackages__"],
-    deps = ["//internal/base64"],
+    deps = [
+        "//internal/base64",
+        "//internal/tokens",
+    ],
 )
 
 alias(
@@ -21,7 +24,10 @@ alias(
 
 go_test(
     name = "json_test",
-    srcs = ["registry_test.go"],
+    srcs = [
+        "json_test.go",
+        "registry_test.go",
+    ],
     deps = [
         ":json",
         "@com_github_stretchr_testify//require",

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -1,6 +1,7 @@
 package json
 
 import (
+	"bytes"
 	"encoding/json/jsontext"
 	jsonv2 "encoding/json/v2"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"sync/atomic"
 
 	"github.com/lestrrat-go/jwx/v4/internal/base64"
+	"github.com/lestrrat-go/jwx/v4/internal/tokens"
 )
 
 var globalUseNumber atomic.Bool
@@ -44,6 +46,33 @@ func NewEncoder(w io.Writer) *jsontext.Encoder {
 
 func Marshal(v any) ([]byte, error) {
 	return jsonv2.Marshal(v)
+}
+
+// WriteQuotedKey writes key as a quoted JSON object member name followed by
+// the separating colon.
+//
+// Member names come from public methods such as Set and Builder.Claim, so
+// they may contain any byte, including `"`. A name copied raw between the
+// quotes could end its own member and start further ones, so the serialized
+// object would no longer match the one the caller built
+// (GHSA-4cf7-xm37-g63h). A name that needs no escaping is written directly,
+// which keeps the common path free of allocations. Every other name goes
+// through the JSON string encoder, which also rejects invalid UTF-8.
+func WriteQuotedKey(buf *bytes.Buffer, key string) error {
+	if tokens.IsJSONSafeASCII(key) {
+		buf.WriteByte('"')
+		buf.WriteString(key)
+		buf.WriteString(`":`)
+		return nil
+	}
+
+	encoded, err := jsonv2.Marshal(key)
+	if err != nil {
+		return fmt.Errorf(`failed to encode object member name: %w`, err)
+	}
+	buf.Write(encoded)
+	buf.WriteByte(':')
+	return nil
 }
 
 func MarshalIndent(v any, prefix, indent string) ([]byte, error) {

--- a/internal/json/json_test.go
+++ b/internal/json/json_test.go
@@ -1,0 +1,67 @@
+package json_test
+
+import (
+	"bytes"
+	jsonv2 "encoding/json/v2"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/internal/json"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteQuotedKey(t *testing.T) {
+	t.Parallel()
+
+	// Every name here must come back out as exactly one member whose key
+	// is byte-for-byte what went in, no matter what it contains.
+	names := map[string]string{
+		"plain":         "hello",
+		"quote":         `hello"world`,
+		"injection":     `x":0,"admin`,
+		"backslash":     `a\b`,
+		"newline":       "a\nb",
+		"tab":           "a\tb",
+		"nul":           "a\x00b",
+		"del":           "a\x7fb",
+		"unicode":       "日本語",
+		"empty":         "",
+		"closing brace": `a"}`,
+	}
+
+	for label, name := range names {
+		t.Run(label, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			buf.WriteByte('{')
+			require.NoError(t, json.WriteQuotedKey(&buf, name), `WriteQuotedKey should succeed`)
+			buf.WriteString(`true`)
+			buf.WriteByte('}')
+
+			var got map[string]any
+			require.NoError(t, jsonv2.Unmarshal(buf.Bytes(), &got), `output should be valid JSON: %s`, buf.String())
+			require.Len(t, got, 1, `exactly one member should be produced: %s`, buf.String())
+			require.Contains(t, got, name, `member name should round-trip unchanged: %s`, buf.String())
+		})
+	}
+}
+
+func TestWriteQuotedKeyInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
+	// Invalid UTF-8 must not be silently emitted raw. Either it is escaped
+	// into valid JSON or the call reports an error; both leave the object
+	// structure intact.
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	err := json.WriteQuotedKey(&buf, "a\xffb")
+	if err != nil {
+		return
+	}
+	buf.WriteString(`true`)
+	buf.WriteByte('}')
+
+	var got map[string]any
+	require.NoError(t, jsonv2.Unmarshal(buf.Bytes(), &got), `output should be valid JSON: %q`, buf.String())
+	require.Len(t, got, 1, `exactly one member should be produced: %q`, buf.String())
+}

--- a/internal/jwxcodegen/cmd/jwxcodegen/genheaders.go
+++ b/internal/jwxcodegen/cmd/jwxcodegen/genheaders.go
@@ -498,13 +498,6 @@ func generateHeaders(cfg *HeaderConfig, obj *codegen.Object) error {
 	o.LL("func fieldPairLess(a, b fieldPair) int {")
 	o.L("return cmp.Compare(a.Name, b.Name)")
 	o.L("}")
-	// writeQuotedKey helper: writes "key": without fmt.Fprintf overhead
-	o.LL("func writeQuotedKey(buf *bytes.Buffer, key string) {")
-	o.L("buf.WriteByte('\"')")
-	o.L("buf.WriteString(key)")
-	o.L("buf.WriteString(`\":`)")
-	o.L("}")
-
 	// MarshalJSON
 	o.LL("func (h *stdHeaders) MarshalJSON() ([]byte, error) {")
 	o.L("l := getFieldPairList()")
@@ -530,7 +523,12 @@ func generateHeaders(cfg *HeaderConfig, obj *codegen.Object) error {
 	o.L("buf.WriteByte('{')")
 	o.L("for i, p := range l.pairs {")
 	o.L("if i > 0 { buf.WriteByte(',') }")
-	o.L("writeQuotedKey(buf, p.Name)")
+	// Header names can come from Set, so they must be JSON-escaped.
+	// json.WriteQuotedKey writes a name that needs no escaping without
+	// allocating.
+	o.L("if err := json.WriteQuotedKey(buf, p.Name); err != nil {")
+	o.L("return nil, fmt.Errorf(`failed to encode field name %%q: %%w`, p.Name, err)")
+	o.L("}")
 	o.L("switch v := p.Value.(type) {")
 	o.L("case []byte:")
 	o.L("buf.WriteByte('\"')")

--- a/internal/jwxcodegen/cmd/jwxcodegen/genjwk.go
+++ b/internal/jwxcodegen/cmd/jwxcodegen/genjwk.go
@@ -722,11 +722,12 @@ func generateKeyMarshalJSON(o *codegen.Output, kt *KeyType, obj *codegen.Object,
 	o.L("buf.WriteByte('{')")
 	o.L("for i, p := range pairs {")
 	o.L("if i > 0 { buf.WriteByte(',') }")
-	// Direct buffer writes for key name (known-safe ASCII, no need for fmt.Fprintf)
-	o.L("buf.WriteByte('\"')")
-	o.L("buf.WriteString(p.Name)")
-	o.L("buf.WriteByte('\"')")
-	o.L("buf.WriteByte(':')")
+	// Field names can come from Set, so they must be JSON-escaped.
+	// json.WriteQuotedKey writes a name that needs no escaping without
+	// allocating.
+	o.L("if err := json.WriteQuotedKey(buf, p.Name); err != nil {")
+	o.L("return nil, fmt.Errorf(`failed to encode field name %%q: %%w`, p.Name, err)")
+	o.L("}")
 	// Value is pre-marshaled []byte
 	o.L("buf.Write(p.Value.([]byte))")
 	o.L("}")

--- a/internal/jwxcodegen/cmd/jwxcodegen/genjwt.go
+++ b/internal/jwxcodegen/cmd/jwxcodegen/genjwt.go
@@ -527,9 +527,12 @@ func generateTokenMakePairsAndMarshal(o *codegen.Output, obj *codegen.Object, pk
 	o.L("buf.WriteByte('{')")
 	o.L("for i, pair := range pairs {")
 	o.L("if i > 0 { buf.WriteByte(',') }")
-	o.L("buf.WriteByte('\"')")
-o.L("buf.WriteString(pair.Name)")
-o.L("buf.WriteString(`\":`)")
+	// Claim names can come from Set, so they must be JSON-escaped.
+	// json.WriteQuotedKey writes a name that needs no escaping without
+	// allocating.
+	o.L("if err := json.WriteQuotedKey(buf, pair.Name); err != nil {")
+	o.L("return nil, fmt.Errorf(`failed to encode claim name %%q: %%w`, pair.Name, err)")
+	o.L("}")
 	o.L("if pair.Name == AudienceKey {")
 	// Need to handle audience flattening specially
 	o.L("if aud, ok := pair.Value.(types.StringList); ok {")

--- a/jwe/headers_gen.go
+++ b/jwe/headers_gen.go
@@ -1011,12 +1011,6 @@ func fieldPairLess(a, b fieldPair) int {
 	return cmp.Compare(a.Name, b.Name)
 }
 
-func writeQuotedKey(buf *bytes.Buffer, key string) {
-	buf.WriteByte('"')
-	buf.WriteString(key)
-	buf.WriteString(`":`)
-}
-
 func (h *stdHeaders) MarshalJSON() ([]byte, error) {
 	l := getFieldPairList()
 	defer putFieldPairList(l)
@@ -1087,7 +1081,9 @@ func (h *stdHeaders) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		writeQuotedKey(buf, p.Name)
+		if err := json.WriteQuotedKey(buf, p.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, p.Name, err)
+		}
 		switch v := p.Value.(type) {
 		case []byte:
 			buf.WriteByte('"')

--- a/jwe/headers_test.go
+++ b/jwe/headers_test.go
@@ -195,3 +195,27 @@ func TestHeaders(t *testing.T) {
 		})
 	})
 }
+
+// A custom header name must never be able to introduce members of its own.
+// See GHSA-4cf7-xm37-g63h.
+func TestHeaderNameCannotInjectMembers(t *testing.T) {
+	t.Parallel()
+
+	const name = `x":0,"kid`
+
+	hdrs := jwe.NewHeaders()
+	require.NoError(t, hdrs.Set(name, "injected"), `Set should succeed`)
+
+	buf, err := json.Marshal(hdrs)
+	require.NoError(t, err, `json.Marshal should succeed`)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf, &got), `serialized headers should be valid JSON`)
+	require.Len(t, got, 1, `exactly one header should be serialized: %s`, buf)
+	require.Contains(t, got, name, `header name should round-trip unchanged: %s`, buf)
+
+	roundtrip := jwe.NewHeaders()
+	require.NoError(t, json.Unmarshal(buf, roundtrip), `headers should unmarshal`)
+	kid, ok := roundtrip.KeyID()
+	require.False(t, ok, `no "kid" header should have been injected, got %q`, kid)
+}

--- a/jwk/akp_gen.go
+++ b/jwk/akp_gen.go
@@ -680,10 +680,9 @@ func (h *akpPublicKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		buf.WriteByte('"')
-		buf.WriteString(p.Name)
-		buf.WriteByte('"')
-		buf.WriteByte(':')
+		if err := json.WriteQuotedKey(buf, p.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, p.Name, err)
+		}
 		buf.Write(p.Value.([]byte))
 	}
 	buf.WriteByte('}')
@@ -1451,10 +1450,9 @@ func (h *akpPrivateKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		buf.WriteByte('"')
-		buf.WriteString(p.Name)
-		buf.WriteByte('"')
-		buf.WriteByte(':')
+		if err := json.WriteQuotedKey(buf, p.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, p.Name, err)
+		}
 		buf.Write(p.Value.([]byte))
 	}
 	buf.WriteByte('}')

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -783,10 +783,9 @@ func (h *ecdsaPublicKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		buf.WriteByte('"')
-		buf.WriteString(p.Name)
-		buf.WriteByte('"')
-		buf.WriteByte(':')
+		if err := json.WriteQuotedKey(buf, p.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, p.Name, err)
+		}
 		buf.Write(p.Value.([]byte))
 	}
 	buf.WriteByte('}')
@@ -1663,10 +1662,9 @@ func (h *ecdsaPrivateKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		buf.WriteByte('"')
-		buf.WriteString(p.Name)
-		buf.WriteByte('"')
-		buf.WriteByte(':')
+		if err := json.WriteQuotedKey(buf, p.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, p.Name, err)
+		}
 		buf.Write(p.Value.([]byte))
 	}
 	buf.WriteByte('}')

--- a/jwk/headers_test.go
+++ b/jwk/headers_test.go
@@ -3,6 +3,7 @@ package jwk_test
 import (
 	"testing"
 
+	"github.com/lestrrat-go/jwx/v4/internal/json"
 	"github.com/lestrrat-go/jwx/v4/jwa"
 	"github.com/lestrrat-go/jwx/v4/jwk"
 	"github.com/stretchr/testify/require"
@@ -102,4 +103,29 @@ func TestHeader(t *testing.T) {
 			require.Equal(t, value, got, "values match")
 		}
 	})
+}
+
+// A custom field name must never be able to introduce members of its own.
+// See GHSA-4cf7-xm37-g63h.
+func TestFieldNameCannotInjectMembers(t *testing.T) {
+	t.Parallel()
+
+	const name = `x":0,"use`
+
+	key, err := jwk.Import[jwk.Key]([]byte("0123456789abcdef"))
+	require.NoError(t, err, `jwk.Import should succeed`)
+	require.NoError(t, key.Set(name, "sig"), `Set should succeed`)
+
+	buf, err := json.Marshal(key)
+	require.NoError(t, err, `json.Marshal should succeed`)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf, &got), `serialized key should be valid JSON`)
+	require.Contains(t, got, name, `field name should round-trip unchanged: %s`, buf)
+	require.NotContains(t, got, "use", `no "use" field should have been injected: %s`, buf)
+
+	roundtrip, err := jwk.ParseKey(buf)
+	require.NoError(t, err, `jwk.ParseKey should succeed`)
+	_, ok := roundtrip.KeyUsage()
+	require.False(t, ok, `no "use" field should have been injected`)
 }

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -729,10 +729,9 @@ func (h *okpPublicKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		buf.WriteByte('"')
-		buf.WriteString(p.Name)
-		buf.WriteByte('"')
-		buf.WriteByte(':')
+		if err := json.WriteQuotedKey(buf, p.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, p.Name, err)
+		}
 		buf.Write(p.Value.([]byte))
 	}
 	buf.WriteByte('}')
@@ -1551,10 +1550,9 @@ func (h *okpPrivateKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		buf.WriteByte('"')
-		buf.WriteString(p.Name)
-		buf.WriteByte('"')
-		buf.WriteByte(':')
+		if err := json.WriteQuotedKey(buf, p.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, p.Name, err)
+		}
 		buf.Write(p.Value.([]byte))
 	}
 	buf.WriteByte('}')

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -736,10 +736,9 @@ func (h *rsaPublicKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		buf.WriteByte('"')
-		buf.WriteString(p.Name)
-		buf.WriteByte('"')
-		buf.WriteByte(':')
+		if err := json.WriteQuotedKey(buf, p.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, p.Name, err)
+		}
 		buf.Write(p.Value.([]byte))
 	}
 	buf.WriteByte('}')
@@ -1822,10 +1821,9 @@ func (h *rsaPrivateKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		buf.WriteByte('"')
-		buf.WriteString(p.Name)
-		buf.WriteByte('"')
-		buf.WriteByte(':')
+		if err := json.WriteQuotedKey(buf, p.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, p.Name, err)
+		}
 		buf.Write(p.Value.([]byte))
 	}
 	buf.WriteByte('}')

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -678,10 +678,9 @@ func (h *symmetricKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		buf.WriteByte('"')
-		buf.WriteString(p.Name)
-		buf.WriteByte('"')
-		buf.WriteByte(':')
+		if err := json.WriteQuotedKey(buf, p.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, p.Name, err)
+		}
 		buf.Write(p.Value.([]byte))
 	}
 	buf.WriteByte('}')

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -755,12 +755,6 @@ func fieldPairLess(a, b fieldPair) int {
 	return cmp.Compare(a.Name, b.Name)
 }
 
-func writeQuotedKey(buf *bytes.Buffer, key string) {
-	buf.WriteByte('"')
-	buf.WriteString(key)
-	buf.WriteString(`":`)
-}
-
 func (h *stdHeaders) MarshalJSON() ([]byte, error) {
 	l := getFieldPairList()
 	defer putFieldPairList(l)
@@ -813,7 +807,9 @@ func (h *stdHeaders) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		writeQuotedKey(buf, p.Name)
+		if err := json.WriteQuotedKey(buf, p.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, p.Name, err)
+		}
 		switch v := p.Value.(type) {
 		case []byte:
 			buf.WriteByte('"')

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -213,3 +213,33 @@ func TestHeaderB64Typed(t *testing.T) {
 		require.Error(t, err, `Set("b64", nil) must reject — b64 is typed bool`)
 	})
 }
+
+// A custom header name must never be able to introduce members of its own.
+// See GHSA-4cf7-xm37-g63h.
+func TestHeaderNameCannotInjectMembers(t *testing.T) {
+	t.Parallel()
+
+	const name = `x":0,"kid`
+
+	hdrs := jws.NewHeaders()
+	require.NoError(t, hdrs.Set(name, "injected"), `Set should succeed`)
+
+	buf, err := json.Marshal(hdrs)
+	require.NoError(t, err, `json.Marshal should succeed`)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf, &got), `serialized headers should be valid JSON`)
+	require.Len(t, got, 1, `exactly one header should be serialized: %s`, buf)
+	require.Contains(t, got, name, `header name should round-trip unchanged: %s`, buf)
+
+	// The injected member must not survive signing either.
+	key := []byte("0123456789abcdef0123456789abcdef")
+	signed, err := jws.Sign([]byte("payload"), jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)))
+	require.NoError(t, err, `jws.Sign should succeed`)
+
+	msg, err := jws.Parse(signed)
+	require.NoError(t, err, `jws.Parse should succeed`)
+
+	kid, ok := msg.Signatures()[0].ProtectedHeaders().KeyID()
+	require.False(t, ok, `no "kid" header should have been injected, got %q`, kid)
+}

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -1582,9 +1582,9 @@ func (t *stdToken) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		buf.WriteByte('"')
-		buf.WriteString(pair.Name)
-		buf.WriteString(`":`)
+		if err := json.WriteQuotedKey(buf, pair.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode claim name %q: %w`, pair.Name, err)
+		}
 		if pair.Name == AudienceKey {
 			if aud, ok := pair.Value.(types.StringList); ok {
 				audBytes, err := json.MarshalAudience(aud, t.options.IsEnabled(jwt.FlattenAudience))

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -651,9 +651,9 @@ func (t *stdToken) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(',')
 		}
-		buf.WriteByte('"')
-		buf.WriteString(pair.Name)
-		buf.WriteString(`":`)
+		if err := json.WriteQuotedKey(buf, pair.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode claim name %q: %w`, pair.Name, err)
+		}
 		if pair.Name == AudienceKey {
 			if aud, ok := pair.Value.(types.StringList); ok {
 				audBytes, err := json.MarshalAudience(aud, t.options.IsEnabled(FlattenAudience))

--- a/jwt/token_test.go
+++ b/jwt/token_test.go
@@ -301,3 +301,37 @@ func TestUnmarshalResetsPrivateClaims(t *testing.T) {
 		require.Equal(t, "y", sub)
 	})
 }
+
+// A custom claim name must never be able to introduce members of its own.
+// See GHSA-4cf7-xm37-g63h.
+func TestClaimNameCannotInjectMembers(t *testing.T) {
+	t.Parallel()
+
+	const name = `x":0,"admin`
+
+	tok, err := jwt.NewBuilder().Claim(name, true).Build()
+	require.NoError(t, err, `jwt.NewBuilder should succeed`)
+
+	buf, err := json.Marshal(tok)
+	require.NoError(t, err, `json.Marshal should succeed`)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf, &got), `serialized token should be valid JSON`)
+	require.Len(t, got, 1, `exactly one claim should be serialized: %s`, buf)
+	require.Contains(t, got, name, `claim name should round-trip unchanged: %s`, buf)
+
+	// The injected member must not survive a sign/verify round trip either.
+	key := []byte("0123456789abcdef0123456789abcdef")
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.HS256(), key))
+	require.NoError(t, err, `jwt.Sign should succeed`)
+
+	parsed, err := jwt.Parse(signed, jwt.WithKey(jwa.HS256(), key))
+	require.NoError(t, err, `jwt.Parse should succeed`)
+
+	_, ok := parsed.Field("admin")
+	require.False(t, ok, `no "admin" claim should have been injected`)
+
+	v, ok := parsed.Field(name)
+	require.True(t, ok, `the original claim should be present`)
+	require.Equal(t, true, v, `the original claim value should be preserved`)
+}


### PR DESCRIPTION
- Fix GHSA-4cf7-xm37-g63h: a custom member name containing a double quote could add JSON members the caller never set.
- Escape names in the generator templates; names that need no escaping keep the allocation-free path.
- Ships through the normal release process; the advisory is published once v4.4.1 and v3.2.1 are tagged.
