### PR TITLE
[v3] escape JSON object member names on output

### DIFF
--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -31,7 +31,8 @@ Leaf Packages (no internal deps)
   jwa → internal/tokens
   cert → internal/{base64,tokens}
   transform → (stdlib + blackmagic)
-  internal/{base64,json,ecutil,pool,tokens}
+  internal/json → internal/{base64,tokens}
+  internal/{base64,ecutil,pool,tokens}
 ```
 
 ## Package Import Summary

--- a/Changes
+++ b/Changes
@@ -5,6 +5,24 @@ v3 has many incompatibilities with v2. To see the full list of differences betwe
 v2 and v3, please read the Changes-v3.md file (https://github.com/lestrrat-go/jwx/blob/develop/v3/Changes-v3.md)
 
 UNRELEASED
+  * [jwt][jws][jwe][jwk] Custom claim, header, and JWK field names are now
+    JSON-escaped on output. Previously a name was written between the quotes
+    as is, so a name containing `"` could close its own member and add
+    members the application never set. For example, calling `Set` with the
+    name `x":0,"admin` produced a signed token containing `"admin":true`.
+    Every name now yields exactly one member, and names that need no
+    escaping serialize exactly as before.
+
+    If your application accepts custom names from callers, an exact-match
+    allowlist was never affected. A blocklist of reserved names, or an
+    allowlist by namespace prefix, could be bypassed by this defect. Both are
+    reasonable designs; the bug was in the serializer. Prefer an exact-match
+    allowlist, and if you accept a prefix, require the rest of the name to be
+    a plain identifier.
+
+    Fixed in v4.4.1 and v3.2.1. v2, v1, and v0 contain the same code and are
+    unmaintained; see SECURITY.md. (GHSA-4cf7-xm37-g63h)
+
   * [jws] Added `jws.WithStrictECDSA(bool)`, a `jws.Sign` option that rejects
     anything RFC 7518 forbids for an ECDSA signature. Today that is Section
     3.4's binding of ES256 to P-256, ES384 to P-384, and ES512 to P-521, so

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,21 @@
 
 ## Supported Versions
 
-Most recent two major versions will receive security updates
+Security fixes are published for the versions marked below. The
+[State of support](https://github.com/lestrrat-go/jwx/discussions/1079)
+discussion is the canonical, up-to-date statement; this table summarizes it.
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| v3.x.x   | :white_check_mark: |
-| v2.x.x   | :white_check_mark: |
-| < v2.0.0 | :x:                |
+| v4.x.x   | :white_check_mark: Current release |
+| v3.x.x   | :white_check_mark: Previous release; receives regular fixes |
+| v2.x.x   | :x: Unmaintained. Do not use |
+| v1.x.x   | :x: Unmaintained. Do not use |
+| < v1.0.0 | :x: Unmaintained. Do not use |
+
+Unmaintained versions receive no fixes of any kind, including for issues
+already fixed in a supported version. Each advisory names the versions that
+carry the fix; a version not named there stays affected.
 
 ## Reporting a Vulnerability
 

--- a/internal/json/BUILD.bazel
+++ b/internal/json/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "json",
@@ -9,11 +9,23 @@ go_library(
     ],
     importpath = "github.com/lestrrat-go/jwx/v3/internal/json",
     visibility = ["//:__subpackages__"],
-    deps = ["//internal/base64"],
+    deps = [
+        "//internal/base64",
+        "//internal/tokens",
+    ],
 )
 
 alias(
     name = "go_default_library",
     actual = ":json",
     visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "json_test",
+    srcs = ["json_test.go"],
+    deps = [
+        ":json",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/lestrrat-go/jwx/v3/internal/base64"
+	"github.com/lestrrat-go/jwx/v3/internal/tokens"
 )
 
 var useNumber atomic.Uint32
@@ -163,4 +164,32 @@ func (dc *decodeCtx) Registry() *Registry {
 
 func (dc *decodeCtx) StrictStrings() bool {
 	return dc.strictStrings
+}
+
+// WriteQuotedKey writes key as a quoted JSON object member name followed by
+// the separating colon and a space.
+//
+// Member names come from public methods such as Set and Builder.Claim, so
+// they may contain any byte, including `"`. A name copied raw between the
+// quotes could end its own member and start further ones, so the serialized
+// object would no longer match the one the caller built
+// (GHSA-4cf7-xm37-g63h). A name that needs no escaping is written directly,
+// which keeps the common path free of allocations. Every other name goes
+// through the JSON string encoder.
+func WriteQuotedKey(buf *bytes.Buffer, key string) error {
+	if tokens.IsJSONSafeASCII(key) {
+		buf.WriteByte(tokens.DoubleQuote)
+		buf.WriteString(key)
+		buf.WriteString(`": `)
+		return nil
+	}
+
+	encoded, err := Marshal(key)
+	if err != nil {
+		return fmt.Errorf(`failed to encode object member name: %w`, err)
+	}
+	buf.Write(encoded)
+	buf.WriteByte(tokens.Colon)
+	buf.WriteByte(' ')
+	return nil
 }

--- a/internal/json/json_test.go
+++ b/internal/json/json_test.go
@@ -1,0 +1,67 @@
+package json_test
+
+import (
+	"bytes"
+	stdjson "encoding/json"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v3/internal/json"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteQuotedKey(t *testing.T) {
+	t.Parallel()
+
+	// Every name here must come back out as exactly one member whose key
+	// is byte-for-byte what went in, no matter what it contains.
+	names := map[string]string{
+		"plain":         "hello",
+		"quote":         `hello"world`,
+		"injection":     `x":0,"admin`,
+		"backslash":     `a\b`,
+		"newline":       "a\nb",
+		"tab":           "a\tb",
+		"nul":           "a\x00b",
+		"del":           "a\x7fb",
+		"unicode":       "日本語",
+		"empty":         "",
+		"closing brace": `a"}`,
+	}
+
+	for label, name := range names {
+		t.Run(label, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			buf.WriteByte('{')
+			require.NoError(t, json.WriteQuotedKey(&buf, name), `WriteQuotedKey should succeed`)
+			buf.WriteString(`true`)
+			buf.WriteByte('}')
+
+			var got map[string]any
+			require.NoError(t, stdjson.Unmarshal(buf.Bytes(), &got), `output should be valid JSON: %s`, buf.String())
+			require.Len(t, got, 1, `exactly one member should be produced: %s`, buf.String())
+			require.Contains(t, got, name, `member name should round-trip unchanged: %s`, buf.String())
+		})
+	}
+}
+
+func TestWriteQuotedKeyInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
+	// Invalid UTF-8 must not be emitted raw. The JSON encoder substitutes
+	// U+FFFD rather than failing, so the name is not preserved here, but the
+	// object structure must still be intact.
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	err := json.WriteQuotedKey(&buf, "a\xffb")
+	if err != nil {
+		return
+	}
+	buf.WriteString(`true`)
+	buf.WriteByte('}')
+
+	var got map[string]any
+	require.NoError(t, stdjson.Unmarshal(buf.Bytes(), &got), `output should be valid JSON: %q`, buf.String())
+	require.Len(t, got, 1, `exactly one member should be produced: %q`, buf.String())
+}

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -11,6 +11,20 @@ const (
 	Period             = '.'
 )
 
+// IsJSONSafeASCII reports whether s can be concatenated into a
+// hand-built JSON string literal without escaping. Any byte that
+// would require a JSON escape (control bytes, `"`, `\`) or any
+// non-ASCII byte disqualifies the value.
+func IsJSONSafeASCII(s string) bool {
+	for i := range len(s) {
+		c := s[i]
+		if c < 0x20 || c >= 0x7f || c == '"' || c == '\\' {
+			return false
+		}
+	}
+	return true
+}
+
 // Cryptographic key sizes
 const (
 	KeySize16 = 16

--- a/jwe/headers_gen.go
+++ b/jwe/headers_gen.go
@@ -962,9 +962,9 @@ func (h *stdHeaders) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(tokens.Comma)
 		}
-		buf.WriteByte('"')
-		buf.WriteString(pair.Name)
-		buf.WriteString(`": `)
+		if err := json.WriteQuotedKey(buf, pair.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, pair.Name, err)
+		}
 		buf.Write(pair.Value.([]byte))
 	}
 	buf.WriteByte(tokens.CloseCurlyBracket)

--- a/jwe/headers_test.go
+++ b/jwe/headers_test.go
@@ -196,3 +196,27 @@ func TestHeaders(t *testing.T) {
 		})
 	})
 }
+
+// A custom header name must never be able to introduce members of its own.
+// See GHSA-4cf7-xm37-g63h.
+func TestHeaderNameCannotInjectMembers(t *testing.T) {
+	t.Parallel()
+
+	const name = `x":0,"kid`
+
+	hdrs := jwe.NewHeaders()
+	require.NoError(t, hdrs.Set(name, "injected"), `Set should succeed`)
+
+	buf, err := json.Marshal(hdrs)
+	require.NoError(t, err, `json.Marshal should succeed`)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf, &got), `serialized headers should be valid JSON`)
+	require.Len(t, got, 1, `exactly one header should be serialized: %s`, buf)
+	require.Contains(t, got, name, `header name should round-trip unchanged: %s`, buf)
+
+	roundtrip := jwe.NewHeaders()
+	require.NoError(t, json.Unmarshal(buf, roundtrip), `headers should unmarshal`)
+	kid, ok := roundtrip.KeyID()
+	require.False(t, ok, `no "kid" header should have been injected, got %q`, kid)
+}

--- a/jwk/ecdsa_gen.go
+++ b/jwk/ecdsa_gen.go
@@ -734,9 +734,9 @@ func (h *ecdsaPublicKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(tokens.Comma)
 		}
-		buf.WriteByte('"')
-		buf.WriteString(pair.Name)
-		buf.WriteString(`": `)
+		if err := json.WriteQuotedKey(buf, pair.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, pair.Name, err)
+		}
 		buf.Write(pair.Value.([]byte))
 	}
 	buf.WriteByte(tokens.CloseCurlyBracket)
@@ -1558,9 +1558,9 @@ func (h *ecdsaPrivateKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(tokens.Comma)
 		}
-		buf.WriteByte('"')
-		buf.WriteString(pair.Name)
-		buf.WriteString(`": `)
+		if err := json.WriteQuotedKey(buf, pair.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, pair.Name, err)
+		}
 		buf.Write(pair.Value.([]byte))
 	}
 	buf.WriteByte(tokens.CloseCurlyBracket)

--- a/jwk/headers_test.go
+++ b/jwk/headers_test.go
@@ -3,6 +3,7 @@ package jwk_test
 import (
 	"testing"
 
+	"github.com/lestrrat-go/jwx/v3/internal/json"
 	"github.com/lestrrat-go/jwx/v3/jwa"
 	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/stretchr/testify/require"
@@ -100,4 +101,29 @@ func TestHeader(t *testing.T) {
 			require.Equal(t, value, got, "values match")
 		}
 	})
+}
+
+// A custom field name must never be able to introduce members of its own.
+// See GHSA-4cf7-xm37-g63h.
+func TestFieldNameCannotInjectMembers(t *testing.T) {
+	t.Parallel()
+
+	const name = `x":0,"use`
+
+	key, err := jwk.Import([]byte("0123456789abcdef"))
+	require.NoError(t, err, `jwk.Import should succeed`)
+	require.NoError(t, key.Set(name, "sig"), `Set should succeed`)
+
+	buf, err := json.Marshal(key)
+	require.NoError(t, err, `json.Marshal should succeed`)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf, &got), `serialized key should be valid JSON`)
+	require.Contains(t, got, name, `field name should round-trip unchanged: %s`, buf)
+	require.NotContains(t, got, "use", `no "use" field should have been injected: %s`, buf)
+
+	roundtrip, err := jwk.ParseKey(buf)
+	require.NoError(t, err, `jwk.ParseKey should succeed`)
+	_, ok := roundtrip.KeyUsage()
+	require.False(t, ok, `no "use" field should have been injected`)
 }

--- a/jwk/okp_gen.go
+++ b/jwk/okp_gen.go
@@ -684,9 +684,9 @@ func (h *okpPublicKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(tokens.Comma)
 		}
-		buf.WriteByte('"')
-		buf.WriteString(pair.Name)
-		buf.WriteString(`": `)
+		if err := json.WriteQuotedKey(buf, pair.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, pair.Name, err)
+		}
 		buf.Write(pair.Value.([]byte))
 	}
 	buf.WriteByte(tokens.CloseCurlyBracket)
@@ -1454,9 +1454,9 @@ func (h *okpPrivateKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(tokens.Comma)
 		}
-		buf.WriteByte('"')
-		buf.WriteString(pair.Name)
-		buf.WriteString(`": `)
+		if err := json.WriteQuotedKey(buf, pair.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, pair.Name, err)
+		}
 		buf.Write(pair.Value.([]byte))
 	}
 	buf.WriteByte(tokens.CloseCurlyBracket)

--- a/jwk/rsa_gen.go
+++ b/jwk/rsa_gen.go
@@ -692,9 +692,9 @@ func (h *rsaPublicKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(tokens.Comma)
 		}
-		buf.WriteByte('"')
-		buf.WriteString(pair.Name)
-		buf.WriteString(`": `)
+		if err := json.WriteQuotedKey(buf, pair.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, pair.Name, err)
+		}
 		buf.Write(pair.Value.([]byte))
 	}
 	buf.WriteByte(tokens.CloseCurlyBracket)
@@ -1707,9 +1707,9 @@ func (h *rsaPrivateKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(tokens.Comma)
 		}
-		buf.WriteByte('"')
-		buf.WriteString(pair.Name)
-		buf.WriteString(`": `)
+		if err := json.WriteQuotedKey(buf, pair.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, pair.Name, err)
+		}
 		buf.Write(pair.Value.([]byte))
 	}
 	buf.WriteByte(tokens.CloseCurlyBracket)

--- a/jwk/symmetric_gen.go
+++ b/jwk/symmetric_gen.go
@@ -638,9 +638,9 @@ func (h *symmetricKey) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(tokens.Comma)
 		}
-		buf.WriteByte('"')
-		buf.WriteString(pair.Name)
-		buf.WriteString(`": `)
+		if err := json.WriteQuotedKey(buf, pair.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, pair.Name, err)
+		}
 		buf.Write(pair.Value.([]byte))
 	}
 	buf.WriteByte(tokens.CloseCurlyBracket)

--- a/jws/headers_gen.go
+++ b/jws/headers_gen.go
@@ -812,9 +812,9 @@ func (h *stdHeaders) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(tokens.Comma)
 		}
-		buf.WriteByte('"')
-		buf.WriteString(pair.Name)
-		buf.WriteString(`": `)
+		if err := json.WriteQuotedKey(buf, pair.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode field name %q: %w`, pair.Name, err)
+		}
 		buf.Write(pair.Value.([]byte))
 	}
 	buf.WriteByte(tokens.CloseCurlyBracket)

--- a/jws/headers_test.go
+++ b/jws/headers_test.go
@@ -211,3 +211,33 @@ func TestHeaderB64Typed(t *testing.T) {
 		require.Error(t, err, `Set("b64", nil) must reject — b64 is typed bool`)
 	})
 }
+
+// A custom header name must never be able to introduce members of its own.
+// See GHSA-4cf7-xm37-g63h.
+func TestHeaderNameCannotInjectMembers(t *testing.T) {
+	t.Parallel()
+
+	const name = `x":0,"kid`
+
+	hdrs := jws.NewHeaders()
+	require.NoError(t, hdrs.Set(name, "injected"), `Set should succeed`)
+
+	buf, err := json.Marshal(hdrs)
+	require.NoError(t, err, `json.Marshal should succeed`)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf, &got), `serialized headers should be valid JSON`)
+	require.Len(t, got, 1, `exactly one header should be serialized: %s`, buf)
+	require.Contains(t, got, name, `header name should round-trip unchanged: %s`, buf)
+
+	// The injected member must not survive signing either.
+	key := []byte("0123456789abcdef0123456789abcdef")
+	signed, err := jws.Sign([]byte("payload"), jws.WithKey(jwa.HS256(), key, jws.WithProtectedHeaders(hdrs)))
+	require.NoError(t, err, `jws.Sign should succeed`)
+
+	msg, err := jws.Parse(signed)
+	require.NoError(t, err, `jws.Parse should succeed`)
+
+	kid, ok := msg.Signatures()[0].ProtectedHeaders().KeyID()
+	require.False(t, ok, `no "kid" header should have been injected, got %q`, kid)
+}

--- a/jwt/openid/token_gen.go
+++ b/jwt/openid/token_gen.go
@@ -1523,9 +1523,9 @@ func (t *stdToken) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(tokens.Comma)
 		}
-		buf.WriteByte('"')
-		buf.WriteString(pair.Name)
-		buf.WriteString(`": `)
+		if err := json.WriteQuotedKey(buf, pair.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode claim name %q: %w`, pair.Name, err)
+		}
 		buf.Write(pair.Value.([]byte))
 	}
 	buf.WriteByte(tokens.CloseCurlyBracket)

--- a/jwt/token_gen.go
+++ b/jwt/token_gen.go
@@ -628,9 +628,9 @@ func (t *stdToken) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buf.WriteByte(tokens.Comma)
 		}
-		buf.WriteByte('"')
-		buf.WriteString(pair.Name)
-		buf.WriteString(`": `)
+		if err := json.WriteQuotedKey(buf, pair.Name); err != nil {
+			return nil, fmt.Errorf(`failed to encode claim name %q: %w`, pair.Name, err)
+		}
 		buf.Write(pair.Value.([]byte))
 	}
 	buf.WriteByte(tokens.CloseCurlyBracket)

--- a/jwt/token_test.go
+++ b/jwt/token_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lestrrat-go/jwx/v3/internal/json"
 
+	"github.com/lestrrat-go/jwx/v3/jwa"
 	"github.com/lestrrat-go/jwx/v3/jwt"
 	"github.com/stretchr/testify/require"
 )
@@ -220,4 +221,34 @@ func TestToken(t *testing.T) {
 			require.NoError(t, newtok.Set(k, v), `newtok.Set should succeed`)
 		}
 	})
+}
+
+// A custom claim name must never be able to introduce members of its own.
+// See GHSA-4cf7-xm37-g63h.
+func TestClaimNameCannotInjectMembers(t *testing.T) {
+	t.Parallel()
+
+	const name = `x":0,"admin`
+
+	tok, err := jwt.NewBuilder().Claim(name, true).Build()
+	require.NoError(t, err, `jwt.NewBuilder should succeed`)
+
+	buf, err := json.Marshal(tok)
+	require.NoError(t, err, `json.Marshal should succeed`)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf, &got), `serialized token should be valid JSON`)
+	require.Len(t, got, 1, `exactly one claim should be serialized: %s`, buf)
+	require.Contains(t, got, name, `claim name should round-trip unchanged: %s`, buf)
+
+	// The injected member must not survive a sign/verify round trip either.
+	key := []byte("0123456789abcdef0123456789abcdef")
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.HS256(), key))
+	require.NoError(t, err, `jwt.Sign should succeed`)
+
+	parsed, err := jwt.Parse(signed, jwt.WithKey(jwa.HS256(), key))
+	require.NoError(t, err, `jwt.Parse should succeed`)
+
+	require.False(t, parsed.Has("admin"), `no "admin" claim should have been injected`)
+	require.True(t, parsed.Has(name), `the original claim should be present`)
 }

--- a/tools/cmd/genjwe/main.go
+++ b/tools/cmd/genjwe/main.go
@@ -478,9 +478,12 @@ func generateHeaders(obj *codegen.Object) error {
 	o.L("if i > 0 {")
 	o.L("buf.WriteByte(tokens.Comma)")
 	o.L("}")
-	o.L(`buf.WriteByte('"')`)
-	o.L(`buf.WriteString(pair.Name)`)
-	o.L("buf.WriteString(`\": `)")
+	// Header names can come from Set, so they must be JSON-escaped.
+	// json.WriteQuotedKey writes a name that needs no escaping without
+	// allocating.
+	o.L("if err := json.WriteQuotedKey(buf, pair.Name); err != nil {")
+	o.L("return nil, fmt.Errorf(`failed to encode field name %%q: %%w`, pair.Name, err)")
+	o.L("}")
 	o.L(`buf.Write(pair.Value.([]byte))`)
 	o.L("}")
 	o.L("buf.WriteByte(tokens.CloseCurlyBracket)")

--- a/tools/cmd/genjwk/main.go
+++ b/tools/cmd/genjwk/main.go
@@ -747,9 +747,12 @@ func generateObject(o *codegen.Output, kt *KeyType, obj *codegen.Object) error {
 	o.L("if i > 0 {")
 	o.L("buf.WriteByte(tokens.Comma)")
 	o.L("}")
-	o.L(`buf.WriteByte('"')`)
-	o.L(`buf.WriteString(pair.Name)`)
-	o.L("buf.WriteString(`\": `)")
+	// Field names can come from Set, so they must be JSON-escaped.
+	// json.WriteQuotedKey writes a name that needs no escaping without
+	// allocating.
+	o.L("if err := json.WriteQuotedKey(buf, pair.Name); err != nil {")
+	o.L("return nil, fmt.Errorf(`failed to encode field name %%q: %%w`, pair.Name, err)")
+	o.L("}")
 	o.L(`buf.Write(pair.Value.([]byte))`)
 	o.L("}")
 	o.L("buf.WriteByte(tokens.CloseCurlyBracket)")

--- a/tools/cmd/genjws/main.go
+++ b/tools/cmd/genjws/main.go
@@ -492,9 +492,12 @@ func generateHeaders(obj *codegen.Object) error {
 	o.L("if i > 0 {")
 	o.L("buf.WriteByte(tokens.Comma)")
 	o.L("}")
-	o.L(`buf.WriteByte('"')`)
-	o.L(`buf.WriteString(pair.Name)`)
-	o.L("buf.WriteString(`\": `)")
+	// Header names can come from Set, so they must be JSON-escaped.
+	// json.WriteQuotedKey writes a name that needs no escaping without
+	// allocating.
+	o.L("if err := json.WriteQuotedKey(buf, pair.Name); err != nil {")
+	o.L("return nil, fmt.Errorf(`failed to encode field name %%q: %%w`, pair.Name, err)")
+	o.L("}")
 	o.L(`buf.Write(pair.Value.([]byte))`)
 	o.L("}")
 	o.L("buf.WriteByte(tokens.CloseCurlyBracket)")

--- a/tools/cmd/genjwt/main.go
+++ b/tools/cmd/genjwt/main.go
@@ -610,9 +610,12 @@ func generateToken(obj *codegen.Object) error {
 	o.L("if i > 0 {")
 	o.L("buf.WriteByte(tokens.Comma)")
 	o.L("}")
-	o.L(`buf.WriteByte('"')`)
-	o.L(`buf.WriteString(pair.Name)`)
-	o.L("buf.WriteString(`\": `)")
+	// Claim names can come from Set, so they must be JSON-escaped.
+	// json.WriteQuotedKey writes a name that needs no escaping without
+	// allocating.
+	o.L("if err := json.WriteQuotedKey(buf, pair.Name); err != nil {")
+	o.L("return nil, fmt.Errorf(`failed to encode claim name %%q: %%w`, pair.Name, err)")
+	o.L("}")
 	o.L(`buf.Write(pair.Value.([]byte))`)
 	o.L("}")
 	o.L("buf.WriteByte(tokens.CloseCurlyBracket)")


### PR DESCRIPTION
- Backport the GHSA-4cf7-xm37-g63h fix: a custom member name with a double quote could add members the caller never set.
- Escape names in the generator templates; also backport tokens.IsJSONSafeASCII, which v3 never received.
- Ships through the normal release process; the advisory is published once v4.4.1 and v3.2.1 are tagged.
